### PR TITLE
feat: token schema (refresh/revoked/email-verification/password-reset) (#12)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/token/TokenSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/token/TokenSchemaIT.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.EmailVerificationToken;
+import io.qnop.entity.PasswordResetToken;
+import io.qnop.entity.RefreshToken;
+import io.qnop.entity.RevokedToken;
+import io.qnop.entity.User;
+import io.qnop.repository.EmailVerificationTokenRepository;
+import io.qnop.repository.PasswordResetTokenRepository;
+import io.qnop.repository.RefreshTokenRepository;
+import io.qnop.repository.RevokedTokenRepository;
+import io.qnop.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the token schema (issue #12) against a real PostgreSQL (ADR-0020): UUIDv7 generation,
+ * the unique hash indexes, the custom revoke/lookup queries, the {@code ON DELETE CASCADE} FKs to
+ * {@code qnop_user}, and the refresh-token rotation self-FK ({@code ON DELETE SET NULL}). Each test
+ * runs in a rolled-back transaction. Extends {@link AbstractIntegrationTest} (Testcontainers).
+ * Requires Docker.
+ */
+@Transactional
+class TokenSchemaIT extends AbstractIntegrationTest {
+
+  private static final Instant EXPIRES = Instant.now().plus(1, ChronoUnit.HOURS);
+
+  @Autowired RefreshTokenRepository refreshTokens;
+  @Autowired RevokedTokenRepository revokedTokens;
+  @Autowired EmailVerificationTokenRepository emailTokens;
+  @Autowired PasswordResetTokenRepository passwordResetTokens;
+  @Autowired UserRepository users;
+  @PersistenceContext EntityManager entityManager;
+
+  private User newUser() {
+    return users.saveAndFlush(
+        User.internal(
+            "Alice",
+            "alice-" + UUID.randomUUID() + "@example.com",
+            "u-" + UUID.randomUUID(),
+            "hash"));
+  }
+
+  // --- refresh_token -------------------------------------------------------
+
+  @Test
+  void persistsRefreshTokenWithGeneratedUuidV7AndIssuedAt() {
+    User user = newUser();
+
+    RefreshToken saved =
+        refreshTokens.saveAndFlush(
+            new RefreshToken(UUID.randomUUID(), user.getId(), "lookup-1", EXPIRES));
+
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getId().version()).isEqualTo(7);
+    assertThat(saved.getIssuedAt()).isNotNull();
+  }
+
+  @Test
+  void enforcesRefreshTokenLookupHashUniqueness() {
+    User user = newUser();
+    refreshTokens.saveAndFlush(
+        new RefreshToken(UUID.randomUUID(), user.getId(), "dup-hash", EXPIRES));
+
+    assertThatThrownBy(
+            () ->
+                refreshTokens.saveAndFlush(
+                    new RefreshToken(UUID.randomUUID(), user.getId(), "dup-hash", EXPIRES)))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void revokeFamilyRevokesOnlyStillActiveRows() {
+    User user = newUser();
+    UUID family = UUID.randomUUID();
+    RefreshToken active =
+        refreshTokens.saveAndFlush(new RefreshToken(family, user.getId(), "active", EXPIRES));
+    RefreshToken alreadyRevoked = new RefreshToken(family, user.getId(), "revoked", EXPIRES);
+    alreadyRevoked.setRevokedAt(Instant.now().minusSeconds(60));
+    alreadyRevoked.setRevocationReason("ROTATED");
+    refreshTokens.saveAndFlush(alreadyRevoked);
+
+    int affected = refreshTokens.revokeFamily(family, "REUSE_DETECTED", Instant.now());
+
+    assertThat(affected).isEqualTo(1);
+    assertThat(refreshTokens.findById(active.getId()).orElseThrow().getRevocationReason())
+        .isEqualTo("REUSE_DETECTED");
+    // The pre-revoked row keeps its original reason (forensics).
+    assertThat(refreshTokens.findById(alreadyRevoked.getId()).orElseThrow().getRevocationReason())
+        .isEqualTo("ROTATED");
+  }
+
+  @Test
+  void revokeAllForUserRevokesActiveTokens() {
+    User user = newUser();
+    refreshTokens.saveAndFlush(new RefreshToken(UUID.randomUUID(), user.getId(), "a", EXPIRES));
+    refreshTokens.saveAndFlush(new RefreshToken(UUID.randomUUID(), user.getId(), "b", EXPIRES));
+
+    int affected = refreshTokens.revokeAllForUser(user.getId(), "LOGOUT", Instant.now());
+
+    assertThat(affected).isEqualTo(2);
+  }
+
+  @Test
+  void cascadesRefreshTokenDeletionWhenUserRemoved() {
+    User user = newUser();
+    RefreshToken token =
+        refreshTokens.saveAndFlush(new RefreshToken(UUID.randomUUID(), user.getId(), "c", EXPIRES));
+
+    users.deleteById(user.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(refreshTokens.findById(token.getId())).isEmpty();
+  }
+
+  @Test
+  void nullsRotatedToIdWhenSuccessorDeleted() {
+    User user = newUser();
+    UUID family = UUID.randomUUID();
+    RefreshToken successor =
+        refreshTokens.saveAndFlush(new RefreshToken(family, user.getId(), "succ", EXPIRES));
+    RefreshToken predecessor = new RefreshToken(family, user.getId(), "pred", EXPIRES);
+    predecessor.setRotatedToId(successor.getId());
+    refreshTokens.saveAndFlush(predecessor);
+
+    refreshTokens.deleteById(successor.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(refreshTokens.findById(predecessor.getId()).orElseThrow().getRotatedToId()).isNull();
+  }
+
+  // --- revoked_token -------------------------------------------------------
+
+  @Test
+  void revokedTokenExistsByJtiAndEnforcesUniqueness() {
+    User user = newUser();
+    revokedTokens.saveAndFlush(new RevokedToken("jti-hash", user.getId(), EXPIRES));
+
+    assertThat(revokedTokens.existsByJti("jti-hash")).isTrue();
+    assertThat(revokedTokens.existsByJti("absent")).isFalse();
+    assertThatThrownBy(
+            () -> revokedTokens.saveAndFlush(new RevokedToken("jti-hash", user.getId(), EXPIRES)))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void cascadesRevokedTokenWhenUserRemoved() {
+    User user = newUser();
+    RevokedToken token =
+        revokedTokens.saveAndFlush(new RevokedToken("jti-x", user.getId(), EXPIRES));
+
+    users.deleteById(user.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(revokedTokens.findById(token.getId())).isEmpty();
+  }
+
+  // --- email_verification_token / password_reset_token ---------------------
+
+  @Test
+  void emailVerificationReturnsOnlyUnconsumedTokensAndExposesEagerUser() {
+    User user = newUser();
+    emailTokens.saveAndFlush(new EmailVerificationToken(user, "ev-active", EXPIRES));
+    EmailVerificationToken consumed = new EmailVerificationToken(user, "ev-consumed", EXPIRES);
+    consumed.setConsumedAt(Instant.now());
+    emailTokens.saveAndFlush(consumed);
+
+    var unconsumed = emailTokens.findUnconsumedTokensForUser(user.getId());
+
+    assertThat(unconsumed)
+        .singleElement()
+        .satisfies(t -> assertThat(t.getTokenHash()).isEqualTo("ev-active"));
+    assertThat(emailTokens.findByTokenHash("ev-active").orElseThrow().getUser().getId())
+        .isEqualTo(user.getId());
+  }
+
+  @Test
+  void enforcesEmailVerificationTokenHashUniqueness() {
+    User user = newUser();
+    emailTokens.saveAndFlush(new EmailVerificationToken(user, "ev-dup", EXPIRES));
+
+    assertThatThrownBy(
+            () -> emailTokens.saveAndFlush(new EmailVerificationToken(user, "ev-dup", EXPIRES)))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void passwordResetReturnsOnlyUnconsumedTokensAndCascades() {
+    User user = newUser();
+    PasswordResetToken token =
+        passwordResetTokens.saveAndFlush(new PasswordResetToken(user, "pr-active", EXPIRES));
+    PasswordResetToken consumed = new PasswordResetToken(user, "pr-consumed", EXPIRES);
+    consumed.setConsumedAt(Instant.now());
+    passwordResetTokens.saveAndFlush(consumed);
+
+    assertThat(passwordResetTokens.findUnconsumedTokensForUser(user.getId())).hasSize(1);
+
+    users.deleteById(user.getId());
+    entityManager.flush();
+    entityManager.clear();
+    assertThat(passwordResetTokens.findById(token.getId())).isEmpty();
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/token/TokenSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/token/TokenSchemaIT.java
@@ -229,6 +229,10 @@ class TokenSchemaIT extends AbstractIntegrationTest {
 
     assertThat(passwordResetTokens.findUnconsumedTokensForUser(user.getId())).hasSize(1);
 
+    // Detach the managed tokens first: their EAGER @ManyToOne to the user would
+    // otherwise trip Hibernate's transient-reference check on flush and mask the
+    // DB-level ON DELETE CASCADE we want to verify.
+    entityManager.clear();
     users.deleteById(user.getId());
     entityManager.flush();
     entityManager.clear();

--- a/qnop-core/src/main/java/io/qnop/entity/EmailVerificationToken.java
+++ b/qnop-core/src/main/java/io/qnop/entity/EmailVerificationToken.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * One row per issued self-registration email-verification token (lifecycle added with the
+ * local-user flow, #20).
+ *
+ * <p>The raw token is never stored — {@code tokenHash} holds hex-encoded SHA-256 (so a DB leak
+ * alone cannot grant account access); the raw token lives only in the verification email and the
+ * inbound {@code ?token=…} query parameter. {@code consumedAt} flips when the link is used; the row
+ * is kept for audit until a scheduled sweep removes expired rows.
+ *
+ * <p>Unlike the other token entities, {@code user} is an <strong>EAGER {@code @ManyToOne}</strong>:
+ * the verify-email consumers read the linked user outside the service transaction (to flip {@code
+ * enabled} / send to {@code email}), and LAZY would raise {@code LazyInitializationException}. The
+ * FK to {@code qnop_user} cascades on delete (Liquibase, ADR-0020).
+ */
+@Entity
+@Table(name = "email_verification_token")
+public class EmailVerificationToken {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "user_id", nullable = false, updatable = false)
+  private User user;
+
+  @Column(name = "token_hash", nullable = false, unique = true, length = 64, updatable = false)
+  private String tokenHash;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "expires_at", nullable = false)
+  private Instant expiresAt;
+
+  @Column(name = "consumed_at")
+  private Instant consumedAt;
+
+  protected EmailVerificationToken() {
+    // for JPA
+  }
+
+  public EmailVerificationToken(User user, String tokenHash, Instant expiresAt) {
+    this.user = user;
+    this.tokenHash = tokenHash;
+    this.expiresAt = expiresAt;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public String getTokenHash() {
+    return tokenHash;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getExpiresAt() {
+    return expiresAt;
+  }
+
+  public Instant getConsumedAt() {
+    return consumedAt;
+  }
+
+  public void setConsumedAt(Instant consumedAt) {
+    this.consumedAt = consumedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof EmailVerificationToken other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/PasswordResetToken.java
+++ b/qnop-core/src/main/java/io/qnop/entity/PasswordResetToken.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * One row per issued self-service password-reset token (lifecycle added with the local-user flow,
+ * #20).
+ *
+ * <p>Storage and lifecycle mirror {@link EmailVerificationToken}: the raw token lives only in the
+ * reset-link email plus the inbound reset request body, and only hex-encoded SHA-256 is persisted
+ * in {@code tokenHash}, so a DB leak alone cannot impersonate a user. {@code consumedAt} flips when
+ * the token is exchanged for a new password; the row is kept for audit until a scheduled sweep
+ * removes it.
+ *
+ * <p>{@code user} is an EAGER {@code @ManyToOne} for the same reason as {@link
+ * EmailVerificationToken} (the reset-password consumer reads the user outside the service
+ * transaction). The FK to {@code qnop_user} cascades on delete (Liquibase, ADR-0020).
+ */
+@Entity
+@Table(name = "password_reset_token")
+public class PasswordResetToken {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "user_id", nullable = false, updatable = false)
+  private User user;
+
+  @Column(name = "token_hash", nullable = false, unique = true, length = 64, updatable = false)
+  private String tokenHash;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "expires_at", nullable = false)
+  private Instant expiresAt;
+
+  @Column(name = "consumed_at")
+  private Instant consumedAt;
+
+  protected PasswordResetToken() {
+    // for JPA
+  }
+
+  public PasswordResetToken(User user, String tokenHash, Instant expiresAt) {
+    this.user = user;
+    this.tokenHash = tokenHash;
+    this.expiresAt = expiresAt;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public String getTokenHash() {
+    return tokenHash;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getExpiresAt() {
+    return expiresAt;
+  }
+
+  public Instant getConsumedAt() {
+    return consumedAt;
+  }
+
+  public void setConsumedAt(Instant consumedAt) {
+    this.consumedAt = consumedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PasswordResetToken other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/RefreshToken.java
+++ b/qnop-core/src/main/java/io/qnop/entity/RefreshToken.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * Server-side record backing the opaque refresh cookie.
+ *
+ * <p>Only the HMAC-SHA256 of the plaintext refresh token is stored ({@code tokenLookupHash}); the
+ * plaintext lives exactly once in the {@code Set-Cookie} header and never touches disk. Lookup is a
+ * unique-index equality probe (constant-time). Every successful refresh revokes this row (sets
+ * {@code revokedAt} + {@code revocationReason}) and issues a successor linked via {@code
+ * rotatedToId}; replaying a revoked token force-revokes the whole {@code familyId} group
+ * (reuse-detection). The token-minting/rotation logic itself lands with the JWT/session core (#17).
+ *
+ * <p>FKs are raw UUID columns (no {@code @ManyToOne}); the FK to {@code qnop_user} cascades on
+ * delete and the self-FK {@code rotatedToId} is {@code SET NULL} — both defined in Liquibase
+ * (ADR-0020). Identifiers are UUIDv7, generated application-side by Hibernate.
+ */
+@Entity
+@Table(name = "refresh_token")
+public class RefreshToken {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "family_id", nullable = false, updatable = false)
+  private UUID familyId;
+
+  @Column(name = "user_id", nullable = false, updatable = false)
+  private UUID userId;
+
+  @Column(
+      name = "token_lookup_hash",
+      nullable = false,
+      unique = true,
+      length = 64,
+      updatable = false)
+  private String tokenLookupHash;
+
+  @CreationTimestamp
+  @Column(name = "issued_at", nullable = false, updatable = false)
+  private Instant issuedAt;
+
+  @Column(name = "expires_at", nullable = false, updatable = false)
+  private Instant expiresAt;
+
+  @Column(name = "revoked_at")
+  private Instant revokedAt;
+
+  @Column(name = "revocation_reason", length = 32)
+  private String revocationReason;
+
+  @Column(name = "rotated_to_id")
+  private UUID rotatedToId;
+
+  @Column(name = "upstream_id_token", columnDefinition = "TEXT")
+  private String upstreamIdToken;
+
+  protected RefreshToken() {
+    // for JPA
+  }
+
+  public RefreshToken(UUID familyId, UUID userId, String tokenLookupHash, Instant expiresAt) {
+    this.familyId = familyId;
+    this.userId = userId;
+    this.tokenLookupHash = tokenLookupHash;
+    this.expiresAt = expiresAt;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getFamilyId() {
+    return familyId;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public String getTokenLookupHash() {
+    return tokenLookupHash;
+  }
+
+  public Instant getIssuedAt() {
+    return issuedAt;
+  }
+
+  public Instant getExpiresAt() {
+    return expiresAt;
+  }
+
+  public Instant getRevokedAt() {
+    return revokedAt;
+  }
+
+  public void setRevokedAt(Instant revokedAt) {
+    this.revokedAt = revokedAt;
+  }
+
+  public String getRevocationReason() {
+    return revocationReason;
+  }
+
+  public void setRevocationReason(String revocationReason) {
+    this.revocationReason = revocationReason;
+  }
+
+  public UUID getRotatedToId() {
+    return rotatedToId;
+  }
+
+  public void setRotatedToId(UUID rotatedToId) {
+    this.rotatedToId = rotatedToId;
+  }
+
+  public String getUpstreamIdToken() {
+    return upstreamIdToken;
+  }
+
+  public void setUpstreamIdToken(String upstreamIdToken) {
+    this.upstreamIdToken = upstreamIdToken;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RefreshToken other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/RevokedToken.java
+++ b/qnop-core/src/main/java/io/qnop/entity/RevokedToken.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * Denylist entry for a revoked access-token {@code jti}.
+ *
+ * <p>On logout or password change the SHA-256 hash of the token's {@code jti} claim is stored here
+ * so the JWT decoder can reject the token before its natural expiry (the validation path is added
+ * with the JWT/session core, #17). Expired rows are purged by a scheduled cleanup job.
+ *
+ * <p><strong>Hashed at rest:</strong> the {@code jti} column holds hex-encoded SHA-256, never the
+ * raw claim — the only question asked is "have I seen this jti?", which a digest answers, so a DB
+ * leak exposes opaque hashes rather than valid token IDs. The FK to {@code qnop_user} cascades on
+ * delete (Liquibase, ADR-0020); the user is a raw UUID (lookups never need the user object).
+ */
+@Entity
+@Table(name = "revoked_token")
+public class RevokedToken {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "jti", nullable = false, unique = true, length = 64, updatable = false)
+  private String jti;
+
+  @Column(name = "user_id", nullable = false, updatable = false)
+  private UUID userId;
+
+  @Column(name = "expires_at", nullable = false, updatable = false)
+  private Instant expiresAt;
+
+  @CreationTimestamp
+  @Column(name = "revoked_at", nullable = false, updatable = false)
+  private Instant revokedAt;
+
+  protected RevokedToken() {
+    // for JPA
+  }
+
+  public RevokedToken(String jti, UUID userId, Instant expiresAt) {
+    this.jti = jti;
+    this.userId = userId;
+    this.expiresAt = expiresAt;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getJti() {
+    return jti;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public Instant getExpiresAt() {
+    return expiresAt;
+  }
+
+  public Instant getRevokedAt() {
+    return revokedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RevokedToken other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/EmailVerificationTokenRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/EmailVerificationTokenRepository.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.EmailVerificationToken;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Data access for {@link EmailVerificationToken}. */
+public interface EmailVerificationTokenRepository
+    extends JpaRepository<EmailVerificationToken, UUID> {
+
+  /** Lookup by the hex-encoded SHA-256 of the raw token presented on the verify-email link. */
+  Optional<EmailVerificationToken> findByTokenHash(String tokenHash);
+
+  /**
+   * All in-flight (unconsumed) tokens for a user — used by the resend path to invalidate previous
+   * tokens before issuing a fresh one, so a user never has two valid verification links at once.
+   */
+  @Query(
+      "SELECT t FROM EmailVerificationToken t WHERE t.user.id = :userId AND t.consumedAt IS NULL")
+  List<EmailVerificationToken> findUnconsumedTokensForUser(@Param("userId") UUID userId);
+
+  /** Scheduled-sweep target: rows whose {@code expires_at} has passed. */
+  long deleteByExpiresAtBefore(Instant cutoff);
+}

--- a/qnop-core/src/main/java/io/qnop/repository/PasswordResetTokenRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.PasswordResetToken;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Data access for {@link PasswordResetToken}. */
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, UUID> {
+
+  /** Lookup by the hex-encoded SHA-256 of the raw token presented on the reset-password request. */
+  Optional<PasswordResetToken> findByTokenHash(String tokenHash);
+
+  /**
+   * All in-flight (unconsumed) tokens for a user — used by the issue path to supersede previous
+   * tokens, so clicking "forgot password" twice leaves only the most-recent link working.
+   */
+  @Query("SELECT t FROM PasswordResetToken t WHERE t.user.id = :userId AND t.consumedAt IS NULL")
+  List<PasswordResetToken> findUnconsumedTokensForUser(@Param("userId") UUID userId);
+
+  /** Scheduled-sweep target: rows whose {@code expires_at} has passed. */
+  long deleteByExpiresAtBefore(Instant cutoff);
+}

--- a/qnop-core/src/main/java/io/qnop/repository/RefreshTokenRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/RefreshTokenRepository.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.RefreshToken;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Data access for {@link RefreshToken}. */
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
+
+  /**
+   * Constant-time lookup by HMAC of the plaintext refresh token (the unique index makes hit and
+   * miss statistically equivalent). Returns the row regardless of revocation; callers check {@code
+   * revokedAt} explicitly so reuse-detection can tell a replayed revoked token from an unknown one.
+   */
+  Optional<RefreshToken> findByTokenLookupHash(String tokenLookupHash);
+
+  /**
+   * Force-revokes every still-active row in a family. Idempotent: already-revoked rows keep their
+   * original {@code revokedAt}/reason (the {@code WHERE} filters them out) for forensics.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      """
+      UPDATE RefreshToken t
+      SET t.revokedAt = :revokedAt, t.revocationReason = :reason
+      WHERE t.familyId = :familyId AND t.revokedAt IS NULL
+      """)
+  int revokeFamily(
+      @Param("familyId") UUID familyId,
+      @Param("reason") String reason,
+      @Param("revokedAt") Instant revokedAt);
+
+  /** Revokes every active refresh token for a user (password-change / admin-disable paths). */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      """
+      UPDATE RefreshToken t
+      SET t.revokedAt = :revokedAt, t.revocationReason = :reason
+      WHERE t.userId = :userId AND t.revokedAt IS NULL
+      """)
+  int revokeAllForUser(
+      @Param("userId") UUID userId,
+      @Param("reason") String reason,
+      @Param("revokedAt") Instant revokedAt);
+
+  /** Purges rows whose absolute expiry has passed. Called by the scheduled cleanup job (#17). */
+  @Modifying
+  @Query("DELETE FROM RefreshToken t WHERE t.expiresAt < :cutoff")
+  int deleteExpiredBefore(@Param("cutoff") Instant cutoff);
+}

--- a/qnop-core/src/main/java/io/qnop/repository/RevokedTokenRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/RevokedTokenRepository.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.RevokedToken;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Data access for {@link RevokedToken} (the access-token {@code jti} denylist). */
+public interface RevokedTokenRepository extends JpaRepository<RevokedToken, UUID> {
+
+  /** Denylist probe: has this (hashed) {@code jti} been revoked? */
+  boolean existsByJti(String jti);
+
+  /** Purges entries whose underlying token would have expired anyway (scheduled cleanup, #17). */
+  @Modifying
+  @Query("DELETE FROM RevokedToken r WHERE r.expiresAt < :cutoff")
+  int deleteExpiredBefore(@Param("cutoff") Instant cutoff);
+
+  /** Wipes a user's revocation rows (the FK also cascades; this is the explicit path). */
+  long deleteByUserId(UUID userId);
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -21,5 +21,8 @@ databaseChangeLog:
       file: migrations/0003-mail-template-schema.yaml
       relativeToChangelogFile: true
   - include:
+      file: migrations/0004-token-schema.yaml
+      relativeToChangelogFile: true
+  - include:
       file: migrations/0005-application-asset-schema.yaml
       relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0004-token-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0004-token-schema.yaml
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Token schema (issue #12): refresh_token, revoked_token, email_verification_token,
+# password_reset_token. All token secrets are stored hashed (HMAC/SHA-256 hex), never
+# in plaintext. FKs to qnop_user cascade on delete; the refresh-token rotation self-FK
+# is SET NULL. Postgres-only partial indexes live in raw `sql:` blocks (ADR-0020); JPA
+# runs ddl-auto=none, so the entity column mapping must match these definitions exactly.
+databaseChangeLog:
+  - changeSet:
+      id: 0004-token-refresh-token
+      author: qnop
+      comment: Server-side refresh-token records (opaque cookie, rotation + reuse-detection).
+      changes:
+        - createTable:
+            tableName: refresh_token
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: family_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: token_lookup_hash
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: issued_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: expires_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column: { name: revoked_at, type: TIMESTAMP WITH TIME ZONE }
+              - column: { name: revocation_reason, type: VARCHAR(32) }
+              - column: { name: rotated_to_id, type: UUID }
+              - column: { name: upstream_id_token, type: TEXT }
+        - addForeignKeyConstraint:
+            baseTableName: refresh_token
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            constraintName: fk_refresh_token_user
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: refresh_token
+            baseColumnNames: rotated_to_id
+            referencedTableName: refresh_token
+            referencedColumnNames: id
+            constraintName: fk_refresh_token_rotated_to
+            onDelete: SET NULL
+        - addUniqueConstraint:
+            tableName: refresh_token
+            columnNames: token_lookup_hash
+            constraintName: ux_refresh_token_lookup_hash
+        - createIndex:
+            tableName: refresh_token
+            indexName: ix_refresh_token_expires_at
+            columns:
+              - column: { name: expires_at }
+        - sql:
+            comment: Partial index for active (unrevoked) tokens — the revoke-by-user/family hot path.
+            sql: |
+              CREATE INDEX ix_refresh_token_active
+                ON refresh_token (user_id) WHERE revoked_at IS NULL;
+
+  - changeSet:
+      id: 0004-token-revoked-token
+      author: qnop
+      comment: Access-token jti denylist (hashed at rest), checked before natural expiry.
+      changes:
+        - createTable:
+            tableName: revoked_token
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: jti
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: expires_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: revoked_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+        - addForeignKeyConstraint:
+            baseTableName: revoked_token
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            constraintName: fk_revoked_token_user
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: revoked_token
+            columnNames: jti
+            constraintName: ux_revoked_token_jti
+        - createIndex:
+            tableName: revoked_token
+            indexName: ix_revoked_token_user_id
+            columns:
+              - column: { name: user_id }
+        - createIndex:
+            tableName: revoked_token
+            indexName: ix_revoked_token_expires_at
+            columns:
+              - column: { name: expires_at }
+
+  - changeSet:
+      id: 0004-token-email-verification-token
+      author: qnop
+      comment: Single-use self-registration email-verification tokens (hashed at rest).
+      changes:
+        - createTable:
+            tableName: email_verification_token
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: token_hash
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: expires_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column: { name: consumed_at, type: TIMESTAMP WITH TIME ZONE }
+        - addForeignKeyConstraint:
+            baseTableName: email_verification_token
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            constraintName: fk_email_verification_token_user
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: email_verification_token
+            columnNames: token_hash
+            constraintName: ux_email_verification_token_hash
+        - createIndex:
+            tableName: email_verification_token
+            indexName: ix_email_verification_token_user_id
+            columns:
+              - column: { name: user_id }
+        - createIndex:
+            tableName: email_verification_token
+            indexName: ix_email_verification_token_expires_at
+            columns:
+              - column: { name: expires_at }
+
+  - changeSet:
+      id: 0004-token-password-reset-token
+      author: qnop
+      comment: Single-use self-service password-reset tokens (hashed at rest).
+      changes:
+        - createTable:
+            tableName: password_reset_token
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: token_hash
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: expires_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column: { name: consumed_at, type: TIMESTAMP WITH TIME ZONE }
+        - addForeignKeyConstraint:
+            baseTableName: password_reset_token
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            constraintName: fk_password_reset_token_user
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: password_reset_token
+            columnNames: token_hash
+            constraintName: ux_password_reset_token_hash
+        - createIndex:
+            tableName: password_reset_token
+            indexName: ix_password_reset_token_user_id
+            columns:
+              - column: { name: user_id }
+        - createIndex:
+            tableName: password_reset_token
+            indexName: ix_password_reset_token_expires_at
+            columns:
+              - column: { name: expires_at }


### PR DESCRIPTION
## Summary

Adds the auth token persistence layer (issue #12): four tables, their JPA entities, and Spring Data repositories. Modelled on the plugwerk implementation and adapted to qnop's conventions established in #11 (Java, `Instant`, UUIDv7, Postgres-only constraints in Liquibase, FKs as raw UUID columns except the EAGER `user` on the single-use tokens). Builds on #11 (`qnop_user`).

### Tables / entities
- **`refresh_token`** — opaque refresh-cookie record: `token_lookup_hash` (HMAC-SHA256 hex, unique), rotation `family_id`, self-FK `rotated_to_id` (`ON DELETE SET NULL`), revocation columns, `upstream_id_token`; partial active index. Raw UUID FKs.
- **`revoked_token`** — access-token `jti` denylist, hashed at rest (SHA-256 hex, unique), FK `ON DELETE CASCADE`.
- **`email_verification_token`** / **`password_reset_token`** — identical single-use shape: hashed `token_hash` (unique), `consumed_at`, **EAGER `@ManyToOne` user**, FK `ON DELETE CASCADE`.

### Repositories
`findByTokenLookupHash`, `revokeFamily`, `revokeAllForUser`, `deleteExpiredBefore` (refresh); `existsByJti`, `deleteExpiredBefore`, `deleteByUserId` (revoked); `findByTokenHash`, `findUnconsumedTokensForUser`, `deleteByExpiresAtBefore` (email/password).

### Migration
`migrations/0002-token-schema.yaml` wired into the master changelog after `0001`. Postgres-only partial indexes in a raw `sql:` block (ADR-0020). JPA `ddl-auto=none`.

### Scope
Schema + entities + repositories only. The token-issuing/rotation/cleanup **services** land later (#17 JWT/session core, #19 mail, #20 local-user lifecycle, #21 OIDC). No new ADR (token security rationale belongs to the identity ADR).

## Test plan
- [x] `./gradlew build -x test` — green (compile, Spotless headers, ArchUnit, `bootJar`)
- [x] `ArchitectureRulesTest` — green (layering respected)
- [ ] CI: `TokenSchemaIT` against real PostgreSQL (Testcontainers/Docker, ADR-0020) — verifies hash uniqueness, `revokeFamily` active-only semantics, FK CASCADE, rotation self-FK SET NULL, EAGER user, unconsumed-token filter. Docker-dependent → runs in CI.

Closes #12 · Part of #7

🤖 Co-Author: Claude (Opus 4.x) via Claude Code