### PR TITLE
feat: JWT & session core (access/refresh tokens, revocation, AuthController)

### DIFF
--- a/docs/adr/0025-jwt-session-and-revocation.md
+++ b/docs/adr/0025-jwt-session-and-revocation.md
@@ -1,0 +1,62 @@
+# ADR-0025: JWT access tokens, rotating refresh tokens, and revocation
+
+- **Status:** Accepted
+- **Date:** 2026-06-15
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+Epic #7 needs an authenticated session model: short-lived credentials for API
+calls, a longer-lived way to stay signed in, and a way to revoke both on logout
+and password change. The security/crypto foundation (ADR-0022) already provides
+HKDF key derivation (`JwtKeyService`), BCrypt, and validated `qnop.auth.*`
+config; the token tables (`refresh_token`, `revoked_token`) landed with issue #12.
+
+## Decision
+
+- **Access tokens** are self-issued HS256 JWTs (Nimbus encoder), signed with a
+  key HKDF-derived from `qnop.auth.jwt-secret` under the `access-token` purpose.
+  Claims: `jti` (random UUID, for revocation), `iss`, `iat`, `exp`, `sub` (the
+  `qnop_user.id`). Default TTL 15m. Sent as `Authorization: Bearer`.
+- **Refresh tokens** are opaque 256-bit random strings; only their
+  `HMAC-SHA256` lookup hash is stored (`refresh_token.token_lookup_hash`). They
+  rotate single-use within a *family*: presenting an active token revokes it
+  (`ROTATED`) and issues a successor; presenting an already-revoked token (a
+  replay) revokes the **whole family** (`REUSE_DETECTED`). Default TTL 7d.
+- **The refresh token rides in an HttpOnly, `SameSite=Strict`, `Secure` cookie**
+  (`qnop_refresh`) scoped to `/api/v1/auth`, so it is invisible to JavaScript and
+  not sent cross-site. `Secure` is configurable (`qnop.auth.cookie-secure`) for
+  local HTTP dev.
+- **Revocation** has two layers: an explicit `jti` denylist (`revoked_token`,
+  SHA-256 hashed, fronted by a Caffeine cache sized to the access-token TTL) and
+  bulk invalidation via `qnop_user.password_invalidated_before` — any token
+  issued before that instant is rejected. `DelegatingJwtDecoder` runs the local
+  HMAC verification then both checks; the resource-server filter uses it. (OIDC
+  provider decoders will be layered in as a fallback by issue #21.)
+- **CSRF:** the API is otherwise stateless and bearer-based (CSRF-exempt), but
+  the two cookie-bearing endpoints (`/auth/refresh`, `/auth/logout`) are
+  protected with a double-submit cookie token (`CookieCsrfTokenRepository` +
+  `X-XSRF-TOKEN`), defended in depth alongside `SameSite=Strict`.
+- **`AuthController`** (implementing the generated `AuthApi`) exposes `login`,
+  `refresh`, `logout`, and `change-password`. Password change re-verifies the
+  current password and invalidates every existing session.
+
+## Consequences
+
+- Logout and password change take effect immediately for access tokens (not just
+  at expiry), at the cost of a per-request revocation check — kept cheap by the
+  Caffeine cache.
+- Expired `revoked_token` / `refresh_token` rows accumulate until a cleanup job
+  (a later ticket) purges them; the repositories already expose `deleteExpiredBefore`.
+- The frontend must read `XSRF-TOKEN` and send `X-XSRF-TOKEN` on refresh/logout.
+
+## Alternatives considered
+
+- **Stateless JWT-only (no refresh, no revocation)** — rejected: cannot revoke on
+  logout/password change, and long-lived access tokens are unsafe.
+- **Server-side sessions** — rejected: the API is designed stateless; a JWT +
+  rotating refresh cookie gives the same UX without session affinity.
+- **Storing refresh tokens in `localStorage`** — rejected: XSS could exfiltrate
+  them; the HttpOnly cookie cannot be read by scripts.
+- **`jjwt` instead of Nimbus** — rejected: Nimbus integrates natively with the
+  Spring resource-server filter.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0022](0022-security-crypto-foundation.md) | Security & crypto foundation — layer placement and primitives | Accepted |
 | [0023](0023-identity-and-access-model.md) | Identity & access model (schema level) | Accepted |
 | [0024](0024-branding-asset-storage.md) | Branding-asset storage location (Postgres bytea) | Accepted |
+| [0025](0025-jwt-session-and-revocation.md) | JWT access tokens, rotating refresh tokens, and revocation | Accepted |
 
 ## Template
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,14 @@ spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
 spring-security-crypto = { module = "org.springframework.security:spring-security-crypto" }
 
+# JWT & session core (issue #17) — versions managed by the Spring Boot BOM.
+# Nimbus JWT encode/decode for self-issued HS256 access tokens.
+spring-security-oauth2-jose = { module = "org.springframework.security:spring-security-oauth2-jose" }
+# Servlet resource-server filter that validates the bearer JWT on each request.
+spring-boot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
+# In-memory cache for the JWT revocation (jti) denylist.
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }
+
 # Test
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 # Spring Boot 4 split the web test slices into per-stack modules; @WebMvcTest now

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -25,6 +25,12 @@ tags:
       Public, unauthenticated server configuration the frontend needs before a
       user is authenticated (edition flag, branding, enabled login providers,
       upload limits, supported document formats).
+  - name: Auth
+    description: |
+      Authentication: local username/email + password login, refresh-token
+      rotation, logout, and password change (issue #17). Access tokens are
+      short-lived JWTs sent as `Authorization: Bearer`; the rotating refresh
+      token lives in an HttpOnly, SameSite=Strict cookie scoped to `/api/v1/auth`.
 paths:
   /config:
     get:
@@ -64,6 +70,135 @@ paths:
                   - PDF
                   - DOCX
                   - MD
+  /auth/login:
+    post:
+      tags:
+        - Auth
+      summary: Authenticate with username/email and password
+      description: |
+        Verifies local credentials and, on success, returns a short-lived access
+        token in the body and sets the rotating refresh token as an HttpOnly
+        `qnop_refresh` cookie. Public (no bearer required).
+      operationId: login
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Authenticated — access token in body, refresh token in cookie.
+          headers:
+            Set-Cookie:
+              description: HttpOnly refresh-token cookie (`qnop_refresh`).
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '401':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/refresh:
+    post:
+      tags:
+        - Auth
+      summary: Rotate the refresh token and issue a new access token
+      description: |
+        Rotates the presented `qnop_refresh` cookie (single-use; replay of a
+        revoked token revokes the whole family) and returns a new access token,
+        setting a fresh refresh cookie. CSRF-protected (double-submit token).
+      operationId: refresh
+      security: []
+      parameters:
+        - name: qnop_refresh
+          in: cookie
+          required: false
+          description: The HttpOnly refresh-token cookie.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Rotated — new access token in body, new refresh token in cookie.
+          headers:
+            Set-Cookie:
+              description: Fresh HttpOnly refresh-token cookie (`qnop_refresh`).
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '401':
+          description: Missing, unknown, expired, or reused refresh token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/logout:
+    post:
+      tags:
+        - Auth
+      summary: Log out — revoke the refresh-token family and clear the cookie
+      description: |
+        Revokes the refresh-token family behind the presented cookie and clears
+        it. Idempotent. CSRF-protected (double-submit token).
+      operationId: logout
+      security: []
+      parameters:
+        - name: qnop_refresh
+          in: cookie
+          required: false
+          description: The HttpOnly refresh-token cookie.
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Logged out (cookie cleared).
+          headers:
+            Set-Cookie:
+              description: Clearing cookie for `qnop_refresh`.
+              schema:
+                type: string
+  /auth/change-password:
+    post:
+      tags:
+        - Auth
+      summary: Change the authenticated user's password
+      description: |
+        Verifies the current password, stores the new one, and invalidates all
+        existing tokens for the user (every active session must re-authenticate).
+        Requires a valid access token.
+      operationId: changePassword
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+      responses:
+        '204':
+          description: Password changed; existing tokens invalidated.
+        '400':
+          description: New password does not meet policy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Missing/invalid access token or wrong current password.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -193,6 +328,56 @@ components:
         - auth
         - upload
         - supportedFormats
+    LoginRequest:
+      type: object
+      description: Local-login credentials (issue #17).
+      properties:
+        usernameOrEmail:
+          type: string
+          description: The internal user's username or email address.
+        password:
+          type: string
+          format: password
+          description: The user's plaintext password (verified against the BCrypt hash).
+      required:
+        - usernameOrEmail
+        - password
+    ChangePasswordRequest:
+      type: object
+      description: Password-change payload for the authenticated user (issue #17).
+      properties:
+        currentPassword:
+          type: string
+          format: password
+          description: The user's current password, re-verified before the change.
+        newPassword:
+          type: string
+          format: password
+          minLength: 12
+          description: The replacement password. Must meet the minimum-length policy.
+      required:
+        - currentPassword
+        - newPassword
+    TokenResponse:
+      type: object
+      description: |
+        A freshly issued access token (issue #17). The refresh token is delivered
+        out-of-band as an HttpOnly cookie and never appears in this body.
+      properties:
+        accessToken:
+          type: string
+          description: Signed JWT access token; send it in the Authorization header as a Bearer token.
+        tokenType:
+          type: string
+          description: Always `Bearer`.
+        expiresInSeconds:
+          type: integer
+          format: int64
+          description: Access-token lifetime in seconds from issuance.
+      required:
+        - accessToken
+        - tokenType
+        - expiresInSeconds
     ErrorResponse:
       type: object
       description: |

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
     implementation(libs.spring.boot.starter.actuator)
     // Servlet security filter chain (io.qnop.web.security, issue #10 / ADR-0022).
     implementation(libs.spring.boot.starter.security)
+    // Resource-server filter that validates the bearer JWT on each request, plus
+    // the JWT (Nimbus) types used by the web-layer decoder/cookie glue (issue #17).
+    implementation(libs.spring.boot.starter.oauth2.resource.server)
     // The bootstrap registers the sibling data packages explicitly via
     // @EntityScan / @EnableJpaRepositories (issue #11), so this module takes a
     // direct JPA dependency for those compile-time symbols (Hibernate itself

--- a/qnop-app/src/main/java/io/qnop/web/AuthController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AuthController.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AuthApi;
+import io.qnop.api.v1.model.ChangePasswordRequest;
+import io.qnop.api.v1.model.LoginRequest;
+import io.qnop.api.v1.model.TokenResponse;
+import io.qnop.security.QnopProperties;
+import io.qnop.service.AuthService;
+import io.qnop.service.AuthService.ChangePasswordOutcome;
+import io.qnop.service.JwtTokenService;
+import io.qnop.service.RefreshTokenService;
+import io.qnop.service.RefreshTokenService.IssuedRefreshToken;
+import io.qnop.service.RefreshTokenService.RotationResult;
+import io.qnop.service.TokenRevocationService;
+import io.qnop.web.security.RefreshTokenCookieFactory;
+import java.util.UUID;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Authentication endpoints (issue #17): local login, refresh-token rotation, logout, and password
+ * change. Implements the generated {@link AuthApi} contract. Access tokens are returned in the
+ * body; the rotating refresh token is delivered as an HttpOnly {@code qnop_refresh} cookie. Bad
+ * credentials and invalid/replayed refresh tokens return {@code 401} without leaking which check
+ * failed.
+ */
+@RestController
+public class AuthController implements AuthApi {
+
+  private static final String TOKEN_TYPE = "Bearer";
+
+  private final AuthService authService;
+  private final JwtTokenService jwtTokenService;
+  private final RefreshTokenService refreshTokenService;
+  private final TokenRevocationService tokenRevocationService;
+  private final RefreshTokenCookieFactory cookieFactory;
+  private final QnopProperties properties;
+
+  public AuthController(
+      AuthService authService,
+      JwtTokenService jwtTokenService,
+      RefreshTokenService refreshTokenService,
+      TokenRevocationService tokenRevocationService,
+      RefreshTokenCookieFactory cookieFactory,
+      QnopProperties properties) {
+    this.authService = authService;
+    this.jwtTokenService = jwtTokenService;
+    this.refreshTokenService = refreshTokenService;
+    this.tokenRevocationService = tokenRevocationService;
+    this.cookieFactory = cookieFactory;
+    this.properties = properties;
+  }
+
+  @Override
+  public ResponseEntity<TokenResponse> login(LoginRequest request) {
+    UUID userId =
+        authService
+            .authenticate(request.getUsernameOrEmail(), request.getPassword())
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials"));
+    return issueSession(userId);
+  }
+
+  @Override
+  public ResponseEntity<TokenResponse> refresh(String refreshCookie) {
+    if (refreshCookie == null || refreshCookie.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing refresh token");
+    }
+    RotationResult result = refreshTokenService.rotate(refreshCookie);
+    if (result instanceof RotationResult.Success success) {
+      return issueSession(success.userId(), success.token());
+    }
+    // Reused or Unknown: clear the cookie and reject. The two are indistinguishable to the client.
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .header(HttpHeaders.SET_COOKIE, cookieFactory.clear().toString())
+        .build();
+  }
+
+  @Override
+  public ResponseEntity<Void> logout(String refreshCookie) {
+    if (refreshCookie != null && !refreshCookie.isBlank()) {
+      refreshTokenService.revokePresentedFamily(refreshCookie);
+    }
+    currentAccessToken().ifPresent(this::revokeAccessToken);
+    return ResponseEntity.noContent()
+        .header(HttpHeaders.SET_COOKIE, cookieFactory.clear().toString())
+        .build();
+  }
+
+  @Override
+  public ResponseEntity<Void> changePassword(ChangePasswordRequest request) {
+    UUID userId = requireAuthenticatedUserId();
+    ChangePasswordOutcome outcome =
+        authService.changePassword(userId, request.getCurrentPassword(), request.getNewPassword());
+    return switch (outcome) {
+      case SUCCESS -> ResponseEntity.noContent().build();
+      case NOT_LOCAL ->
+          throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST, "Password change is not available for this account");
+      case WRONG_PASSWORD, USER_NOT_FOUND ->
+          throw new ResponseStatusException(
+              HttpStatus.UNAUTHORIZED, "Current password is incorrect");
+    };
+  }
+
+  private ResponseEntity<TokenResponse> issueSession(UUID userId) {
+    return issueSession(userId, refreshTokenService.issue(userId));
+  }
+
+  private ResponseEntity<TokenResponse> issueSession(UUID userId, IssuedRefreshToken refreshToken) {
+    String accessToken = jwtTokenService.issueAccessToken(userId);
+    ResponseCookie cookie = cookieFactory.build(refreshToken.plaintext(), refreshToken.maxAge());
+    TokenResponse body =
+        new TokenResponse()
+            .accessToken(accessToken)
+            .tokenType(TOKEN_TYPE)
+            .expiresInSeconds(properties.auth().accessTokenTtl().toSeconds());
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(body);
+  }
+
+  private void revokeAccessToken(Jwt jwt) {
+    if (jwt.getId() != null && jwt.getSubject() != null && jwt.getExpiresAt() != null) {
+      tokenRevocationService.revokeToken(
+          jwt.getId(), UUID.fromString(jwt.getSubject()), jwt.getExpiresAt());
+    }
+  }
+
+  private UUID requireAuthenticatedUserId() {
+    return currentAccessToken()
+        .map(Jwt::getSubject)
+        .map(UUID::fromString)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated"));
+  }
+
+  private java.util.Optional<Jwt> currentAccessToken() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
+      return java.util.Optional.of(jwt);
+    }
+    return java.util.Optional.empty();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/CsrfCookieFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/CsrfCookieFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Forces the deferred {@link CsrfToken} to be rendered on every response so the {@code
+ * CookieCsrfTokenRepository} writes the {@code XSRF-TOKEN} cookie (issue #17). The SPA reads that
+ * cookie and echoes it as the {@code X-XSRF-TOKEN} header on the cookie-bearing auth endpoints
+ * (refresh/logout). Without this, Spring's lazy token would never reach the client and those
+ * requests could not pass the double-submit check.
+ */
+public class CsrfCookieFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+    if (csrfToken != null) {
+      csrfToken.getToken(); // resolve the token, triggering the repository to set the cookie
+    }
+    filterChain.doFilter(request, response);
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/DelegatingJwtDecoder.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/DelegatingJwtDecoder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import io.qnop.service.TokenRevocationService;
+import java.time.Instant;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+/**
+ * The {@link JwtDecoder} used by the resource-server filter (issue #17). It verifies the token with
+ * the local HMAC decoder, then enforces revocation: a locally-issued token must carry {@code
+ * jti}/{@code sub}/{@code iat}, and must not be denylisted or pre-date the user's password
+ * invalidation. Missing claims fail loudly rather than silently skipping the revocation check.
+ *
+ * <p>External OIDC provider decoders will be layered in here as a fallback by issue #21.
+ */
+@Component
+public class DelegatingJwtDecoder implements JwtDecoder {
+
+  private final JwtDecoder localDecoder;
+  private final TokenRevocationService tokenRevocationService;
+
+  public DelegatingJwtDecoder(
+      @Qualifier("localJwtDecoder") JwtDecoder localDecoder,
+      TokenRevocationService tokenRevocationService) {
+    this.localDecoder = localDecoder;
+    this.tokenRevocationService = tokenRevocationService;
+  }
+
+  @Override
+  public Jwt decode(String token) throws JwtException {
+    Jwt jwt = localDecoder.decode(token); // throws JwtException when signature/expiry invalid
+    String jti = jwt.getId();
+    String subject = jwt.getSubject();
+    Instant issuedAt = jwt.getIssuedAt();
+    if (jti == null || subject == null || issuedAt == null) {
+      throw new JwtException("Token missing a required claim (jti/sub/iat)");
+    }
+    if (tokenRevocationService.isRevoked(jti, subject, issuedAt)) {
+      throw new JwtException("Token has been revoked");
+    }
+    return jwt;
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/DelegatingJwtDecoder.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/DelegatingJwtDecoder.java
@@ -23,6 +23,7 @@ package io.qnop.web.security;
 import io.qnop.service.TokenRevocationService;
 import java.time.Instant;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
@@ -55,11 +56,13 @@ public class DelegatingJwtDecoder implements JwtDecoder {
     String jti = jwt.getId();
     String subject = jwt.getSubject();
     Instant issuedAt = jwt.getIssuedAt();
+    // BadJwtException (not a plain JwtException) so the resource server maps these to a 401
+    // (InvalidBearerTokenException) rather than a 500 (AuthenticationServiceException).
     if (jti == null || subject == null || issuedAt == null) {
-      throw new JwtException("Token missing a required claim (jti/sub/iat)");
+      throw new BadJwtException("Token missing a required claim (jti/sub/iat)");
     }
     if (tokenRevocationService.isRevoked(jti, subject, issuedAt)) {
-      throw new JwtException("Token has been revoked");
+      throw new BadJwtException("Token has been revoked");
     }
     return jwt;
   }

--- a/qnop-app/src/main/java/io/qnop/web/security/RefreshTokenCookieFactory.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/RefreshTokenCookieFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import io.qnop.security.QnopProperties;
+import java.time.Duration;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+/**
+ * Builds the {@code Set-Cookie} header carrying the opaque refresh token (issue #17). {@code
+ * HttpOnly} keeps it out of JavaScript (XSS cannot exfiltrate the session), {@code SameSite=Strict}
+ * plus the narrow {@code /api/v1/auth} path defend against CSRF, and {@code Secure} is on by
+ * default (toggle off via {@code qnop.auth.cookie-secure} only for local HTTP dev).
+ */
+@Component
+public class RefreshTokenCookieFactory {
+
+  /** Cookie name — stable so refactors cannot silently rename it. */
+  public static final String COOKIE_NAME = "qnop_refresh";
+
+  /** Narrow path: the cookie is sent only to the auth endpoints. */
+  public static final String COOKIE_PATH = "/api/v1/auth";
+
+  private static final String SAME_SITE = "Strict";
+
+  private final boolean secure;
+
+  public RefreshTokenCookieFactory(QnopProperties properties) {
+    this.secure = Boolean.TRUE.equals(properties.auth().cookieSecure());
+  }
+
+  /** Cookie for a freshly issued refresh token. */
+  public ResponseCookie build(String plaintext, Duration maxAge) {
+    return base(plaintext).maxAge(maxAge).build();
+  }
+
+  /** Clearing cookie (empty value, immediate expiry) for logout / failed refresh. */
+  public ResponseCookie clear() {
+    return base("").maxAge(0).build();
+  }
+
+  private ResponseCookie.ResponseCookieBuilder base(String value) {
+    return ResponseCookie.from(COOKIE_NAME, value)
+        .httpOnly(true)
+        .secure(secure)
+        .sameSite(SAME_SITE)
+        .path(COOKIE_PATH);
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -32,7 +32,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -40,11 +44,14 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 /**
  * The servlet security filter chain for the Community server (issue #10, ADR-0022).
  *
- * <p>The API is stateless (token-based, from issue #17), so sessions and CSRF cookies are disabled
- * and unauthenticated requests receive a JSON {@code 401} rather than a login redirect. Actuator
- * health is public; everything else requires authentication. Security headers (a strict CSP for a
- * JSON API, frame-deny, referrer policy, HSTS) are applied to every response. CORS is driven by
- * {@link QnopProperties} so the SPA origin is configurable per environment.
+ * <p>The API is stateless: bearer access tokens are validated by the resource-server filter using
+ * {@link DelegatingJwtDecoder} (local HMAC + revocation, issue #17), and unauthenticated requests
+ * receive a JSON {@code 401} rather than a login redirect. The login endpoint and actuator health
+ * are public; refresh/logout are public but ride on the HttpOnly refresh cookie, so they are
+ * CSRF-protected via a double-submit cookie token (the rest of the API is token-based and exempt).
+ * Everything else requires authentication. Security headers (a strict CSP for a JSON API,
+ * frame-deny, referrer policy, HSTS) are applied to every response. CORS is driven by {@link
+ * QnopProperties} so the SPA origin is configurable per environment.
  */
 @Configuration
 @EnableWebSecurity
@@ -53,13 +60,26 @@ public class SecurityConfiguration {
 
   private static final long HSTS_MAX_AGE_SECONDS = 31_536_000L; // one year
 
+  /** Cookie-bearing, state-changing auth endpoints that require a double-submit CSRF token. */
+  private static final RequestMatcher AUTH_CSRF_MATCHER =
+      request ->
+          "POST".equalsIgnoreCase(request.getMethod())
+              && ("/api/v1/auth/refresh".equals(request.getRequestURI())
+                  || "/api/v1/auth/logout".equals(request.getRequestURI()));
+
   @Bean
   SecurityFilterChain securityFilterChain(
       HttpSecurity http,
       AuthenticationEntryPoint authenticationEntryPoint,
-      CorsConfigurationSource corsConfigurationSource)
+      CorsConfigurationSource corsConfigurationSource,
+      DelegatingJwtDecoder jwtDecoder)
       throws Exception {
-    http.csrf(csrf -> csrf.disable())
+    http.csrf(
+            csrf ->
+                csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                    .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+                    .requireCsrfProtectionMatcher(AUTH_CSRF_MATCHER))
+        .addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class)
         .cors(cors -> cors.configurationSource(corsConfigurationSource))
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -67,8 +87,12 @@ public class SecurityConfiguration {
             auth ->
                 auth.requestMatchers("/actuator/health", "/actuator/health/**")
                     .permitAll()
+                    .requestMatchers(
+                        "/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/logout")
+                    .permitAll()
                     .anyRequest()
                     .authenticated())
+        .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder)))
         .httpBasic(httpBasic -> httpBasic.disable())
         .formLogin(formLogin -> formLogin.disable())
         .exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryPoint))

--- a/qnop-app/src/test/java/io/qnop/service/RefreshTokenServiceTest.java
+++ b/qnop-app/src/test/java/io/qnop/service/RefreshTokenServiceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.RefreshToken;
+import io.qnop.repository.RefreshTokenRepository;
+import io.qnop.security.JwtKeyService;
+import io.qnop.security.QnopProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Unit tests for {@link RefreshTokenService} rotation and reuse-detection (DB-free). */
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+  @Mock private RefreshTokenRepository repository;
+
+  private RefreshTokenService service;
+
+  @BeforeEach
+  void setUp() {
+    QnopProperties properties =
+        new QnopProperties(
+            new QnopProperties.Auth(
+                "unit-test-jwt-secret-0123456789abcdef",
+                "unit-test-encryption-key-0123456789",
+                "0123456789abcdef",
+                Duration.ofMinutes(15),
+                Duration.ofDays(7),
+                "qnop",
+                Boolean.TRUE),
+            new QnopProperties.Cors(null));
+    RefreshTokenHasher hasher = new RefreshTokenHasher(new JwtKeyService(properties));
+    service = new RefreshTokenService(repository, hasher, properties);
+  }
+
+  @Test
+  void issueReturnsPlaintextAndExpiry() {
+    when(repository.save(any(RefreshToken.class))).thenAnswer(call -> call.getArgument(0));
+
+    RefreshTokenService.IssuedRefreshToken issued = service.issue(UUID.randomUUID());
+
+    assertThat(issued.plaintext()).isNotBlank();
+    assertThat(issued.expiresAt()).isAfter(Instant.now());
+  }
+
+  @Test
+  void rotateUnknownTokenReturnsUnknown() {
+    when(repository.findByTokenLookupHash(any())).thenReturn(Optional.empty());
+
+    assertThat(service.rotate("nope"))
+        .isInstanceOf(RefreshTokenService.RotationResult.Unknown.class);
+    verify(repository, never()).revokeFamily(any(), any(), any());
+  }
+
+  @Test
+  void rotateActiveTokenIssuesSuccessor() {
+    UUID userId = UUID.randomUUID();
+    RefreshToken active =
+        new RefreshToken(UUID.randomUUID(), userId, "hash", Instant.now().plusSeconds(3600));
+    when(repository.findByTokenLookupHash(any())).thenReturn(Optional.of(active));
+    when(repository.save(any(RefreshToken.class))).thenAnswer(call -> call.getArgument(0));
+
+    RefreshTokenService.RotationResult result = service.rotate("present");
+
+    assertThat(result).isInstanceOf(RefreshTokenService.RotationResult.Success.class);
+    assertThat(((RefreshTokenService.RotationResult.Success) result).userId()).isEqualTo(userId);
+    assertThat(active.getRevokedAt()).isNotNull();
+    assertThat(active.getRevocationReason()).isEqualTo(RefreshTokenService.ROTATED);
+  }
+
+  @Test
+  void rotateRevokedTokenDetectsReuseAndRevokesFamily() {
+    UUID family = UUID.randomUUID();
+    RefreshToken revoked =
+        new RefreshToken(family, UUID.randomUUID(), "hash", Instant.now().plusSeconds(3600));
+    revoked.setRevokedAt(Instant.now().minusSeconds(60));
+    when(repository.findByTokenLookupHash(any())).thenReturn(Optional.of(revoked));
+
+    RefreshTokenService.RotationResult result = service.rotate("replayed");
+
+    assertThat(result).isInstanceOf(RefreshTokenService.RotationResult.Reused.class);
+    verify(repository).revokeFamily(eq(family), eq(RefreshTokenService.REUSE_DETECTED), any());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.UserRepository;
+import io.qnop.web.security.RefreshTokenCookieFactory;
+import jakarta.servlet.http.Cookie;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * End-to-end auth flow against a real PostgreSQL (issue #17): login issues an access token plus a
+ * refresh cookie, refresh rotates the token, a replayed refresh token is rejected (reuse
+ * detection), logout clears the cookie, and a password change invalidates existing access tokens.
+ * Uses MockMvc with the {@code csrf()} post-processor for the double-submit-protected endpoints.
+ */
+@AutoConfigureMockMvc
+@Transactional
+class AuthControllerIT extends AbstractIntegrationTest {
+
+  private static final String PASSWORD = "correct horse battery";
+
+  private static final Pattern ACCESS_TOKEN =
+      Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+  @Autowired MockMvc mockMvc;
+  @Autowired UserRepository userRepository;
+  @Autowired PasswordEncoder passwordEncoder;
+
+  @Test
+  void loginIssuesAccessTokenAndRefreshCookie() throws Exception {
+    createUser("alice");
+
+    MvcResult result =
+        mockMvc
+            .perform(loginRequest("alice", PASSWORD))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").isNotEmpty())
+            .andExpect(jsonPath("$.tokenType").value("Bearer"))
+            .andExpect(jsonPath("$.expiresInSeconds").value(900))
+            .andReturn();
+
+    Cookie cookie = result.getResponse().getCookie(RefreshTokenCookieFactory.COOKIE_NAME);
+    assertThat(cookie).isNotNull();
+    assertThat(cookie.getValue()).isNotBlank();
+    assertThat(cookie.isHttpOnly()).isTrue();
+  }
+
+  @Test
+  void rejectsInvalidCredentials() throws Exception {
+    createUser("bob");
+
+    mockMvc.perform(loginRequest("bob", "wrong-password")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void refreshRotatesTheToken() throws Exception {
+    createUser("carol");
+    Cookie refresh = login("carol");
+
+    MvcResult rotated =
+        mockMvc
+            .perform(post("/api/v1/auth/refresh").cookie(refresh).with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").isNotEmpty())
+            .andReturn();
+
+    Cookie newCookie = rotated.getResponse().getCookie(RefreshTokenCookieFactory.COOKIE_NAME);
+    assertThat(newCookie).isNotNull();
+    assertThat(newCookie.getValue()).isNotEqualTo(refresh.getValue());
+  }
+
+  @Test
+  void rejectsReusedRefreshToken() throws Exception {
+    createUser("dave");
+    Cookie refresh = login("dave");
+
+    // First rotation consumes the token.
+    mockMvc
+        .perform(post("/api/v1/auth/refresh").cookie(refresh).with(csrf()))
+        .andExpect(status().isOk());
+
+    // Replaying the now-revoked token is rejected (and revokes the whole family).
+    mockMvc
+        .perform(post("/api/v1/auth/refresh").cookie(refresh).with(csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void logoutClearsTheCookie() throws Exception {
+    createUser("erin");
+    Cookie refresh = login("erin");
+
+    MvcResult result =
+        mockMvc
+            .perform(post("/api/v1/auth/logout").cookie(refresh).with(csrf()))
+            .andExpect(status().isNoContent())
+            .andReturn();
+
+    Cookie cleared = result.getResponse().getCookie(RefreshTokenCookieFactory.COOKIE_NAME);
+    assertThat(cleared).isNotNull();
+    assertThat(cleared.getMaxAge()).isZero();
+  }
+
+  @Test
+  void changePasswordInvalidatesExistingAccessTokens() throws Exception {
+    User user = createUser("frank");
+    String accessToken = loginAccessToken("frank");
+
+    // The access token works before the change.
+    mockMvc
+        .perform(get("/api/v1/config").header("Authorization", "Bearer " + accessToken))
+        .andExpect(status().isOk());
+
+    String body =
+        "{\"currentPassword\":\"%s\",\"newPassword\":\"%s\"}"
+            .formatted(PASSWORD, "a-brand-new-strong-password");
+    mockMvc
+        .perform(
+            post("/api/v1/auth/change-password")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isNoContent());
+
+    // The previously issued access token is now rejected (passwordInvalidatedBefore bumped).
+    mockMvc
+        .perform(get("/api/v1/config").header("Authorization", "Bearer " + accessToken))
+        .andExpect(status().isUnauthorized());
+
+    assertThat(user.getId()).isNotNull();
+  }
+
+  private User createUser(String username) {
+    return userRepository.saveAndFlush(
+        User.internal(
+            username, username + "@example.com", username, passwordEncoder.encode(PASSWORD)));
+  }
+
+  private MockHttpServletRequestBuilder loginRequest(String usernameOrEmail, String password) {
+    String body =
+        "{\"usernameOrEmail\":\"%s\",\"password\":\"%s\"}".formatted(usernameOrEmail, password);
+    return post("/api/v1/auth/login").contentType(MediaType.APPLICATION_JSON).content(body);
+  }
+
+  private Cookie login(String username) throws Exception {
+    MvcResult result =
+        mockMvc.perform(loginRequest(username, PASSWORD)).andExpect(status().isOk()).andReturn();
+    return result.getResponse().getCookie(RefreshTokenCookieFactory.COOKIE_NAME);
+  }
+
+  private String loginAccessToken(String username) throws Exception {
+    MvcResult result =
+        mockMvc.perform(loginRequest(username, PASSWORD)).andExpect(status().isOk()).andReturn();
+    Matcher matcher = ACCESS_TOKEN.matcher(result.getResponse().getContentAsString());
+    assertThat(matcher.find()).isTrue();
+    return matcher.group(1);
+  }
+}

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -32,6 +32,13 @@ dependencies {
     implementation(libs.spring.boot.starter.validation)
     implementation(libs.spring.security.crypto)
 
+    // JWT & session core (issue #17): Nimbus encode/decode for self-issued HS256
+    // access tokens, and Caffeine for the in-memory revocation (jti) denylist.
+    // Framework-light (no spring-security-web); the servlet resource-server
+    // filter is wired in qnop-app.
+    implementation(libs.spring.security.oauth2.jose)
+    implementation(libs.caffeine)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/qnop-core/src/main/java/io/qnop/security/JwtConfiguration.java
+++ b/qnop-core/src/main/java/io/qnop/security/JwtConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import javax.crypto.SecretKey;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+/**
+ * Nimbus encoder/decoder beans for self-issued HMAC-SHA256 (HS256) access tokens (issue #17). The
+ * signing key is HKDF-derived from {@code qnop.auth.jwt-secret} via {@link JwtKeyService}
+ * (ADR-0022), domain-separated under the {@code access-token} purpose.
+ *
+ * <p>The {@code localJwtDecoder} bean verifies tokens this server minted; it is wrapped by {@code
+ * io.qnop.web.security.DelegatingJwtDecoder}, which adds revocation checks and (later, issue #21)
+ * OIDC provider fallback. The resource-server filter uses the delegating decoder, not this one.
+ */
+@Configuration
+public class JwtConfiguration {
+
+  private final SecretKey signingKey;
+
+  public JwtConfiguration(JwtKeyService jwtKeyService) {
+    this.signingKey = jwtKeyService.deriveKey("access-token");
+  }
+
+  @Bean
+  JwtEncoder jwtEncoder() {
+    return new NimbusJwtEncoder(new ImmutableSecret<>(signingKey));
+  }
+
+  @Bean
+  JwtDecoder localJwtDecoder() {
+    return NimbusJwtDecoder.withSecretKey(signingKey).macAlgorithm(MacAlgorithm.HS256).build();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
+++ b/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
@@ -23,6 +23,7 @@ package io.qnop.security;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import java.time.Duration;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -50,6 +51,11 @@ public record QnopProperties(@Valid Auth auth, @Valid Cors cors) {
    * @param encryptionKey password for symmetric text encryption; must be a strong, non-default
    *     secret
    * @param encryptionSalt hex-encoded salt for symmetric text encryption (Encryptors.delux)
+   * @param accessTokenTtl lifetime of a self-issued access token (default 15m, issue #17)
+   * @param refreshTokenTtl lifetime of a refresh token / its cookie (default 7d, issue #17)
+   * @param issuer the {@code iss} claim of self-issued tokens (default {@code qnop})
+   * @param cookieSecure whether the refresh cookie carries {@code Secure} (default true; set false
+   *     only for local HTTP dev — browsers drop {@code Secure} cookies on plain HTTP)
    */
   public record Auth(
       @ValidSecret String jwtSecret,
@@ -59,7 +65,19 @@ public record QnopProperties(@Valid Auth auth, @Valid Cors cors) {
               regexp = "^[0-9a-fA-F]{16,}$",
               message =
                   "qnop.auth.encryption-salt must be a hex-encoded string of at least 16 characters")
-          String encryptionSalt) {}
+          String encryptionSalt,
+      Duration accessTokenTtl,
+      Duration refreshTokenTtl,
+      String issuer,
+      Boolean cookieSecure) {
+
+    public Auth {
+      accessTokenTtl = accessTokenTtl != null ? accessTokenTtl : Duration.ofMinutes(15);
+      refreshTokenTtl = refreshTokenTtl != null ? refreshTokenTtl : Duration.ofDays(7);
+      issuer = (issuer == null || issuer.isBlank()) ? "qnop" : issuer;
+      cookieSecure = cookieSecure == null ? Boolean.TRUE : cookieSecure;
+    }
+  }
 
   /**
    * Cross-origin resource sharing policy.

--- a/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
+++ b/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
@@ -77,15 +77,6 @@ public record QnopProperties(@Valid Auth auth, @Valid Cors cors) {
       issuer = (issuer == null || issuer.isBlank()) ? "qnop" : issuer;
       cookieSecure = cookieSecure == null ? Boolean.TRUE : cookieSecure;
     }
-
-    /**
-     * Convenience constructor for the secret-only fields; token/cookie settings fall back to their
-     * defaults. Spring binds via the canonical record constructor, so this is for programmatic
-     * construction (mainly tests) only.
-     */
-    public Auth(String jwtSecret, String encryptionKey, String encryptionSalt) {
-      this(jwtSecret, encryptionKey, encryptionSalt, null, null, null, null);
-    }
   }
 
   /**

--- a/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
+++ b/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
@@ -77,6 +77,15 @@ public record QnopProperties(@Valid Auth auth, @Valid Cors cors) {
       issuer = (issuer == null || issuer.isBlank()) ? "qnop" : issuer;
       cookieSecure = cookieSecure == null ? Boolean.TRUE : cookieSecure;
     }
+
+    /**
+     * Convenience constructor for the secret-only fields; token/cookie settings fall back to their
+     * defaults. Spring binds via the canonical record constructor, so this is for programmatic
+     * construction (mainly tests) only.
+     */
+    public Auth(String jwtSecret, String encryptionKey, String encryptionSalt) {
+      this(jwtSecret, encryptionKey, encryptionSalt, null, null, null, null);
+    }
   }
 
   /**

--- a/qnop-core/src/main/java/io/qnop/service/AuthService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AuthService.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.User;
+import io.qnop.entity.UserSource;
+import io.qnop.repository.UserRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Credential verification and password management for local (INTERNAL) users (issue #17). Keeps the
+ * repository and entity access in the service layer so the web layer never touches them directly
+ * (ADR-0004); the controller orchestrates token issuance on top of the results returned here.
+ */
+@Service
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final TokenRevocationService tokenRevocationService;
+  private final RefreshTokenService refreshTokenService;
+
+  public AuthService(
+      UserRepository userRepository,
+      PasswordEncoder passwordEncoder,
+      TokenRevocationService tokenRevocationService,
+      RefreshTokenService refreshTokenService) {
+    this.userRepository = userRepository;
+    this.passwordEncoder = passwordEncoder;
+    this.tokenRevocationService = tokenRevocationService;
+    this.refreshTokenService = refreshTokenService;
+  }
+
+  /**
+   * Verifies local credentials. Accepts the username or the (case-insensitive) email. Returns the
+   * user id on success, or empty on any failure (unknown user, disabled, wrong password) — the
+   * caller must not distinguish the reasons.
+   */
+  @Transactional(readOnly = true)
+  public Optional<UUID> authenticate(String usernameOrEmail, String password) {
+    User user =
+        userRepository
+            .findByUsernameAndSource(usernameOrEmail, UserSource.INTERNAL)
+            .or(
+                () ->
+                    userRepository.findByEmailIgnoreCaseAndSource(
+                        usernameOrEmail, UserSource.INTERNAL))
+            .orElse(null);
+    if (user == null
+        || !user.isEnabled()
+        || user.getPasswordHash() == null
+        || !passwordEncoder.matches(password, user.getPasswordHash())) {
+      return Optional.empty();
+    }
+    return Optional.of(user.getId());
+  }
+
+  /**
+   * Re-verifies the current password, stores the new hash, and invalidates every existing session
+   * (access tokens via {@code passwordInvalidatedBefore}; refresh families revoked).
+   */
+  @Transactional
+  public ChangePasswordOutcome changePassword(
+      UUID userId, String currentPassword, String newPassword) {
+    User user = userRepository.findById(userId).orElse(null);
+    if (user == null) {
+      return ChangePasswordOutcome.USER_NOT_FOUND;
+    }
+    if (user.getSource() != UserSource.INTERNAL || user.getPasswordHash() == null) {
+      return ChangePasswordOutcome.NOT_LOCAL;
+    }
+    if (!passwordEncoder.matches(currentPassword, user.getPasswordHash())) {
+      return ChangePasswordOutcome.WRONG_PASSWORD;
+    }
+    user.setPasswordHash(passwordEncoder.encode(newPassword));
+    userRepository.save(user);
+    tokenRevocationService.revokeAllForUser(userId);
+    refreshTokenService.revokeAllForUser(userId);
+    return ChangePasswordOutcome.SUCCESS;
+  }
+
+  /** Result of a {@link #changePassword} attempt. */
+  public enum ChangePasswordOutcome {
+    SUCCESS,
+    WRONG_PASSWORD,
+    NOT_LOCAL,
+    USER_NOT_FOUND
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/JwtTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/JwtTokenService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.security.QnopProperties;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Service;
+
+/**
+ * Issues short-lived HS256 access tokens (issue #17). The subject is the {@code qnop_user.id} UUID;
+ * every token carries a unique {@code jti} so it can be individually revoked (see {@code
+ * TokenRevocationService}). TTL and issuer come from {@code qnop.auth} (default 15m / {@code
+ * qnop}).
+ */
+@Service
+public class JwtTokenService {
+
+  private final JwtEncoder jwtEncoder;
+  private final QnopProperties properties;
+
+  public JwtTokenService(JwtEncoder jwtEncoder, QnopProperties properties) {
+    this.jwtEncoder = jwtEncoder;
+    this.properties = properties;
+  }
+
+  /** Mints a signed access token for the given user id. */
+  public String issueAccessToken(UUID userId) {
+    QnopProperties.Auth auth = properties.auth();
+    Instant now = Instant.now();
+    JwtClaimsSet claims =
+        JwtClaimsSet.builder()
+            .id(UUID.randomUUID().toString())
+            .issuer(auth.issuer())
+            .issuedAt(now)
+            .expiresAt(now.plus(auth.accessTokenTtl()))
+            .subject(userId.toString())
+            .build();
+    JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+    return jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/RefreshTokenHasher.java
+++ b/qnop-core/src/main/java/io/qnop/service/RefreshTokenHasher.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.security.JwtKeyService;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Component;
+
+/**
+ * Computes the lookup hash stored for an opaque refresh token (issue #17). Only {@code
+ * HMAC-SHA256(plaintext)} is persisted (column {@code refresh_token.token_lookup_hash}); the
+ * plaintext lives solely in the client's cookie, so a database leak exposes no usable tokens. The
+ * HMAC key is HKDF-derived from {@code qnop.auth.jwt-secret} (ADR-0022), domain-separated from the
+ * JWT signing key.
+ */
+@Component
+public class RefreshTokenHasher {
+
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+  private final SecretKey key;
+
+  public RefreshTokenHasher(JwtKeyService jwtKeyService) {
+    this.key = jwtKeyService.deriveKey("refresh-token-lookup");
+  }
+
+  /** Returns the 64-character lowercase-hex HMAC-SHA256 of the token. */
+  public String hash(String plaintext) {
+    try {
+      Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+      mac.init(key);
+      byte[] digest = mac.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(digest.length * 2);
+      for (byte b : digest) {
+        hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+        hex.append(Character.forDigit(b & 0xF, 16));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+      throw new IllegalStateException("Unable to compute refresh-token lookup hash", e);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.RefreshToken;
+import io.qnop.repository.RefreshTokenRepository;
+import io.qnop.security.QnopProperties;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Mints, rotates, and revokes the opaque refresh tokens that back the HttpOnly session cookie
+ * (issue #17). Only the {@link RefreshTokenHasher HMAC} of each token is stored. Rotation is
+ * single-use with family-wide reuse detection:
+ *
+ * <ul>
+ *   <li>presenting an <em>active</em> token revokes it ({@code ROTATED}) and issues a successor in
+ *       the same family;
+ *   <li>presenting an already-<em>revoked</em> token (a replay) revokes the entire family ({@code
+ *       REUSE_DETECTED}) — the standard refresh-token reuse response;
+ *   <li>an unknown or expired token yields {@link RotationResult.Unknown}, indistinguishable from
+ *       reuse to the caller.
+ * </ul>
+ */
+@Service
+public class RefreshTokenService {
+
+  static final String ROTATED = "ROTATED";
+  static final String REUSE_DETECTED = "REUSE_DETECTED";
+  static final String LOGOUT = "LOGOUT";
+  private static final int TOKEN_BYTES = 32;
+
+  private final RefreshTokenRepository repository;
+  private final RefreshTokenHasher hasher;
+  private final QnopProperties properties;
+  private final SecureRandom secureRandom = new SecureRandom();
+
+  public RefreshTokenService(
+      RefreshTokenRepository repository, RefreshTokenHasher hasher, QnopProperties properties) {
+    this.repository = repository;
+    this.hasher = hasher;
+    this.properties = properties;
+  }
+
+  /** Issues a fresh refresh token in a new family (initial login). */
+  @Transactional
+  public IssuedRefreshToken issue(UUID userId) {
+    return issueInFamily(userId, UUID.randomUUID()).toIssued(properties.auth().refreshTokenTtl());
+  }
+
+  /** Rotates a presented token; see the class doc for reuse-detection semantics. */
+  @Transactional
+  public RotationResult rotate(String presentedPlaintext) {
+    RefreshToken row =
+        repository.findByTokenLookupHash(hasher.hash(presentedPlaintext)).orElse(null);
+    if (row == null) {
+      return new RotationResult.Unknown();
+    }
+    Instant now = Instant.now();
+    if (row.getRevokedAt() != null) {
+      repository.revokeFamily(row.getFamilyId(), REUSE_DETECTED, now);
+      return new RotationResult.Reused();
+    }
+    if (row.getExpiresAt().isBefore(now)) {
+      return new RotationResult.Unknown();
+    }
+    Minted successor = issueInFamily(row.getUserId(), row.getFamilyId());
+    row.setRevokedAt(now);
+    row.setRevocationReason(ROTATED);
+    row.setRotatedToId(successor.entity().getId());
+    return new RotationResult.Success(
+        row.getUserId(), successor.toIssued(properties.auth().refreshTokenTtl()));
+  }
+
+  /** Revokes the whole family behind a presented cookie (logout). Returns true if a row matched. */
+  @Transactional
+  public boolean revokePresentedFamily(String presentedPlaintext) {
+    RefreshToken row =
+        repository.findByTokenLookupHash(hasher.hash(presentedPlaintext)).orElse(null);
+    if (row == null) {
+      return false;
+    }
+    return repository.revokeFamily(row.getFamilyId(), LOGOUT, Instant.now()) > 0;
+  }
+
+  /** Revokes every active refresh token for a user (e.g. on password change). */
+  @Transactional
+  public void revokeAllForUser(UUID userId) {
+    repository.revokeAllForUser(userId, LOGOUT, Instant.now());
+  }
+
+  private Minted issueInFamily(UUID userId, UUID familyId) {
+    String plaintext = generatePlaintext();
+    Instant expiresAt = Instant.now().plus(properties.auth().refreshTokenTtl());
+    RefreshToken saved =
+        repository.save(new RefreshToken(familyId, userId, hasher.hash(plaintext), expiresAt));
+    return new Minted(saved, plaintext);
+  }
+
+  private String generatePlaintext() {
+    byte[] bytes = new byte[TOKEN_BYTES];
+    secureRandom.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  /** A persisted refresh-token row paired with its plaintext (which is never stored). */
+  private record Minted(RefreshToken entity, String plaintext) {
+
+    IssuedRefreshToken toIssued(Duration ttl) {
+      return new IssuedRefreshToken(plaintext, entity.getExpiresAt(), ttl);
+    }
+  }
+
+  /** A newly issued refresh token: the plaintext for the cookie plus its expiry/max-age. */
+  public record IssuedRefreshToken(String plaintext, Instant expiresAt, Duration maxAge) {}
+
+  /** Outcome of a {@link #rotate} call. */
+  public sealed interface RotationResult {
+
+    /** Rotation succeeded; a new access token should be minted for {@code userId}. */
+    record Success(UUID userId, IssuedRefreshToken token) implements RotationResult {}
+
+    /** A revoked token was replayed; the whole family has been revoked. */
+    record Reused() implements RotationResult {}
+
+    /** No active token matched (unknown or expired). */
+    record Unknown() implements RotationResult {}
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.qnop.entity.RevokedToken;
+import io.qnop.entity.User;
+import io.qnop.repository.RevokedTokenRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.security.QnopProperties;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JWT revocation (issue #17): an explicit {@code jti} denylist (the {@code revoked_token} table,
+ * fronted by a Caffeine cache to avoid a DB round-trip per request) plus bulk invalidation via
+ * {@code qnop_user.password_invalidated_before} — any token issued before that instant is rejected.
+ * The raw {@code jti} is SHA-256 hashed before it is cached or persisted, so a leak exposes only
+ * opaque digests.
+ */
+@Service
+public class TokenRevocationService {
+
+  private static final long CACHE_MAX_SIZE = 10_000;
+
+  private final RevokedTokenRepository revokedTokenRepository;
+  private final UserRepository userRepository;
+  private final Cache<String, Boolean> revokedJtiCache;
+
+  public TokenRevocationService(
+      RevokedTokenRepository revokedTokenRepository,
+      UserRepository userRepository,
+      QnopProperties properties) {
+    this.revokedTokenRepository = revokedTokenRepository;
+    this.userRepository = userRepository;
+    this.revokedJtiCache =
+        Caffeine.newBuilder()
+            .maximumSize(CACHE_MAX_SIZE)
+            .expireAfterWrite(properties.auth().accessTokenTtl())
+            .build();
+  }
+
+  /** Adds a single access token's {@code jti} to the denylist until it would have expired. */
+  @Transactional
+  public void revokeToken(String jti, UUID userId, Instant expiresAt) {
+    String jtiHash = hashJti(jti);
+    if (revokedTokenRepository.existsByJti(jtiHash)) {
+      return;
+    }
+    revokedTokenRepository.save(new RevokedToken(jtiHash, userId, expiresAt));
+    revokedJtiCache.put(jtiHash, Boolean.TRUE);
+  }
+
+  /**
+   * Whether a token must be rejected — either its {@code jti} is denylisted, or it was issued
+   * before the user's password was last invalidated.
+   */
+  @Transactional(readOnly = true)
+  public boolean isRevoked(String jti, String subject, Instant issuedAt) {
+    String jtiHash = hashJti(jti);
+    Boolean denylisted = revokedJtiCache.get(jtiHash, revokedTokenRepository::existsByJti);
+    if (Boolean.TRUE.equals(denylisted)) {
+      return true;
+    }
+    UUID userId;
+    try {
+      userId = UUID.fromString(subject);
+    } catch (IllegalArgumentException e) {
+      return false; // non-UUID subject can't match a user; JWS verification already passed
+    }
+    User user = userRepository.findById(userId).orElse(null);
+    if (user == null || user.getPasswordInvalidatedBefore() == null) {
+      return false;
+    }
+    return issuedAt.isBefore(user.getPasswordInvalidatedBefore());
+  }
+
+  /**
+   * Bulk-invalidates every existing token for a user by bumping {@code passwordInvalidatedBefore}.
+   */
+  @Transactional
+  public void revokeAllForUser(UUID userId) {
+    userRepository
+        .findById(userId)
+        .ifPresent(
+            user -> {
+              user.setPasswordInvalidatedBefore(Instant.now());
+              userRepository.save(user);
+            });
+  }
+
+  private static String hashJti(String jti) {
+    try {
+      byte[] digest =
+          MessageDigest.getInstance("SHA-256").digest(jti.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(digest.length * 2);
+      for (byte b : digest) {
+        hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+        hex.append(Character.forDigit(b & 0xF, 16));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/security/CryptoConfigurationTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/CryptoConfigurationTest.java
@@ -40,7 +40,11 @@ class CryptoConfigurationTest {
         new QnopProperties.Auth(
             "crypto-test-jwt-secret-0123456789-abc",
             "crypto-test-encryption-key-0123456789",
-            "0123456789abcdef0123456789abcdef"),
+            "0123456789abcdef0123456789abcdef",
+            null,
+            null,
+            null,
+            null),
         new QnopProperties.Cors(List.of()));
   }
 

--- a/qnop-core/src/test/java/io/qnop/security/JwtKeyServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/JwtKeyServiceTest.java
@@ -38,7 +38,11 @@ class JwtKeyServiceTest {
             new QnopProperties.Auth(
                 "jwt-key-service-test-secret-0123456789",
                 "jwt-key-service-test-enckey-0123456789",
-                "0123456789abcdef0123456789abcdef"),
+                "0123456789abcdef0123456789abcdef",
+                null,
+                null,
+                null,
+                null),
             new QnopProperties.Cors(List.of()));
     return new JwtKeyService(properties);
   }


### PR DESCRIPTION
## What

JWT access tokens + rotating refresh tokens + revocation + `AuthController` (issue #17). Closes #17. Builds on the #10 crypto foundation (`JwtKeyService`, BCrypt) and the #12 token schema.

### Tokens & services (`io.qnop.service`, `io.qnop.security`)
- **`JwtTokenService`** — HS256 access tokens (jti/iss/iat/exp/sub, 15m) via `JwtKeyService.deriveKey("access-token")` + Nimbus.
- **`RefreshTokenService`** — opaque token (HMAC-SHA256 lookup hash), single-use family rotation, **reuse-detection revokes the whole family**, 7d TTL.
- **`TokenRevocationService`** — `jti` denylist (`revoked_token`, SHA-256, Caffeine-cached) + bulk invalidation via `passwordInvalidatedBefore`.
- **`AuthService`** — credential verification + password change (keeps repo/entity in the service layer).
- **`DelegatingJwtDecoder`** + **`RefreshTokenCookieFactory`** (`io.qnop.web.security`).

### Web
- OpenAPI `/auth/login`, `/auth/refresh`, `/auth/logout`, `/auth/change-password` → generated `AuthApi`, implemented by `AuthController`.
- Refresh token in an HttpOnly, `SameSite=Strict`, `Secure` cookie (`qnop_refresh`, path `/api/v1/auth`).
- `SecurityConfiguration`: resource-server (bearer JWT) + **double-submit CSRF** scoped to the cookie endpoints (`CookieCsrfTokenRepository` + `CsrfCookieFilter`).

### Config / deps / ADR
- `qnop.auth` gains access/refresh TTLs, issuer, cookie-secure (defaults; back-compat 3-arg `Auth` ctor).
- Deps: `spring-security-oauth2-jose`, `spring-boot-starter-oauth2-resource-server`, `caffeine`.
- **ADR-0025** (JWT + refresh rotation + revocation).

Grounded throughout in the plugwerk reference implementation; UUIDs/VERSION_7 and qnop conventions kept.

## Note for #21
`DelegatingJwtDecoder` is local-HMAC + revocation only; OIDC provider decoders are layered in as a fallback by #21.

## Test plan
- [x] compile, spotlessCheck, ArchUnit, `RefreshTokenServiceTest` (unit) — local
- [ ] `AuthControllerIT` (Testcontainers, CI): login, refresh rotation, reuse-detection → 401, logout clears cookie, change-password invalidates existing access tokens

🤖 Co-Author: Claude (Opus 4.x) via Claude Code
