### PR TITLE
feat: auth endpoint rate limiting (Bucket4j)

### DIFF
--- a/docs/adr/0027-auth-rate-limiting.md
+++ b/docs/adr/0027-auth-rate-limiting.md
@@ -1,0 +1,79 @@
+# ADR-0027: Auth rate limiting & trusted-proxy IP resolution
+
+- **Status:** Accepted
+- **Date:** 2026-06-15
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+The public/auth endpoints (issue #17's `AuthController`, and #20's registration /
+password-reset to come) are exposed to online abuse: credential brute-force on
+login, refresh-token spam, and brute-force of the current password on
+change-password. We need per-endpoint throttling that returns a standard HTTP
+`429 Too Many Requests` with `Retry-After`, keyed appropriately per endpoint, and
+tunable per deployment. Ported from plugwerk's security package.
+
+Two cross-cutting concerns shape the design:
+
+- **Where the limit is enforced.** IP-keyed limits can be applied pre-auth in a
+  servlet filter (no request body needed). Subject-keyed limits need the
+  authenticated principal, so they must run after the resource-server bearer
+  filter. Email-/token-keyed limits (register, password-reset) need the parsed
+  request body and therefore belong inside the controller — those land with #20.
+- **Trusting `X-Forwarded-For`.** Per-IP limiting is only as sound as the client
+  IP. A naive read of `X-Forwarded-For` lets an attacker spoof the header to
+  rotate buckets and bypass the limit entirely.
+
+## Decision
+
+- **Bucket4j + Caffeine.** A single `BucketRateLimitService` holds token buckets
+  in a Caffeine cache keyed `scope:key`, with `expireAfterAccess` + a size cap to
+  bound memory. Callers pass scope, key, capacity and window at consume time, so
+  one service backs every rate-limit context. Bucket4j carries an explicit version
+  (not in the Spring Boot BOM); Caffeine is BOM-managed and already present from
+  the #17 revocation denylist.
+- **`OncePerRequestFilter` per endpoint, returning `429` + `Retry-After`.** The
+  IP-keyed login and refresh filters run before CSRF/auth processing; the
+  subject-keyed change-password filter runs after bearer authentication (before
+  `AuthorizationFilter`) so it can key on the JWT `sub`. A `null` key (e.g.
+  unauthenticated change-password) passes through to the normal `401` rather than
+  being masked by a rate-limit decision.
+- **Trusted-proxy `X-Forwarded-For`, secure by default.**
+  `HttpClientIpResolver` only honours `X-Forwarded-For` when the immediate hop
+  (`getRemoteAddr()`) matches a configured trusted-proxy CIDR. **The default trust
+  list is empty**, so a server with no reverse proxy ignores the header entirely
+  and cannot be spoofed. Operators behind a proxy MUST set
+  `qnop.auth.rate-limit.trusted-proxy-cidrs` to the proxy's egress IPs.
+- **Tunable via `qnop.auth.rate-limit.*`** (`RateLimitProperties`). Defaults match
+  issue #18: login 10/60s (IP), refresh 30/60s (IP), change-password 5/300s
+  (subject). Register (10/60s IP + 5/3600s email) and password-reset (5/900s IP +
+  10/3600s token) limits are added when their endpoints land in #20.
+
+## Consequences
+
+- Brute-force and spam against the live auth endpoints are bounded; clients get a
+  standard `429` + `Retry-After` they can honour.
+- Per-IP limiting is correct behind a single reverse proxy **only if**
+  `trusted-proxy-cidrs` is configured; otherwise every client shares the proxy's
+  bucket. This is documented on the property and resolver. Multi-hop proxy chains
+  would need a right-to-left walk — deferred until a deployment needs it.
+- The rate-limit subsystem lives in the web layer (`io.qnop.web.security.ratelimit`)
+  with its own `RateLimitProperties`, keeping Bucket4j/servlet concerns out of
+  `qnop-core` and out of the crypto foundation's `QnopProperties`.
+- Register / forgot-password / reset-password rate limiting (the email- and
+  token-keyed buckets, enforced in-controller) is deferred to issue #20 alongside
+  those endpoints; the reusable service and config surface are in place for it.
+
+## Alternatives considered
+
+- **Gateway/proxy-level rate limiting (nginx, ALB).** Rejected as the sole
+  mechanism: not all deployments have a configurable gateway, and subject-keyed
+  limits (change-password) need application context the proxy lacks. App-level
+  limiting is portable and edition-agnostic; a gateway can still add a coarse
+  outer layer.
+- **Trusting `X-Forwarded-For` unconditionally.** Rejected: trivially spoofable to
+  defeat per-IP limits. The trusted-proxy gate is the whole point.
+- **Distributed bucket store (Redis).** Rejected for now: Community runs
+  single-node and Redis is explicitly deferred (ADR-0013). The in-process Caffeine
+  store is sufficient; a distributed backend can replace it behind the same
+  service if horizontal scaling arrives.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0024](0024-branding-asset-storage.md) | Branding-asset storage location (Postgres bytea) | Accepted |
 | [0025](0025-application-settings-architecture.md) | Application settings — registry-authoritative, snapshot-backed runtime | Accepted |
 | [0026](0026-jwt-session-and-revocation.md) | JWT access tokens, rotating refresh tokens, and revocation | Accepted |
+| [0027](0027-auth-rate-limiting.md) | Auth rate limiting & trusted-proxy IP resolution | Accepted |
 
 ## Template
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,10 @@ jacksonAnnotations = "2.21"
 swaggerAnnotations = "2.2.50"
 jakartaValidation = "3.1.1"
 jakartaAnnotation = "3.0.0"
+# Auth rate limiting (issue #18, ADR-0027). bucket4j is not in the Spring Boot BOM,
+# so it carries an explicit version; caffeine IS BOM-managed (declared below
+# without a version). bucket4j_jdk17-core targets JDK 17+ (we run JDK 21).
+bucket4j = "8.18.0"
 
 # --- Pinned for later phases (NOT yet applied) -------------------------
 awsSdk = "2.31.6"            # software.amazon.awssdk:s3 — vendor-neutral S3 client
@@ -66,6 +70,11 @@ spring-security-oauth2-jose = { module = "org.springframework.security:spring-se
 spring-boot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
 # In-memory cache for the JWT revocation (jti) denylist.
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }
+
+# Auth rate limiting (issue #18, ADR-0027). Token-bucket limiter; not in the Spring
+# Boot BOM, so it carries an explicit version. The Caffeine cache above backs the
+# per-key bucket store.
+bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }
 
 # Test
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -27,6 +27,12 @@ dependencies {
     // Resource-server filter that validates the bearer JWT on each request, plus
     // the JWT (Nimbus) types used by the web-layer decoder/cookie glue (issue #17).
     implementation(libs.spring.boot.starter.oauth2.resource.server)
+    // Auth-endpoint rate limiting (io.qnop.web.security.ratelimit, issue #18 / ADR-0027):
+    // Bucket4j token buckets in a Caffeine cache. Caffeine is BOM-managed (also used by the
+    // #17 revocation denylist in qnop-core); declared here too because that is an
+    // implementation dependency and does not reach this module's compile classpath.
+    implementation(libs.bucket4j.core)
+    implementation(libs.caffeine)
     // The bootstrap registers the sibling data packages explicitly via
     // @EntityScan / @EnableJpaRepositories (issue #11), so this module takes a
     // direct JPA dependency for those compile-time symbols (Hibernate itself

--- a/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
@@ -21,6 +21,7 @@
 package io.qnop.bootstrap;
 
 import io.qnop.security.QnopProperties;
+import io.qnop.web.security.ratelimit.RateLimitProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -36,7 +37,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
  * sibling packages, so they are registered explicitly (the data model arrived with issue #11).
  */
 @SpringBootApplication(scanBasePackages = "io.qnop")
-@EnableConfigurationProperties(QnopProperties.class)
+@EnableConfigurationProperties({QnopProperties.class, RateLimitProperties.class})
 @EntityScan("io.qnop.entity")
 @EnableJpaRepositories("io.qnop.repository")
 public class QnopApplication {

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -21,6 +21,9 @@
 package io.qnop.web.security;
 
 import io.qnop.security.QnopProperties;
+import io.qnop.web.security.ratelimit.ChangePasswordRateLimitFilter;
+import io.qnop.web.security.ratelimit.LoginRateLimitFilter;
+import io.qnop.web.security.ratelimit.RefreshRateLimitFilter;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,6 +35,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
@@ -72,7 +76,10 @@ public class SecurityConfiguration {
       HttpSecurity http,
       AuthenticationEntryPoint authenticationEntryPoint,
       CorsConfigurationSource corsConfigurationSource,
-      DelegatingJwtDecoder jwtDecoder)
+      DelegatingJwtDecoder jwtDecoder,
+      LoginRateLimitFilter loginRateLimitFilter,
+      RefreshRateLimitFilter refreshRateLimitFilter,
+      ChangePasswordRateLimitFilter changePasswordRateLimitFilter)
       throws Exception {
     http.csrf(
             csrf ->
@@ -80,6 +87,15 @@ public class SecurityConfiguration {
                     .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
                     .requireCsrfProtectionMatcher(AUTH_CSRF_MATCHER))
         .addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class)
+        // Rate-limit auth endpoints (issue #18, ADR-0027). The IP-keyed login/refresh limiters run
+        // before CSRF/auth processing so abuse is dropped as cheaply as possible; the
+        // change-password
+        // limiter runs after bearer authentication (before AuthorizationFilter) so it can key on
+        // the
+        // authenticated subject.
+        .addFilterBefore(loginRateLimitFilter, CsrfFilter.class)
+        .addFilterBefore(refreshRateLimitFilter, CsrfFilter.class)
+        .addFilterBefore(changePasswordRateLimitFilter, AuthorizationFilter.class)
         .cors(cors -> cors.configurationSource(corsConfigurationSource))
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/AbstractRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/AbstractRateLimitFilter.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Base for the per-endpoint rate-limit filters (issue #18). A subclass declares which requests it
+ * {@linkplain #handles(HttpServletRequest) handles}, how to {@linkplain
+ * #resolveKey(HttpServletRequest) key} the bucket, and the {@linkplain #scope() scope}/limit; this
+ * base consumes a token and, on rejection, short-circuits the chain with {@code 429} + {@code
+ * Retry-After} and a JSON body matching the API's bare error shape.
+ *
+ * <p>A {@code null} key means the request cannot be keyed (e.g. an unauthenticated change-password
+ * request with no subject) — the filter passes it through untouched so the downstream chain returns
+ * its normal {@code 401}, rather than masking it behind a rate-limit decision.
+ */
+abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
+
+  private final BucketRateLimitService rateLimitService;
+  private final String message;
+
+  protected AbstractRateLimitFilter(BucketRateLimitService rateLimitService, String message) {
+    this.rateLimitService = rateLimitService;
+    this.message = message;
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return !handles(request);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    String key = resolveKey(request);
+    if (key == null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    RateLimitResult result =
+        rateLimitService.tryConsume(scope(), key, maxAttempts(), windowSeconds());
+    if (result instanceof RateLimitResult.Rejected rejected) {
+      writeTooManyRequests(response, rejected.retryAfterSeconds());
+      return;
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  private void writeTooManyRequests(HttpServletResponse response, long retryAfterSeconds)
+      throws IOException {
+    response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+    response.setHeader(HttpHeaders.RETRY_AFTER, Long.toString(retryAfterSeconds));
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response
+        .getWriter()
+        .write(
+            "{\"error\":\"too_many_requests\",\"message\":\""
+                + message
+                + "\",\"retryAfterSeconds\":"
+                + retryAfterSeconds
+                + "}");
+  }
+
+  /** Whether this filter applies to the request (method + path match). */
+  protected abstract boolean handles(HttpServletRequest request);
+
+  /** The bucket key for the request, or {@code null} to pass through without a check. */
+  protected abstract String resolveKey(HttpServletRequest request);
+
+  /** Stable scope label namespacing this filter's buckets. */
+  protected abstract String scope();
+
+  protected abstract int maxAttempts();
+
+  protected abstract long windowSeconds();
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/BucketRateLimitService.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/BucketRateLimitService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+/**
+ * Reusable Bucket4j-backed rate limiter (issue #18, ADR-0027). Callers pass a {@code scope} label,
+ * the in-scope {@code key} (IP, subject, hashed email, …) and the bucket's capacity / refill window
+ * at consume time, so one service backs every rate-limit context.
+ *
+ * <p>Buckets are held in a Caffeine cache keyed {@code "scope:key"} so the same literal key in two
+ * scopes (e.g. login vs change-password) never collides. Idle buckets expire to bound memory; the
+ * cache is also size-capped against high-cardinality keys.
+ */
+@Component
+public class BucketRateLimitService {
+
+  /** Upper bound on how long an idle bucket lingers, independent of the caller's window. */
+  private static final long MAX_BUCKET_TTL_SECONDS = 3_600;
+
+  private static final long MAX_BUCKETS = 100_000;
+
+  private final Caffeine<Object, Object> cacheBuilder =
+      Caffeine.newBuilder()
+          .expireAfterAccess(MAX_BUCKET_TTL_SECONDS, TimeUnit.SECONDS)
+          .maximumSize(MAX_BUCKETS);
+
+  private final java.util.concurrent.ConcurrentMap<String, Bucket> buckets =
+      cacheBuilder.<String, Bucket>build().asMap();
+
+  /**
+   * Attempts to consume one token from the bucket identified by {@code scope + key}.
+   *
+   * @param scope rate-limit context label (e.g. {@code "login"}, {@code "change-password"})
+   * @param key the in-scope bucket identifier (IP address, subject, …)
+   * @param maxAttempts bucket capacity / greedy-refill size
+   * @param windowSeconds refill window in seconds
+   * @return {@link RateLimitResult.Allowed} with the remaining tokens, or {@link
+   *     RateLimitResult.Rejected} with the seconds to wait before the next token refills
+   */
+  public RateLimitResult tryConsume(String scope, String key, int maxAttempts, long windowSeconds) {
+    Bucket bucket =
+        buckets.computeIfAbsent(
+            scope + ":" + key, ignored -> newBucket(maxAttempts, windowSeconds));
+    ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+    if (probe.isConsumed()) {
+      return new RateLimitResult.Allowed(probe.getRemainingTokens());
+    }
+    long retryAfterSeconds = Duration.ofNanos(probe.getNanosToWaitForRefill()).toSeconds() + 1;
+    return new RateLimitResult.Rejected(retryAfterSeconds);
+  }
+
+  private static Bucket newBucket(int maxAttempts, long windowSeconds) {
+    return Bucket.builder()
+        .addLimit(
+            Bandwidth.builder()
+                .capacity(maxAttempts)
+                .refillGreedy(maxAttempts, Duration.ofSeconds(windowSeconds))
+                .build())
+        .build();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/ChangePasswordRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/ChangePasswordRateLimitFilter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rate-limits {@code POST /api/v1/auth/change-password} per authenticated subject (issue #18),
+ * stopping online brute-force against the current password while tolerating legitimate
+ * password-rotation retries (default 5/300s).
+ *
+ * <p>Keyed by the JWT {@code sub} from the security context, so it must run after the
+ * resource-server bearer authentication populates it. An unauthenticated request has no subject
+ * ({@code null} key) and passes through to the normal {@code 401}.
+ */
+@Component
+public class ChangePasswordRateLimitFilter extends AbstractRateLimitFilter {
+
+  static final String PATH = "/api/v1/auth/change-password";
+
+  private final RateLimitProperties.Limit limit;
+
+  public ChangePasswordRateLimitFilter(
+      BucketRateLimitService rateLimitService, RateLimitProperties properties) {
+    super(rateLimitService, "Too many password-change attempts. Please try again later.");
+    this.limit = properties.changePassword();
+  }
+
+  @Override
+  protected boolean handles(HttpServletRequest request) {
+    return "POST".equalsIgnoreCase(request.getMethod()) && PATH.equals(request.getRequestURI());
+  }
+
+  @Override
+  protected String resolveKey(HttpServletRequest request) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
+      return jwt.getSubject();
+    }
+    return null;
+  }
+
+  @Override
+  protected String scope() {
+    return "change-password";
+  }
+
+  @Override
+  protected int maxAttempts() {
+    return limit.maxAttempts();
+  }
+
+  @Override
+  protected long windowSeconds() {
+    return limit.windowSeconds();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/HttpClientIpResolver.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/HttpClientIpResolver.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the client IP for rate-limit keying (issue #18, ADR-0027), gating {@code
+ * X-Forwarded-For} behind a configurable trusted-proxy allow-list so the header cannot be spoofed
+ * to rotate per-IP buckets.
+ *
+ * <p>Resolution rules:
+ *
+ * <ol>
+ *   <li>No / blank {@code X-Forwarded-For} → {@code request.getRemoteAddr()}.
+ *   <li>Empty trusted-proxy list → no proxy is trusted; ignore the header and use {@code
+ *       getRemoteAddr()}. This is the secure default for a server with no reverse proxy: otherwise
+ *       an attacker spoofs the header to cycle buckets at will.
+ *   <li>The immediate hop ({@code getRemoteAddr()}) is not in the trust list → the header is
+ *       attacker-controlled; use {@code getRemoteAddr()}.
+ *   <li>Otherwise the immediate hop is a trusted proxy → return the leftmost {@code
+ *       X-Forwarded-For} entry (the original client). Single-hop trust; multi-hop chains would need
+ *       a right-to-left walk.
+ * </ol>
+ *
+ * <p>Operators behind a reverse proxy MUST set {@code qnop.auth.rate-limit.trusted-proxy-cidrs} to
+ * the proxy's egress IPs, or every client appears to come from the proxy and per-IP limiting
+ * collapses to a single shared bucket.
+ */
+@Component
+public class HttpClientIpResolver {
+
+  private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+
+  private final List<IpAddressMatcher> trustedProxyMatchers;
+
+  public HttpClientIpResolver(RateLimitProperties properties) {
+    this.trustedProxyMatchers =
+        properties.trustedProxyCidrs().stream()
+            .map(String::trim)
+            .map(IpAddressMatcher::new)
+            .toList();
+  }
+
+  /** Returns the best-trusted client IP for the request. */
+  public String resolve(HttpServletRequest request) {
+    String remoteAddr = request.getRemoteAddr();
+    String forwarded = request.getHeader(X_FORWARDED_FOR);
+    if (forwarded == null || forwarded.isBlank()) {
+      return remoteAddr;
+    }
+    if (trustedProxyMatchers.isEmpty()) {
+      return remoteAddr;
+    }
+    if (trustedProxyMatchers.stream().noneMatch(matcher -> matcher.matches(remoteAddr))) {
+      return remoteAddr;
+    }
+    return forwarded.split(",")[0].trim();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/LoginRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/LoginRateLimitFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rate-limits {@code POST /api/v1/auth/login} per client IP (issue #18), throttling online password
+ * brute-force from a single source before any credential check runs.
+ */
+@Component
+public class LoginRateLimitFilter extends AbstractRateLimitFilter {
+
+  static final String PATH = "/api/v1/auth/login";
+
+  private final HttpClientIpResolver clientIpResolver;
+  private final RateLimitProperties.Limit limit;
+
+  public LoginRateLimitFilter(
+      BucketRateLimitService rateLimitService,
+      HttpClientIpResolver clientIpResolver,
+      RateLimitProperties properties) {
+    super(rateLimitService, "Too many login attempts. Please try again later.");
+    this.clientIpResolver = clientIpResolver;
+    this.limit = properties.login();
+  }
+
+  @Override
+  protected boolean handles(HttpServletRequest request) {
+    return "POST".equalsIgnoreCase(request.getMethod()) && PATH.equals(request.getRequestURI());
+  }
+
+  @Override
+  protected String resolveKey(HttpServletRequest request) {
+    return clientIpResolver.resolve(request);
+  }
+
+  @Override
+  protected String scope() {
+    return "login";
+  }
+
+  @Override
+  protected int maxAttempts() {
+    return limit.maxAttempts();
+  }
+
+  @Override
+  protected long windowSeconds() {
+    return limit.windowSeconds();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RateLimitProperties.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RateLimitProperties.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Tunable limits for the auth rate-limiting subsystem (issue #18, ADR-0027), bound from {@code
+ * qnop.auth.rate-limit.*}. Each scope carries its own bucket capacity ({@code maxAttempts}) and
+ * refill window ({@code windowSeconds}); defaults match the issue. All values are optional — absent
+ * entries fall back to the per-component {@link DefaultValue}s.
+ *
+ * <p>The register and password-reset endpoints (and their email-/token-keyed buckets) arrive with
+ * issue #20; their limits are added here when those endpoints land. This module wires the limits
+ * for the endpoints that exist today: login, refresh, and change-password.
+ *
+ * @param trustedProxyCidrs CIDR ranges whose {@code X-Forwarded-For} header is trusted by {@link
+ *     HttpClientIpResolver}. Empty by default — the secure default for a server with no reverse
+ *     proxy, which then ignores {@code X-Forwarded-For} entirely. Operators behind a proxy MUST set
+ *     this to the proxy's egress IPs, or per-IP limits collapse to one shared bucket.
+ * @param login IP-keyed limit for {@code POST /api/v1/auth/login} (default 10 / 60s)
+ * @param refresh IP-keyed limit for {@code POST /api/v1/auth/refresh} (default 30 / 60s)
+ * @param changePassword subject-keyed limit for {@code POST /api/v1/auth/change-password} (default
+ *     5 / 300s)
+ */
+@ConfigurationProperties(prefix = "qnop.auth.rate-limit")
+public record RateLimitProperties(
+    List<String> trustedProxyCidrs, Limit login, Limit refresh, Limit changePassword) {
+
+  // A whole scope absent from config arrives as null here; substitute its per-scope default. The
+  // Limit components themselves carry @DefaultValue, so a partially-specified scope keeps the
+  // unset field at the catalogue default rather than 0.
+  public RateLimitProperties {
+    trustedProxyCidrs = trustedProxyCidrs == null ? List.of() : List.copyOf(trustedProxyCidrs);
+    login = login != null ? login : new Limit(10, 60);
+    refresh = refresh != null ? refresh : new Limit(30, 60);
+    changePassword = changePassword != null ? changePassword : new Limit(5, 300);
+  }
+
+  /**
+   * A single bucket configuration: {@code maxAttempts} tokens, greedily refilled over {@code
+   * windowSeconds}.
+   */
+  public record Limit(
+      @DefaultValue("10") int maxAttempts, @DefaultValue("60") long windowSeconds) {}
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RateLimitResult.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RateLimitResult.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+/** Outcome of a {@link BucketRateLimitService#tryConsume} call. */
+public sealed interface RateLimitResult {
+
+  /** The request was within the limit; {@code remainingTokens} are left in the bucket. */
+  record Allowed(long remainingTokens) implements RateLimitResult {}
+
+  /** The limit was exceeded; the caller should wait {@code retryAfterSeconds} before retrying. */
+  record Rejected(long retryAfterSeconds) implements RateLimitResult {}
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RefreshRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RefreshRateLimitFilter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rate-limits {@code POST /api/v1/auth/refresh} per client IP (issue #18), bounding refresh-token
+ * spam / DoS. The limit is generous (default 30/60s) so an active multi-tab session refreshing
+ * normally is never throttled.
+ */
+@Component
+public class RefreshRateLimitFilter extends AbstractRateLimitFilter {
+
+  static final String PATH = "/api/v1/auth/refresh";
+
+  private final HttpClientIpResolver clientIpResolver;
+  private final RateLimitProperties.Limit limit;
+
+  public RefreshRateLimitFilter(
+      BucketRateLimitService rateLimitService,
+      HttpClientIpResolver clientIpResolver,
+      RateLimitProperties properties) {
+    super(rateLimitService, "Too many refresh attempts. Please try again later.");
+    this.clientIpResolver = clientIpResolver;
+    this.limit = properties.refresh();
+  }
+
+  @Override
+  protected boolean handles(HttpServletRequest request) {
+    return "POST".equalsIgnoreCase(request.getMethod()) && PATH.equals(request.getRequestURI());
+  }
+
+  @Override
+  protected String resolveKey(HttpServletRequest request) {
+    return clientIpResolver.resolve(request);
+  }
+
+  @Override
+  protected String scope() {
+    return "refresh";
+  }
+
+  @Override
+  protected int maxAttempts() {
+    return limit.maxAttempts();
+  }
+
+  @Override
+  protected long windowSeconds() {
+    return limit.windowSeconds();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/package-info.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Bucket4j-backed rate limiting for the public/auth endpoints (issue #18, ADR-0027).
+ *
+ * <p>A reusable {@link io.qnop.web.security.ratelimit.BucketRateLimitService} (Bucket4j + Caffeine)
+ * is fronted by {@code OncePerRequestFilter}s that return {@code 429} + {@code Retry-After} when a
+ * scope's bucket is drained. Client IPs are resolved through {@link
+ * io.qnop.web.security.ratelimit.HttpClientIpResolver}, which only honours {@code X-Forwarded-For}
+ * from configured trusted proxies. Limits are tunable via {@code qnop.auth.rate-limit.*} ({@link
+ * io.qnop.web.security.ratelimit.RateLimitProperties}).
+ */
+package io.qnop.web.security.ratelimit;

--- a/qnop-app/src/test/java/io/qnop/web/security/ratelimit/BucketRateLimitServiceTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/ratelimit/BucketRateLimitServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the shared Bucket4j limiter — no Spring context, no Docker. */
+class BucketRateLimitServiceTest {
+
+  private final BucketRateLimitService service = new BucketRateLimitService();
+
+  @Test
+  void allowsUpToCapacityThenRejects() {
+    for (int i = 0; i < 3; i++) {
+      assertThat(service.tryConsume("login", "1.2.3.4", 3, 60))
+          .isInstanceOf(RateLimitResult.Allowed.class);
+    }
+
+    RateLimitResult result = service.tryConsume("login", "1.2.3.4", 3, 60);
+
+    assertThat(result).isInstanceOf(RateLimitResult.Rejected.class);
+    assertThat(((RateLimitResult.Rejected) result).retryAfterSeconds()).isPositive();
+  }
+
+  @Test
+  void reportsRemainingTokens() {
+    RateLimitResult first = service.tryConsume("login", "key", 5, 60);
+
+    assertThat(((RateLimitResult.Allowed) first).remainingTokens()).isEqualTo(4);
+  }
+
+  @Test
+  void isolatesBucketsByScope() {
+    service.tryConsume("login", "same-key", 1, 60); // drains the login bucket
+
+    // A different scope with the same literal key has its own, full bucket.
+    assertThat(service.tryConsume("change-password", "same-key", 1, 60))
+        .isInstanceOf(RateLimitResult.Allowed.class);
+  }
+
+  @Test
+  void isolatesBucketsByKey() {
+    service.tryConsume("login", "ip-a", 1, 60); // drains ip-a
+
+    assertThat(service.tryConsume("login", "ip-b", 1, 60))
+        .isInstanceOf(RateLimitResult.Allowed.class);
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/security/ratelimit/HttpClientIpResolverTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/ratelimit/HttpClientIpResolverTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the trusted-proxy client-IP resolution (ADR-0027). The spoofing defences here are
+ * the security crux of per-IP rate limiting, so they are covered without a Spring context or
+ * Docker.
+ */
+class HttpClientIpResolverTest {
+
+  private static HttpServletRequest request(String remoteAddr, String xForwardedFor) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRemoteAddr()).thenReturn(remoteAddr);
+    when(request.getHeader("X-Forwarded-For")).thenReturn(xForwardedFor);
+    return request;
+  }
+
+  private static HttpClientIpResolver resolver(List<String> trustedCidrs) {
+    return new HttpClientIpResolver(new RateLimitProperties(trustedCidrs, null, null, null));
+  }
+
+  @Test
+  void usesRemoteAddrWhenNoForwardedHeader() {
+    HttpClientIpResolver resolver = resolver(List.of("10.0.0.0/8"));
+
+    assertThat(resolver.resolve(request("203.0.113.5", null))).isEqualTo("203.0.113.5");
+  }
+
+  @Test
+  void ignoresForwardedHeaderWhenNoProxyIsTrusted() {
+    // Secure default: with an empty trust list the header is attacker-controlled and ignored.
+    HttpClientIpResolver resolver = resolver(List.of());
+
+    assertThat(resolver.resolve(request("203.0.113.5", "1.1.1.1"))).isEqualTo("203.0.113.5");
+  }
+
+  @Test
+  void ignoresForwardedHeaderFromUntrustedImmediateHop() {
+    HttpClientIpResolver resolver = resolver(List.of("10.0.0.0/8"));
+
+    // remoteAddr is not in the trusted range, so X-Forwarded-For cannot be believed.
+    assertThat(resolver.resolve(request("203.0.113.5", "1.1.1.1"))).isEqualTo("203.0.113.5");
+  }
+
+  @Test
+  void trustsForwardedHeaderFromTrustedProxy() {
+    HttpClientIpResolver resolver = resolver(List.of("10.0.0.0/8"));
+
+    assertThat(resolver.resolve(request("10.1.2.3", "198.51.100.7"))).isEqualTo("198.51.100.7");
+  }
+
+  @Test
+  void takesLeftmostForwardedEntryFromTrustedProxy() {
+    HttpClientIpResolver resolver = resolver(List.of("10.0.0.0/8"));
+
+    assertThat(resolver.resolve(request("10.1.2.3", "198.51.100.7, 10.1.2.3")))
+        .isEqualTo("198.51.100.7");
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/security/ratelimit/RateLimitIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/ratelimit/RateLimitIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/**
+ * End-to-end check of the login rate-limit filter (issue #18, ADR-0027) against the live server: a
+ * burst of failed logins from one client is throttled with {@code 429} + {@code Retry-After} once
+ * the default 10/60s bucket drains. Drives the server over HTTP like {@code
+ * SecurityConfigurationTest}. Requires Docker (Testcontainers).
+ *
+ * <p>The default login limit is 10 per 60s and no other test hits {@code /api/v1/auth/login}, so
+ * the shared service's bucket for the loopback client starts full: the first ten attempts get the
+ * normal {@code 401} (bad credentials), the eleventh is rejected before the controller runs.
+ */
+class RateLimitIT extends AbstractIntegrationTest {
+
+  private static final int LOGIN_LIMIT = 10;
+  private static final String BODY =
+      "{\"usernameOrEmail\":\"nobody@example.com\",\"password\":\"wrong-password\"}";
+
+  @LocalServerPort int port;
+
+  private HttpResponse<String> postLogin() throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/v1/auth/login"))
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString(BODY))
+            .build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+
+  @Test
+  void throttlesLoginBurstWith429AndRetryAfter() throws Exception {
+    for (int attempt = 1; attempt <= LOGIN_LIMIT; attempt++) {
+      assertThat(postLogin().statusCode())
+          .as("attempt %d within the limit must not be rate-limited", attempt)
+          .isNotEqualTo(429);
+    }
+
+    HttpResponse<String> throttled = postLogin();
+
+    assertThat(throttled.statusCode()).isEqualTo(429);
+    assertThat(throttled.headers().firstValue("Retry-After")).isPresent();
+  }
+}


### PR DESCRIPTION
## Summary

Throttles the public/auth endpoints against brute-force and spam, ported from plugwerk (issue #18, ADR-0027). A reusable `BucketRateLimitService` (Bucket4j + Caffeine) is fronted by `OncePerRequestFilter`s that return **`429 Too Many Requests` + `Retry-After`** when a scope's bucket drains.

Depends on #17 (AuthController, resource-server wiring) — now merged.

## Changes

- **`BucketRateLimitService`** — scope-namespaced token buckets in a size-capped, idle-expiring Caffeine cache; `tryConsume(scope, key, max, window)` backs every context.
- **`HttpClientIpResolver`** — trusted-proxy-CIDR-aware `X-Forwarded-For`, **secure by default**: an empty trust list ignores the header entirely, so it can't be spoofed to rotate per-IP buckets.
- **Filters** (`io.qnop.web.security.ratelimit`) wired into `SecurityConfiguration`: login + refresh (IP-keyed, before CSRF/auth) and change-password (subject-keyed, after bearer auth, before `AuthorizationFilter`). A `null` key passes through to the normal `401` instead of masking it.
- **`RateLimitProperties`** (`qnop.auth.rate-limit.*`): login 10/60s, refresh 30/60s, change-password 5/300s; `trusted-proxy-cidrs` empty by default. Registered via `@EnableConfigurationProperties`.
- **Deps**: `bucket4j` 8.18.0 (explicit version — not in the Spring Boot BOM) + Caffeine (BOM-managed, already present from #17).
- **ADR-0027**: Bucket4j+Caffeine, secure-by-default XFF, IP-filter-vs-controller-bucket split, Redis deferred (ADR-0013).

## Scope note (deferred to #20)

The issue also lists register / forgot-password / reset-password limits. Those endpoints arrive with **#20** (local-user lifecycle) and their email-/token-keyed buckets are enforced *inside the controller* after body parsing — so they land with #20, consuming the reusable `BucketRateLimitService` + config surface delivered here. This PR fully covers the endpoints that exist today (login, refresh, change-password).

## Test plan

- [x] `HttpClientIpResolverTest` — trusted-proxy / XFF spoofing defences (unit, no Docker)
- [x] `BucketRateLimitServiceTest` — capacity, rejection + Retry-After, scope/key isolation (unit, no Docker)
- [x] `ArchitectureRulesTest` green — new `io.qnop.web.security.ratelimit` package respects layering
- [ ] `RateLimitIT` (Testcontainers, CI) — login burst → `429` + `Retry-After` after the 10/60s bucket drains

Closes #18

🤖 Co-Author: Claude (Opus 4.x) via Claude Code