### PR TITLE
feat: application asset schema (application_asset)

### DIFF
--- a/docs/adr/0024-branding-asset-storage.md
+++ b/docs/adr/0024-branding-asset-storage.md
@@ -1,0 +1,73 @@
+# ADR-0024: Branding-asset storage location
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+Epic #7 ports plugwerk's branding domain. Issue #15 introduces three
+operator-uploadable branding slots — `logo_light`, `logo_dark`, `logomark`
+(`BrandingSlot`) — each holding a single small asset (SVG/PNG/WebP, capped in
+the application layer at a few hundred KB). These assets are served on
+authentication-free surfaces (login page, OG metadata) and need an
+ETag/cache-buster on the read path (the SHA-256 serves both, issue #23).
+
+qnop already provisions S3-compatible object storage (MinIO locally) — but per
+the architecture that store is reserved for **binary review documents** (the
+large, per-document payloads of the core review workflow). Branding assets are a
+different kind of data: a handful of small, config-like blobs that belong with
+the rest of the application configuration.
+
+The choice is where the branding bytes live: in object storage alongside review
+documents, or in PostgreSQL.
+
+## Decision
+
+Branding bytes live in **PostgreSQL**, in a dedicated `application_asset` table
+with a `bytea` `content` column (Liquibase migration `0005`). One row per slot,
+enforced by a `(slot)` unique constraint: re-uploading a slot replaces the
+current row — the contract is "current asset", not history.
+
+Rationale:
+
+- **Backup/restore atomicity.** Branding is application configuration; keeping it
+  in the database means a DB backup is a complete restore, with no second store
+  to keep in sync.
+- **Separation of concerns.** Object storage stays dedicated to review documents.
+  Mixing tiny config blobs into the document store invites lifecycle bugs — most
+  concretely an orphan-reaper that GCs any stored object without a matching
+  document row would silently delete unreferenced branding files. (plugwerk hit
+  exactly this; see its ADR-0037 as prior art.)
+- **Small, bounded payloads.** With a low slot count and per-slot size caps,
+  `bytea` storage and retrieval is cheap and avoids a network round-trip to the
+  object store on the (cacheable) read path.
+
+The Postgres-only invariants — the `slot` and `content_type` CHECK domains, the
+`(slot)` uniqueness, and the no-cascade `uploaded_by → qnop_user` foreign key —
+live in Liquibase, not JPA annotations (ADR-0020). The `slot` column stores the
+snake_case `BrandingSlot.dbValue` via an `AttributeConverter`, keeping the
+persisted values aligned with the CHECK domain and with the URL form used in
+issue #23.
+
+## Consequences
+
+- A DB backup captures branding; no separate object-storage backup is needed for
+  it.
+- Large/numerous binary assets must **not** follow this pattern — review
+  documents stay in object storage. This decision is scoped to small, bounded,
+  config-like branding assets.
+- `uploaded_by` does not cascade: a user who uploaded a branding asset cannot be
+  deleted until the asset row is reassigned or removed. Acceptable because
+  branding rows are few and admin-managed.
+- SVG sanitization, size caps, SHA-256/size computation, and the upload/read
+  endpoints are deferred to the branding service work (issue #23); #15 is schema
+  + entity + repository only.
+
+## Alternatives considered
+
+- **Object storage (MinIO/S3) for branding too.** Rejected: couples branding to
+  the review-document store's lifecycle (orphan reaping), and splits application
+  configuration across two backup domains for no benefit at this size.
+- **Filesystem directory.** Rejected: not horizontally scalable, and reintroduces
+  the same backup-split and orphan-lifecycle concerns as object storage.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0021](0021-openapi-first-contract-tooling.md) | OpenAPI-first REST contract tooling and the qnop-api submodule split | Accepted |
 | [0022](0022-security-crypto-foundation.md) | Security & crypto foundation — layer placement and primitives | Accepted |
 | [0023](0023-identity-and-access-model.md) | Identity & access model (schema level) | Accepted |
+| [0024](0024-branding-asset-storage.md) | Branding-asset storage location (Postgres bytea) | Accepted |
 
 ## Template
 

--- a/qnop-app/src/test/java/io/qnop/branding/ApplicationAssetSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/branding/ApplicationAssetSchemaIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.branding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.ApplicationAsset;
+import io.qnop.entity.BrandingSlot;
+import io.qnop.entity.User;
+import io.qnop.repository.ApplicationAssetRepository;
+import io.qnop.repository.UserRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the application-asset / branding schema (issue #15) against a real PostgreSQL
+ * (ADR-0020): UUIDv7 generation, the {@code bytea} round-trip, the snake_case slot mapping, the
+ * Postgres-only CHECK and {@code (slot)} unique constraints that JPA cannot express, and the
+ * no-cascade {@code uploaded_by} foreign key. Each test runs in a rolled-back transaction for
+ * isolation. Extends {@link AbstractIntegrationTest}, which boots the full context against
+ * Testcontainers. Requires Docker.
+ */
+@Transactional
+class ApplicationAssetSchemaIT extends AbstractIntegrationTest {
+
+  private static final byte[] PNG = {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+
+  @Autowired ApplicationAssetRepository assets;
+  @Autowired UserRepository users;
+  @Autowired JdbcTemplate jdbc;
+
+  private static ApplicationAsset asset(BrandingSlot slot, UUID uploadedBy) {
+    return ApplicationAsset.create(slot, "image/png", PNG, "deadbeef", PNG.length, uploadedBy);
+  }
+
+  @Test
+  void persistsAssetWithGeneratedUuidV7AndTimestamp() {
+    ApplicationAsset saved = assets.saveAndFlush(asset(BrandingSlot.LOGO_LIGHT, null));
+
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getId().version()).isEqualTo(7);
+    assertThat(saved.getUploadedAt()).isNotNull();
+  }
+
+  @Test
+  void roundTripsBinaryContent() {
+    UUID id = assets.saveAndFlush(asset(BrandingSlot.LOGOMARK, null)).getId();
+    assets.flush();
+
+    ApplicationAsset reloaded = assets.findById(id).orElseThrow();
+
+    assertThat(reloaded.getContent()).containsExactly(PNG);
+    assertThat(reloaded.getSlot()).isEqualTo(BrandingSlot.LOGOMARK);
+    assertThat(reloaded.getSizeBytes()).isEqualTo(PNG.length);
+    assertThat(reloaded.getSha256()).isEqualTo("deadbeef");
+  }
+
+  @Test
+  void storesSlotAsSnakeCaseDbValue() {
+    UUID id = assets.saveAndFlush(asset(BrandingSlot.LOGO_DARK, null)).getId();
+
+    String rawSlot =
+        jdbc.queryForObject("SELECT slot FROM application_asset WHERE id = ?", String.class, id);
+
+    assertThat(rawSlot).isEqualTo("logo_dark");
+  }
+
+  @Test
+  void findBySlotReturnsTheCurrentAsset() {
+    assets.saveAndFlush(asset(BrandingSlot.LOGO_LIGHT, null));
+
+    assertThat(assets.findBySlot(BrandingSlot.LOGO_LIGHT)).isPresent();
+    assertThat(assets.findBySlot(BrandingSlot.LOGO_DARK)).isEmpty();
+  }
+
+  @Test
+  void enforcesOneAssetPerSlot() {
+    assets.saveAndFlush(asset(BrandingSlot.LOGO_LIGHT, null));
+
+    assertThatThrownBy(() -> assets.saveAndFlush(asset(BrandingSlot.LOGO_LIGHT, null)))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void rejectsUnsupportedContentType() {
+    ApplicationAsset invalid =
+        ApplicationAsset.create(BrandingSlot.LOGO_LIGHT, "image/gif", PNG, "sha", PNG.length, null);
+
+    assertThatThrownBy(() -> assets.saveAndFlush(invalid))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void rejectsUnknownSlotValueAtTheDatabaseLevel() {
+    // The enum makes an invalid slot unreachable through the entity, so assert the
+    // defence-in-depth CHECK directly via raw SQL.
+    assertThatThrownBy(
+            () ->
+                jdbc.update(
+                    "INSERT INTO application_asset"
+                        + " (id, slot, content_type, content, sha256, size_bytes, uploaded_at)"
+                        + " VALUES (?, ?, ?, ?, ?, ?, now())",
+                    UUID.randomUUID(),
+                    "favicon",
+                    "image/png",
+                    PNG,
+                    "sha",
+                    PNG.length))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  void allowsNullUploadedBy() {
+    ApplicationAsset saved = assets.saveAndFlush(asset(BrandingSlot.LOGOMARK, null));
+
+    assertThat(saved.getUploadedBy()).isNull();
+  }
+
+  @Test
+  void blocksUserDeletionWhileAssetReferencesThem() {
+    User uploader = users.saveAndFlush(User.external("Uploader", "uploader@example.com"));
+    assets.saveAndFlush(asset(BrandingSlot.LOGO_DARK, uploader.getId()));
+
+    assertThatThrownBy(
+            () -> {
+              users.deleteById(uploader.getId());
+              users.flush(); // force the DELETE so the no-cascade FK rejects it
+            })
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/ApplicationAsset.java
+++ b/qnop-core/src/main/java/io/qnop/entity/ApplicationAsset.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * One operator-uploaded branding asset, one row per {@link BrandingSlot} (issue #15, ported from
+ * plugwerk). The {@code slot} column is unique, so re-uploading a slot replaces the current asset
+ * rather than versioning it — the contract is "current asset", not history.
+ *
+ * <p>The bytes live in Postgres ({@code bytea}) rather than object storage so a database backup is
+ * a complete restore; see ADR-0024 (and plugwerk's ADR-0037 as prior art). The {@code slot} and
+ * {@code content_type} domains, the {@code (slot)} uniqueness, and the no-cascade {@code
+ * uploaded_by → qnop_user} foreign key are enforced in Liquibase (migration {@code 0005}), not in
+ * JPA annotations (ADR-0020); JPA runs {@code ddl-auto=none}. Identifiers are UUIDv7, generated
+ * application-side by Hibernate.
+ */
+@Entity
+@Table(name = "application_asset")
+public class ApplicationAsset {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Convert(converter = BrandingSlotConverter.class)
+  @Column(name = "slot", nullable = false, length = 32)
+  private BrandingSlot slot;
+
+  @Column(name = "content_type", nullable = false, length = 64)
+  private String contentType;
+
+  @Column(name = "content", nullable = false)
+  private byte[] content;
+
+  /** Hex-encoded SHA-256 of {@link #content}; used as the HTTP ETag / cache-buster on read. */
+  @Column(name = "sha256", nullable = false, length = 64)
+  private String sha256;
+
+  @Column(name = "size_bytes", nullable = false)
+  private long sizeBytes;
+
+  @CreationTimestamp
+  @Column(name = "uploaded_at", nullable = false, updatable = false)
+  private Instant uploadedAt;
+
+  /**
+   * The user who uploaded the asset, if known. Nullable; the FK does not cascade on user delete.
+   */
+  @Column(name = "uploaded_by")
+  private UUID uploadedBy;
+
+  protected ApplicationAsset() {
+    // for JPA
+  }
+
+  /** Creates an asset for the given slot. {@code uploadedBy} may be {@code null}. */
+  public static ApplicationAsset create(
+      BrandingSlot slot,
+      String contentType,
+      byte[] content,
+      String sha256,
+      long sizeBytes,
+      UUID uploadedBy) {
+    ApplicationAsset asset = new ApplicationAsset();
+    asset.slot = slot;
+    asset.contentType = contentType;
+    asset.content = content;
+    asset.sha256 = sha256;
+    asset.sizeBytes = sizeBytes;
+    asset.uploadedBy = uploadedBy;
+    return asset;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public BrandingSlot getSlot() {
+    return slot;
+  }
+
+  public void setSlot(BrandingSlot slot) {
+    this.slot = slot;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  public byte[] getContent() {
+    return content;
+  }
+
+  public void setContent(byte[] content) {
+    this.content = content;
+  }
+
+  public String getSha256() {
+    return sha256;
+  }
+
+  public void setSha256(String sha256) {
+    this.sha256 = sha256;
+  }
+
+  public long getSizeBytes() {
+    return sizeBytes;
+  }
+
+  public void setSizeBytes(long sizeBytes) {
+    this.sizeBytes = sizeBytes;
+  }
+
+  public Instant getUploadedAt() {
+    return uploadedAt;
+  }
+
+  public UUID getUploadedBy() {
+    return uploadedBy;
+  }
+
+  public void setUploadedBy(UUID uploadedBy) {
+    this.uploadedBy = uploadedBy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ApplicationAsset other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/BrandingSlot.java
+++ b/qnop-core/src/main/java/io/qnop/entity/BrandingSlot.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+/**
+ * The branding slots an operator can upload (ported from plugwerk, issue #15). Each slot holds at
+ * most one {@link ApplicationAsset} — re-uploading replaces the row rather than versioning it.
+ *
+ * <p>Every constant carries two stable string forms: {@link #dbValue} (snake_case) is what lands in
+ * the {@code application_asset.slot} column and the Postgres {@code CHECK}, while {@link #urlValue}
+ * (kebab-case) is the form used on the read path (e.g. {@code /api/v1/branding/{slot}}, issue #23).
+ * The column stores {@link #dbValue} via {@link BrandingSlotConverter}, not the enum name, so the
+ * persisted values match the {@code CHECK} domain exactly.
+ */
+public enum BrandingSlot {
+  LOGO_LIGHT("logo_light", "logo-light"),
+  LOGO_DARK("logo_dark", "logo-dark"),
+  LOGOMARK("logomark", "logomark");
+
+  private final String dbValue;
+  private final String urlValue;
+
+  BrandingSlot(String dbValue, String urlValue) {
+    this.dbValue = dbValue;
+    this.urlValue = urlValue;
+  }
+
+  /** The snake_case value persisted in {@code application_asset.slot}. */
+  public String dbValue() {
+    return dbValue;
+  }
+
+  /** The kebab-case value used in branding URLs (issue #23). */
+  public String urlValue() {
+    return urlValue;
+  }
+
+  /** Resolves a slot from its {@link #dbValue}, or throws if unknown. */
+  public static BrandingSlot fromDbValue(String value) {
+    for (BrandingSlot slot : values()) {
+      if (slot.dbValue.equals(value)) {
+        return slot;
+      }
+    }
+    throw new IllegalArgumentException("Unknown branding slot db value: " + value);
+  }
+
+  /** Resolves a slot from its {@link #urlValue}, or {@code null} if unknown. */
+  public static BrandingSlot fromUrlValue(String value) {
+    for (BrandingSlot slot : values()) {
+      if (slot.urlValue.equals(value)) {
+        return slot;
+      }
+    }
+    return null;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/BrandingSlotConverter.java
+++ b/qnop-core/src/main/java/io/qnop/entity/BrandingSlotConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Maps {@link BrandingSlot} to its snake_case {@link BrandingSlot#dbValue()} for the {@code
+ * application_asset.slot} column, instead of the default {@code @Enumerated(STRING)} enum-name
+ * mapping. This keeps the persisted values aligned with the Postgres {@code CHECK} domain ({@code
+ * 'logo_light' | 'logo_dark' | 'logomark'}, see migration {@code 0005}).
+ */
+@Converter
+public class BrandingSlotConverter implements AttributeConverter<BrandingSlot, String> {
+
+  @Override
+  public String convertToDatabaseColumn(BrandingSlot slot) {
+    return slot == null ? null : slot.dbValue();
+  }
+
+  @Override
+  public BrandingSlot convertToEntityAttribute(String dbValue) {
+    return dbValue == null ? null : BrandingSlot.fromDbValue(dbValue);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/ApplicationAssetRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ApplicationAssetRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.ApplicationAsset;
+import io.qnop.entity.BrandingSlot;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Data access for {@link ApplicationAsset}. One asset per {@link BrandingSlot}. */
+public interface ApplicationAssetRepository extends JpaRepository<ApplicationAsset, UUID> {
+
+  /** Finds the current asset for a slot (matches the {@code (slot)} unique index). */
+  Optional<ApplicationAsset> findBySlot(BrandingSlot slot);
+
+  boolean existsBySlot(BrandingSlot slot);
+
+  long deleteBySlot(BrandingSlot slot);
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -20,3 +20,6 @@ databaseChangeLog:
   - include:
       file: migrations/0003-mail-template-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0005-application-asset-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0005-application-asset-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0005-application-asset-schema.yaml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Application-asset / branding schema (issue #15): application_asset.
+# Ported from plugwerk (migration 0035); see ADR-0024 for why branding bytes
+# live in Postgres bytea rather than object storage. Postgres-only CHECK
+# constraints live here in Liquibase, NOT in JPA annotations (ADR-0020). JPA
+# runs ddl-auto=none, so the entity column mapping must match exactly. The slot
+# column stores the snake_case BrandingSlot.dbValue (via BrandingSlotConverter).
+databaseChangeLog:
+  - changeSet:
+      id: 0005-application-asset
+      author: qnop
+      comment: Branding-asset storage; one row per slot, current-asset (not history).
+      changes:
+        - createTable:
+            tableName: application_asset
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: slot
+                  type: VARCHAR(32)
+                  constraints: { nullable: false }
+              - column:
+                  name: content_type
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: content
+                  type: BYTEA
+                  constraints: { nullable: false }
+              - column:
+                  name: sha256
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: size_bytes
+                  type: BIGINT
+                  constraints: { nullable: false }
+              - column:
+                  name: uploaded_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column: { name: uploaded_by, type: UUID }
+        - addUniqueConstraint:
+            tableName: application_asset
+            columnNames: slot
+            constraintName: ux_application_asset_slot
+        # No ON DELETE action (no cascade, issue #15): a user who uploaded a
+        # branding asset cannot be deleted until the asset row is reassigned or
+        # removed. Contrast oidc_identity, whose user FK cascades.
+        - addForeignKeyConstraint:
+            baseTableName: application_asset
+            baseColumnNames: uploaded_by
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            constraintName: fk_application_asset_user
+        - sql:
+            comment: Postgres-only CHECK constraints on the slot + content_type domains.
+            splitStatements: true
+            sql: |
+              ALTER TABLE application_asset ADD CONSTRAINT ck_application_asset_slot
+                CHECK (slot IN ('logo_light', 'logo_dark', 'logomark'));
+              ALTER TABLE application_asset ADD CONSTRAINT ck_application_asset_content_type
+                CHECK (content_type IN ('image/svg+xml', 'image/png', 'image/webp'));


### PR DESCRIPTION
## Summary

Branding-asset storage for epic #7, ported from plugwerk. Adds the `application_asset` table + entity + repository: one row per `BrandingSlot` (`logo_light`, `logo_dark`, `logomark`), holding the bytes in Postgres `bytea` alongside `content_type`, `sha256`, `size_bytes`, `uploaded_at` and a **no-cascade** `uploaded_by` FK to `qnop_user`.

Depends on #11 (identity schema, merged). Part of epic #7, phase 2 (data model).

## Changes

- **`BrandingSlot`** enum with `dbValue` (snake_case, DB) + `urlValue` (kebab-case, for the read path in #23), persisted via **`BrandingSlotConverter`** so column values match the Postgres CHECK domain.
- **`ApplicationAsset`** entity (UUIDv7, `@CreationTimestamp uploaded_at`, nullable `uploaded_by`) + **`ApplicationAssetRepository`** (`findBySlot`, `existsBySlot`, `deleteBySlot`).
- **Liquibase `0005-application-asset-schema.yaml`** (wired into the master changelog): `(slot)` UNIQUE, `slot` + `content_type` CHECK domains, and the no-cascade `uploaded_by → qnop_user` FK — Postgres-only invariants live in Liquibase, not JPA (ADR-0020).
- **ADR-0024**: why branding bytes live in Postgres `bytea` rather than object storage (which stays reserved for review documents); plugwerk's ADR-0037 as prior art.

## Design notes (plugwerk alignment)

- `uploaded_by`: **nullable + no cascade** (ON DELETE NO ACTION) — a user who uploaded an asset can't be deleted until the row is reassigned/removed. Matches plugwerk.
- `slot` stored as **lowercase `dbValue`** (`logo_light`), not the uppercase `@Enumerated(STRING)` convention from #11 — matches both plugwerk and the issue text, and the URL form needed by #23.

## Out of scope (→ #23)

SVG sanitization, per-slot size caps, SHA-256/size computation, and the upload/read endpoints.

## Test plan

- [x] `:qnop-core:build` — compile + Spotless + checks green
- [x] ArchUnit `ArchitectureRulesTest` green (layering respected: entity ▸ repository)
- [ ] `ApplicationAssetSchemaIT` (Testcontainers) — runs in CI (Docker absent locally, ADR-0020): UUIDv7, `bytea` round-trip, snake_case slot mapping, `(slot)` uniqueness, both CHECK domains, and FK-blocks-user-deletion.

## Coordination

`db.changelog-master.yaml` is also touched by #12/#13/#14 — resolve the `include` order by epic order on merge.

Closes #15

🤖 Co-Author: Claude (Opus 4.x) via Claude Code