### PR TITLE
feat: application settings service + admin endpoints

### DIFF
--- a/docs/adr/0025-application-settings-architecture.md
+++ b/docs/adr/0025-application-settings-architecture.md
@@ -1,0 +1,30 @@
+# ADR-0025: Application settings — registry-authoritative, snapshot-backed runtime
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Deciders:** qnop core team (with Claude)
+
+## Context
+
+The application needs operator-configurable global settings (general, upload, tracking, SMTP, auth) read on hot paths and edited by superadmins. The schema (issue #13) gives `application_setting` (typed key/value) and `user_setting`. Issue #16 adds the runtime service and admin API. Three questions had to be settled: where the source of truth for keys/types/defaults lives, how reads stay cheap and consistent, and how secrets are handled.
+
+## Decision
+
+- **A code registry is authoritative for keys.** `ApplicationSettingKey` (an enum) defines every global key with its `SettingValueType`, default, description, and — for `ENUM` — its allowed options. The `application_setting` table is the **persisted projection**: the Liquibase seed (issue #13) initializes it and must mirror the registry. `value_type` is stored on the row as a denormalized, self-describing copy (admin UI rendering, redaction, DBA/ops) — see the rationale below.
+- **Reads are served from an immutable snapshot** held in an `AtomicReference<Map<ApplicationSettingKey,String>>`. The snapshot holds *effective, decrypted* values; it is rebuilt **after a write commits** (`TransactionSynchronization.afterCommit`), then registered `SettingsChangeListener` beans are notified of the changed keys (e.g. SMTP reconfiguration, issue #19). Reads are lock-free; writes are rare.
+- **Secrets are encrypted at the value, not the column.** `PASSWORD` values are encrypted with the application `TextEncryptor` (ADR-0022) on write and decrypted into the snapshot on load. The admin API masks them as `***` (`ConfigurationKeyRedactor`); sending the mask back on `PATCH` means "unchanged", so a secret never round-trips through the browser.
+- **`user_setting` carries no type.** Per-user keys are typed by their own registry (issues #22/#24), not by a per-row `value_type` — there are N rows per key, so a per-row type would be redundant and drift-prone. The 1:1 `application_setting` row may carry `value_type`; the N:1 `user_setting` rows may not.
+- **Admin authorization is a URL rule.** `/api/v1/admin/**` requires `SUPERADMIN` in the security filter chain (issue #10), covering all current and future admin endpoints. The authenticated principal (and thus `updated_by` attribution) is wired with the auth subsystem (issue #17).
+
+## Consequences
+
+- Hot-path reads never touch the DB and see a consistent, post-commit view.
+- The registry and the `#13` seed must be kept in sync (asserted by a test); the registry wins on conflict.
+- Secrets are safe at rest and in transit; the masked-sentinel update keeps the API simple.
+- Endpoints are authorization-ready now but only reachable end-to-end once issue #17 provides authentication.
+
+## Alternatives considered
+
+- **DB-only definition (drop the registry, derive types from rows).** Rejected: defaults/validation/enum-options are behavior that belongs in code; a registry gives compile-time exhaustiveness.
+- **Per-request DB reads / a cache abstraction (Caffeine).** Rejected as premature: the settings set is tiny and changes rarely; an `AtomicReference` snapshot is simpler and allocation-free on reads.
+- **A native Postgres enum for `value_type`.** Rejected: a `VARCHAR` + `CHECK` (issue #13) matches the project's enum convention and avoids Postgres enum migration friction.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0022](0022-security-crypto-foundation.md) | Security & crypto foundation — layer placement and primitives | Accepted |
 | [0023](0023-identity-and-access-model.md) | Identity & access model (schema level) | Accepted |
 | [0024](0024-branding-asset-storage.md) | Branding-asset storage location (Postgres bytea) | Accepted |
+| [0025](0025-application-settings-architecture.md) | Application settings — registry-authoritative, snapshot-backed runtime | Accepted |
 
 ## Template
 

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -25,6 +25,10 @@ tags:
       Public, unauthenticated server configuration the frontend needs before a
       user is authenticated (edition flag, branding, enabled login providers,
       upload limits, supported document formats).
+  - name: AdminSettings
+    description: |
+      Superadmin-only administration of the global application settings
+      (issue #16). Sensitive values are masked as `***`.
 paths:
   /config:
     get:
@@ -64,6 +68,79 @@ paths:
                   - PDF
                   - DOCX
                   - MD
+  /admin/settings:
+    get:
+      tags:
+        - AdminSettings
+      summary: List application settings
+      description: |
+        Returns all global application settings with their current values
+        (sensitive values masked as `***`), declared types, and descriptions.
+        Superadmin only.
+      operationId: getAdminSettings
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current application settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminSettingsResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - AdminSettings
+      summary: Update application settings
+      description: |
+        Applies a partial set of setting changes (`key` → raw value). Sending
+        `***` for a sensitive key leaves the stored secret unchanged. Returns the
+        full, updated settings. Superadmin only.
+      operationId: updateAdminSettings
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminSettingsUpdateRequest'
+      responses:
+        '200':
+          description: Updated application settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminSettingsResponse'
+        '400':
+          description: Unknown key or type-invalid value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -193,6 +270,61 @@ components:
         - auth
         - upload
         - supportedFormats
+    SettingValueType:
+      type: string
+      description: The declared type of an application setting value.
+      enum:
+        - STRING
+        - INTEGER
+        - BOOLEAN
+        - ENUM
+        - PASSWORD
+    AdminSetting:
+      type: object
+      description: One application setting with its current (possibly masked) value.
+      properties:
+        key:
+          type: string
+          description: Stable dotted setting key (e.g. `smtp.host`).
+        value:
+          type: string
+          description: Current value; sensitive values are masked as `***`.
+        type:
+          $ref: '#/components/schemas/SettingValueType'
+        description:
+          type: string
+          description: Human-readable description of the setting.
+        sensitive:
+          type: boolean
+          description: Whether the value is a secret (masked here, encrypted at rest).
+      required:
+        - key
+        - type
+        - description
+        - sensitive
+    AdminSettingsResponse:
+      type: object
+      description: The full set of global application settings.
+      properties:
+        settings:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminSetting'
+      required:
+        - settings
+    AdminSettingsUpdateRequest:
+      type: object
+      description: |
+        Partial map of setting key to new raw value. Omitted keys are left
+        unchanged; `***` for a sensitive key keeps the stored secret.
+      properties:
+        values:
+          type: object
+          additionalProperties:
+            type: string
+          description: Map of setting key to new value.
+      required:
+        - values
     ErrorResponse:
       type: object
       description: |

--- a/qnop-app/src/main/java/io/qnop/web/AdminSettingsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminSettingsController.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AdminSettingsApi;
+import io.qnop.api.v1.model.AdminSetting;
+import io.qnop.api.v1.model.AdminSettingsResponse;
+import io.qnop.api.v1.model.AdminSettingsUpdateRequest;
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.api.v1.model.SettingValueType;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.SettingValidationException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Superadmin settings administration ({@code GET/PATCH /api/v1/admin/settings}), implementing the
+ * generated {@link AdminSettingsApi} contract (issue #16, ADR-0025). Authorization for the {@code
+ * /api/v1/admin/**} namespace is enforced centrally in the security filter chain (issue #10).
+ *
+ * <p>Sensitive values are returned masked ({@code ***}); sending the mask back on {@code PATCH}
+ * leaves the stored secret unchanged. The editing user is not yet attributed — the authenticated
+ * principal is wired in once the auth subsystem lands (issue #17).
+ */
+@RestController
+public class AdminSettingsController implements AdminSettingsApi {
+
+  private final ApplicationSettingsService settings;
+
+  public AdminSettingsController(ApplicationSettingsService settings) {
+    this.settings = settings;
+  }
+
+  @Override
+  public ResponseEntity<AdminSettingsResponse> getAdminSettings() {
+    return ResponseEntity.ok(currentSettings());
+  }
+
+  @Override
+  public ResponseEntity<AdminSettingsResponse> updateAdminSettings(
+      AdminSettingsUpdateRequest adminSettingsUpdateRequest) {
+    settings.update(adminSettingsUpdateRequest.getValues(), null);
+    return ResponseEntity.ok(currentSettings());
+  }
+
+  private AdminSettingsResponse currentSettings() {
+    List<AdminSetting> items =
+        settings.describeAll().stream()
+            .map(
+                descriptor ->
+                    new AdminSetting()
+                        .key(descriptor.key())
+                        .value(descriptor.value())
+                        .type(SettingValueType.fromValue(descriptor.type()))
+                        .description(descriptor.description())
+                        .sensitive(descriptor.sensitive()))
+            .toList();
+    return new AdminSettingsResponse().settings(items);
+  }
+
+  @ExceptionHandler(SettingValidationException.class)
+  public ResponseEntity<ErrorResponse> onInvalidSetting(SettingValidationException ex) {
+    return ResponseEntity.badRequest()
+        .body(
+            new ErrorResponse()
+                .code("INVALID_SETTING")
+                .message(ex.getMessage())
+                .timestamp(OffsetDateTime.now()));
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -67,6 +67,8 @@ public class SecurityConfiguration {
             auth ->
                 auth.requestMatchers("/actuator/health", "/actuator/health/**")
                     .permitAll()
+                    .requestMatchers("/api/v1/admin/**")
+                    .hasRole("SUPERADMIN")
                     .anyRequest()
                     .authenticated())
         .httpBasic(httpBasic -> httpBasic.disable())

--- a/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies the admin settings endpoints (issue #16, ADR-0025) end-to-end through the real security
+ * filter chain: the {@code /api/v1/admin/**} namespace requires {@code SUPERADMIN}, the GET returns
+ * the (redacted) settings, and PATCH validates and applies updates. Requires Docker.
+ */
+@AutoConfigureMockMvc
+class AdminSettingsControllerIT extends AbstractIntegrationTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ApplicationSettingsService settings;
+
+  @AfterEach
+  void resetMutatedKeys() {
+    settings.update(Map.of(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB.getKey(), "25"), null);
+  }
+
+  @Test
+  @WithMockUser(roles = "SUPERADMIN")
+  void getReturnsSettingsForSuperadmin() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/admin/settings"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.settings").isArray())
+        .andExpect(jsonPath("$.settings.length()").value(16));
+  }
+
+  @Test
+  @WithMockUser(roles = "USER")
+  void getForbiddenForNonSuperadmin() throws Exception {
+    mockMvc.perform(get("/api/v1/admin/settings")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void getUnauthorizedForAnonymous() throws Exception {
+    mockMvc.perform(get("/api/v1/admin/settings")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = "SUPERADMIN")
+  void patchUpdatesSetting() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/v1/admin/settings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"upload.max_file_size_mb\":\"40\"}}"))
+        .andExpect(status().isOk());
+
+    assertThat(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).isEqualTo(40);
+  }
+
+  @Test
+  @WithMockUser(roles = "SUPERADMIN")
+  void patchRejectsTypeInvalidValue() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/v1/admin/settings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"upload.max_file_size_mb\":\"abc\"}}"))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
@@ -21,6 +21,7 @@
 package io.qnop.settings;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -31,23 +32,35 @@ import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 /**
  * Verifies the admin settings endpoints (issue #16, ADR-0025) end-to-end through the real security
  * filter chain: the {@code /api/v1/admin/**} namespace requires {@code SUPERADMIN}, the GET returns
- * the (redacted) settings, and PATCH validates and applies updates. Requires Docker.
+ * the (redacted) settings, and PATCH validates and applies updates.
+ *
+ * <p>MockMvc is built explicitly with {@code springSecurity()} so {@code @WithMockUser} is honored
+ * by the filter chain (Spring Boot 4's {@code @AutoConfigureMockMvc} does not apply it on its own
+ * here). Requires Docker.
  */
-@AutoConfigureMockMvc
 class AdminSettingsControllerIT extends AbstractIntegrationTest {
 
-  @Autowired MockMvc mockMvc;
+  @Autowired WebApplicationContext context;
   @Autowired ApplicationSettingsService settings;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
 
   @AfterEach
   void resetMutatedKeys() {

--- a/qnop-app/src/test/java/io/qnop/settings/SettingsServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/SettingsServiceIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.ConfigurationKeyRedactor;
+import io.qnop.service.SettingValidationException;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Verifies {@link ApplicationSettingsService} against a real PostgreSQL (ADR-0020, ADR-0025): the
+ * snapshot loads the seeded defaults, an update refreshes it after commit, secrets are encrypted at
+ * rest yet decrypted in the snapshot and masked in the admin view, the mask sentinel preserves a
+ * secret, and validation rejects bad input. Not transactional — the service commits its own writes
+ * so {@code afterCommit} fires. Requires Docker.
+ */
+class SettingsServiceIT extends AbstractIntegrationTest {
+
+  @Autowired ApplicationSettingsService settings;
+  @Autowired JdbcTemplate jdbc;
+
+  @AfterEach
+  void resetMutatedKeys() {
+    settings.update(
+        Map.of(
+            ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB.getKey(), "25",
+            ApplicationSettingKey.SMTP_PASSWORD.getKey(), ""),
+        null);
+  }
+
+  @Test
+  void loadsSeededDefaultsIntoSnapshot() {
+    assertThat(settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME))
+        .isEqualTo("qnop");
+    assertThat(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).isEqualTo(25);
+    assertThat(settings.getBoolean(ApplicationSettingKey.SMTP_TLS_ENABLED)).isTrue();
+  }
+
+  @Test
+  void updateRefreshesSnapshotAfterCommit() {
+    settings.update(Map.of(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB.getKey(), "50"), null);
+
+    assertThat(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).isEqualTo(50);
+  }
+
+  @Test
+  void encryptsSecretAtRestDecryptsInSnapshotAndMasksInView() {
+    settings.update(Map.of(ApplicationSettingKey.SMTP_PASSWORD.getKey(), "s3cr3t"), null);
+
+    String stored =
+        jdbc.queryForObject(
+            "SELECT setting_value FROM application_setting WHERE setting_key = ?",
+            String.class,
+            "smtp.password");
+    assertThat(stored).isNotNull().isNotEqualTo("s3cr3t");
+    assertThat(settings.getString(ApplicationSettingKey.SMTP_PASSWORD)).isEqualTo("s3cr3t");
+    assertThat(redactedValue("smtp.password")).isEqualTo(ConfigurationKeyRedactor.MASK);
+  }
+
+  @Test
+  void maskSentinelLeavesSecretUnchanged() {
+    settings.update(Map.of(ApplicationSettingKey.SMTP_PASSWORD.getKey(), "first"), null);
+    settings.update(
+        Map.of(ApplicationSettingKey.SMTP_PASSWORD.getKey(), ConfigurationKeyRedactor.MASK), null);
+
+    assertThat(settings.getString(ApplicationSettingKey.SMTP_PASSWORD)).isEqualTo("first");
+  }
+
+  @Test
+  void rejectsUnknownKey() {
+    assertThatThrownBy(() -> settings.update(Map.of("nope.key", "x"), null))
+        .isInstanceOf(SettingValidationException.class);
+  }
+
+  @Test
+  void rejectsTypeInvalidValue() {
+    assertThatThrownBy(() -> settings.update(Map.of("upload.max_file_size_mb", "abc"), null))
+        .isInstanceOf(SettingValidationException.class);
+  }
+
+  private String redactedValue(String key) {
+    return settings.describeAll().stream()
+        .filter(descriptor -> descriptor.key().equals(key))
+        .findFirst()
+        .orElseThrow()
+        .value();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.SettingValueType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * The authoritative registry of known application settings (issue #16): each key carries its {@link
+ * SettingValueType}, default value, human description, and (for {@code ENUM}) the allowed options.
+ *
+ * <p>This registry is the single source of truth for the global settings; the {@code
+ * application_setting} table (issue #13) is its persisted projection. The key set here must stay in
+ * sync with the Liquibase seed. Per-user settings have their own registry (issues #22/#24); this
+ * enum covers only the global, superadmin-managed ones.
+ */
+public enum ApplicationSettingKey {
+  GENERAL_APPLICATION_NAME(
+      "general.application_name",
+      SettingValueType.STRING,
+      "qnop",
+      "Display name of this qnop instance."),
+  GENERAL_BASE_URL(
+      "general.base_url",
+      SettingValueType.STRING,
+      "",
+      "Public base URL, used in generated links and emails."),
+  GENERAL_DEFAULT_LANGUAGE(
+      "general.default_language",
+      SettingValueType.STRING,
+      "en",
+      "Default UI language (ISO 639-1)."),
+  UPLOAD_MAX_FILE_SIZE_MB(
+      "upload.max_file_size_mb",
+      SettingValueType.INTEGER,
+      "25",
+      "Maximum document upload size in megabytes."),
+  TRACKING_ENABLED(
+      "tracking.enabled",
+      SettingValueType.BOOLEAN,
+      "false",
+      "Whether anonymous usage tracking is enabled."),
+  TRACKING_PROVIDER(
+      "tracking.provider",
+      SettingValueType.ENUM,
+      "none",
+      "Usage-tracking provider.",
+      List.of("none", "matomo", "plausible", "umami")),
+  SMTP_HOST("smtp.host", SettingValueType.STRING, "", "SMTP server host."),
+  SMTP_PORT("smtp.port", SettingValueType.INTEGER, "587", "SMTP server port."),
+  SMTP_USERNAME("smtp.username", SettingValueType.STRING, "", "SMTP authentication username."),
+  SMTP_PASSWORD(
+      "smtp.password",
+      SettingValueType.PASSWORD,
+      "",
+      "SMTP authentication password (stored encrypted, redacted in API)."),
+  SMTP_FROM("smtp.from", SettingValueType.STRING, "", "Default From address for outgoing mail."),
+  SMTP_TLS_ENABLED(
+      "smtp.tls_enabled", SettingValueType.BOOLEAN, "true", "Whether to use STARTTLS for SMTP."),
+  AUTH_SELF_REGISTRATION_ENABLED(
+      "auth.self_registration_enabled",
+      SettingValueType.BOOLEAN,
+      "false",
+      "Whether visitors may register their own local accounts."),
+  AUTH_SELF_REGISTRATION_DEFAULT_ROLE(
+      "auth.self_registration_default_role",
+      SettingValueType.STRING,
+      "USER",
+      "Role assigned to self-registered users."),
+  AUTH_PASSWORD_RESET_ENABLED(
+      "auth.password_reset_enabled",
+      SettingValueType.BOOLEAN,
+      "true",
+      "Whether local users may reset their password by email."),
+  AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES(
+      "auth.password_reset_token_ttl_minutes",
+      SettingValueType.INTEGER,
+      "30",
+      "Validity window of a password-reset token, in minutes.");
+
+  private static final Map<String, ApplicationSettingKey> BY_KEY =
+      Arrays.stream(values())
+          .collect(
+              Collectors.toUnmodifiableMap(ApplicationSettingKey::getKey, Function.identity()));
+
+  private final String key;
+  private final SettingValueType type;
+  private final String defaultValue;
+  private final String description;
+  private final List<String> enumOptions;
+
+  ApplicationSettingKey(
+      String key, SettingValueType type, String defaultValue, String description) {
+    this(key, type, defaultValue, description, List.of());
+  }
+
+  ApplicationSettingKey(
+      String key,
+      SettingValueType type,
+      String defaultValue,
+      String description,
+      List<String> enumOptions) {
+    this.key = key;
+    this.type = type;
+    this.defaultValue = defaultValue;
+    this.description = description;
+    this.enumOptions = List.copyOf(enumOptions);
+  }
+
+  public static Optional<ApplicationSettingKey> fromKey(String key) {
+    return Optional.ofNullable(BY_KEY.get(key));
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public SettingValueType getType() {
+    return type;
+  }
+
+  public String getDefaultValue() {
+    return defaultValue;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public List<String> getEnumOptions() {
+    return enumOptions;
+  }
+
+  /** A sensitive value is encrypted at rest and redacted in API responses. */
+  public boolean isSensitive() {
+    return type == SettingValueType.PASSWORD;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingsService.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingsService.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.ApplicationSetting;
+import io.qnop.repository.ApplicationSettingRepository;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Runtime access to the global application settings (issue #16). Reads are served lock-free from an
+ * immutable snapshot held in an {@link java.util.concurrent.atomic.AtomicReference}; the snapshot
+ * is rebuilt after a write commits ({@code afterCommit}), and registered {@link
+ * SettingsChangeListener} beans are then notified of the changed keys.
+ *
+ * <p>The snapshot holds <em>effective, decrypted</em> values (so consumers like the mail subsystem
+ * get the plaintext SMTP password); secrets are encrypted on write and re-masked only for the admin
+ * API view ({@link #describeAll()}). The registry ({@link ApplicationSettingKey}) is authoritative
+ * for keys, types and defaults; the DB rows (issue #13) are the persisted projection.
+ */
+@Service
+public class ApplicationSettingsService {
+
+  private final ApplicationSettingRepository repository;
+  private final TextEncryptor textEncryptor;
+  private final ConfigurationKeyRedactor redactor;
+  private final List<SettingsChangeListener> listeners;
+
+  private final java.util.concurrent.atomic.AtomicReference<Map<ApplicationSettingKey, String>>
+      snapshot = new java.util.concurrent.atomic.AtomicReference<>(Map.of());
+
+  public ApplicationSettingsService(
+      ApplicationSettingRepository repository,
+      TextEncryptor textEncryptor,
+      ConfigurationKeyRedactor redactor,
+      List<SettingsChangeListener> listeners) {
+    this.repository = repository;
+    this.textEncryptor = textEncryptor;
+    this.redactor = redactor;
+    this.listeners = listeners;
+  }
+
+  @PostConstruct
+  public void reload() {
+    snapshot.set(buildSnapshot());
+  }
+
+  private Map<ApplicationSettingKey, String> buildSnapshot() {
+    Map<String, ApplicationSetting> rows = new HashMap<>();
+    repository.findAll().forEach(row -> rows.put(row.getSettingKey(), row));
+
+    Map<ApplicationSettingKey, String> resolved = new EnumMap<>(ApplicationSettingKey.class);
+    for (ApplicationSettingKey key : ApplicationSettingKey.values()) {
+      ApplicationSetting row = rows.get(key.getKey());
+      String value = row != null ? row.getSettingValue() : key.getDefaultValue();
+      resolved.put(key, decryptIfSecret(key, value));
+    }
+    return Collections.unmodifiableMap(resolved);
+  }
+
+  // --- typed reads -----------------------------------------------------------
+
+  public String getString(ApplicationSettingKey key) {
+    return snapshot.get().get(key);
+  }
+
+  public int getInteger(ApplicationSettingKey key) {
+    return Integer.parseInt(snapshot.get().get(key).trim());
+  }
+
+  public boolean getBoolean(ApplicationSettingKey key) {
+    return Boolean.parseBoolean(snapshot.get().get(key));
+  }
+
+  /** All settings with their (redacted) current values, for the admin API. */
+  public List<SettingDescriptor> describeAll() {
+    Map<ApplicationSettingKey, String> current = snapshot.get();
+    List<SettingDescriptor> descriptors = new ArrayList<>();
+    for (ApplicationSettingKey key : ApplicationSettingKey.values()) {
+      descriptors.add(
+          new SettingDescriptor(
+              key.getKey(),
+              redactor.redact(key, current.get(key)),
+              key.getType().name(),
+              key.getDescription(),
+              key.isSensitive()));
+    }
+    return descriptors;
+  }
+
+  // --- writes ----------------------------------------------------------------
+
+  /**
+   * Applies a partial set of changes ({@code key -> raw value}). Unknown keys and type-invalid
+   * values are rejected with {@link SettingValidationException}; a {@link
+   * ConfigurationKeyRedactor#MASK} value for a sensitive key means "unchanged". The snapshot
+   * refresh and listener notifications run after the surrounding transaction commits.
+   *
+   * @param changes raw key/value pairs to apply
+   * @param actor the editing user's id, or {@code null} when unattributed (wired in issue #17)
+   */
+  @Transactional
+  public void update(Map<String, String> changes, UUID actor) {
+    Set<ApplicationSettingKey> changed = EnumSet.noneOf(ApplicationSettingKey.class);
+    for (Map.Entry<String, String> entry : changes.entrySet()) {
+      ApplicationSettingKey key =
+          ApplicationSettingKey.fromKey(entry.getKey())
+              .orElseThrow(
+                  () -> new SettingValidationException(entry.getKey(), "unknown setting key"));
+      String value = entry.getValue();
+      if (key.isSensitive() && redactor.isMask(value)) {
+        continue; // sentinel: leave the stored secret untouched
+      }
+      ValueValidator.validate(key, value);
+
+      ApplicationSetting row =
+          repository
+              .findById(key.getKey())
+              .orElseGet(() -> new ApplicationSetting(key.getKey(), null, key.getType()));
+      row.setSettingValue(encryptIfSecret(key, value));
+      row.setValueType(key.getType());
+      row.setUpdatedBy(actor);
+      repository.save(row);
+      changed.add(key);
+    }
+    if (!changed.isEmpty()) {
+      refreshAfterCommit(changed);
+    }
+  }
+
+  private void refreshAfterCommit(Set<ApplicationSettingKey> changed) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              notifyChanged(changed);
+            }
+          });
+    } else {
+      notifyChanged(changed);
+    }
+  }
+
+  private void notifyChanged(Set<ApplicationSettingKey> changed) {
+    reload();
+    listeners.forEach(listener -> listener.onSettingsChanged(changed));
+  }
+
+  private String encryptIfSecret(ApplicationSettingKey key, String value) {
+    if (key.isSensitive() && value != null && !value.isBlank()) {
+      return textEncryptor.encrypt(value);
+    }
+    return value;
+  }
+
+  private String decryptIfSecret(ApplicationSettingKey key, String value) {
+    if (key.isSensitive() && value != null && !value.isBlank()) {
+      return textEncryptor.decrypt(value);
+    }
+    return value;
+  }
+
+  /** A self-contained, web-safe view of one setting — no entity types reach the web layer. */
+  public record SettingDescriptor(
+      String key, String value, String type, String description, boolean sensitive) {}
+
+  // retained for symmetry with values()/keys() callers
+  static List<ApplicationSettingKey> allKeys() {
+    return Arrays.asList(ApplicationSettingKey.values());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/ConfigurationKeyRedactor.java
+++ b/qnop-core/src/main/java/io/qnop/service/ConfigurationKeyRedactor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Masks sensitive setting values for API responses (issue #16): a non-blank {@code PASSWORD} value
+ * is replaced by {@link #MASK}. A client that sends {@code MASK} back on update is treated as
+ * "leave unchanged" by the settings service, so the real secret is never round-tripped through the
+ * browser.
+ */
+@Component
+public class ConfigurationKeyRedactor {
+
+  /** Placeholder shown instead of a stored secret. */
+  public static final String MASK = "***";
+
+  public String redact(ApplicationSettingKey key, String value) {
+    if (key.isSensitive() && value != null && !value.isBlank()) {
+      return MASK;
+    }
+    return value;
+  }
+
+  public boolean isMask(String value) {
+    return MASK.equals(value);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/SettingValidationException.java
+++ b/qnop-core/src/main/java/io/qnop/service/SettingValidationException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+/**
+ * Raised when a settings update references an unknown key or carries a value that violates the
+ * key's {@link io.qnop.entity.SettingValueType}. Mapped to HTTP 400 at the web layer.
+ */
+public class SettingValidationException extends RuntimeException {
+
+  private final String settingKey;
+
+  public SettingValidationException(String settingKey, String reason) {
+    super("Invalid setting '" + settingKey + "': " + reason);
+    this.settingKey = settingKey;
+  }
+
+  public String getSettingKey() {
+    return settingKey;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/SettingsChangeListener.java
+++ b/qnop-core/src/main/java/io/qnop/service/SettingsChangeListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import java.util.Set;
+
+/**
+ * Notified after a settings change has been committed and the in-memory snapshot refreshed (issue
+ * #16). Implementations react to specific keys — e.g. the mail subsystem (issue #19) reconfigures
+ * its SMTP client when any {@code smtp.*} key changes.
+ */
+public interface SettingsChangeListener {
+
+  void onSettingsChanged(Set<ApplicationSettingKey> changedKeys);
+}

--- a/qnop-core/src/main/java/io/qnop/service/ValueValidator.java
+++ b/qnop-core/src/main/java/io/qnop/service/ValueValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+/**
+ * Validates a raw setting value string against its key's declared type (issue #16). Shared, plain,
+ * DB-free logic (ADR-0004). Throws {@link SettingValidationException} on violation.
+ */
+public final class ValueValidator {
+
+  private ValueValidator() {}
+
+  public static void validate(ApplicationSettingKey key, String value) {
+    if (value == null) {
+      throw new SettingValidationException(key.getKey(), "value must not be null");
+    }
+    switch (key.getType()) {
+      case INTEGER -> requireInteger(key, value);
+      case BOOLEAN -> requireBoolean(key, value);
+      case ENUM -> requireEnumOption(key, value);
+      case STRING, PASSWORD -> {
+        // any string is acceptable
+      }
+    }
+  }
+
+  private static void requireInteger(ApplicationSettingKey key, String value) {
+    try {
+      Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      throw new SettingValidationException(key.getKey(), "must be an integer");
+    }
+  }
+
+  private static void requireBoolean(ApplicationSettingKey key, String value) {
+    if (!"true".equals(value) && !"false".equals(value)) {
+      throw new SettingValidationException(key.getKey(), "must be 'true' or 'false'");
+    }
+  }
+
+  private static void requireEnumOption(ApplicationSettingKey key, String value) {
+    if (!key.getEnumOptions().contains(value)) {
+      throw new SettingValidationException(key.getKey(), "must be one of " + key.getEnumOptions());
+    }
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.qnop.entity.SettingValueType;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the {@link ApplicationSettingKey} registry, including that its key set matches the
+ * Liquibase seed from issue #13 (the registry is authoritative; the seed is its projection —
+ * ADR-0025).
+ */
+class ApplicationSettingKeyTest {
+
+  /** The keys seeded by db/changelog/migrations/0002-settings-schema.yaml (issue #13). */
+  private static final Set<String> SEEDED_KEYS =
+      Set.of(
+          "general.application_name",
+          "general.base_url",
+          "general.default_language",
+          "upload.max_file_size_mb",
+          "tracking.enabled",
+          "tracking.provider",
+          "smtp.host",
+          "smtp.port",
+          "smtp.username",
+          "smtp.password",
+          "smtp.from",
+          "smtp.tls_enabled",
+          "auth.self_registration_enabled",
+          "auth.self_registration_default_role",
+          "auth.password_reset_enabled",
+          "auth.password_reset_token_ttl_minutes");
+
+  @Test
+  void registryMatchesSeededKeys() {
+    Set<String> registryKeys =
+        Arrays.stream(ApplicationSettingKey.values())
+            .map(ApplicationSettingKey::getKey)
+            .collect(Collectors.toSet());
+
+    assertEquals(SEEDED_KEYS, registryKeys);
+  }
+
+  @Test
+  void resolvesKnownKeyAndRejectsUnknown() {
+    assertEquals(
+        Optional.of(ApplicationSettingKey.SMTP_HOST), ApplicationSettingKey.fromKey("smtp.host"));
+    assertTrue(ApplicationSettingKey.fromKey("does.not.exist").isEmpty());
+  }
+
+  @Test
+  void onlyPasswordKeysAreSensitive() {
+    assertTrue(ApplicationSettingKey.SMTP_PASSWORD.isSensitive());
+    assertFalse(ApplicationSettingKey.SMTP_USERNAME.isSensitive());
+    Arrays.stream(ApplicationSettingKey.values())
+        .filter(ApplicationSettingKey::isSensitive)
+        .forEach(key -> assertEquals(SettingValueType.PASSWORD, key.getType()));
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/ConfigurationKeyRedactorTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/ConfigurationKeyRedactorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ConfigurationKeyRedactor}. */
+class ConfigurationKeyRedactorTest {
+
+  private final ConfigurationKeyRedactor redactor = new ConfigurationKeyRedactor();
+
+  @Test
+  void masksNonBlankSecrets() {
+    assertEquals(
+        ConfigurationKeyRedactor.MASK,
+        redactor.redact(ApplicationSettingKey.SMTP_PASSWORD, "s3cr3t"));
+  }
+
+  @Test
+  void leavesBlankSecretsVisible() {
+    assertEquals("", redactor.redact(ApplicationSettingKey.SMTP_PASSWORD, ""));
+  }
+
+  @Test
+  void leavesNonSecretsUntouched() {
+    assertEquals(
+        "mail.example.com", redactor.redact(ApplicationSettingKey.SMTP_HOST, "mail.example.com"));
+  }
+
+  @Test
+  void recognizesMaskSentinel() {
+    assertTrue(redactor.isMask(ConfigurationKeyRedactor.MASK));
+    assertFalse(redactor.isMask("real-value"));
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/ValueValidatorTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/ValueValidatorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ValueValidator} across the setting value types. */
+class ValueValidatorTest {
+
+  @Test
+  void acceptsValidTypedValues() {
+    assertDoesNotThrow(
+        () -> ValueValidator.validate(ApplicationSettingKey.GENERAL_APPLICATION_NAME, "anything"));
+    assertDoesNotThrow(
+        () -> ValueValidator.validate(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB, "42"));
+    assertDoesNotThrow(
+        () -> ValueValidator.validate(ApplicationSettingKey.SMTP_TLS_ENABLED, "false"));
+    assertDoesNotThrow(
+        () -> ValueValidator.validate(ApplicationSettingKey.TRACKING_PROVIDER, "matomo"));
+    assertDoesNotThrow(() -> ValueValidator.validate(ApplicationSettingKey.SMTP_PASSWORD, "p@ss"));
+  }
+
+  @Test
+  void rejectsNonInteger() {
+    assertThrows(
+        SettingValidationException.class,
+        () -> ValueValidator.validate(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB, "abc"));
+  }
+
+  @Test
+  void rejectsNonBoolean() {
+    assertThrows(
+        SettingValidationException.class,
+        () -> ValueValidator.validate(ApplicationSettingKey.SMTP_TLS_ENABLED, "yes"));
+  }
+
+  @Test
+  void rejectsUnknownEnumOption() {
+    assertThrows(
+        SettingValidationException.class,
+        () -> ValueValidator.validate(ApplicationSettingKey.TRACKING_PROVIDER, "google-analytics"));
+  }
+
+  @Test
+  void rejectsNull() {
+    assertThrows(
+        SettingValidationException.class,
+        () -> ValueValidator.validate(ApplicationSettingKey.GENERAL_BASE_URL, null));
+  }
+}


### PR DESCRIPTION
Closes #16 · part of epic #7 · depends on #10, #13 (both merged).

## What
Runtime application-settings service over the #13 schema, plus the superadmin admin API.

- **`ApplicationSettingKey`** — authoritative enum registry (16 keys with type, default, description, ENUM options), kept in sync with the #13 Liquibase seed (asserted by a test). The DB rows are the persisted projection (ADR-0025).
- **`ApplicationSettingsService`** — lock-free `AtomicReference` snapshot of *effective, decrypted* values, rebuilt in `afterCommit`; `SettingsChangeListener` fan-out for changed keys (e.g. SMTP, #19). `PASSWORD` encrypted on write via the #10 `TextEncryptor`, decrypted into the snapshot, masked `***` in the admin view; the mask is the "leave unchanged" sentinel.
- **`ValueValidator`** (→ `SettingValidationException` → 400) and **`ConfigurationKeyRedactor`**.
- **OpenAPI** — `GET/PATCH /api/v1/admin/settings` (flat typed list) generates `AdminSettingsApi` + DTOs; `AdminSettingsController` implements it. Entity↔DTO mapping lives in the service, so the web layer never references entities (ArchUnit-clean).
- **Authz** — `/api/v1/admin/**` → `hasRole('SUPERADMIN')` in `SecurityConfiguration`.
- **ADR-0025** records the registry-authoritative, snapshot-backed design (incl. why `user_setting` is untyped and why `application_setting.value_type` is a projection).

## Phasing note
The endpoints are authorization-ready but only reachable end-to-end once the auth subsystem (**#17**) provides an authenticated principal (it also maps `is_superadmin` → `SUPERADMIN` and supplies `updated_by`).

## Test plan
- [x] Unit (core, JUnit): `ValueValidator`, `ApplicationSettingKey` (registry == seed), `ConfigurationKeyRedactor` — green locally
- [x] API generation, compile (core + app), Spotless + SPDX, ArchUnit layering — green locally
- [ ] `SettingsServiceIT` (Testcontainers): snapshot load, `afterCommit` refresh, encrypt-at-rest + decrypt-in-snapshot + mask-in-view, mask-sentinel, validation — **CI only**
- [ ] `AdminSettingsControllerIT` (MockMvc + mock security): SUPERADMIN 200 / USER 403 / anon 401, PATCH update + 400 on invalid — **CI only**

🤖 Co-Author: Claude (Opus 4.x) via Claude Code