### PR TITLE
feat: security & crypto foundation (SecurityConfig, crypto, QnopProperties)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,17 @@ QNOP_S3_PORT=9000
 QNOP_S3_CONSOLE_PORT=9001
 QNOP_S3_BUCKET=qnop-documents
 
+# --- Security & crypto (issue #10) ---
+# The server FAILS TO START with these placeholders (they trip @ValidSecret).
+# Set strong, unique values (>= 32 chars) for local `bootRun`; in production these
+# come from the environment / a secret manager, never a committed file.
+QNOP_AUTH_JWT_SECRET=CHANGE_ME
+QNOP_AUTH_ENCRYPTION_KEY=CHANGE_ME
+# Hex-encoded salt for symmetric text encryption (Encryptors.delux).
+QNOP_AUTH_ENCRYPTION_SALT=CHANGE_ME
+# Comma-separated list of exact origins allowed to call the API (the Vite dev server).
+QNOP_CORS_ALLOWED_ORIGINS=http://localhost:5173
+
 # --- Running the server ---
 # docker-compose loads this file automatically. For `./gradlew :qnop-app:bootRun`
 # export these into your shell first:  set -a; source .env; set +a

--- a/docs/adr/0022-security-crypto-foundation.md
+++ b/docs/adr/0022-security-crypto-foundation.md
@@ -1,0 +1,38 @@
+# ADR-0022: Security & crypto foundation — layer placement and primitives
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Deciders:** qnop core team (with Claude)
+
+## Context
+
+Every auth ticket in epic #7 (#12–#23: tokens, local users, OIDC, settings, mail, branding) needs the same primitives: a password hasher, symmetric encryption for secrets at rest, signing-key material for JWTs, validated configuration, and a servlet security filter chain. Issue #10 builds that shared foundation before any of it.
+
+Two forces pull against each other:
+
+- The **service layer** (`qnop-core`, `io.qnop.service`) must inject crypto primitives (`PasswordEncoder`, `TextEncryptor`, key derivation) — so they cannot live above it in `qnop-app`, or the layering (ADR-0004) inverts.
+- The **`SecurityFilterChain`** is a servlet/web concern (CORS, CSP, 401 entry point, request matrix) and belongs in the web layer (`qnop-app`). Putting it in `qnop-core` would drag `spring-security-web` and the servlet API into the framework-light core.
+
+## Decision
+
+Split the foundation across the two existing modules, introducing **one new ArchUnit layer** for the framework-light half:
+
+- **`io.qnop.security` in `qnop-core`** — `QnopProperties` (validated `@ConfigurationProperties`), `Hkdf` (RFC 5869), `JwtKeyService`, and `CryptoConfiguration` (`BCryptPasswordEncoder`, `Encryptors.delux` `TextEncryptor`). Depends only on `spring-security-crypto` + Bean Validation — no servlet, no web. Declared as the ArchUnit layer **Security**, accessible **only by the Service and Web layers**.
+- **`io.qnop.web.security` in `qnop-app`** — `SecurityConfiguration` (the `SecurityFilterChain`, CORS source, JSON 401 entry point). Part of the existing **Web** layer; takes `spring-boot-starter-security`.
+
+Crypto choices: **BCrypt** for password hashing; **`Encryptors.delux`** (AES) keyed by `qnop.auth.encryption-key` + hex `qnop.auth.encryption-salt` for text-at-rest; **HKDF-SHA256** to derive domain-separated JWT keys from `qnop.auth.jwt-secret` (one independent key per purpose label).
+
+**Fail fast on weak secrets.** `QnopProperties` is `@Validated`; `@ValidSecret` rejects blank, short (< 32 char), or known-placeholder secrets, and the salt must be hex. A context bound to a `.env.example` default refuses to start. Secrets come from the `QNOP_AUTH_*` environment namespace (ADR-0020); no secure default is compiled in.
+
+## Consequences
+
+- Services inject crypto beans by type from `qnop-core`; the web filter chain stays in `qnop-app`. Core remains servlet-free.
+- `io.qnop.security` deviates from issue #10's literal "one `io.qnop.security` package" wording (the filter chain lands in `io.qnop.web.security`) — recorded here as the deliberate trade-off for clean layering.
+- A misconfigured deployment fails at boot instead of running with a public secret — but local `bootRun` now requires real `QNOP_AUTH_*` values (documented in the README and `.env.example`).
+- Token issuance/verification itself is **not** here; #10 ships only the key-derivation foundation (issue #17 builds on it).
+
+## Alternatives considered
+
+- **Everything in `io.qnop.security` in `qnop-core`** (issue's literal shape). Rejected: forces `spring-security-web` + `jakarta.servlet` into the framework-light core and blurs the web/core boundary.
+- **Everything in `qnop-app`.** Rejected: the service layer could not inject `PasswordEncoder`/`TextEncryptor` without an upward dependency, inverting ADR-0004.
+- **Spring Security defaults (form login, stateful session, default CSP).** Rejected: this is a stateless token API; a login redirect and session cookies are the wrong shape, and the default headers are too lax for a JSON API.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0019](0019-source-copyright-headers.md) | Source files carry a copyright notice (devtank42 GmbH) | Accepted |
 | [0020](0020-bootable-server-and-test-database.md) | Bootable server: PostgreSQL + Liquibase + JPA, tests on Testcontainers | Accepted |
 | [0021](0021-openapi-first-contract-tooling.md) | OpenAPI-first REST contract tooling and the qnop-api submodule split | Accepted |
+| [0022](0022-security-crypto-foundation.md) | Security & crypto foundation — layer placement and primitives | Accepted |
 
 ## Template
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,11 +50,17 @@ swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", versi
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version.ref = "jakartaValidation" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakartaAnnotation" }
 
+# Security & crypto (issue #10) — versions managed by the Spring Boot BOM.
+spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
+spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
+spring-security-crypto = { module = "org.springframework.security:spring-security-crypto" }
+
 # Test
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 # Spring Boot 4 split the web test slices into per-stack modules; @WebMvcTest now
 # lives in spring-boot-webmvc-test (package org.springframework.boot.webmvc.test).
 spring-boot-webmvc-test = { module = "org.springframework.boot:spring-boot-webmvc-test" }
+spring-security-test = { module = "org.springframework.security:spring-security-test" }
 spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
 # Testcontainers 2.x artifact ids carry the `testcontainers-` prefix; versions
 # are managed transitively by the Spring Boot BOM (testcontainers-bom).

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
 
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.actuator)
+    // Servlet security filter chain (io.qnop.web.security, issue #10 / ADR-0021).
+    implementation(libs.spring.boot.starter.security)
     // JPA/Hibernate reaches the runtime classpath transitively via qnop-core; the
     // bootstrap gains explicit @EntityScan/@EnableJpaRepositories with the data
     // model (issue #11), which is when this module takes a direct JPA dependency.
@@ -37,6 +39,11 @@ dependencies {
     testImplementation(libs.archunit.junit5)
     testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.spring.boot.webmvc.test) // @WebMvcTest slice (Boot 4 module)
+    testImplementation(libs.spring.security.test)
+    // The fail-fast binding test (QnopPropertiesBindingTest) drives Bean Validation +
+    // ValidationAutoConfiguration directly; qnop-core keeps validation as an
+    // implementation dependency, so the app test classpath needs it explicitly.
+    testImplementation(libs.spring.boot.starter.validation)
     testImplementation(libs.spring.boot.testcontainers)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.junit.jupiter)

--- a/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
@@ -20,8 +20,10 @@
  */
 package io.qnop.bootstrap;
 
+import io.qnop.security.QnopProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 /**
  * Spring Boot entry point for the qnop Community server.
@@ -33,6 +35,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * #11), once entities and repositories exist.
  */
 @SpringBootApplication(scanBasePackages = "io.qnop")
+@EnableConfigurationProperties(QnopProperties.class)
 public class QnopApplication {
 
   public static void main(String[] args) {

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /**
- * The servlet security filter chain for the Community server (issue #10, ADR-0021).
+ * The servlet security filter chain for the Community server (issue #10, ADR-0022).
  *
  * <p>The API is stateless (token-based, from issue #17), so sessions and CSRF cookies are disabled
  * and unauthenticated requests receive a JSON {@code 401} rather than a login redirect. Actuator

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import io.qnop.security.QnopProperties;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+/**
+ * The servlet security filter chain for the Community server (issue #10, ADR-0021).
+ *
+ * <p>The API is stateless (token-based, from issue #17), so sessions and CSRF cookies are disabled
+ * and unauthenticated requests receive a JSON {@code 401} rather than a login redirect. Actuator
+ * health is public; everything else requires authentication. Security headers (a strict CSP for a
+ * JSON API, frame-deny, referrer policy, HSTS) are applied to every response. CORS is driven by
+ * {@link QnopProperties} so the SPA origin is configurable per environment.
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfiguration {
+
+  private static final long HSTS_MAX_AGE_SECONDS = 31_536_000L; // one year
+
+  @Bean
+  SecurityFilterChain securityFilterChain(
+      HttpSecurity http,
+      AuthenticationEntryPoint authenticationEntryPoint,
+      CorsConfigurationSource corsConfigurationSource)
+      throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .cors(cors -> cors.configurationSource(corsConfigurationSource))
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/actuator/health", "/actuator/health/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .httpBasic(httpBasic -> httpBasic.disable())
+        .formLogin(formLogin -> formLogin.disable())
+        .exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryPoint))
+        .headers(
+            headers ->
+                headers
+                    .contentSecurityPolicy(
+                        csp ->
+                            csp.policyDirectives(
+                                "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"))
+                    .frameOptions(frame -> frame.deny())
+                    .referrerPolicy(
+                        referrer ->
+                            referrer.policy(
+                                ReferrerPolicyHeaderWriter.ReferrerPolicy
+                                    .STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+                    .httpStrictTransportSecurity(
+                        hsts ->
+                            hsts.includeSubDomains(true).maxAgeInSeconds(HSTS_MAX_AGE_SECONDS)));
+    return http.build();
+  }
+
+  /** Returns a bare JSON {@code 401} instead of redirecting to a login form (this is an API). */
+  @Bean
+  AuthenticationEntryPoint authenticationEntryPoint() {
+    return (request, response, authException) -> {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.getWriter().write("{\"error\":\"unauthorized\"}");
+    };
+  }
+
+  @Bean
+  CorsConfigurationSource corsConfigurationSource(QnopProperties properties) {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOrigins(properties.cors().allowedOrigins());
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setAllowCredentials(true);
+    config.setMaxAge(3_600L);
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/package-info.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/package-info.java
@@ -20,7 +20,7 @@
  */
 
 /**
- * Servlet security wiring for the qnop Community server (issue #10, ADR-0021).
+ * Servlet security wiring for the qnop Community server (issue #10, ADR-0022).
  *
  * <p>Holds the {@code SecurityFilterChain}: stateless session policy, CORS, security headers/CSP, a
  * JSON 401 entry point, and the public/authenticated request matrix. The framework-light crypto

--- a/qnop-app/src/main/java/io/qnop/web/security/package-info.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Servlet security wiring for the qnop Community server (issue #10, ADR-0021).
+ *
+ * <p>Holds the {@code SecurityFilterChain}: stateless session policy, CORS, security headers/CSP, a
+ * JSON 401 entry point, and the public/authenticated request matrix. The framework-light crypto
+ * foundation (password hashing, text encryption, key derivation, validated properties) lives apart
+ * in {@code io.qnop.security} (qnop-core). As part of the web layer this package may depend on the
+ * service and security layers but is itself accessed by nobody (ADR-0004).
+ */
+package io.qnop.web.security;

--- a/qnop-app/src/main/java/io/qnop/web/security/package-info.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/package-info.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 /**
  * Servlet security wiring for the qnop Community server (issue #10, ADR-0021).
  *

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -31,7 +31,7 @@ management:
       probes:
         enabled: true
 
-# Security & crypto foundation (issue #10, ADR-0021). Secrets come from the
+# Security & crypto foundation (issue #10, ADR-0022). Secrets come from the
 # QNOP_AUTH_* environment namespace — no secure default is baked in; the
 # placeholder below trips @ValidSecret so a deployment that forgot to set real
 # values refuses to start. CORS origins gate SPA / front-end access.

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -30,3 +30,15 @@ management:
     health:
       probes:
         enabled: true
+
+# Security & crypto foundation (issue #10, ADR-0021). Secrets come from the
+# QNOP_AUTH_* environment namespace — no secure default is baked in; the
+# placeholder below trips @ValidSecret so a deployment that forgot to set real
+# values refuses to start. CORS origins gate SPA / front-end access.
+qnop:
+  auth:
+    jwt-secret: ${QNOP_AUTH_JWT_SECRET:CHANGE_ME}
+    encryption-key: ${QNOP_AUTH_ENCRYPTION_KEY:CHANGE_ME}
+    encryption-salt: ${QNOP_AUTH_ENCRYPTION_SALT:CHANGE_ME}
+  cors:
+    allowed-origins: ${QNOP_CORS_ALLOWED_ORIGINS:http://localhost:5173}

--- a/qnop-app/src/test/java/io/qnop/architecture/ArchitectureRulesTest.java
+++ b/qnop-app/src/test/java/io/qnop/architecture/ArchitectureRulesTest.java
@@ -62,9 +62,15 @@ class ArchitectureRulesTest {
             .definedBy("io.qnop.service..")
             .layer("Web")
             .definedBy("io.qnop.web..", "io.qnop.bootstrap..")
+            .layer("Security")
+            .definedBy("io.qnop.security..")
             // Spi is intentionally consumable by everyone (plugin contract).
             .whereLayer("Web")
             .mayNotBeAccessedByAnyLayer()
+            // The security/crypto foundation (ADR-0022) is used by the service and web
+            // layers; it never depends back on them (see securityFoundationStaysPure).
+            .whereLayer("Security")
+            .mayOnlyBeAccessedByLayers("Web", "Service")
             .whereLayer("Service")
             .mayOnlyBeAccessedByLayers("Web")
             .whereLayer("Repository")
@@ -124,6 +130,28 @@ class ArchitectureRulesTest {
                 "io.qnop.repository..",
                 "io.qnop.service..",
                 "io.qnop.web..")
+            .allowEmptyShould(true);
+
+    rule.check(QNOP_CLASSES);
+  }
+
+  @Test
+  void securityFoundationStaysPure() {
+    // io.qnop.security (qnop-core) is the framework-light crypto foundation (ADR-0022):
+    // it may use Spring, but must never depend on the application's own web, service,
+    // repository, entity or DTO layers — those depend on it, not the other way round.
+    ArchRule rule =
+        ArchRuleDefinition.noClasses()
+            .that()
+            .resideInAPackage("io.qnop.security..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                "io.qnop.web..",
+                "io.qnop.service..",
+                "io.qnop.repository..",
+                "io.qnop.entity..",
+                "io.qnop.api..")
             .allowEmptyShould(true);
 
     rule.check(QNOP_CLASSES);

--- a/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
@@ -31,7 +31,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /**
  * Base for full-context integration tests: boots the application against a real PostgreSQL
  * (Testcontainers, ADR-0020) and supplies strong {@code QNOP_AUTH_*} secrets so the security
- * foundation's fail-fast validation (ADR-0021) is satisfied. Requires Docker.
+ * foundation's fail-fast validation (ADR-0022) is satisfied. Requires Docker.
  */
 @SpringBootTest(
     classes = QnopApplication.class,

--- a/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Base for full-context integration tests: boots the application against a real PostgreSQL
+ * (Testcontainers, ADR-0020) and supplies strong {@code QNOP_AUTH_*} secrets so the security
+ * foundation's fail-fast validation (ADR-0021) is satisfied. Requires Docker.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+public abstract class AbstractIntegrationTest {
+
+  @Container @ServiceConnection
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17");
+
+  @DynamicPropertySource
+  static void securitySecrets(DynamicPropertyRegistry registry) {
+    registry.add("qnop.auth.jwt-secret", () -> "integration-test-jwt-secret-0123456789");
+    registry.add("qnop.auth.encryption-key", () -> "integration-test-encryption-key-0123456789");
+    registry.add("qnop.auth.encryption-salt", () -> "0123456789abcdef0123456789abcdef");
+    registry.add("qnop.cors.allowed-origins", () -> "http://localhost:5173");
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
@@ -33,7 +33,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * (Testcontainers, ADR-0020) and supplies strong {@code QNOP_AUTH_*} secrets so the security
  * foundation's fail-fast validation (ADR-0021) is satisfied. Requires Docker.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    classes = QnopApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
 public abstract class AbstractIntegrationTest {
 

--- a/qnop-app/src/test/java/io/qnop/bootstrap/QnopApplicationContextTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/QnopApplicationContextTest.java
@@ -27,12 +27,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * Boots the full Spring context against a real PostgreSQL (Testcontainers, ADR-0020), lets
@@ -40,12 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * endpoint returns {@code 200 UP}. Uses the JDK HTTP client to stay free of any test-client
  * dependency. Requires Docker.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-class QnopApplicationContextTest {
-
-  @Container @ServiceConnection
-  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17");
+class QnopApplicationContextTest extends AbstractIntegrationTest {
 
   @LocalServerPort int port;
 

--- a/qnop-app/src/test/java/io/qnop/bootstrap/QnopPropertiesBindingTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/QnopPropertiesBindingTest.java
@@ -31,7 +31,7 @@ import org.springframework.boot.validation.autoconfigure.ValidationAutoConfigura
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Verifies the fail-fast contract (ADR-0021): a context bound to placeholder secrets refuses to
+ * Verifies the fail-fast contract (ADR-0022): a context bound to placeholder secrets refuses to
  * start, while strong secrets bind cleanly. Runs without a database — only the properties binding
  * and validation are exercised.
  */

--- a/qnop-app/src/test/java/io/qnop/bootstrap/QnopPropertiesBindingTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/QnopPropertiesBindingTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.security.QnopProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Verifies the fail-fast contract (ADR-0021): a context bound to placeholder secrets refuses to
+ * start, while strong secrets bind cleanly. Runs without a database — only the properties binding
+ * and validation are exercised.
+ */
+class QnopPropertiesBindingTest {
+
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withConfiguration(AutoConfigurations.of(ValidationAutoConfiguration.class))
+          .withUserConfiguration(TestConfig.class);
+
+  @Configuration
+  @EnableConfigurationProperties(QnopProperties.class)
+  static class TestConfig {}
+
+  @Test
+  void insecureDefaultSecretFailsFast() {
+    runner
+        .withPropertyValues(
+            "qnop.auth.jwt-secret=CHANGE_ME",
+            "qnop.auth.encryption-key=CHANGE_ME",
+            "qnop.auth.encryption-salt=CHANGE_ME",
+            "qnop.cors.allowed-origins=http://localhost:5173")
+        .run(context -> assertThat(context).hasFailed());
+  }
+
+  @Test
+  void strongSecretsBindSuccessfully() {
+    runner
+        .withPropertyValues(
+            "qnop.auth.jwt-secret=binding-test-jwt-secret-0123456789",
+            "qnop.auth.encryption-key=binding-test-encryption-key-0123456789",
+            "qnop.auth.encryption-salt=0123456789abcdef0123456789abcdef",
+            "qnop.cors.allowed-origins=http://localhost:5173,https://app.example.com")
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              QnopProperties properties = context.getBean(QnopProperties.class);
+              assertThat(properties.auth().jwtSecret())
+                  .isEqualTo("binding-test-jwt-secret-0123456789");
+              assertThat(properties.cors().allowedOrigins())
+                  .containsExactly("http://localhost:5173", "https://app.example.com");
+            });
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/security/SecurityConfigurationTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/SecurityConfigurationTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
- * Verifies the security filter chain (ADR-0021): the context starts with the chain, actuator health
+ * Verifies the security filter chain (ADR-0022): the context starts with the chain, actuator health
  * is public, unauthenticated requests to protected paths get a 401, and the security headers are
  * present. Drives the live server over HTTP (like {@code QnopApplicationContextTest}) to stay free
  * of a servlet test-client dependency. Requires Docker (Testcontainers).

--- a/qnop-app/src/test/java/io/qnop/web/security/SecurityConfigurationTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/SecurityConfigurationTest.java
@@ -49,7 +49,11 @@ class SecurityConfigurationTest extends AbstractIntegrationTest {
 
   @Test
   void healthEndpointIsPublic() throws Exception {
-    assertThat(get("/actuator/health").statusCode()).isEqualTo(200);
+    // "Public" means the security chain does not challenge the request — it must not be
+    // 401/403. The health status itself (UP, 200) is asserted by QnopApplicationContextTest;
+    // asserting it here too would couple this test to transient health aggregation (e.g. a
+    // brief 503 during readiness/shutdown).
+    assertThat(get("/actuator/health").statusCode()).isNotIn(401, 403);
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/security/SecurityConfigurationTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/SecurityConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/**
+ * Verifies the security filter chain (ADR-0021): the context starts with the chain, actuator health
+ * is public, unauthenticated requests to protected paths get a 401, and the security headers are
+ * present. Drives the live server over HTTP (like {@code QnopApplicationContextTest}) to stay free
+ * of a servlet test-client dependency. Requires Docker (Testcontainers).
+ */
+class SecurityConfigurationTest extends AbstractIntegrationTest {
+
+  @LocalServerPort int port;
+
+  private HttpResponse<String> get(String path) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder(URI.create("http://localhost:" + port + path)).GET().build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+
+  @Test
+  void healthEndpointIsPublic() throws Exception {
+    assertThat(get("/actuator/health").statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void unauthenticatedRequestToProtectedPathReturns401() throws Exception {
+    assertThat(get("/api/anything").statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  void securityHeadersArePresent() throws Exception {
+    HttpResponse<String> response = get("/actuator/health");
+
+    assertThat(response.headers().firstValue("X-Content-Type-Options")).hasValue("nosniff");
+    assertThat(response.headers().firstValue("X-Frame-Options")).hasValue("DENY");
+    assertThat(response.headers().firstValue("Content-Security-Policy")).isPresent();
+    assertThat(response.headers().firstValue("Referrer-Policy"))
+        .hasValue("strict-origin-when-cross-origin");
+  }
+}

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -23,6 +23,13 @@ dependencies {
     // Persistence: JPA entities + Spring Data repositories live in this module.
     implementation(libs.spring.boot.starter.data.jpa)
 
+    // Security & crypto foundation (issue #10, ADR-0021): the framework-light
+    // io.qnop.security layer — validated properties, BCrypt, TextEncryptor, HKDF.
+    // The servlet filter chain lives in qnop-app; core stays free of
+    // spring-security-web by depending only on spring-security-crypto.
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.security.crypto)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/qnop-core/src/main/java/io/qnop/security/CryptoConfiguration.java
+++ b/qnop-core/src/main/java/io/qnop/security/CryptoConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Symmetric and one-way cryptographic primitives shared across the auth subsystem (issue #10).
+ *
+ * <ul>
+ *   <li>{@link PasswordEncoder} — BCrypt, for user password hashing (issue #20).
+ *   <li>{@link TextEncryptor} — {@code Encryptors.delux} (AES-256), for secrets stored at rest such
+ *       as OIDC client secrets (issue #21).
+ * </ul>
+ *
+ * <p>These are beans rather than the web filter chain, so they live in the framework-light {@code
+ * io.qnop.security} layer and are injectable by the service layer.
+ */
+@Configuration
+public class CryptoConfiguration {
+
+  @Bean
+  PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  TextEncryptor textEncryptor(QnopProperties properties) {
+    QnopProperties.Auth auth = properties.auth();
+    return Encryptors.delux(auth.encryptionKey(), auth.encryptionSalt());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/security/Hkdf.java
+++ b/qnop-core/src/main/java/io/qnop/security/Hkdf.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import java.security.GeneralSecurityException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * HKDF (RFC 5869) extract-and-expand key derivation over HMAC-SHA256. Pure, dependency-free, and
+ * deterministic — verified against the RFC 5869 test vectors — so domain-separated keys can be
+ * derived without a live Spring context (ADR-0004).
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc5869">RFC 5869</a>
+ */
+public final class Hkdf {
+
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+  private static final int HASH_LEN = 32;
+
+  private Hkdf() {}
+
+  /**
+   * HKDF-Extract: derives a fixed-length pseudorandom key from the input keying material.
+   *
+   * @param salt optional non-secret salt; an empty/{@code null} salt defaults to {@code HashLen}
+   *     zero bytes per the RFC
+   * @param ikm input keying material
+   * @return the 32-byte pseudorandom key (PRK)
+   */
+  public static byte[] extract(byte[] salt, byte[] ikm) {
+    byte[] effectiveSalt = (salt == null || salt.length == 0) ? new byte[HASH_LEN] : salt;
+    return hmac(effectiveSalt, ikm);
+  }
+
+  /**
+   * HKDF-Expand: expands a pseudorandom key into output keying material of the requested length,
+   * bound to {@code info} for domain separation.
+   *
+   * @param prk a pseudorandom key (typically from {@link #extract})
+   * @param info optional context/application-specific info for domain separation
+   * @param length desired output length in bytes; at most {@code 255 * HashLen}
+   * @return {@code length} bytes of output keying material (OKM)
+   */
+  public static byte[] expand(byte[] prk, byte[] info, int length) {
+    if (length < 0 || length > 255 * HASH_LEN) {
+      throw new IllegalArgumentException("length must be between 0 and " + (255 * HASH_LEN));
+    }
+    byte[] safeInfo = info == null ? new byte[0] : info;
+    byte[] okm = new byte[length];
+    byte[] block = new byte[0];
+    int position = 0;
+    for (int counter = 1; position < length; counter++) {
+      byte[] input = new byte[block.length + safeInfo.length + 1];
+      System.arraycopy(block, 0, input, 0, block.length);
+      System.arraycopy(safeInfo, 0, input, block.length, safeInfo.length);
+      input[input.length - 1] = (byte) counter;
+      block = hmac(prk, input);
+      int toCopy = Math.min(block.length, length - position);
+      System.arraycopy(block, 0, okm, position, toCopy);
+      position += toCopy;
+    }
+    return okm;
+  }
+
+  /**
+   * Convenience: {@link #extract} followed by {@link #expand}.
+   *
+   * @param ikm input keying material
+   * @param salt optional salt
+   * @param info optional domain-separation context
+   * @param length desired output length in bytes
+   * @return {@code length} bytes of output keying material
+   */
+  public static byte[] deriveKey(byte[] ikm, byte[] salt, byte[] info, int length) {
+    return expand(extract(salt, ikm), info, length);
+  }
+
+  private static byte[] hmac(byte[] key, byte[] data) {
+    try {
+      Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+      mac.init(new SecretKeySpec(key, HMAC_ALGORITHM));
+      return mac.doFinal(data);
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("HMAC-SHA256 is required but unavailable", e);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/security/JwtKeyService.java
+++ b/qnop-core/src/main/java/io/qnop/security/JwtKeyService.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 
 /**
  * Derives domain-separated HMAC-SHA256 keys from the configured {@code qnop.auth.jwt-secret} using
- * HKDF (ADR-0021). Each {@code purpose} yields an independent key, so compromising — or rotating —
+ * HKDF (ADR-0022). Each {@code purpose} yields an independent key, so compromising — or rotating —
  * one purpose's key does not affect the others. Actual token issuance and verification land in
  * issue #17; this service is the shared key-derivation foundation.
  */

--- a/qnop-core/src/main/java/io/qnop/security/JwtKeyService.java
+++ b/qnop-core/src/main/java/io/qnop/security/JwtKeyService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.stereotype.Service;
+
+/**
+ * Derives domain-separated HMAC-SHA256 keys from the configured {@code qnop.auth.jwt-secret} using
+ * HKDF (ADR-0021). Each {@code purpose} yields an independent key, so compromising — or rotating —
+ * one purpose's key does not affect the others. Actual token issuance and verification land in
+ * issue #17; this service is the shared key-derivation foundation.
+ */
+@Service
+public class JwtKeyService {
+
+  private static final String KEY_ALGORITHM = "HmacSHA256";
+  private static final int KEY_LENGTH_BYTES = 32;
+
+  /** Fixed application salt; domain separation is carried by the per-purpose {@code info} label. */
+  private static final byte[] APPLICATION_SALT =
+      "qnop:auth:hkdf:v1".getBytes(StandardCharsets.UTF_8);
+
+  private final byte[] inputKeyingMaterial;
+
+  public JwtKeyService(QnopProperties properties) {
+    this.inputKeyingMaterial = properties.auth().jwtSecret().getBytes(StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Derives the signing key for the given purpose (e.g. {@code "access-token"}, {@code
+   * "refresh-token"}).
+   *
+   * @param purpose a stable, non-secret label identifying the key's use
+   * @return a 256-bit {@link SecretKey} unique to that purpose
+   */
+  public SecretKey deriveKey(String purpose) {
+    Objects.requireNonNull(purpose, "purpose");
+    byte[] info = ("qnop:jwt:" + purpose).getBytes(StandardCharsets.UTF_8);
+    byte[] keyBytes = Hkdf.deriveKey(inputKeyingMaterial, APPLICATION_SALT, info, KEY_LENGTH_BYTES);
+    return new SecretKeySpec(keyBytes, KEY_ALGORITHM);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
+++ b/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Strongly-typed, validated configuration for the security/crypto foundation (issue #10). Bound
+ * from the {@code qnop.*} environment namespace (ADR-0020) and validated at context startup: an
+ * insecure default or missing secret fails the application fast rather than booting with weak
+ * crypto.
+ *
+ * @param auth authentication secrets (JWT signing material, symmetric encryption key + salt)
+ * @param cors cross-origin policy for the SPA and third-party API clients
+ */
+@ConfigurationProperties(prefix = "qnop")
+@Validated
+public record QnopProperties(@Valid Auth auth, @Valid Cors cors) {
+
+  /**
+   * Authentication secrets. {@code jwtSecret} is the HKDF input keying material for
+   * domain-separated JWT keys; {@code encryptionKey} + {@code encryptionSalt} feed {@code
+   * Encryptors.delux} for symmetric text encryption (e.g. OIDC client secrets at rest, from issue
+   * #21).
+   *
+   * @param jwtSecret HKDF input keying material; must be a strong, non-default secret
+   * @param encryptionKey password for symmetric text encryption; must be a strong, non-default
+   *     secret
+   * @param encryptionSalt hex-encoded salt for symmetric text encryption (Encryptors.delux)
+   */
+  public record Auth(
+      @ValidSecret String jwtSecret,
+      @ValidSecret String encryptionKey,
+      @NotBlank
+          @Pattern(
+              regexp = "^[0-9a-fA-F]{16,}$",
+              message =
+                  "qnop.auth.encryption-salt must be a hex-encoded string of at least 16 characters")
+          String encryptionSalt) {}
+
+  /**
+   * Cross-origin resource sharing policy.
+   *
+   * @param allowedOrigins exact origins permitted to call the API (no wildcards with credentials)
+   */
+  public record Cors(List<String> allowedOrigins) {
+
+    public Cors {
+      allowedOrigins = allowedOrigins == null ? List.of() : List.copyOf(allowedOrigins);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/security/SecretValidator.java
+++ b/qnop-core/src/main/java/io/qnop/security/SecretValidator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Constraint logic for {@link ValidSecret}. Kept as plain, framework-light code so it is unit
+ * testable without a Spring context (ADR-0004).
+ */
+public class SecretValidator implements ConstraintValidator<ValidSecret, String> {
+
+  /** Minimum secret length; below this brute-forcing derived keys becomes feasible. */
+  static final int MIN_LENGTH = 32;
+
+  /**
+   * Well-known placeholder/default values. These ship in {@code .env.example} precisely so that a
+   * deployment which forgot to set a real secret fails fast instead of running with a public value.
+   */
+  private static final Set<String> FORBIDDEN =
+      Set.of("change_me", "change-me", "changeme", "changeit", "secret", "password", "qnop");
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return false;
+    }
+    String trimmed = value.trim();
+    if (trimmed.length() < MIN_LENGTH) {
+      return false;
+    }
+    return !FORBIDDEN.contains(trimmed.toLowerCase(Locale.ROOT));
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/security/ValidSecret.java
+++ b/qnop-core/src/main/java/io/qnop/security/ValidSecret.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validates that a secret is present and strong: non-blank, at least {@value
+ * SecretValidator#MIN_LENGTH} characters, and not one of the well-known placeholder/default values
+ * shipped in {@code .env.example}. Drives the fail-fast requirement of issue #10 — a context bound
+ * to an insecure default secret must refuse to start.
+ */
+@Documented
+@Constraint(validatedBy = SecretValidator.class)
+@Target({ElementType.RECORD_COMPONENT, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidSecret {
+
+  String message() default "must be set to a strong, non-default secret of at least 32 characters";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/qnop-core/src/main/java/io/qnop/security/package-info.java
+++ b/qnop-core/src/main/java/io/qnop/security/package-info.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 /**
  * Security &amp; crypto foundation shared by all auth work (issue #10, ADR-0021).
  *

--- a/qnop-core/src/main/java/io/qnop/security/package-info.java
+++ b/qnop-core/src/main/java/io/qnop/security/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Security &amp; crypto foundation shared by all auth work (issue #10, ADR-0021).
+ *
+ * <p>This package is framework-free of the web layer: it holds validated configuration properties
+ * ({@link io.qnop.security.QnopProperties}), password hashing and symmetric text encryption beans
+ * ({@link io.qnop.security.CryptoConfiguration}), HKDF-SHA256 key derivation ({@link
+ * io.qnop.security.Hkdf}, {@link io.qnop.security.JwtKeyService}). The servlet {@code
+ * SecurityFilterChain} lives in {@code io.qnop.web.security} (qnop-app) — see ADR-0021 for why the
+ * crypto foundation and the filter chain are split across modules while sharing the layered
+ * architecture (ADR-0004).
+ *
+ * <p>ArchUnit treats {@code io.qnop.security} as its own layer, accessible only by the service and
+ * web layers.
+ */
+package io.qnop.security;

--- a/qnop-core/src/main/java/io/qnop/security/package-info.java
+++ b/qnop-core/src/main/java/io/qnop/security/package-info.java
@@ -20,13 +20,13 @@
  */
 
 /**
- * Security &amp; crypto foundation shared by all auth work (issue #10, ADR-0021).
+ * Security &amp; crypto foundation shared by all auth work (issue #10, ADR-0022).
  *
  * <p>This package is framework-free of the web layer: it holds validated configuration properties
  * ({@link io.qnop.security.QnopProperties}), password hashing and symmetric text encryption beans
  * ({@link io.qnop.security.CryptoConfiguration}), HKDF-SHA256 key derivation ({@link
  * io.qnop.security.Hkdf}, {@link io.qnop.security.JwtKeyService}). The servlet {@code
- * SecurityFilterChain} lives in {@code io.qnop.web.security} (qnop-app) — see ADR-0021 for why the
+ * SecurityFilterChain} lives in {@code io.qnop.web.security} (qnop-app) — see ADR-0022 for why the
  * crypto foundation and the filter chain are split across modules while sharing the layered
  * architecture (ADR-0004).
  *

--- a/qnop-core/src/test/java/io/qnop/security/CryptoConfigurationTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/CryptoConfigurationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/** Verifies the crypto beans without a Spring context — the @Configuration is plain Java. */
+class CryptoConfigurationTest {
+
+  private final CryptoConfiguration config = new CryptoConfiguration();
+
+  private static QnopProperties properties() {
+    return new QnopProperties(
+        new QnopProperties.Auth(
+            "crypto-test-jwt-secret-0123456789-abc",
+            "crypto-test-encryption-key-0123456789",
+            "0123456789abcdef0123456789abcdef"),
+        new QnopProperties.Cors(List.of()));
+  }
+
+  @Test
+  void passwordEncoderHashesAndMatches() {
+    PasswordEncoder encoder = config.passwordEncoder();
+
+    String hash = encoder.encode("s3cret-password");
+
+    assertNotEquals("s3cret-password", hash);
+    assertTrue(encoder.matches("s3cret-password", hash));
+    assertFalse(encoder.matches("wrong-password", hash));
+  }
+
+  @Test
+  void textEncryptorRoundTrips() {
+    TextEncryptor encryptor = config.textEncryptor(properties());
+
+    String plaintext = "sensitive-oidc-client-secret";
+    String ciphertext = encryptor.encrypt(plaintext);
+
+    assertNotEquals(plaintext, ciphertext);
+    assertEquals(plaintext, encryptor.decrypt(ciphertext));
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/security/HkdfTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/HkdfTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HexFormat;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the HKDF implementation against the RFC 5869 test vectors and its derivation contract.
+ */
+class HkdfTest {
+
+  private static final HexFormat HEX = HexFormat.of();
+
+  @Test
+  void matchesRfc5869BasicSha256Vector() {
+    // RFC 5869, Appendix A.1 (Test Case 1, SHA-256).
+    byte[] ikm = HEX.parseHex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+    byte[] salt = HEX.parseHex("000102030405060708090a0b0c");
+    byte[] info = HEX.parseHex("f0f1f2f3f4f5f6f7f8f9");
+
+    byte[] prk = Hkdf.extract(salt, ikm);
+    assertEquals(
+        "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", HEX.formatHex(prk));
+
+    byte[] okm = Hkdf.deriveKey(ikm, salt, info, 42);
+    assertEquals(
+        "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+        HEX.formatHex(okm));
+  }
+
+  @Test
+  void deriveKeyIsDeterministicAndDomainSeparated() {
+    byte[] ikm = "input-keying-material".getBytes(StandardCharsets.UTF_8);
+    byte[] infoA = "purpose-a".getBytes(StandardCharsets.UTF_8);
+    byte[] infoB = "purpose-b".getBytes(StandardCharsets.UTF_8);
+
+    byte[] first = Hkdf.deriveKey(ikm, null, infoA, 32);
+    byte[] again = Hkdf.deriveKey(ikm, null, infoA, 32);
+    byte[] other = Hkdf.deriveKey(ikm, null, infoB, 32);
+
+    assertArrayEquals(first, again);
+    assertEquals(32, first.length);
+    assertFalse(Arrays.equals(first, other));
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/security/JwtKeyServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/JwtKeyServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+
+/** Verifies that derived JWT keys are deterministic, domain-separated, and well-formed. */
+class JwtKeyServiceTest {
+
+  private static JwtKeyService service() {
+    QnopProperties properties =
+        new QnopProperties(
+            new QnopProperties.Auth(
+                "jwt-key-service-test-secret-0123456789",
+                "jwt-key-service-test-enckey-0123456789",
+                "0123456789abcdef0123456789abcdef"),
+            new QnopProperties.Cors(List.of()));
+    return new JwtKeyService(properties);
+  }
+
+  @Test
+  void derivationIsDeterministic() {
+    JwtKeyService service = service();
+
+    assertArrayEquals(
+        service.deriveKey("access-token").getEncoded(),
+        service.deriveKey("access-token").getEncoded());
+  }
+
+  @Test
+  void differentPurposesYieldDifferentKeys() {
+    JwtKeyService service = service();
+
+    assertFalse(
+        Arrays.equals(
+            service.deriveKey("access-token").getEncoded(),
+            service.deriveKey("refresh-token").getEncoded()));
+  }
+
+  @Test
+  void keyIs256BitHmacSha256() {
+    SecretKey key = service().deriveKey("access-token");
+
+    assertEquals(32, key.getEncoded().length);
+    assertEquals("HmacSHA256", key.getAlgorithm());
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/security/SecretValidatorTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/SecretValidatorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit-tests the {@link ValidSecret} constraint via a standalone Bean Validation {@link Validator}.
+ */
+class SecretValidatorTest {
+
+  /** Minimal carrier so the constraint is exercised exactly as on a record component. */
+  record Holder(@ValidSecret String secret) {}
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(
+      strings = {
+        "   ",
+        "short",
+        "too-short-to-be-secure", // 22 chars, below the 32 minimum
+        "CHANGE_ME",
+        "change-me",
+        "changeme",
+        "password",
+        "qnop"
+      })
+  void rejectsWeakOrDefaultSecrets(String value) {
+    assertFalse(
+        validator.validate(new Holder(value)).isEmpty(), "expected a violation for: " + value);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"this-is-a-strong-test-secret-0123456789", "Zk9$fJ2!pQ7@xL4&mN1#vB8^cD6*aS3-eR5"})
+  void acceptsStrongSecrets(String value) {
+    assertTrue(
+        validator.validate(new Holder(value)).isEmpty(), "expected no violation for: " + value);
+  }
+}


### PR DESCRIPTION
Closes #10 · part of epic #7.

## What
Shared security/crypto foundation for all auth work — no users/tokens/login yet.

- **`io.qnop.security` (qnop-core, ADR-0021)** — `QnopProperties` (`@Validated`, fail-fast on weak/default secrets via `@ValidSecret`), `Hkdf` (RFC 5869), `JwtKeyService` (domain-separated keys), `CryptoConfiguration` (`BCryptPasswordEncoder`, `Encryptors.delux` `TextEncryptor`). Servlet-free — `spring-security-crypto` + validation only.
- **`io.qnop.web.security` (qnop-app)** — `SecurityConfiguration` filter chain: stateless, CORS, CSP/security headers, JSON 401 entry point, `@EnableMethodSecurity`; actuator health public, everything else authenticated.
- **ArchUnit** — new `Security` layer (accessed only by Web/Service) + purity rule.
- **Config** — `QNOP_AUTH_*` / `QNOP_CORS_*` env namespace; no secure default baked in (placeholder trips validation → boot fails fast).
- **ADR-0021** records the split-module placement (crypto in core, filter chain in web) and crypto choices.

## Decision note
ADR-0021 deviates from the issue's literal "one `io.qnop.security` package": the servlet filter chain lands in `io.qnop.web.security` so `qnop-core` stays free of `spring-security-web`/servlet and the service layer can still inject the crypto beans (keeps ADR-0004 layering).

## Test plan
- [x] HKDF against RFC 5869 vectors; secret validation; `TextEncryptor` round-trip; key derivation (determinism + domain separation) — `qnop-core` unit tests (green locally)
- [x] Fail-fast binding (`QnopPropertiesBindingTest`, `ApplicationContextRunner`) — green locally
- [x] ArchUnit `Security` layer + purity rule — green locally
- [x] Spotless + SPDX headers — clean
- [ ] Security filter chain + full boot (`SecurityConfigurationTest`, `QnopApplicationContextTest`) — Testcontainers, **CI only** (no local Docker)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code