### PR TITLE
chore: project governance & tooling (CLA, Renovate, copyright headers, branch-protection ADR)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>qnophq/.github"],
+  "packageRules": [
+    {
+      "description": "Spring Boot starters, BOM, security, and dependency-management plugin",
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "matchPackageNames": [
+        "/^org\\.springframework\\.boot/",
+        "/^org\\.springframework\\.security/",
+        "/^io\\.spring\\.dependency-management/"
+      ],
+      "groupName": "Spring Boot",
+      "groupSlug": "spring-boot"
+    },
+    {
+      "description": "JUnit 5 and ArchUnit",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": [
+        "/^org\\.junit/",
+        "/^com\\.tngtech\\.archunit/"
+      ],
+      "groupName": "Test dependencies",
+      "groupSlug": "test-deps"
+    },
+    {
+      "description": "Liquibase database migrations",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["/^org\\.liquibase/"],
+      "groupName": "Liquibase",
+      "groupSlug": "liquibase"
+    },
+    {
+      "description": "PostgreSQL JDBC driver",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["/^org\\.postgresql/"],
+      "groupName": "PostgreSQL",
+      "groupSlug": "postgresql"
+    },
+    {
+      "description": "AWS SDK v2 (vendor-neutral S3 client for object storage)",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["/^software\\.amazon\\.awssdk/"],
+      "groupName": "AWS SDK",
+      "groupSlug": "aws-sdk"
+    },
+    {
+      "description": "Document processing — Apache PDFBox and POI",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": [
+        "/^org\\.apache\\.pdfbox/",
+        "/^org\\.apache\\.poi/"
+      ],
+      "groupName": "Document processing",
+      "groupSlug": "document-processing"
+    },
+    {
+      "description": "Build tooling — Spotless",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["/^com\\.diffplug\\.spotless/"],
+      "groupName": "Build tooling",
+      "groupSlug": "build-tooling"
+    },
+    {
+      "description": "Gradle wrapper version",
+      "matchManagers": ["gradle-wrapper"],
+      "groupName": "Gradle wrapper",
+      "groupSlug": "gradle-wrapper"
+    },
+    {
+      "description": "Frontend — React and its type definitions",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["frontend/**"],
+      "matchPackageNames": [
+        "/^react$/",
+        "/^react-dom$/",
+        "/^@types\\/react/"
+      ],
+      "groupName": "React",
+      "groupSlug": "react"
+    },
+    {
+      "description": "Frontend — MUI and Emotion",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["frontend/**"],
+      "matchPackageNames": [
+        "/^@mui\\//",
+        "/^@emotion\\//"
+      ],
+      "groupName": "MUI",
+      "groupSlug": "mui"
+    },
+    {
+      "description": "Frontend — Vite and the React plugin",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["frontend/**"],
+      "matchPackageNames": [
+        "/^vite$/",
+        "/^@vitejs\\//"
+      ],
+      "groupName": "Vite",
+      "groupSlug": "vite"
+    },
+    {
+      "description": "Frontend — ESLint, TypeScript, and Prettier tooling",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["frontend/**"],
+      "matchPackageNames": [
+        "/^eslint/",
+        "/^@eslint\\//",
+        "/^typescript-eslint$/",
+        "/^typescript$/",
+        "/^prettier$/"
+      ],
+      "groupName": "Frontend lint/types tooling",
+      "groupSlug": "frontend-lint-types"
+    }
+  ]
+}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# ---------------------------------------------------------------------------
+# CLA Assistant
+#
+# SECURITY NOTE (ADR-0016)
+#
+# This workflow uses `pull_request_target`, which runs in the context of the
+# base repo with access to repo secrets — even for PRs from forks. That makes
+# it the single highest-risk workflow in this repository. Three layered
+# hardenings apply:
+#
+#   1. The `contributor-assistant/github-action` reference is pinned to a
+#      full commit SHA below. Renovate (`.github/renovate.json`, group
+#      "GitHub Actions") opens update PRs when the action releases a new
+#      version. Do not revert to a floating tag.
+#
+#   2. Permissions live at job level, not workflow level. The workflow-level
+#      `permissions: {}` drops every default; future jobs added to this file
+#      do NOT inherit the CLA job's write permissions.
+#
+#   3. This workflow must NEVER add `actions/checkout` or otherwise execute
+#      code from the PR head. `pull_request_target` + checkout + fork is the
+#      classic supply-chain exploit pattern. If you need to build/lint a PR's
+#      code, do it in a separate workflow on `pull_request` (fork-safe, no
+#      secrets). See ADR-0016 for the full threat model.
+#
+# The `actions: write`, `contents: write`, `pull-requests: write`, and
+# `statuses: write` permissions on the CLA job match the action's README
+# requirements at the pinned SHA — do not narrow without re-reading the
+# action's docs at the pinned version.
+# ---------------------------------------------------------------------------
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions: {}
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+
+    # GitHub fires `issue_comment` for both Issue AND PR comments — they share
+    # the same event payload. Without this filter, every comment on a regular
+    # Issue triggers the CLA action, which then tries to GraphQL-resolve a PR
+    # with the issue's number and crashes with "Could not resolve to a
+    # PullRequest". The `issue.pull_request` field is set only when the parent
+    # is a PR, so this is the canonical "PR comment only" filter. Uses
+    # `event_name` and a presence check — no untrusted user input is
+    # interpolated.
+    if: |
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
+
+    # Match the action's documented permission requirements. Scoped to this
+    # job only so future jobs in this file do not inherit write access.
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
+
+    steps:
+      - name: CLA Assistant
+        # v2.6.1 pinned by commit SHA. See ADR-0016.
+        # Maintained by Renovate (`.github/renovate.json`, group "GitHub Actions").
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: signatures/cla.json
+          path-to-document: https://github.com/qnophq/qnop/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: bigpuritz,devtank42,*[bot]
+          create-file-commit-message: "chore: initialize CLA signatures file"
+          signed-commit-message: "chore: add $contributorName to CLA signatories"
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! :tada:
+
+            Before we can merge this PR, you need to sign the **Contributor License Agreement (CLA)**.
+            This is required so that qnop can offer commercial add-ons and a possible SaaS alongside its AGPL-3.0 Community edition.
+
+            Please read [CLA.md](https://github.com/qnophq/qnop/blob/main/CLA.md) — it is short and written in plain language.
+
+            Then post the following comment **in this PR**:
+
+            > I have read the CLA Document and I hereby sign the CLA
+
+            If you are contributing on behalf of a company, an authorized representative of your employer must also post this comment.
+
+            If you use an AI coding agent, you (the human operator) sign on behalf of the submission.
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          lock-pullrequest-aftermerge: false

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Self-hosted Renovate trigger for this repo.
+#
+# This workflow defines the schedule and permissions, then delegates the
+# actual Renovate run to the org-wide reusable workflow at
+# qnophq/.github/.github/workflows/renovate.yml. See ADR-0017 for the
+# rationale (org preset + self-hosted single-repo instance).
+#
+# Cron mirrors the `before 6am every weekday` schedule filter inside the org
+# default (Mon-Fri 04:00 UTC). workflow_dispatch lets any maintainer trigger
+# an on-demand run from the Actions tab or via `gh workflow run renovate.yml`.
+
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 4 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level"
+        type: choice
+        default: "info"
+        options:
+          - info
+          - debug
+
+jobs:
+  renovate:
+    # Pinned to a qnophq/.github commit SHA; Renovate keeps it current.
+    uses: qnophq/.github/.github/workflows/renovate.yml@94c4381a80ff3297b4017be99f49bb9193f778d1 # main
+    # Permissions belong on the calling job, not on the reusable workflow.
+    # The reusable workflow inherits these for the duration of the call.
+    permissions:
+      contents: write       # branch + push
+      pull-requests: write  # open + label PRs
+      issues: write         # update Dependency Dashboard issue
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,77 @@
+# Contributor License Agreement
+
+**qnop — Qualified Notes on Papers**
+
+This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the qnop project. By signing this Agreement, you accept and agree to the following terms for your present and future contributions to qnop.
+
+---
+
+## 1. Definitions
+
+**"You"** means the individual or legal entity submitting a Contribution.
+
+**"Contribution"** means any original work of authorship, including modifications or additions, that you intentionally submit to the project.
+
+**"Licensor"** means the copyright owner of qnop who accepts your Contribution.
+
+---
+
+## 2. Grant of Copyright License
+
+You grant the Licensor a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable** copyright license to:
+
+- reproduce, prepare derivative works of, publicly display, publicly perform, and distribute your Contributions and any derivative works thereof;
+- **sublicense the above rights under any license terms**, including proprietary commercial licenses.
+
+This sublicensing right is essential to qnop's open-core model: the Community edition is distributed under the GNU AGPL-3.0, while commercial add-ons and a possible SaaS offering are distributed under separate commercial terms. Without this grant, contributions could not be offered through both paths.
+
+---
+
+## 3. Grant of Patent License
+
+You grant the Licensor a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your Contributions, where such license applies to patent claims licensable by you that are necessarily infringed by your Contributions.
+
+---
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. Each Contribution is your original creation, or you have sufficient rights to submit it under this Agreement.
+3. Your Contribution does not include third-party material that would restrict the Licensor's ability to sublicense it.
+4. If your employer has rights to intellectual property that you create (including your Contributions), your employer has either waived those rights or signed a Corporate CLA with the Licensor.
+
+You agree to notify the Licensor promptly if any of these representations become inaccurate.
+
+---
+
+## 5. Corporate Contributors
+
+If you are contributing on behalf of a company or organization, **both you and your employer** must agree to this CLA. An authorized representative of your employer signs by posting the acknowledgment comment below. Individual engineers then do not need to sign separately.
+
+---
+
+## 6. No Obligation to Use
+
+This Agreement does not obligate the Licensor to include your Contribution in the project or in any product.
+
+---
+
+## 7. How to Sign
+
+**Sign electronically** by posting the following comment on your first Pull Request:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your GitHub username and the date of signing are recorded automatically in `signatures/cla.json`.
+
+---
+
+## 8. AI Agent Contributions
+
+If you use an AI coding agent (Claude Code, GitHub Copilot, Cursor, Codex, etc.) to generate or assist with a Contribution, **you** (the human operator) are the contributor and must sign this CLA. The AI agent itself does not sign. By signing, you represent that you have reviewed the AI-generated Contribution and take responsibility for it.
+
+---
+
+*This Agreement is governed by applicable law. Questions: open an issue or contact the maintainers.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,15 @@ Read `docs/ARCHITECTURE.md` and `docs/adr/` first — they hold the binding deci
 
 1. **Issue first** — every change starts with a GitHub issue.
 2. **Never commit or push to `main`** — it is integration-only/protected (ruleset deferred until the repo is public or the org is on Team — see ADR-0018; convention is binding now).
-3. **Feature branch → PR** — branches `feat/…`, `fix/…`, `docs/…`, `chore/…`; the PR references its issue.
+3. **Feature branch → PR** — branch names follow Conventional Branch (rule 9): `feat/…`, `fix/…`, `chore/…`, `hotfix/…`, `release/…`; the PR references its issue.
 4. **Claude attribution everywhere** — commits get a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer; issues and PRs get an attribution line in the body: `🤖 Co-Author: Claude (Opus 4.x) via Claude Code`.
 5. **Record important architecture decisions as ADRs** in `docs/adr/` (template in its README). Add the ADR in the same PR as the change.
 6. **Sign the CLA** (`CLA.md`, ADR-0016) — enforced on PRs by the CLA-Assistant workflow; maintainers/bots are allowlisted.
 7. **English everywhere in the project** — issues, PR descriptions, commit messages, documentation, ADRs, and code comments are written in English. This holds even when the working chat language is German: chat may be German, but anything that lands in the repo, an issue, or a PR is English.
 8. **Clean copyright on every source file** — the copyright + SPDX header from the root `license-header.txt` (`Copyright (c) 2026-present devtank42 GmbH`, AGPL-3.0-only). Enforced for Java via Spotless; see ADR-0019. Run `./gradlew spotlessApply` before committing.
+9. **Conventional Commits & Conventional Branches** — commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (`<type>: <subject>`, types `feat|fix|refactor|docs|test|chore|perf|ci|build`). Branch names follow [Conventional Branch](https://conventionalbranch.org/): `<type>/<kebab-description>`, type ∈ `{feat, fix, hotfix, release, chore}` (`feat`/`fix` are the accepted short forms of `feature`/`bugfix`), lowercase + hyphens only, optional issue number — e.g. `feat/issue-123-new-login`. `main`/`master`/`develop` carry no prefix.
 
-Commits follow Conventional Commits and are signed off (`git commit -s`, DCO). See `CONTRIBUTING.md`.
+Commits are signed off (`git commit -s`, DCO). See `CONTRIBUTING.md`.
 
 ## Current state — Phase 0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Read `docs/ARCHITECTURE.md` and `docs/adr/` first — they hold the binding deci
 1. **Issue first** — every change starts with a GitHub issue.
 2. **Never commit or push to `main`** — it is integration-only/protected (ruleset deferred until the repo is public or the org is on Team — see ADR-0018; convention is binding now).
 3. **Feature branch → PR** — branches `feat/…`, `fix/…`, `docs/…`, `chore/…`; the PR references its issue.
-4. **Claude attribution everywhere** — commits get a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer; issues and PRs get an attribution line in the body (e.g. `🤖 Mitarbeit: Claude … via Claude Code`).
+4. **Claude attribution everywhere** — commits get a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer; issues and PRs get an attribution line in the body: `🤖 Co-Author: Claude (Opus 4.x) via Claude Code`.
 5. **Record important architecture decisions as ADRs** in `docs/adr/` (template in its README). Add the ADR in the same PR as the change.
 6. **Sign the CLA** (`CLA.md`, ADR-0016) — enforced on PRs by the CLA-Assistant workflow; maintainers/bots are allowlisted.
 7. **English everywhere in the project** — issues, PR descriptions, commit messages, documentation, ADRs, and code comments are written in English. This holds even when the working chat language is German: chat may be German, but anything that lands in the repo, an issue, or a PR is English.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,11 @@ Read `docs/ARCHITECTURE.md` and `docs/adr/` first — they hold the binding deci
 ## Working rules (binding — see ADR-0008)
 
 1. **Issue first** — every change starts with a GitHub issue.
-2. **Never commit or push to `main`** — it is integration-only/protected.
+2. **Never commit or push to `main`** — it is integration-only/protected (ruleset deferred until the repo is public or the org is on Team — see ADR-0018; convention is binding now).
 3. **Feature branch → PR** — branches `feat/…`, `fix/…`, `docs/…`, `chore/…`; the PR references its issue.
 4. **Claude attribution everywhere** — commits get a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer; issues and PRs get an attribution line in the body (e.g. `🤖 Mitarbeit: Claude … via Claude Code`).
 5. **Record important architecture decisions as ADRs** in `docs/adr/` (template in its README). Add the ADR in the same PR as the change.
+6. **Sign the CLA** (`CLA.md`, ADR-0016) — enforced on PRs by the CLA-Assistant workflow; maintainers/bots are allowlisted.
 
 Commits follow Conventional Commits and are signed off (`git commit -s`, DCO). See `CONTRIBUTING.md`.
 
@@ -28,6 +29,7 @@ A compiling **skeleton**, not a running app. Deliberately deferred to **Phase 1*
 - **Frontend**: Vite + React 19 + TypeScript + MaterialUI, package manager **pnpm** (`frontend/`).
 - **Persistence**: PostgreSQL + Liquibase; S3-compatible object storage (MinIO locally) for binary documents.
 - **Quality**: Spotless (google-java-format + SPDX header), ArchUnit (layered boundaries), JUnit 5.
+- **Dependencies**: self-hosted Renovate via GitHub Actions; org preset in public `qnophq/.github`, extended by `.github/renovate.json` (ADR-0017). Don't hand-bump deps; review Renovate PRs.
 
 ## Common commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-**qnop** — "Qualified Notes on Papers": an enterprise **document review** system. Reviewers (individual users or teams) mark up lines/regions of PDF/DOCX documents, comment, and run a coordinated review workflow (comments accepted/rejected → new document versions → finalized when no open annotations remain). Open-core: an AGPL Community edition plus commercial add-ons (e.g. AI features) and a possible SaaS.
+**qnop** — "Qualified Notes on Papers": an enterprise **document review** system. Reviewers (individual users or teams) mark up lines/regions of documents, comment, and run a coordinated review workflow (comments accepted/rejected → new document versions → finalized when no open annotations remain). Open-core: an AGPL Community edition plus commercial add-ons (e.g. AI features) and a possible SaaS.
+
+**Scope of supported formats.** The focus is on reviewing **textual documents first — PDF, DOCX, and Markdown (`.md`)**. Other formats (e.g. images, and later possibly more) may follow once the text workflow is solid; such additional formats are a likely **Enterprise** feature rather than Community scope. Design the ingest/anchoring/rendering seams so a new format is an added implementation, not a core rewrite.
 
 Read `docs/ARCHITECTURE.md` and `docs/adr/` first — they hold the binding decisions and rationale.
 
@@ -16,6 +18,8 @@ Read `docs/ARCHITECTURE.md` and `docs/adr/` first — they hold the binding deci
 4. **Claude attribution everywhere** — commits get a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer; issues and PRs get an attribution line in the body (e.g. `🤖 Mitarbeit: Claude … via Claude Code`).
 5. **Record important architecture decisions as ADRs** in `docs/adr/` (template in its README). Add the ADR in the same PR as the change.
 6. **Sign the CLA** (`CLA.md`, ADR-0016) — enforced on PRs by the CLA-Assistant workflow; maintainers/bots are allowlisted.
+7. **English everywhere in the project** — issues, PR descriptions, commit messages, documentation, ADRs, and code comments are written in English. This holds even when the working chat language is German: chat may be German, but anything that lands in the repo, an issue, or a PR is English.
+8. **Clean copyright on every source file** — the copyright + SPDX header from the root `license-header.txt` (`Copyright (c) 2026-present devtank42 GmbH`, AGPL-3.0-only). Enforced for Java via Spotless; see ADR-0019. Run `./gradlew spotlessApply` before committing.
 
 Commits follow Conventional Commits and are signed off (`git commit -s`, DCO). See `CONTRIBUTING.md`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,10 @@ Thanks for contributing! qnop is the AGPL-3.0 Community core of an open-core pro
 5. **Sign the CLA** on your first PR (see below) — a bot will prompt you.
 6. CI must be green (backend build + ArchUnit + Spotless, frontend lint/build, SPDX check) before merge.
 
+## Language
+
+All project artifacts are written in **English**: issues, pull-request descriptions, commit messages, documentation, ADRs, and code comments. Maintainer chat may happen in another language, but anything that lands in the repo, an issue, or a PR is English.
+
 ## Commits
 
 Conventional Commits:
@@ -42,7 +46,7 @@ Work produced with Claude must be attributed:
 
 ## Code quality
 
-- **Backend**: `./gradlew spotlessApply` before committing; `./gradlew build` must pass (runs Spotless check + ArchUnit). Every source file needs an `SPDX-License-Identifier: AGPL-3.0-only` header.
+- **Backend**: `./gradlew spotlessApply` before committing; `./gradlew build` must pass (runs Spotless check + ArchUnit). Every source file carries the copyright + `SPDX-License-Identifier: AGPL-3.0-only` header from the root `license-header.txt` ([ADR-0019](docs/adr/0019-source-copyright-headers.md)); Spotless inserts it for Java automatically (add it by hand in `package-info.java` and frontend files).
 - **Frontend**: `pnpm format && pnpm lint && pnpm build` from `frontend/`.
 - Respect the layered boundaries ([ADR-0004](docs/adr/0004-layered-architecture-enforced-by-archunit.md)) — `web → service → repository → entity`; the published contracts (`qnop-spi`, `qnop-api`) stay Spring-free.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Work produced with Claude must be attributed:
   ```
   Co-Authored-By: Claude <noreply@anthropic.com>
   ```
-- **Issues / PRs** — add an attribution line in the body, e.g.
-  `🤖 Mitarbeit: Claude (Opus 4.x) via Claude Code`.
+- **Issues / PRs** — add an attribution line in the body:
+  `🤖 Co-Author: Claude (Opus 4.x) via Claude Code`.
 
 ## Code quality
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Thanks for contributing! qnop is the AGPL-3.0 Community core of an open-core pro
 2. **Branch off `main`.** Use `feat/…`, `fix/…`, `docs/…`, `chore/…`, `refactor/…`, `test/…`.
 3. **Never commit or push directly to `main`.** `main` is integration-only and protected; all changes land via Pull Request.
 4. **Open a PR** that references its issue (e.g. `Closes #12`). Keep PRs focused.
-5. CI must be green (backend build + ArchUnit + Spotless, frontend lint/build, SPDX check) before merge.
+5. **Sign the CLA** on your first PR (see below) — a bot will prompt you.
+6. CI must be green (backend build + ArchUnit + Spotless, frontend lint/build, SPDX check) before merge.
 
 ## Commits
 
@@ -45,9 +46,21 @@ Work produced with Claude must be attributed:
 - **Frontend**: `pnpm format && pnpm lint && pnpm build` from `frontend/`.
 - Respect the layered boundaries ([ADR-0004](docs/adr/0004-layered-architecture-enforced-by-archunit.md)) — `web → service → repository → entity`; the published contracts (`qnop-spi`, `qnop-api`) stay Spring-free.
 
+## Contributor License Agreement (CLA)
+
+qnop is open-core: the AGPL-3.0 Community edition plus commercial add-ons. To keep that dual path legal, every contributor signs a one-time [CLA](CLA.md) granting the project the right to sublicense contributions (including under commercial terms). On your first PR a bot comments with instructions; you sign by posting:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+If you use an AI coding agent, **you** (the human operator) sign on behalf of the submission. The DCO sign-off (above) and the CLA are complementary — both are required. Rationale: [ADR-0016](docs/adr/0016-contributor-license-agreement.md).
+
 ## Architecture decisions
 
 Significant decisions are recorded as [ADRs](docs/adr/README.md). If your change involves one, add an ADR in the same PR.
+
+## Dependency updates
+
+Dependencies are kept current by a self-hosted [Renovate](https://docs.renovatebot.com/) instance that opens grouped PRs (see [ADR-0017](docs/adr/0017-renovate-dependency-automation.md)). Review Renovate PRs like any other; do not bump dependencies by hand unless fixing an urgent security issue.
 
 ## License & dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for contributing! qnop is the AGPL-3.0 Community core of an open-core pro
 ## Workflow
 
 1. **Open an issue first.** Describe the intent before changing code.
-2. **Branch off `main`.** Use `feat/…`, `fix/…`, `docs/…`, `chore/…`, `refactor/…`, `test/…`.
+2. **Branch off `main`.** Name the branch per [Conventional Branch](https://conventionalbranch.org/) (see [Branches](#branches)): `feat/…`, `fix/…`, `chore/…`, `hotfix/…`, `release/…`.
 3. **Never commit or push directly to `main`.** `main` is integration-only and protected; all changes land via Pull Request.
 4. **Open a PR** that references its issue (e.g. `Closes #12`). Keep PRs focused.
 5. **Sign the CLA** on your first PR (see below) — a bot will prompt you.
@@ -15,9 +15,18 @@ Thanks for contributing! qnop is the AGPL-3.0 Community core of an open-core pro
 
 All project artifacts are written in **English**: issues, pull-request descriptions, commit messages, documentation, ADRs, and code comments. Maintainer chat may happen in another language, but anything that lands in the repo, an issue, or a PR is English.
 
+## Branches
+
+Branch names follow [Conventional Branch](https://conventionalbranch.org/): `<type>/<description>`.
+
+- **Types**: `feat` (= `feature`), `fix` (= `bugfix`), `hotfix`, `release`, `chore`.
+- **Description**: lowercase `a-z`, digits `0-9`, hyphen-separated; no underscores, spaces, or special characters; no leading/trailing/consecutive hyphens. Dots only in release versions (`release/v1.2.0`).
+- Optionally include an issue number, e.g. `feat/issue-123-new-login`.
+- `main` (and `master`/`develop`) carry no prefix.
+
 ## Commits
 
-Conventional Commits:
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
 
 ```
 <type>: <subject>
@@ -27,7 +36,7 @@ Conventional Commits:
 Signed-off-by: Your Name <you@example.com>
 ```
 
-Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`, `build`.
 
 ### Developer Certificate of Origin (DCO)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 An enterprise **document review** system with a browser-first, maximally usable review experience.
 
-Reviewers — individual users or whole teams — mark up lines and regions of a document (PDF or Word), comment, and run a coordinated review workflow: comments are accepted or rejected, changes produce new document versions, and a review is finalized once no open annotations remain.
+Reviewers — individual users or whole teams — mark up lines and regions of a document, comment, and run a coordinated review workflow: comments are accepted or rejected, changes produce new document versions, and a review is finalized once no open annotations remain.
+
+The focus is on **textual documents first — PDF, Word (DOCX), and Markdown**. Support for further formats (for example images) may follow once the text review workflow is solid, and such formats are a likely **Enterprise** feature rather than part of the Community scope.
 
 > **Status: Phase 0 — project skeleton.** The structure, build, conventions and local infrastructure are in place; the domain core and the running server arrive in Phase 1. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and the roadmap there.
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 plugins {
     `kotlin-dsl`

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 rootProject.name = "build-logic"
 

--- a/build-logic/src/main/kotlin/qnop.java-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/qnop.java-conventions.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // Shared Java conventions for every qnop module: toolchain, formatting,
@@ -29,8 +30,9 @@ tasks.withType<JavaCompile>().configureEach {
 spotless {
     java {
         googleJavaFormat()
-        // ADR-0007: every source file carries an SPDX identifier.
-        licenseHeader("// SPDX-License-Identifier: AGPL-3.0-only\n\n")
+        // ADR-0007 + ADR-0019: every source file carries a copyright notice and
+        // an SPDX identifier. The block lives in the root `license-header.txt`.
+        licenseHeaderFile(rootProject.file("license-header.txt"))
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // Root build. Cross-module configuration lives in convention plugins under

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 qnop ("Qualified Notes on Papers") is an enterprise **document review** system. Reviewers (individual users or teams) mark up lines/regions of a document, comment, and run a coordinated review workflow: comments are accepted or rejected, changes produce new document versions, and a review finalizes when no open annotations remain.
 
+**Supported formats — text first.** The initial scope is reviewing **textual documents: PDF, DOCX, and Markdown (`.md`)**. Other formats (e.g. images, and possibly more later) may follow once the text workflow is solid; those additional formats are a likely **Enterprise** feature rather than Community scope. The ingest → extract/anchor → render pipeline is designed so a new format is an added implementation behind the existing seams (cf. [ADR-0009](adr/0009-multi-layer-annotation-anchoring.md), [ADR-0010](adr/0010-docx-representation-strategy.md)), not a core rewrite.
+
 This document is the map. The binding decisions and their rationale live as [ADRs](adr/README.md); this overview links to them rather than repeating them.
 
 ## Distribution model (open-core)

--- a/docs/adr/0016-contributor-license-agreement.md
+++ b/docs/adr/0016-contributor-license-agreement.md
@@ -1,0 +1,45 @@
+# ADR-0016: Contributor License Agreement enforced via CLA Assistant
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+qnop is open-core (ADR-0002): the Community edition is AGPL-3.0, while commercial add-ons and a possible SaaS are distributed under separate commercial terms. To relicense contributed code under those commercial terms, the project needs each contributor to grant a sublicensing right — the inbound AGPL license alone does not permit the Licensor to offer the same code under a proprietary license.
+
+Contributions may also come from AI coding agents operated by a human. We need an unambiguous record that the human operator, not the agent, is the accountable contributor.
+
+We want enforcement to be automatic, auditable, and to live in the repo as code — not a manual checklist a maintainer has to remember.
+
+## Decision
+
+Require every contributor to sign a **Contributor License Agreement** before their first PR can be merged.
+
+- `CLA.md` (repo root) states the grant: a perpetual, irrevocable copyright license **with the right to sublicense under any terms, including commercial**, plus a patent grant, representations, a corporate-contributor clause, and an explicit AI-agent clause (the human operator signs).
+- `.github/workflows/cla.yml` runs [`contributor-assistant/github-action`](https://github.com/contributor-assistant/github-action), pinned to a full commit SHA. Signatures are recorded in `signatures/cla.json` on a dedicated `cla-signatures` branch. The signing phrase is *"I have read the CLA Document and I hereby sign the CLA"*.
+- Allowlist: `bigpuritz,devtank42,*[bot]` (maintainers and bots are exempt).
+- The workflow requires a repo secret **`CLA_TOKEN`** (a fine-grained PAT with `contents` + `pull-requests` write) so the action can commit signatures and re-check status.
+
+### Security model (the reason this ADR exists)
+
+The workflow triggers on `pull_request_target` + `issue_comment`, which run in the **base-repo context with access to secrets**, even for fork PRs. This is the highest-risk workflow in the repo. Three hardenings are mandatory and must not be removed:
+
+1. **SHA-pinned action.** Never a floating tag. Renovate (group "GitHub Actions") proposes updates.
+2. **Job-level permissions.** Workflow-level `permissions: {}` drops all defaults; the write scopes (`actions`, `contents`, `pull-requests`, `statuses`) live on the `cla-check` job only, so future jobs do not inherit them.
+3. **Never check out PR head.** `pull_request_target` + `actions/checkout` of the fork head + secrets is the classic supply-chain exploit. Code-building/linting of PRs happens in separate `pull_request` workflows (fork-safe, no secrets).
+
+The `issue_comment` trigger is filtered to PR comments only (`github.event.issue.pull_request != null`); no untrusted event payload is interpolated into any shell.
+
+## Consequences
+
+- Easier: the project can legally offer commercial editions of contributed code; provenance is auditable in `signatures/cla.json`.
+- Harder: first-time external contributors must take one extra step (post the signing comment). The bot guides them automatically.
+- Operational dependency: the `CLA_TOKEN` secret must exist, or the workflow cannot record signatures. This is a one-time maintainer setup.
+- The CLA is referenced from `CONTRIBUTING.md` (ADR-0008 workflow).
+
+## Alternatives considered
+
+- **DCO only (no CLA).** Already in force (ADR-0007) and kept — but the DCO certifies origin under the *inbound* license; it grants no sublicensing right, so it cannot support commercial relicensing. CLA and DCO are complementary, not alternatives.
+- **No agreement.** Would force every commercial use to obtain per-contributor permission retroactively — unworkable for open-core.
+- **Self-hosted CLA bot / CLA-assistant.io.** More moving parts and an external service; the GitHub Action keeps enforcement in-repo with no extra hosting.

--- a/docs/adr/0017-renovate-dependency-automation.md
+++ b/docs/adr/0017-renovate-dependency-automation.md
@@ -1,0 +1,38 @@
+# ADR-0017: Dependency automation via self-hosted Renovate and an org-wide preset
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+qnop spans several dependency ecosystems: Gradle (Java 21, Spring Boot 4.x, Liquibase, AWS SDK, PDFBox/POI), the Gradle wrapper, GitHub Actions, Docker images (`docker-compose.yml`), and an npm/pnpm frontend (React 19, MUI, Vite, TypeScript). Keeping these current by hand does not scale and tends to let security patches rot.
+
+We also expect more repos under the `qnophq` org over time (e.g. the private `qnop-enterprise` repo, examples, a website). Update policy (grouping, scheduling, digest pinning) should be defined once, not copy-pasted per repo.
+
+We do not want to grant a third-party SaaS (the Mend-hosted Renovate GitHub App) write access across the org.
+
+## Decision
+
+Run **our own Renovate** via GitHub Actions, configured through an **org-wide preset**.
+
+1. **Org preset** lives in the public repo **`qnophq/.github`** as `default.json`. Repos opt in with `extends: ["github>qnophq/.github"]`. It sets: weekday-morning schedule (Europe/Berlin), dependency dashboard, GitHub Actions + Docker **digest pinning**, grouped minor/patch updates, per-package major-update PRs, and exact npm version pinning (we ship applications, not libraries).
+2. **Reusable workflow** in `qnophq/.github/.github/workflows/renovate.yml` runs `renovatebot/github-action` (SHA-pinned). Consumer repos add a short stub (`.github/workflows/renovate.yml`) that wires their cron + permissions and calls it. This is the "own/self-hosted instance" — no Mend app.
+3. **Single-repo token model.** Each run uses the caller's repo-scoped `GITHUB_TOKEN` (`RENOVATE_REPOSITORIES = github.repository`). No PAT, no cross-repo write access.
+4. **Repo-specific rules** for qnop live in `qnophq/qnop/.github/renovate.json`, which extends the org preset and adds Gradle/frontend package groupings.
+5. A **`renovate-config-validator`** workflow in `qnophq/.github` fails the build if `default.json` is syntactically broken, so a bad org preset cannot silently disable updates org-wide.
+
+`qnophq/.github` is **public** so Renovate can resolve the `github>qnophq/.github` preset with the repo-scoped token alone; the preset holds only policy, no secrets.
+
+## Consequences
+
+- Easier: one place to evolve org-wide update policy; every repo inherits it. Security patches surface as grouped PRs on a predictable cadence. No third-party app holds org write access.
+- Harder: the reusable-workflow SHA and the org preset are cross-cutting — a breaking change there affects every consumer; the validator workflow mitigates this.
+- The frontend currently has no committed lockfile; Renovate's npm manager still pins `package.json` ranges. A lockfile should be committed when the frontend stabilizes.
+- GitHub Actions minutes are consumed on the private `qnop` repo per scheduled run (within the free quota at current cadence).
+
+## Alternatives considered
+
+- **Mend-hosted Renovate App.** Zero maintenance, but grants a third-party SaaS write access across the org and moves config out of our control. Rejected for an open-core project that will host a private commercial repo in the same org.
+- **Dependabot.** Native and simple, but weaker grouping/scheduling, no shared org preset of this richness, and no `gradle-wrapper`/`docker-compose` parity with what we want.
+- **Per-repo Renovate config with no org preset.** Duplicates policy across repos and drifts. Rejected in favor of `extends: github>qnophq/.github`.

--- a/docs/adr/0018-main-branch-protection-ruleset.md
+++ b/docs/adr/0018-main-branch-protection-ruleset.md
@@ -1,0 +1,64 @@
+# ADR-0018: main-branch protection via a repository ruleset (deferred enforcement)
+
+- **Status:** Proposed
+- **Date:** 2026-06-14
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+ADR-0008 and `CONTRIBUTING.md` make `main` integration-only: no direct commits, all changes via PR. So far this is convention-only. We want it **enforced by the platform** so the rule cannot be bypassed by mistake.
+
+Two constraints shaped the decision:
+
+1. **GitHub rulesets cannot target individual users** as bypass actors — only roles, teams, GitHub Apps, or "Organization/Repository admin". Both maintainers (`bigpuritz`, `devtank42`) are **org owners**, so the `OrganizationAdmin` actor covers exactly the intended two people without creating a team (which would need `admin:org`).
+2. **`qnophq/qnop` is private on the GitHub Free plan**, where rulesets/branch protection are unavailable (the API returns `403: "Upgrade to GitHub Pro or make this repository public"`). `plugwerk/plugwerk` is public, which is why the same setup works there for free.
+
+## Decision
+
+Adopt a **repository ruleset** named `main-branch-protection` on `refs/heads/main`:
+
+- **Pull-request rule:** 1 approving review, dismiss stale approvals on push, all merge methods allowed.
+- **Block deletion** and **block force-push** (`non_fast_forward`).
+- **Bypass:** `OrganizationAdmin` with mode **`pull_request`** — the two owners may merge PRs that bypass the review requirement, but **nobody (not even owners) may push directly to `main`**. This is stricter than "owner may direct-commit" and matches the CLAUDE.md / ADR-0008 rule that everything lands via PR.
+
+**Enforcement is deferred** until one of: (a) `qnophq/qnop` becomes public, or (b) the `qnophq` org upgrades to GitHub Team. The ruleset definition below is the source of truth; apply it unchanged once the plan/visibility allows.
+
+```bash
+gh api --method POST repos/qnophq/qnop/rulesets \
+  --input - <<'JSON'
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/heads/main"], "exclude": [] } },
+  "rules": [
+    { "type": "pull_request", "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash", "merge", "rebase"]
+    }},
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ],
+  "bypass_actors": [
+    { "actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "pull_request" }
+  ]
+}
+JSON
+```
+
+## Consequences
+
+- Once enforced: `main` is tamper-resistant; PRs are mandatory; the two owners retain a merge bypass for solo/urgent work but still cannot force-push or delete `main`.
+- Until enforced: the rule remains convention-only (ADR-0008). This ADR stays **Proposed** until the ruleset is live, then flips to **Accepted**.
+- If a future contributor must merge but is not an org owner, grant them the role via a team-based bypass (needs `admin:org`) rather than widening `OrganizationAdmin`.
+
+## Alternatives considered
+
+- **Make the repo public now** to unlock free rulesets. Rejected for now — qnop is not ready for public release; revisit at launch.
+- **Upgrade the org to GitHub Team** purely for branch protection. Deferred — not worth a paid plan at this stage; the convention plus the merged-PR workflow is sufficient for a two-owner team.
+- **Bypass mode `always`** (owners may direct-push). Rejected — contradicts the "everything via PR" rule; `pull_request` mode keeps history honest.
+- **Per-user / team bypass split** (owner direct-push, second owner PR-only). Rejected — needs `admin:org` and two teams for marginal value at this team size.

--- a/docs/adr/0019-source-copyright-headers.md
+++ b/docs/adr/0019-source-copyright-headers.md
@@ -1,0 +1,51 @@
+# ADR-0019: Source files carry a copyright notice (devtank42 GmbH)
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+[ADR-0007](0007-spdx-dco-license-scanning.md) requires every source file to carry an `SPDX-License-Identifier: AGPL-3.0-only` line, and the bare SPDX line was all the header contained. For an open-core product whose value rests on provable, enforceable copyright (and on the CLA's "Licensor", ADR-0016), each source file should also name the copyright holder explicitly — a "clean copyright" notice, not just a machine tag.
+
+## Decision
+
+Every source file carries a copyright notice for **`devtank42 GmbH`** (the qnop Licensor) alongside the SPDX identifier. The canonical block lives in the root **`license-header.txt`**:
+
+```
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ * ... GNU AGPL-3.0 recital ...
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+```
+
+Application by file type:
+
+| Type | Header | Enforcement |
+| --- | --- | --- |
+| Java (`.java`) | full block from `license-header.txt` | Spotless `licenseHeaderFile` (auto-applied on `spotlessApply`, checked by `spotlessCheck`) |
+| Frontend (`.ts`, `.tsx`, `.css`) | full block (`/* */`) | prettier-compatible; manual for now |
+| Gradle Kotlin DSL (`.gradle.kts`) | two `//` lines: copyright + SPDX | manual (build scripts are not Spotless-managed) |
+| Config (`.yml`, `.json`, `.properties`) | SPDX where present (YAML); no copyright recital | CI `license-headers` grep for `.kts`/`.java` |
+
+The copyright holder and year (`2026-present`) are hardcoded — no `$YEAR` ratchet — matching the `plugwerk` convention this project mirrors.
+
+### package-info.java caveat
+
+Spotless's `spotlessApply` does **not** auto-insert the header into `package-info.java` (its delimiter logic treats the package Javadoc as content), though `spotlessCheck` accepts a correctly-placed block. The existing `package-info.java` files were given the block manually. New ones must add it by hand; the CI `license-headers` job still guarantees the SPDX line is present on every `.java`/`.kts`.
+
+## Consequences
+
+- Easier: the copyright owner is named in every source file; provenance is unambiguous for relicensing and audits. The header is one file (`license-header.txt`) to change if the holder/year ever moves.
+- Harder: a slightly larger per-file header; `package-info.java` and frontend headers are not auto-inserted (documented above).
+- This **complements** ADR-0007 (it keeps the SPDX line); it does not supersede it.
+
+## Alternatives considered
+
+- **Keep the bare SPDX line only.** Rejected — does not name the copyright holder, which the open-core/CLA model wants explicit.
+- **Concise two-line `// SPDX-FileCopyrightText` + `// SPDX-License-Identifier` everywhere (REUSE style).** Cleaner to enforce uniformly (works on `package-info.java` too), but does not match the fuller `plugwerk` header the project is aligning with. Rejected for the verbose block on real source; the two-line form is used only for build scripts.
+- **Adopt plugwerk's Apache-2.0 header for the published contracts (`qnop-spi`, `qnop-api`).** Deliberately **not** done here: ADR-0003/0007 keep all modules AGPL-3.0-only. Relicensing the contracts permissively is a separate business decision that would need its own ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,9 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0013](0013-redis-and-search-deferred.md) | Redis & search index deferred | Proposed |
 | [0014](0014-frontend-enterprise-separation.md) | Frontend enterprise separation | Proposed |
 | [0015](0015-published-rest-api-contract-module.md) | Published REST API contract module (qnop-api) | Accepted |
+| [0016](0016-contributor-license-agreement.md) | Contributor License Agreement enforced via CLA Assistant | Accepted |
+| [0017](0017-renovate-dependency-automation.md) | Dependency automation via self-hosted Renovate + org-wide preset | Accepted |
+| [0018](0018-main-branch-protection-ruleset.md) | main-branch protection via a repository ruleset (deferred) | Proposed |
 
 ## Template
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0016](0016-contributor-license-agreement.md) | Contributor License Agreement enforced via CLA Assistant | Accepted |
 | [0017](0017-renovate-dependency-automation.md) | Dependency automation via self-hosted Renovate + org-wide preset | Accepted |
 | [0018](0018-main-branch-protection-ruleset.md) | main-branch protection via a repository ruleset (deferred) | Proposed |
+| [0019](0019-source-copyright-headers.md) | Source files carry a copyright notice (devtank42 GmbH) | Accepted |
 
 ## Template
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Box from '@mui/material/Box';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import CssBaseline from '@mui/material/CssBaseline';

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 import { createTheme } from '@mui/material/styles';
 
 /**

--- a/license-header.txt
+++ b/license-header.txt
@@ -18,10 +18,3 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-/* Layout primitives only; MUI CssBaseline owns the reset and base styles. */
-html,
-body,
-#root {
-  height: 100%;
-}

--- a/qnop-api/build.gradle.kts
+++ b/qnop-api/build.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // qnop-api — the PUBLISHED REST API contract (ADR-0015): request/response DTOs

--- a/qnop-api/src/main/java/io/qnop/api/package-info.java
+++ b/qnop-api/src/main/java/io/qnop/api/package-info.java
@@ -1,4 +1,23 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 
 /** Published REST API contract: request/response DTOs and the OpenAPI definition. */
 package io.qnop.api;

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // qnop-core — the layered backend core: JPA entities, Spring Data repositories

--- a/qnop-core/src/main/java/io/qnop/entity/package-info.java
+++ b/qnop-core/src/main/java/io/qnop/entity/package-info.java
@@ -1,4 +1,23 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 
 /** JPA entities — the persistent domain model. */
 package io.qnop.entity;

--- a/qnop-core/src/main/java/io/qnop/repository/package-info.java
+++ b/qnop-core/src/main/java/io/qnop/repository/package-info.java
@@ -1,4 +1,23 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 
 /** Spring Data repositories (PostgreSQL). */
 package io.qnop.repository;

--- a/qnop-core/src/main/java/io/qnop/service/package-info.java
+++ b/qnop-core/src/main/java/io/qnop/service/package-info.java
@@ -1,4 +1,23 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 
 /**
  * Service layer: business logic, workflow state machine, anchoring, API/DTO mapping, SPI default

--- a/qnop-spi/build.gradle.kts
+++ b/qnop-spi/build.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // qnop-spi — the extension-point boundary between the AGPL core and commercial

--- a/qnop-spi/src/main/java/io/qnop/spi/package-info.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/package-info.java
@@ -1,4 +1,23 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 
 /** Extension-point interfaces and DTOs (the AGPL/commercial boundary). */
 package io.qnop.spi;

--- a/qnop-web/build.gradle.kts
+++ b/qnop-web/build.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // qnop-web — the runnable Community module: @RestControllers implementing the

--- a/qnop-web/src/main/java/io/qnop/bootstrap/package-info.java
+++ b/qnop-web/src/main/java/io/qnop/bootstrap/package-info.java
@@ -1,4 +1,23 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 
 /** Composition root / Spring Boot bootstrap (Community build). */
 package io.qnop.bootstrap;

--- a/qnop-web/src/main/java/io/qnop/web/package-info.java
+++ b/qnop-web/src/main/java/io/qnop/web/package-info.java
@@ -1,4 +1,23 @@
-// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 
 /** REST controllers, DTO mapping and OpenAPI. */
 package io.qnop.web;

--- a/qnop-web/src/test/java/io/qnop/architecture/ArchitectureRulesTest.java
+++ b/qnop-web/src/test/java/io/qnop/architecture/ArchitectureRulesTest.java
@@ -1,5 +1,23 @@
-// SPDX-License-Identifier: AGPL-3.0-only
-
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
 package io.qnop.architecture;
 
 import static com.tngtech.archunit.library.Architectures.layeredArchitecture;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
+// Copyright (c) 2026-present devtank42 GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
 rootProject.name = "qnop"


### PR DESCRIPTION
Aligns project governance and conventions with `plugwerk/plugwerk`. Closes #3.

## What's included

### 1. CLA (ADR-0016)
- `CLA.md` — adapted to qnop's open-core model (AGPL Community + commercial add-ons; sublicensing grant; AI-agent clause).
- `.github/workflows/cla.yml` — `contributor-assistant/github-action` (SHA-pinned v2.6.1), hardened `pull_request_target`: workflow-wide `permissions: {}` + job-level scopes, no PR-head checkout, issue/PR-comment filter. Signatures in `signatures/cla.json` (branch `cla-signatures`). Allowlist `bigpuritz,devtank42,*[bot]`.

### 2. Renovate — own instance + org preset (ADR-0017)
- New **public** repo **`qnophq/.github`** with `default.json` (org preset), a reusable Renovate workflow (`renovatebot/github-action`, single-repo `GITHUB_TOKEN`) and a `renovate-config-validator`. ✅ validator run green.
- `.github/renovate.json` inherits via `extends: ["github>qnophq/.github"]` + stack-specific groups (Spring Boot, JUnit/ArchUnit, Liquibase, PostgreSQL, AWS SDK, PDFBox/POI, Spotless, Gradle wrapper, frontend: React/MUI/Vite/lint). ✅ validated locally with `renovate-config-validator --strict`.
- `.github/workflows/renovate.yml` — thin stub, pinned to `qnophq/.github@94c4381`.

### 3. main branch protection (ADR-0018, **deferred**)
- **Blocker:** `qnophq/qnop` is private on the Free plan → rulesets return `403` (need Pro/Team or public).
- The ADR documents the target ruleset (PR required, 1 approval, deletion/force-push blocked, bypass = `OrganizationAdmin` mode `pull_request` → both owners merge PRs, nobody pushes directly) **including a ready-to-run `gh api` command** to apply once plan/visibility allows.

### 4. Source copyright headers (ADR-0019)
- Root `license-header.txt` (`Copyright (c) 2026-present devtank42 GmbH` + AGPL recital + SPDX line), modelled on the plugwerk header.
- Spotless applies it to Java via `licenseHeaderFile`; `package-info.java` files get the block manually (spotlessApply skips them). Frontend `.ts/.tsx/.css` get the full block; Gradle Kotlin DSL build scripts get a two-line copyright + SPDX header.

### 5. Governance rules (CLAUDE.md / CONTRIBUTING.md)
- **English everywhere** in the project (issues, PRs, commits, docs, ADRs, code comments) — even when maintainer chat is in another language.
- **Clean copyright** on every source file.

### 6. Project scope (CLAUDE.md / README.md / ARCHITECTURE.md)
- The focus is **textual documents first — PDF, DOCX, Markdown**; other formats (e.g. images) are a likely **Enterprise** feature later.

## ⚠️ Required follow-up (owner-side)
- Create the **`CLA_TOKEN`** repo secret (fine-grained PAT, `contents` + `pull-requests` write) so the CLA workflow can commit signatures. Until then the maintainers are allowlisted anyway.

## Test plan
- [x] `renovate-config-validator --strict` for `default.json` (org-repo CI) and `.github/renovate.json` (local) — green.
- [x] JSON syntax of both configs validated.
- [x] `./gradlew build` (Spotless + ArchUnit) green; frontend `format:check` + `lint` + `build` green; CI on this PR green.
- [ ] After merge: trigger a first Renovate run via `gh workflow run renovate.yml`.
- [ ] Set `CLA_TOKEN`, then verify the CLA flow on a test PR.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code
