### PR TITLE
feat: mail template schema (mail_template + en seed)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/mail/MailTemplateSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/mail/MailTemplateSchemaIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.MailTemplate;
+import io.qnop.repository.MailTemplateRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the mail-template schema (issue #14) against a real PostgreSQL (ADR-0020): the English
+ * seed templates are applied by Liquibase, the {@code (template_key, locale)} uniqueness holds, the
+ * key lookup backs the locale fallback chain, and new rows get a generated UUIDv7. Each test runs
+ * in a rolled-back transaction. Requires Docker.
+ */
+@Transactional
+class MailTemplateSchemaIT extends AbstractIntegrationTest {
+
+  @Autowired MailTemplateRepository templates;
+
+  @Test
+  void seedsEnglishAuthTemplates() {
+    assertThat(templates.findByTemplateKeyAndLocale("auth.registration_verification", "en"))
+        .hasValueSatisfying(
+            t -> {
+              assertThat(t.getSubject()).contains("{{siteName}}");
+              assertThat(t.getBodyPlain()).contains("{{username}}", "{{verificationLink}}");
+              assertThat(t.getBodyHtml()).isNotBlank();
+            });
+    assertThat(templates.findByTemplateKeyAndLocale("auth.password_reset", "en"))
+        .hasValueSatisfying(t -> assertThat(t.getBodyPlain()).contains("{{resetLink}}"));
+    assertThat(templates.findByTemplateKeyAndLocale("auth.admin_password_reset", "en")).isPresent();
+  }
+
+  @Test
+  void enforcesKeyLocaleUniqueness() {
+    // auth.registration_verification/en already exists from the seed.
+    MailTemplate duplicate =
+        new MailTemplate("auth.registration_verification", "en", "Dup", "body");
+
+    assertThatThrownBy(() -> templates.saveAndFlush(duplicate))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void findByTemplateKeyReturnsEveryLocaleVariant() {
+    templates.saveAndFlush(
+        new MailTemplate("auth.password_reset", "de", "Passwort zuruecksetzen", "Hallo"));
+
+    assertThat(templates.findByTemplateKey("auth.password_reset"))
+        .extracting(MailTemplate::getLocale)
+        .contains("en", "de");
+  }
+
+  @Test
+  void persistsNewTemplateWithGeneratedUuidV7() {
+    MailTemplate saved =
+        templates.saveAndFlush(new MailTemplate("test.sample", "en", "Subject", "Body"));
+
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getId().version()).isEqualTo(7);
+    assertThat(saved.getUpdatedAt()).isNotNull();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/MailTemplate.java
+++ b/qnop-core/src/main/java/io/qnop/entity/MailTemplate.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * One per-locale email template variant (issue #14). {@code templateKey} is a dotted identifier
+ * (e.g. {@code auth.password_reset}); {@code locale} is a BCP-47 tag, so {@code (templateKey,
+ * locale)} is unique and new languages are added purely as rows. {@code bodyPlain} is always
+ * present; {@code bodyHtml} is the optional alternative the mail layer sends as
+ * multipart/alternative. Subject and bodies carry Mustache placeholders rendered at send time
+ * (issue #19). There is intentionally no {@code created_at}.
+ */
+@Entity
+@Table(name = "mail_template")
+public class MailTemplate {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "template_key", nullable = false, length = 128, updatable = false)
+  private String templateKey;
+
+  @Column(name = "locale", nullable = false, length = 16, updatable = false)
+  private String locale;
+
+  @Column(name = "subject", nullable = false, columnDefinition = "text")
+  private String subject;
+
+  @Column(name = "body_plain", nullable = false, columnDefinition = "text")
+  private String bodyPlain;
+
+  @Column(name = "body_html", columnDefinition = "text")
+  private String bodyHtml;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @Column(name = "updated_by", length = 255)
+  private String updatedBy;
+
+  protected MailTemplate() {
+    // for JPA
+  }
+
+  public MailTemplate(String templateKey, String locale, String subject, String bodyPlain) {
+    this.templateKey = templateKey;
+    this.locale = locale;
+    this.subject = subject;
+    this.bodyPlain = bodyPlain;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getTemplateKey() {
+    return templateKey;
+  }
+
+  public String getLocale() {
+    return locale;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  public String getBodyPlain() {
+    return bodyPlain;
+  }
+
+  public void setBodyPlain(String bodyPlain) {
+    this.bodyPlain = bodyPlain;
+  }
+
+  public String getBodyHtml() {
+    return bodyHtml;
+  }
+
+  public void setBodyHtml(String bodyHtml) {
+    this.bodyHtml = bodyHtml;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  public void setUpdatedBy(String updatedBy) {
+    this.updatedBy = updatedBy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MailTemplate other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/MailTemplateRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/MailTemplateRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.MailTemplate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Data access for {@link MailTemplate}. */
+public interface MailTemplateRepository extends JpaRepository<MailTemplate, UUID> {
+
+  /** Resolves the exact template for a key and locale. */
+  Optional<MailTemplate> findByTemplateKeyAndLocale(String templateKey, String locale);
+
+  /** All locale variants of a template — backs the render-time fallback chain (issue #19). */
+  List<MailTemplate> findByTemplateKey(String templateKey);
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -17,3 +17,6 @@ databaseChangeLog:
   - include:
       file: migrations/0002-settings-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0003-mail-template-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0003-mail-template-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0003-mail-template-schema.yaml
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Mail template schema (issue #14): per-locale email templates stored in the
+# database so operators can edit them at runtime (admin UI lands with #19). The
+# composite unique on (template_key, locale) makes future i18n purely additive —
+# a new locale is just another row, no schema change. Two body columns:
+# body_plain is always required (accessibility / spam-filter friendliness),
+# body_html is the optional alternative the mail layer sends as
+# multipart/alternative. Seeds ship usable English defaults out of the box;
+# Mustache placeholders ({{username}}, {{verificationLink}}/{{resetLink}},
+# {{expiresAtHuman}}, {{siteName}}) are rendered by MailTemplateService (#19).
+databaseChangeLog:
+  - changeSet:
+      id: 0003-create-mail-template
+      author: qnop
+      comment: Per-locale email template storage.
+      changes:
+        - createTable:
+            tableName: mail_template
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: template_key
+                  type: VARCHAR(128)
+                  constraints: { nullable: false }
+              - column:
+                  name: locale
+                  type: VARCHAR(16)
+                  constraints: { nullable: false }
+              - column:
+                  name: subject
+                  type: TEXT
+                  constraints: { nullable: false }
+              - column:
+                  name: body_plain
+                  type: TEXT
+                  constraints: { nullable: false }
+              - column: { name: body_html, type: TEXT }
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: now()
+                  constraints: { nullable: false }
+              - column: { name: updated_by, type: VARCHAR(255) }
+        - addUniqueConstraint:
+            tableName: mail_template
+            columnNames: template_key, locale
+            constraintName: ux_mail_template_key_locale
+        - createIndex:
+            tableName: mail_template
+            indexName: idx_mail_template_key
+            columns:
+              - column: { name: template_key }
+      rollback:
+        - dropTable:
+            tableName: mail_template
+
+  - changeSet:
+      id: 0003-seed-auth-registration-verification-en
+      author: qnop
+      comment: English default for the account-verification email.
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: auth.registration_verification }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "Verify your {{siteName}} account" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{username}},
+
+                    Please verify your email address to finish setting up your
+                    {{siteName}} account. This link expires {{expiresAtHuman}}.
+
+                    {{verificationLink}}
+
+                    If you did not create an account, you can safely ignore this message.
+              - column:
+                  name: body_html
+                  value: |
+                    <!DOCTYPE html>
+                    <html>
+                      <body>
+                        <p>Hi {{username}},</p>
+                        <p>Please verify your email address to finish setting up your
+                          {{siteName}} account. This link expires {{expiresAtHuman}}.</p>
+                        <p><a href="{{verificationLink}}">Verify my email</a></p>
+                        <p>If the button does not work, paste this URL into your browser:<br>
+                          <a href="{{verificationLink}}">{{verificationLink}}</a></p>
+                        <p style="color:#666;font-size:0.9em;">If you did not create an account,
+                          you can safely ignore this message.</p>
+                      </body>
+                    </html>
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'auth.registration_verification' AND locale = 'en'"
+
+  - changeSet:
+      id: 0003-seed-auth-password-reset-en
+      author: qnop
+      comment: English default for the self-service password-reset email.
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: auth.password_reset }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "Reset your {{siteName}} password" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{username}},
+
+                    We received a request to reset the password on your {{siteName}}
+                    account. Click the link below to choose a new one — it is valid
+                    {{expiresAtHuman}}.
+
+                    {{resetLink}}
+
+                    If you did not request a password reset, you can safely ignore this
+                    message — your existing password remains active.
+              - column:
+                  name: body_html
+                  value: |
+                    <!DOCTYPE html>
+                    <html>
+                      <body>
+                        <p>Hi {{username}},</p>
+                        <p>We received a request to reset the password on your {{siteName}}
+                          account. Click the button below to choose a new one — it is valid
+                          {{expiresAtHuman}}.</p>
+                        <p><a href="{{resetLink}}">Reset my password</a></p>
+                        <p>If the button does not work, paste this URL into your browser:<br>
+                          <a href="{{resetLink}}">{{resetLink}}</a></p>
+                        <p style="color:#666;font-size:0.9em;">If you did not request a password
+                          reset, you can safely ignore this message — your existing password
+                          remains active.</p>
+                      </body>
+                    </html>
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'auth.password_reset' AND locale = 'en'"
+
+  - changeSet:
+      id: 0003-seed-auth-admin-password-reset-en
+      author: qnop
+      comment: English default for the admin-initiated password-reset email.
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: auth.admin_password_reset }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "An administrator reset your {{siteName}} password" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{username}},
+
+                    An administrator has initiated a password reset on your {{siteName}}
+                    account. Click the link below to choose a new password — it is valid
+                    {{expiresAtHuman}}.
+
+                    {{resetLink}}
+
+                    If you have questions about this change, contact your administrator.
+              - column:
+                  name: body_html
+                  value: |
+                    <!DOCTYPE html>
+                    <html>
+                      <body>
+                        <p>Hi {{username}},</p>
+                        <p>An administrator has initiated a password reset on your {{siteName}}
+                          account. Click the button below to choose a new password — it is valid
+                          {{expiresAtHuman}}.</p>
+                        <p><a href="{{resetLink}}">Choose new password</a></p>
+                        <p>If the button does not work, paste this URL into your browser:<br>
+                          <a href="{{resetLink}}">{{resetLink}}</a></p>
+                        <p style="color:#666;font-size:0.9em;">If you have questions about this
+                          change, contact your administrator.</p>
+                      </body>
+                    </html>
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'auth.admin_password_reset' AND locale = 'en'"


### PR DESCRIPTION
## What

Adds the DB-stored mail-template schema for the mail subsystem (#19). Closes #14.

### Schema (Liquibase `0002-mail-template-schema.yaml`)
- `mail_template`: UUIDv7 `id`, `template_key` (varchar 128), `locale` (varchar 16, BCP-47), `subject`/`body_plain` TEXT, optional `body_html` TEXT, `updated_at` timestamptz `default now()`, `updated_by` varchar(255) null. `unique(template_key, locale)` + index on `template_key`. No `created_at` (matches the plugwerk reference table).
- Seeds English `auth.registration_verification`, `auth.password_reset`, `auth.admin_password_reset` (plain + HTML) with Mustache placeholders; ids via `gen_random_uuid()`, each changeset with a rollback delete.

### Entity & repository
- `MailTemplate` entity (UUIDv7 via `@UuidGenerator(VERSION_7)`, `@UpdateTimestamp`), `MailTemplateRepository` with `findByTemplateKeyAndLocale` and `findByTemplateKey` (for the locale fallback chain in #19).

## plugwerk parity / deviations
Modeled on plugwerk's `mail_template` (`updated_by` = nullable `varchar(255)`, TEXT bodies, seed plain+HTML). Deviations: UUIDs use **VERSION_7** per ADR-0023 (plugwerk uses TIME); subjects use a `{{siteName}}` placeholder instead of a hard-coded brand.

## Note for #19
The entity is named `MailTemplate`, so the template-key enum in #19 should be `MailTemplateKey` to avoid a clash.

## Test plan
- [x] compile, spotlessCheck, ArchUnit (local)
- [ ] Testcontainers IT (`MailTemplateSchemaIT`) — runs in CI (Docker): seed presence, `(key, locale)` uniqueness, key lookup, UUIDv7.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code
