### PR TITLE
feat: settings schema (application_setting + user_setting + seed)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/settings/SettingsSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/SettingsSchemaIT.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.ApplicationSetting;
+import io.qnop.entity.SettingValueType;
+import io.qnop.entity.User;
+import io.qnop.entity.UserSetting;
+import io.qnop.repository.ApplicationSettingRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.repository.UserSettingRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the settings schema (issue #13) against a real PostgreSQL (ADR-0020): typed
+ * application/user settings, the seeded defaults, the {@code value_type} CHECK that JPA cannot
+ * express, UUIDv7 generation, the {@code (user_id, setting_key)} uniqueness, the {@code ON DELETE
+ * CASCADE} on user settings, and the {@code ON DELETE SET NULL} audit reference on application
+ * settings. Each test runs in a rolled-back transaction. Extends {@link AbstractIntegrationTest}.
+ * Requires Docker.
+ */
+@Transactional
+class SettingsSchemaIT extends AbstractIntegrationTest {
+
+  @Autowired ApplicationSettingRepository applicationSettings;
+  @Autowired UserSettingRepository userSettings;
+  @Autowired UserRepository users;
+  @Autowired JdbcTemplate jdbc;
+  @PersistenceContext EntityManager entityManager;
+
+  @Test
+  void persistsAndReadsApplicationSetting() {
+    ApplicationSetting saved =
+        applicationSettings.saveAndFlush(
+            new ApplicationSetting("custom.greeting", "hello", SettingValueType.STRING));
+
+    ApplicationSetting found = applicationSettings.findById(saved.getSettingKey()).orElseThrow();
+    assertThat(found.getSettingValue()).isEqualTo("hello");
+    assertThat(found.getValueType()).isEqualTo(SettingValueType.STRING);
+    assertThat(found.getUpdatedAt()).isNotNull();
+  }
+
+  @Test
+  void seedsDefaultSettingsWithDeclaredTypes() {
+    assertThat(applicationSettings.findById("upload.max_file_size_mb"))
+        .get()
+        .satisfies(
+            s -> {
+              assertThat(s.getSettingValue()).isEqualTo("25");
+              assertThat(s.getValueType()).isEqualTo(SettingValueType.INTEGER);
+            });
+    assertThat(applicationSettings.findById("smtp.password"))
+        .get()
+        .satisfies(s -> assertThat(s.getValueType()).isEqualTo(SettingValueType.PASSWORD));
+  }
+
+  @Test
+  void rejectsUnknownValueType() {
+    assertThatThrownBy(
+            () ->
+                jdbc.update(
+                    "INSERT INTO application_setting (setting_key, value_type) VALUES (?, ?)",
+                    "bad.key",
+                    "BOGUS"))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void persistsUserSettingWithGeneratedUuidV7() {
+    User user = users.saveAndFlush(User.internal("Ann", "ann@example.com", "ann", "hash"));
+
+    UserSetting saved =
+        userSettings.saveAndFlush(new UserSetting(user.getId(), "ui.theme", "dark"));
+
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getId().version()).isEqualTo(7);
+    assertThat(userSettings.findByUserIdAndSettingKey(user.getId(), "ui.theme")).isPresent();
+  }
+
+  @Test
+  void enforcesUserSettingUniqueness() {
+    User user = users.saveAndFlush(User.internal("Bea", "bea@example.com", "bea", "hash"));
+    userSettings.saveAndFlush(new UserSetting(user.getId(), "ui.theme", "dark"));
+
+    assertThatThrownBy(
+            () -> userSettings.saveAndFlush(new UserSetting(user.getId(), "ui.theme", "light")))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void cascadesUserSettingsWhenUserRemoved() {
+    User user = users.saveAndFlush(User.internal("Cas", "cas@example.com", "cas", "hash"));
+    UUID settingId =
+        userSettings.saveAndFlush(new UserSetting(user.getId(), "ui.density", "compact")).getId();
+
+    users.deleteById(user.getId());
+    entityManager.flush(); // let the DB-level ON DELETE CASCADE fire
+    entityManager.clear();
+
+    assertThat(userSettings.findById(settingId)).isEmpty();
+  }
+
+  @Test
+  void nullsUpdatedByWhenEditingUserRemoved() {
+    User editor = users.saveAndFlush(User.internal("Ed", "ed@example.com", "ed", "hash"));
+    ApplicationSetting setting =
+        new ApplicationSetting("custom.audited", "v", SettingValueType.STRING);
+    setting.setUpdatedBy(editor.getId());
+    applicationSettings.saveAndFlush(setting);
+
+    users.deleteById(editor.getId());
+    entityManager.flush(); // ON DELETE SET NULL on application_setting.updated_by
+    entityManager.clear();
+
+    ApplicationSetting reloaded = applicationSettings.findById("custom.audited").orElseThrow();
+    assertThat(reloaded.getUpdatedBy()).isNull();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/ApplicationSetting.java
+++ b/qnop-core/src/main/java/io/qnop/entity/ApplicationSetting.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * A global, typed application setting keyed by {@code setting_key} (the natural primary key). The
+ * runtime settings service (issue #16) reads and writes these; superadmins edit them via the admin
+ * API.
+ *
+ * <p>There is intentionally no {@code created_at} (matches the reference model). {@code updatedBy}
+ * is a nullable raw UUID reference to the editing {@link User}; the Postgres {@code ON DELETE SET
+ * NULL} foreign key and the {@code value_type} {@code CHECK} live in Liquibase, not in JPA
+ * annotations (ADR-0020).
+ */
+@Entity
+@Table(name = "application_setting")
+public class ApplicationSetting {
+
+  @Id
+  @Column(name = "setting_key", nullable = false, updatable = false)
+  private String settingKey;
+
+  @Column(name = "setting_value")
+  private String settingValue;
+
+  @Column(name = "setting_desc")
+  private String settingDesc;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "value_type", nullable = false, length = 16)
+  private SettingValueType valueType;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @Column(name = "updated_by")
+  private UUID updatedBy;
+
+  protected ApplicationSetting() {
+    // for JPA
+  }
+
+  public ApplicationSetting(String settingKey, String settingValue, SettingValueType valueType) {
+    this.settingKey = settingKey;
+    this.settingValue = settingValue;
+    this.valueType = valueType;
+  }
+
+  public String getSettingKey() {
+    return settingKey;
+  }
+
+  public String getSettingValue() {
+    return settingValue;
+  }
+
+  public void setSettingValue(String settingValue) {
+    this.settingValue = settingValue;
+  }
+
+  public String getSettingDesc() {
+    return settingDesc;
+  }
+
+  public void setSettingDesc(String settingDesc) {
+    this.settingDesc = settingDesc;
+  }
+
+  public SettingValueType getValueType() {
+    return valueType;
+  }
+
+  public void setValueType(SettingValueType valueType) {
+    this.valueType = valueType;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public UUID getUpdatedBy() {
+    return updatedBy;
+  }
+
+  public void setUpdatedBy(UUID updatedBy) {
+    this.updatedBy = updatedBy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ApplicationSetting other)) {
+      return false;
+    }
+    return settingKey != null && settingKey.equals(other.settingKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(settingKey);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/SettingValueType.java
+++ b/qnop-core/src/main/java/io/qnop/entity/SettingValueType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+/**
+ * The declared type of an {@link ApplicationSetting} (and, by key, a {@link UserSetting}) value.
+ *
+ * <p>Values are stored as text; this type tells the settings service (issue #16) how to parse,
+ * validate, and present each value. {@code PASSWORD} values are encrypted at rest and redacted in
+ * API responses. The set is pinned by a Postgres {@code CHECK} constraint in Liquibase, not here
+ * (ADR-0020).
+ */
+public enum SettingValueType {
+  STRING,
+  INTEGER,
+  BOOLEAN,
+  ENUM,
+  PASSWORD
+}

--- a/qnop-core/src/main/java/io/qnop/entity/UserSetting.java
+++ b/qnop-core/src/main/java/io/qnop/entity/UserSetting.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * A per-user override of a setting, keyed by {@code (user_id, setting_key)} (unique). Identifiers
+ * are UUIDv7, generated application-side by Hibernate.
+ *
+ * <p>{@code user_id} is a raw UUID reference to the owning {@link User} (no {@code @ManyToOne});
+ * the {@code ON DELETE CASCADE} foreign key and the {@code (user_id, setting_key)} uniqueness live
+ * in Liquibase, not in JPA annotations (ADR-0020). There is intentionally no {@code created_at}.
+ */
+@Entity
+@Table(name = "user_setting")
+public class UserSetting {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @Column(name = "setting_key", nullable = false)
+  private String settingKey;
+
+  @Column(name = "setting_value")
+  private String settingValue;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  protected UserSetting() {
+    // for JPA
+  }
+
+  public UserSetting(UUID userId, String settingKey, String settingValue) {
+    this.userId = userId;
+    this.settingKey = settingKey;
+    this.settingValue = settingValue;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public String getSettingKey() {
+    return settingKey;
+  }
+
+  public String getSettingValue() {
+    return settingValue;
+  }
+
+  public void setSettingValue(String settingValue) {
+    this.settingValue = settingValue;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UserSetting other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/ApplicationSettingRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ApplicationSettingRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.ApplicationSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Data access for {@link ApplicationSetting}, keyed by its natural {@code setting_key}. The runtime
+ * settings service (issue #16) loads the full set on startup and refreshes it after writes.
+ */
+public interface ApplicationSettingRepository extends JpaRepository<ApplicationSetting, String> {}

--- a/qnop-core/src/main/java/io/qnop/repository/UserSettingRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserSettingRepository.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.UserSetting;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Data access for {@link UserSetting} (per-user overrides, issue #22). */
+public interface UserSettingRepository extends JpaRepository<UserSetting, UUID> {
+
+  List<UserSetting> findByUserId(UUID userId);
+
+  Optional<UserSetting> findByUserIdAndSettingKey(UUID userId, String settingKey);
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -14,3 +14,6 @@ databaseChangeLog:
   - include:
       file: migrations/0001-identity-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0002-settings-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0002-settings-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0002-settings-schema.yaml
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Settings schema (issue #13): application_setting + user_setting, plus seed
+# defaults. Postgres-only CHECK constraints live here in Liquibase, NOT in JPA
+# annotations (ADR-0020). JPA runs ddl-auto=none, so the entity column mapping
+# must match these definitions exactly.
+databaseChangeLog:
+  - changeSet:
+      id: 0002-settings-application-setting
+      author: qnop
+      comment: Global, typed key/value application settings edited by superadmins (issue #16).
+      changes:
+        - createTable:
+            tableName: application_setting
+            columns:
+              - column:
+                  name: setting_key
+                  type: VARCHAR(128)
+                  constraints: { primaryKey: true, nullable: false }
+              - column: { name: setting_value, type: TEXT }
+              - column: { name: setting_desc, type: VARCHAR(512) }
+              - column:
+                  name: value_type
+                  type: VARCHAR(16)
+                  constraints: { nullable: false }
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: now()
+                  constraints: { nullable: false }
+              # Nullable audit reference; kept as a raw UUID column (no @ManyToOne).
+              - column: { name: updated_by, type: UUID }
+        - addForeignKeyConstraint:
+            baseTableName: application_setting
+            baseColumnNames: updated_by
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            constraintName: fk_application_setting_updated_by
+            onDelete: SET NULL
+        - sql:
+            comment: Postgres-only CHECK on the value-type enum (not expressible in JPA).
+            sql: |
+              ALTER TABLE application_setting ADD CONSTRAINT ck_application_setting_value_type
+                CHECK (value_type IN ('STRING', 'INTEGER', 'BOOLEAN', 'ENUM', 'PASSWORD'));
+
+  - changeSet:
+      id: 0002-settings-user-setting
+      author: qnop
+      comment: Per-user setting overrides; cascades when the user is deleted (issue #22).
+      changes:
+        - createTable:
+            tableName: user_setting
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: setting_key
+                  type: VARCHAR(128)
+                  constraints: { nullable: false }
+              - column: { name: setting_value, type: TEXT }
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+        - addForeignKeyConstraint:
+            baseTableName: user_setting
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            constraintName: fk_user_setting_user
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: user_setting
+            columnNames: user_id, setting_key
+            constraintName: ux_user_setting_user_key
+
+  - changeSet:
+      id: 0002-settings-seed
+      author: qnop
+      comment: Default application settings. Must mirror the ApplicationSettingKey registry (issue #16).
+      changes:
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "general.application_name" }
+              - column: { name: setting_value, value: "qnop" }
+              - column: { name: setting_desc, value: "Display name of this qnop instance." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "general.base_url" }
+              - column: { name: setting_value, value: "" }
+              - column: { name: setting_desc, value: "Public base URL, used in generated links and emails." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "general.default_language" }
+              - column: { name: setting_value, value: "en" }
+              - column: { name: setting_desc, value: "Default UI language (ISO 639-1)." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "upload.max_file_size_mb" }
+              - column: { name: setting_value, value: "25" }
+              - column: { name: setting_desc, value: "Maximum document upload size in megabytes." }
+              - column: { name: value_type, value: "INTEGER" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "tracking.enabled" }
+              - column: { name: setting_value, value: "false" }
+              - column: { name: setting_desc, value: "Whether anonymous usage tracking is enabled." }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "tracking.provider" }
+              - column: { name: setting_value, value: "none" }
+              - column: { name: setting_desc, value: "Usage-tracking provider." }
+              - column: { name: value_type, value: "ENUM" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "smtp.host" }
+              - column: { name: setting_value, value: "" }
+              - column: { name: setting_desc, value: "SMTP server host." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "smtp.port" }
+              - column: { name: setting_value, value: "587" }
+              - column: { name: setting_desc, value: "SMTP server port." }
+              - column: { name: value_type, value: "INTEGER" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "smtp.username" }
+              - column: { name: setting_value, value: "" }
+              - column: { name: setting_desc, value: "SMTP authentication username." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "smtp.password" }
+              - column: { name: setting_value, value: "" }
+              - column: { name: setting_desc, value: "SMTP authentication password (stored encrypted, redacted in API)." }
+              - column: { name: value_type, value: "PASSWORD" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "smtp.from" }
+              - column: { name: setting_value, value: "" }
+              - column: { name: setting_desc, value: "Default From address for outgoing mail." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "smtp.tls_enabled" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: setting_desc, value: "Whether to use STARTTLS for SMTP." }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "auth.self_registration_enabled" }
+              - column: { name: setting_value, value: "false" }
+              - column: { name: setting_desc, value: "Whether visitors may register their own local accounts." }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "auth.self_registration_default_role" }
+              - column: { name: setting_value, value: "USER" }
+              - column: { name: setting_desc, value: "Role assigned to self-registered users." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "auth.password_reset_enabled" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: setting_desc, value: "Whether local users may reset their password by email." }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "auth.password_reset_token_ttl_minutes" }
+              - column: { name: setting_value, value: "30" }
+              - column: { name: setting_desc, value: "Validity window of a password-reset token, in minutes." }
+              - column: { name: value_type, value: "INTEGER" }


### PR DESCRIPTION
Closes #13 · part of epic #7 · depends on #11 (merged).

## What
Settings persistence layer following the identity-schema conventions (#11).

- **`application_setting`** — typed key/value: `setting_key` natural PK, `value_type` (`SettingValueType` STRING/INTEGER/BOOLEAN/ENUM/PASSWORD) pinned by a Postgres `CHECK`, nullable `updated_by` audit FK → `qnop_user` `ON DELETE SET NULL`, `updated_at` (default `now()` for seed), **no `created_at`**.
- **`user_setting`** — UUIDv7 surrogate `id`, `user_id` FK → `qnop_user` `ON DELETE CASCADE`, `unique(user_id, setting_key)`, no `created_at`.
- Liquibase `0002-settings-schema.yaml` (schema + seed) wired into the master changelog; Postgres-only `CHECK`/FK/unique live in Liquibase, not JPA (ADR-0020).
- Entities `ApplicationSetting`/`UserSetting` (raw-UUID FK columns, `@Enumerated(STRING)`, `@UpdateTimestamp`); repos `ApplicationSettingRepository`/`UserSettingRepository`.
- Seed defaults: `general.*`, `upload.max_file_size_mb`, `tracking.*`, `smtp.*` (`smtp.password` = PASSWORD), `auth.self_registration_*`, `auth.password_reset_*`.

## Note
Seed keys must stay in sync with the `ApplicationSettingKey` registry built in **#16** (single source of truth for defaults/validation/redaction).

## Test plan
- [x] Compile (core + app), Spotless + SPDX, ArchUnit layering — green locally
- [ ] `SettingsSchemaIT` (Testcontainers): typed read/write, seeded defaults + types, `value_type` CHECK rejection, UUIDv7, `(user_id,setting_key)` uniqueness, user-delete CASCADE, `updated_by` SET NULL — **CI only** (no local Docker)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code