### PR TITLE
docs: correct ADR-0016 — CLA_TOKEN optional, document cla-signatures bootstrap

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,6 +28,13 @@
 # `statuses: write` permissions on the CLA job match the action's README
 # requirements at the pinned SHA — do not narrow without re-reading the
 # action's docs at the pinned version.
+#
+# PREREQUISITE (ADR-0016): the `cla-signatures` branch must already exist and
+# be UNPROTECTED, holding an initialized `signatures/cla.json`
+# (`{"signedContributors": []}`). The action does NOT create a non-default
+# branch — without it the first run fails with "Branch cla-signatures not
+# found". `CLA_TOKEN` below is OPTIONAL; `GITHUB_TOKEN` is enough for
+# same-repo signature storage.
 # ---------------------------------------------------------------------------
 name: CLA
 

--- a/docs/adr/0016-contributor-license-agreement.md
+++ b/docs/adr/0016-contributor-license-agreement.md
@@ -18,8 +18,9 @@ Require every contributor to sign a **Contributor License Agreement** before the
 
 - `CLA.md` (repo root) states the grant: a perpetual, irrevocable copyright license **with the right to sublicense under any terms, including commercial**, plus a patent grant, representations, a corporate-contributor clause, and an explicit AI-agent clause (the human operator signs).
 - `.github/workflows/cla.yml` runs [`contributor-assistant/github-action`](https://github.com/contributor-assistant/github-action), pinned to a full commit SHA. Signatures are recorded in `signatures/cla.json` on a dedicated `cla-signatures` branch. The signing phrase is *"I have read the CLA Document and I hereby sign the CLA"*.
-- Allowlist: `bigpuritz,devtank42,*[bot]` (maintainers and bots are exempt).
-- The workflow requires a repo secret **`CLA_TOKEN`** (a fine-grained PAT with `contents` + `pull-requests` write) so the action can commit signatures and re-check status.
+- Allowlist: `bigpuritz,devtank42,*[bot]` (maintainers and bots are exempt). AI co-authors added via a `Co-Authored-By:` trailer (e.g. `Claude <noreply@anthropic.com>`) are **not** asked to sign — they have no GitHub login and, per CLA §8, the human operator signs, not the agent.
+- **One-time bootstrap (required):** the `cla-signatures` branch must already exist and be **unprotected**, holding an initialized `signatures/cla.json` (`{"signedContributors": []}`). The action does **not** create a non-default branch — without it the first run fails with *"Branch cla-signatures not found"*. (Bootstrapped as an orphan branch; the action then creates/updates the file itself.)
+- A repo secret **`CLA_TOKEN`** (PAT) is **optional** — useful for storing signatures in a remote repo or for extra robustness. The default `GITHUB_TOKEN` (with the job's `contents`/`pull-requests` write scopes) is sufficient for same-repo signature storage; verified green with no PAT set.
 
 ### Security model (the reason this ADR exists)
 
@@ -35,7 +36,7 @@ The `issue_comment` trigger is filtered to PR comments only (`github.event.issue
 
 - Easier: the project can legally offer commercial editions of contributed code; provenance is auditable in `signatures/cla.json`.
 - Harder: first-time external contributors must take one extra step (post the signing comment). The bot guides them automatically.
-- Operational dependency: the `CLA_TOKEN` secret must exist, or the workflow cannot record signatures. This is a one-time maintainer setup.
+- One-time setup: the unprotected `cla-signatures` branch with an initialized `signatures/cla.json` must exist before the first run (the action does not auto-create it). No secret is strictly required — `GITHUB_TOKEN` suffices; `CLA_TOKEN` stays optional.
 - The CLA is referenced from `CONTRIBUTING.md` (ADR-0008 workflow).
 
 ## Alternatives considered


### PR DESCRIPTION
Corrects ADR-0016 to match how the CLA workflow actually behaves (verified after #4 merged). Closes #5.

## Changes
- **`CLA_TOKEN` is optional**, not required. The CLA check passed green with an empty PAT — `GITHUB_TOKEN` (with the job's `contents`/`pull-requests` scopes) is sufficient for same-repo signature storage. A PAT only helps for remote-repo storage or extra robustness.
- **Documented the real one-time bootstrap:** the `cla-signatures` branch must already exist and be **unprotected**, with an initialized `signatures/cla.json` (`{"signedContributors": []}`). The action does **not** create a non-default branch — without it the first run fails with *"Branch cla-signatures not found"*.
- **AI co-authors don't sign:** noted that a `Co-Authored-By: Claude …` trailer does not trigger a signing requirement (no GitHub login; per CLA §8 the human operator signs).
- Added a `PREREQUISITE` note to the `cla.yml` header comment so a maintainer debugging the workflow finds it there too.

Docs/comment only — no code or behaviour change.

## Test plan
- [x] CLA check on `qnophq/qnop` is green after creating the orphan `cla-signatures` branch + initialized `signatures/cla.json` (run 27494053264, re-run → success).
- [ ] CI on this PR green (no source changes).

🤖 Co-Author: Claude (Opus 4.x) via Claude Code