### PR TITLE
feat: mail subsystem — runtime SMTP, jmustache templates, admin endpoints (#19)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,10 @@ jakartaAnnotation = "3.0.0"
 # so it carries an explicit version; caffeine IS BOM-managed (declared below
 # without a version). bucket4j_jdk17-core targets JDK 17+ (we run JDK 21).
 bucket4j = "8.18.0"
+# Mail subsystem (issue #19): logic-less Mustache for admin-editable templates,
+# safe to render untrusted template bodies. SMTP via spring-boot-starter-mail
+# (version managed by the Spring Boot BOM).
+jmustache = "1.16"
 
 # --- Pinned for later phases (NOT yet applied) -------------------------
 awsSdk = "2.31.6"            # software.amazon.awssdk:s3 — vendor-neutral S3 client
@@ -75,6 +79,9 @@ caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }
 # Boot BOM, so it carries an explicit version. The Caffeine cache above backs the
 # per-key bucket store.
 bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }
+# Mail subsystem (issue #19) — JavaMail + logic-less Mustache template rendering.
+spring-boot-starter-mail = { module = "org.springframework.boot:spring-boot-starter-mail" }
+jmustache = { module = "com.samskivert:jmustache", version.ref = "jmustache" }
 
 # Test
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -147,6 +147,242 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /admin/email/test:
+    post:
+      tags:
+        - AdminEmail
+      summary: Send a test email
+      description: |
+        Sends a fixed test message to the given recipient using the current SMTP
+        settings, to verify mail delivery. Superadmin only. Never returns a 5xx
+        for a delivery problem — the outcome is reported in the body `status`.
+      operationId: sendTestEmail
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendTestEmailRequest'
+      responses:
+        '200':
+          description: Send attempt completed (see `status` for the outcome)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendTestEmailResponse'
+        '400':
+          description: Invalid recipient
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /admin/email/templates:
+    get:
+      tags:
+        - AdminEmail
+      summary: List mail templates
+      description: |
+        Returns the effective content of every known mail template at the
+        configured default locale, marking whether each comes from a stored
+        override (`DATABASE`) or the built-in default (`DEFAULT`). Superadmin only.
+      operationId: listMailTemplates
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: All mail templates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MailTemplateListResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /admin/email/templates/{key}:
+    get:
+      tags:
+        - AdminEmail
+      summary: Get a mail template
+      operationId: getMailTemplate
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/MailTemplateKeyParam'
+      responses:
+        '200':
+          description: The effective template content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MailTemplateResponse'
+        '404':
+          description: Unknown template key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+        - AdminEmail
+      summary: Create or update a mail template override
+      operationId: updateMailTemplate
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/MailTemplateKeyParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateMailTemplateRequest'
+      responses:
+        '200':
+          description: The saved template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MailTemplateResponse'
+        '400':
+          description: Invalid template content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown template key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - AdminEmail
+      summary: Reset a mail template to its default
+      description: Removes the stored override, reverting to the built-in default.
+      operationId: resetMailTemplate
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/MailTemplateKeyParam'
+      responses:
+        '204':
+          description: Override removed (or none existed)
+        '404':
+          description: Unknown template key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /admin/email/templates/{key}/preview:
+    post:
+      tags:
+        - AdminEmail
+      summary: Preview a mail template
+      description: |
+        Renders the template with the supplied variables (or representative sample
+        data when none are given), without sending. Superadmin only.
+      operationId: previewMailTemplate
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/MailTemplateKeyParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreviewMailTemplateRequest'
+      responses:
+        '200':
+          description: The rendered preview
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MailTemplatePreviewResponse'
+        '400':
+          description: Render error (e.g. a referenced variable is missing)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown template key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /auth/login:
     post:
       tags:
@@ -287,6 +523,14 @@ components:
         `Authorization: Bearer <token>` on authenticated endpoints. The auth flow
         itself is introduced in a later issue; the scheme is declared here so the
         contract is complete from the first endpoint.
+  parameters:
+    MailTemplateKeyParam:
+      name: key
+      in: path
+      required: true
+      description: The template storage key (e.g. `auth.password_reset`).
+      schema:
+        type: string
   schemas:
     Edition:
       type: string
@@ -510,6 +754,122 @@ components:
         - accessToken
         - tokenType
         - expiresInSeconds
+    SendTestEmailRequest:
+      type: object
+      description: Request to send a test email.
+      properties:
+        recipient:
+          type: string
+          format: email
+          description: Address the test message is sent to.
+      required:
+        - recipient
+    SendStatus:
+      type: string
+      description: Outcome of a mail send attempt.
+      enum:
+        - SENT
+        - SKIPPED
+        - FAILED
+    SendTestEmailResponse:
+      type: object
+      description: Outcome of a test-email send (never a transport-level error to the client).
+      properties:
+        status:
+          $ref: '#/components/schemas/SendStatus'
+        detail:
+          type: string
+          description: Human-readable detail (e.g. "SMTP is not configured").
+      required:
+        - status
+        - detail
+    MailTemplateSource:
+      type: string
+      description: Where the effective template content originates.
+      enum:
+        - DATABASE
+        - DEFAULT
+    MailTemplateResponse:
+      type: object
+      description: The effective content of one mail template.
+      properties:
+        key:
+          type: string
+          description: Stable template storage key (e.g. `auth.password_reset`).
+        locale:
+          type: string
+        subject:
+          type: string
+        bodyPlain:
+          type: string
+        bodyHtml:
+          type: string
+          description: Optional HTML alternative; absent when the template is plain-text only.
+        source:
+          $ref: '#/components/schemas/MailTemplateSource'
+        updatedAt:
+          type: string
+          format: date-time
+          description: When a stored override was last saved; absent for built-in defaults.
+        updatedBy:
+          type: string
+          description: Id of the admin who last saved the override; absent for built-in defaults.
+      required:
+        - key
+        - locale
+        - subject
+        - bodyPlain
+        - source
+    MailTemplateListResponse:
+      type: object
+      properties:
+        templates:
+          type: array
+          items:
+            $ref: '#/components/schemas/MailTemplateResponse'
+      required:
+        - templates
+    UpdateMailTemplateRequest:
+      type: object
+      description: Create-or-update a per-locale template override.
+      properties:
+        locale:
+          type: string
+        subject:
+          type: string
+        bodyPlain:
+          type: string
+        bodyHtml:
+          type: string
+          description: Optional HTML alternative.
+      required:
+        - locale
+        - subject
+        - bodyPlain
+    PreviewMailTemplateRequest:
+      type: object
+      description: Render a template without sending.
+      properties:
+        locale:
+          type: string
+          description: Locale to render; falls back to the default language when omitted.
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+          description: Template variables; representative sample data is used when omitted.
+    MailTemplatePreviewResponse:
+      type: object
+      properties:
+        subject:
+          type: string
+        bodyPlain:
+          type: string
+        bodyHtml:
+          type: string
+      required:
+        - subject
+        - bodyPlain
     ErrorResponse:
       type: object
       description: |

--- a/qnop-app/src/main/java/io/qnop/web/AdminEmailController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminEmailController.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AdminEmailApi;
+import io.qnop.api.v1.model.MailTemplateListResponse;
+import io.qnop.api.v1.model.MailTemplatePreviewResponse;
+import io.qnop.api.v1.model.MailTemplateResponse;
+import io.qnop.api.v1.model.MailTemplateSource;
+import io.qnop.api.v1.model.PreviewMailTemplateRequest;
+import io.qnop.api.v1.model.SendStatus;
+import io.qnop.api.v1.model.SendTestEmailRequest;
+import io.qnop.api.v1.model.SendTestEmailResponse;
+import io.qnop.api.v1.model.UpdateMailTemplateRequest;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailService.SendResult;
+import io.qnop.service.mail.MailTemplateKey;
+import io.qnop.service.mail.MailTemplateService;
+import io.qnop.service.mail.MailTemplateView;
+import io.qnop.service.mail.RenderedMail;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Superadmin mail administration endpoints ({@code /api/v1/admin/email/**}), implementing the
+ * generated {@link AdminEmailApi} contract (issue #19). Authorization is enforced by the security
+ * chain ({@code /api/v1/admin/**} requires {@code SUPERADMIN}, issue #17); these handlers assume an
+ * authenticated superadmin. Template render failures map to 400 and unknown keys to 404; a failed
+ * SMTP delivery is reported in the body (never a 5xx) because {@link MailService} never throws.
+ */
+@RestController
+public class AdminEmailController implements AdminEmailApi {
+
+  private static final String TEST_SUBJECT = "qnop test email";
+  private static final String TEST_BODY =
+      "This is a test email from qnop. If you received it, your SMTP settings are working.";
+
+  private final MailService mailService;
+  private final MailTemplateService templates;
+
+  public AdminEmailController(MailService mailService, MailTemplateService templates) {
+    this.mailService = mailService;
+    this.templates = templates;
+  }
+
+  @Override
+  public ResponseEntity<SendTestEmailResponse> sendTestEmail(SendTestEmailRequest request) {
+    SendResult result = mailService.sendMail(request.getRecipient(), TEST_SUBJECT, TEST_BODY, null);
+    SendTestEmailResponse body =
+        switch (result) {
+          case SendResult.Sent sent -> response(SendStatus.SENT, "Sent to " + sent.recipient());
+          case SendResult.Skipped skipped -> response(SendStatus.SKIPPED, skipped.reason());
+          case SendResult.Failed failed -> response(SendStatus.FAILED, failed.reason());
+        };
+    return ResponseEntity.ok(body);
+  }
+
+  @Override
+  public ResponseEntity<MailTemplateListResponse> listMailTemplates() {
+    List<MailTemplateResponse> all = templates.listAll().stream().map(this::toResponse).toList();
+    return ResponseEntity.ok(new MailTemplateListResponse().templates(all));
+  }
+
+  @Override
+  public ResponseEntity<MailTemplateResponse> getMailTemplate(String key) {
+    return ResponseEntity.ok(toResponse(templates.getEffective(resolveKey(key))));
+  }
+
+  @Override
+  public ResponseEntity<MailTemplateResponse> updateMailTemplate(
+      String key, UpdateMailTemplateRequest request) {
+    MailTemplateView saved =
+        templates.update(
+            resolveKey(key),
+            request.getLocale(),
+            request.getSubject(),
+            request.getBodyPlain(),
+            request.getBodyHtml(),
+            currentActor());
+    return ResponseEntity.ok(toResponse(saved));
+  }
+
+  @Override
+  public ResponseEntity<Void> resetMailTemplate(String key) {
+    templates.reset(resolveKey(key));
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<MailTemplatePreviewResponse> previewMailTemplate(
+      String key, PreviewMailTemplateRequest request) {
+    MailTemplateKey templateKey = resolveKey(key);
+    RenderedMail rendered;
+    try {
+      rendered =
+          templates.preview(templateKey, request.getLocale(), toVars(request.getVariables()));
+    } catch (RuntimeException e) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Template render failed: " + e.getMessage());
+    }
+    return ResponseEntity.ok(
+        new MailTemplatePreviewResponse()
+            .subject(rendered.subject())
+            .bodyPlain(rendered.bodyPlain())
+            .bodyHtml(rendered.bodyHtml()));
+  }
+
+  private MailTemplateKey resolveKey(String key) {
+    return MailTemplateKey.fromKey(key)
+        .orElseThrow(
+            () ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, "Unknown mail template: " + key));
+  }
+
+  private SendTestEmailResponse response(SendStatus status, String detail) {
+    return new SendTestEmailResponse().status(status).detail(detail);
+  }
+
+  private Map<String, Object> toVars(Map<String, String> variables) {
+    return variables == null ? Map.of() : new HashMap<>(variables);
+  }
+
+  /** The authenticated superadmin's id (the JWT subject), or null if not parseable. */
+  private UUID currentActor() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth == null) {
+      return null;
+    }
+    try {
+      return UUID.fromString(auth.getName());
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private MailTemplateResponse toResponse(MailTemplateView view) {
+    return new MailTemplateResponse()
+        .key(view.key())
+        .locale(view.locale())
+        .subject(view.subject())
+        .bodyPlain(view.bodyPlain())
+        .bodyHtml(view.bodyHtml())
+        .source(MailTemplateSource.valueOf(view.source().name()))
+        .updatedAt(view.updatedAt() == null ? null : view.updatedAt().atOffset(ZoneOffset.UTC))
+        .updatedBy(view.updatedBy());
+  }
+}

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -39,7 +39,14 @@ dependencies {
     implementation(libs.spring.security.oauth2.jose)
     implementation(libs.caffeine)
 
+    // Mail subsystem (issue #19): runtime SMTP (JavaMailSender) + logic-less
+    // Mustache rendering of DB-stored, admin-editable templates.
+    implementation(libs.spring.boot.starter.mail)
+    implementation(libs.jmustache)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)
+    // Brings AssertJ + Mockito for the mail-layer unit tests (stubbed JavaMailSender).
+    testImplementation(libs.spring.boot.starter.test)
 }

--- a/qnop-core/src/main/java/io/qnop/service/mail/EmailLayoutBuilder.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/EmailLayoutBuilder.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Wraps a rendered HTML content fragment in a responsive, email-client-safe HTML document (issue
+ * #19): a centered, max-width table layout with inline styles (the only CSS most mail clients
+ * honor) and an optional call-to-action button. Template authors and the mail-sending flows (#20)
+ * supply the inner content; this builder owns the shared chrome so every qnop email looks
+ * consistent.
+ *
+ * <p>The caller is responsible for HTML-escaping any user-supplied values in {@code contentHtml}
+ * (the Mustache HTML compiler in {@link MailTemplateService} escapes variables by default).
+ */
+@Component
+public class EmailLayoutBuilder {
+
+  /**
+   * Builds the full HTML document.
+   *
+   * @param contentHtml the inner content fragment (already rendered + escaped)
+   * @param ctaUrl optional call-to-action URL; when null no button is rendered
+   * @param ctaText label for the call-to-action button (used only when {@code ctaUrl} is set)
+   * @param footerLine a short footer line (e.g. the product name / a do-not-reply notice)
+   */
+  public String wrap(String contentHtml, String ctaUrl, String ctaText, String footerLine) {
+    String button = ctaUrl == null || ctaUrl.isBlank() ? "" : ctaButton(ctaUrl, ctaText);
+    return """
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          </head>
+          <body style="margin:0;padding:0;background:#f4f5f7;">
+            <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" style="background:#f4f5f7;">
+              <tr>
+                <td align="center" style="padding:32px 16px;">
+                  <table role="presentation" width="100%%" cellpadding="0" cellspacing="0"
+                         style="max-width:560px;background:#ffffff;border-radius:12px;overflow:hidden;
+                                font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
+                    <tr>
+                      <td style="padding:32px;color:#1a1a1a;font-size:15px;line-height:1.6;">
+                        %s
+                        %s
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="padding:16px 32px 32px;color:#8a8f98;font-size:12px;line-height:1.5;">
+                        %s
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </body>
+        </html>
+        """
+        .formatted(contentHtml, button, footerLine);
+  }
+
+  private String ctaButton(String ctaUrl, String ctaText) {
+    return """
+        <table role="presentation" cellpadding="0" cellspacing="0" style="margin:24px 0;">
+          <tr>
+            <td align="center" style="border-radius:8px;background:#2d6cdf;">
+              <a href="%s" style="display:inline-block;padding:12px 24px;color:#ffffff;
+                 text-decoration:none;font-weight:600;font-size:15px;">%s</a>
+            </td>
+          </tr>
+        </table>
+        """
+        .formatted(ctaUrl, ctaText == null ? "Open" : ctaText);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailSenderProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailSenderProvider.java
@@ -27,6 +27,7 @@ import java.util.EnumSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.stereotype.Component;
@@ -54,7 +55,10 @@ public class MailSenderProvider implements SettingsChangeListener {
   private final ApplicationSettingsService settings;
   private final AtomicReference<JavaMailSender> cached = new AtomicReference<>();
 
-  public MailSenderProvider(ApplicationSettingsService settings) {
+  // @Lazy breaks the construction cycle: ApplicationSettingsService injects the
+  // List<SettingsChangeListener> (which includes this bean), while this bean
+  // needs the settings service. A lazy proxy defers resolution until first use.
+  public MailSenderProvider(@Lazy ApplicationSettingsService settings) {
     this.settings = settings;
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailSenderProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailSenderProvider.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.SettingsChangeListener;
+import java.util.EnumSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.stereotype.Component;
+
+/**
+ * Builds a {@link JavaMailSender} from the runtime {@code smtp.*} application settings (issue #16)
+ * and caches it (issue #19). SMTP is considered <em>configured</em> when {@code smtp.host} is
+ * non-blank; otherwise {@link #current()} returns {@code null} and the mail layer treats sending as
+ * a no-op. The cached sender is rebuilt lazily after any SMTP setting changes — this bean registers
+ * as a {@link SettingsChangeListener}, so an admin editing SMTP settings transparently
+ * re-provisions the transport without a restart.
+ */
+@Component
+public class MailSenderProvider implements SettingsChangeListener {
+
+  private static final Set<ApplicationSettingKey> SMTP_KEYS =
+      EnumSet.of(
+          ApplicationSettingKey.SMTP_HOST,
+          ApplicationSettingKey.SMTP_PORT,
+          ApplicationSettingKey.SMTP_USERNAME,
+          ApplicationSettingKey.SMTP_PASSWORD,
+          ApplicationSettingKey.SMTP_FROM,
+          ApplicationSettingKey.SMTP_TLS_ENABLED);
+
+  private final ApplicationSettingsService settings;
+  private final AtomicReference<JavaMailSender> cached = new AtomicReference<>();
+
+  public MailSenderProvider(ApplicationSettingsService settings) {
+    this.settings = settings;
+  }
+
+  /** Whether SMTP is configured (host is set). */
+  public boolean isEnabled() {
+    return !settings.getString(ApplicationSettingKey.SMTP_HOST).isBlank();
+  }
+
+  /** The configured default From address (may be blank if not set). */
+  public String from() {
+    return settings.getString(ApplicationSettingKey.SMTP_FROM);
+  }
+
+  /** The cached sender, building it on first use; {@code null} when SMTP is not configured. */
+  public JavaMailSender current() {
+    if (!isEnabled()) {
+      return null;
+    }
+    JavaMailSender existing = cached.get();
+    if (existing != null) {
+      return existing;
+    }
+    JavaMailSender built = build();
+    return cached.compareAndSet(null, built) ? built : cached.get();
+  }
+
+  /** Drops the cached sender; the next {@link #current()} rebuilds from the latest settings. */
+  public void invalidate() {
+    cached.set(null);
+  }
+
+  @Override
+  public void onSettingsChanged(Set<ApplicationSettingKey> changedKeys) {
+    if (changedKeys.stream().anyMatch(SMTP_KEYS::contains)) {
+      invalidate();
+    }
+  }
+
+  private JavaMailSender build() {
+    JavaMailSenderImpl sender = new JavaMailSenderImpl();
+    sender.setHost(settings.getString(ApplicationSettingKey.SMTP_HOST));
+    sender.setPort(settings.getInteger(ApplicationSettingKey.SMTP_PORT));
+    sender.setDefaultEncoding("UTF-8");
+
+    String username = settings.getString(ApplicationSettingKey.SMTP_USERNAME);
+    boolean authenticated = !username.isBlank();
+    if (authenticated) {
+      sender.setUsername(username);
+      sender.setPassword(settings.getString(ApplicationSettingKey.SMTP_PASSWORD));
+    }
+
+    Properties props = sender.getJavaMailProperties();
+    props.put("mail.transport.protocol", "smtp");
+    props.put("mail.smtp.auth", String.valueOf(authenticated));
+    props.put(
+        "mail.smtp.starttls.enable",
+        String.valueOf(settings.getBoolean(ApplicationSettingKey.SMTP_TLS_ENABLED)));
+    return sender;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailService.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailService.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import jakarta.mail.internet.MimeMessage;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+/**
+ * Sends mail via the runtime SMTP transport (issue #19). {@link #sendMail} <strong>never
+ * throws</strong>: it returns a sealed {@link SendResult} describing the outcome — {@code Sent},
+ * {@code Skipped} (SMTP not configured), or {@code Failed} (delivery error). Callers treat mail as
+ * best-effort and decide how to react (e.g. surface a "verification email could not be sent"
+ * notice). Messages with an HTML body are sent as multipart/alternative.
+ */
+@Service
+public class MailService {
+
+  private static final Logger log = LoggerFactory.getLogger(MailService.class);
+
+  private final MailSenderProvider senderProvider;
+  private final MailTemplateService templates;
+
+  public MailService(MailSenderProvider senderProvider, MailTemplateService templates) {
+    this.senderProvider = senderProvider;
+    this.templates = templates;
+  }
+
+  /** Sends a message; returns the outcome without throwing. */
+  public SendResult sendMail(String to, String subject, String bodyPlain, String bodyHtml) {
+    JavaMailSender sender = senderProvider.current();
+    if (sender == null) {
+      return new SendResult.Skipped("SMTP is not configured");
+    }
+    boolean multipart = bodyHtml != null && !bodyHtml.isBlank();
+    try {
+      MimeMessage message = sender.createMimeMessage();
+      MimeMessageHelper helper = new MimeMessageHelper(message, multipart, "UTF-8");
+      String from = senderProvider.from();
+      if (from != null && !from.isBlank()) {
+        helper.setFrom(from);
+      }
+      helper.setTo(to);
+      helper.setSubject(subject);
+      if (multipart) {
+        helper.setText(bodyPlain, bodyHtml);
+      } else {
+        helper.setText(bodyPlain, false);
+      }
+      sender.send(message);
+      return new SendResult.Sent(to);
+    } catch (Exception e) {
+      log.warn("Failed to send mail to {}: {}", to, e.getMessage());
+      return new SendResult.Failed(e.getMessage());
+    }
+  }
+
+  /** Renders {@code key} for {@code locale} with {@code vars}, then sends. Never throws. */
+  public SendResult sendMailFromTemplate(
+      MailTemplateKey key, String to, Map<String, Object> vars, String locale) {
+    RenderedMail mail;
+    try {
+      mail = templates.render(key, vars, locale);
+    } catch (RuntimeException e) {
+      log.warn("Failed to render template {} for {}: {}", key, to, e.getMessage());
+      return new SendResult.Failed("template render failed: " + e.getMessage());
+    }
+    return sendMail(to, mail.subject(), mail.bodyPlain(), mail.bodyHtml());
+  }
+
+  /** The outcome of a send attempt. */
+  public sealed interface SendResult
+      permits SendResult.Sent, SendResult.Skipped, SendResult.Failed {
+
+    /** Delivery handed off to the SMTP server. */
+    record Sent(String recipient) implements SendResult {}
+
+    /** No delivery attempted because SMTP is not configured. */
+    record Skipped(String reason) implements SendResult {}
+
+    /** Delivery attempted but failed; {@code reason} carries the (non-sensitive) cause. */
+    record Failed(String reason) implements SendResult {}
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import java.util.Optional;
+
+/**
+ * The catalog of known mail templates (issue #19). Each key carries built-in default content used
+ * as the final fallback when no per-locale row exists in the {@code mail_template} table (issue
+ * #14). The stable {@link #key()} string matches the {@code template_key} column and the seeded
+ * rows; the DB row, when present, always wins over these defaults.
+ *
+ * <p>This is a separate type from the {@code io.qnop.entity.MailTemplate} JPA entity (the DB row):
+ * the enum is the authoritative <em>registry</em> of which templates exist, the entity is one
+ * stored per-locale override.
+ *
+ * <p>Bodies are logic-less Mustache; variables (e.g. {@code {{siteName}}}, {@code {{actionUrl}}})
+ * are supplied at render time. HTML defaults are intentionally absent here — the seeded rows carry
+ * the rich responsive HTML; when neither exists the message is sent plain-text only.
+ */
+public enum MailTemplateKey {
+  REGISTRATION_VERIFICATION(
+      "auth.registration_verification",
+      "Verify your {{siteName}} account",
+      """
+      Hi {{recipientName}},
+
+      Please confirm your email address to activate your {{siteName}} account:
+
+      {{actionUrl}}
+
+      If you did not create this account, you can safely ignore this message.
+      """),
+  PASSWORD_RESET(
+      "auth.password_reset",
+      "Reset your {{siteName}} password",
+      """
+      Hi {{recipientName}},
+
+      We received a request to reset your {{siteName}} password. Use the link below to choose a new one:
+
+      {{actionUrl}}
+
+      If you did not request this, you can safely ignore this message; your password stays unchanged.
+      """),
+  ADMIN_PASSWORD_RESET(
+      "auth.admin_password_reset",
+      "Your {{siteName}} password was reset by an administrator",
+      """
+      Hi {{recipientName}},
+
+      An administrator has reset your {{siteName}} password. Use the link below to set a new one:
+
+      {{actionUrl}}
+      """);
+
+  private final String key;
+  private final String defaultSubject;
+  private final String defaultBodyPlain;
+
+  MailTemplateKey(String key, String defaultSubject, String defaultBodyPlain) {
+    this.key = key;
+    this.defaultSubject = defaultSubject;
+    this.defaultBodyPlain = defaultBodyPlain;
+  }
+
+  /** The stable storage key (matches the {@code template_key} column). */
+  public String key() {
+    return key;
+  }
+
+  public String defaultSubject() {
+    return defaultSubject;
+  }
+
+  public String defaultBodyPlain() {
+    return defaultBodyPlain;
+  }
+
+  /** Resolves a storage key back to its catalog entry, if known. */
+  public static Optional<MailTemplateKey> fromKey(String key) {
+    for (MailTemplateKey value : values()) {
+      if (value.key.equals(key)) {
+        return Optional.of(value);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateService.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateService.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import com.samskivert.mustache.Mustache;
+import io.qnop.entity.MailTemplate;
+import io.qnop.repository.MailTemplateRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Renders and administers mail templates (issue #19). Effective content is resolved per request
+ * locale through a fallback chain — requested locale → configured default language → {@code en} →
+ * the built-in {@link MailTemplateKey} catalog defaults — and rendered with logic-less Mustache
+ * (strict: a missing variable raises rather than silently producing a blank). Two compilers keep
+ * plain-text bodies unescaped and HTML bodies HTML-escaped.
+ *
+ * <p>The admin operations ({@link #listAll}, {@link #getEffective}, {@link #update}, {@link
+ * #reset}, {@link #preview}) back the {@code /api/v1/admin/email/templates} endpoints and never
+ * expose the JPA entity to the web layer.
+ */
+@Service
+public class MailTemplateService {
+
+  private static final String FALLBACK_LOCALE = "en";
+
+  private final MailTemplateRepository repository;
+  private final ApplicationSettingsService settings;
+  private final Mustache.Compiler plainCompiler = Mustache.compiler().escapeHTML(false);
+  private final Mustache.Compiler htmlCompiler = Mustache.compiler().escapeHTML(true);
+
+  public MailTemplateService(
+      MailTemplateRepository repository, ApplicationSettingsService settings) {
+    this.repository = repository;
+    this.settings = settings;
+  }
+
+  /**
+   * Renders the template for {@code locale} (with fallback) using {@code vars}. Throws {@link
+   * com.samskivert.mustache.MustacheException} if a referenced variable is missing.
+   */
+  public RenderedMail render(MailTemplateKey key, Map<String, Object> vars, String locale) {
+    Optional<MailTemplate> row = resolve(key, locale);
+    String subject = row.map(MailTemplate::getSubject).orElseGet(key::defaultSubject);
+    String plain = row.map(MailTemplate::getBodyPlain).orElseGet(key::defaultBodyPlain);
+    String html = row.map(MailTemplate::getBodyHtml).orElse(null);
+
+    String renderedSubject = plainCompiler.compile(subject).execute(vars);
+    String renderedPlain = plainCompiler.compile(plain).execute(vars);
+    String renderedHtml =
+        html != null && !html.isBlank() ? htmlCompiler.compile(html).execute(vars) : null;
+    return new RenderedMail(renderedSubject, renderedPlain, renderedHtml);
+  }
+
+  /** Renders {@code key} with the provided variables, or representative sample data if none. */
+  public RenderedMail preview(MailTemplateKey key, String locale, Map<String, Object> vars) {
+    return render(key, vars == null || vars.isEmpty() ? sampleVars() : vars, locale);
+  }
+
+  /** The effective view per known template at the configured default locale. */
+  public List<MailTemplateView> listAll() {
+    String locale = defaultLocale();
+    return java.util.Arrays.stream(MailTemplateKey.values())
+        .map(key -> getEffective(key, locale))
+        .toList();
+  }
+
+  /** The effective view for one template at {@code locale} (exact row, else catalog default). */
+  public MailTemplateView getEffective(MailTemplateKey key, String locale) {
+    return findRow(key, locale)
+        .map(row -> toView(row, MailTemplateView.Source.DATABASE))
+        .orElseGet(
+            () ->
+                new MailTemplateView(
+                    key.key(),
+                    locale,
+                    key.defaultSubject(),
+                    key.defaultBodyPlain(),
+                    null,
+                    MailTemplateView.Source.DEFAULT,
+                    null,
+                    null));
+  }
+
+  /** Upserts the stored override for {@code key}/{@code locale}; returns the saved view. */
+  @Transactional
+  public MailTemplateView update(
+      MailTemplateKey key,
+      String locale,
+      String subject,
+      String bodyPlain,
+      String bodyHtml,
+      UUID actor) {
+    MailTemplate row =
+        findRow(key, locale)
+            .orElseGet(() -> new MailTemplate(key.key(), locale, subject, bodyPlain));
+    row.setSubject(subject);
+    row.setBodyPlain(bodyPlain);
+    row.setBodyHtml(bodyHtml);
+    row.setUpdatedBy(actor == null ? null : actor.toString());
+    return toView(repository.save(row), MailTemplateView.Source.DATABASE);
+  }
+
+  /**
+   * Removes the stored override, reverting to the catalog default. Returns whether a row existed.
+   */
+  @Transactional
+  public boolean reset(MailTemplateKey key, String locale) {
+    return findRow(key, locale)
+        .map(
+            row -> {
+              repository.delete(row);
+              return true;
+            })
+        .orElse(false);
+  }
+
+  /** The effective view for one template at the configured default locale. */
+  public MailTemplateView getEffective(MailTemplateKey key) {
+    return getEffective(key, defaultLocale());
+  }
+
+  /** Removes the default-locale override for {@code key}; returns whether a row existed. */
+  @Transactional
+  public boolean reset(MailTemplateKey key) {
+    return reset(key, defaultLocale());
+  }
+
+  private Optional<MailTemplate> resolve(MailTemplateKey key, String locale) {
+    String requested = locale == null || locale.isBlank() ? defaultLocale() : locale;
+    return findRow(key, requested)
+        .or(() -> findRow(key, defaultLocale()))
+        .or(() -> findRow(key, FALLBACK_LOCALE));
+  }
+
+  private Optional<MailTemplate> findRow(MailTemplateKey key, String locale) {
+    return repository.findByTemplateKeyAndLocale(key.key(), locale);
+  }
+
+  private String defaultLocale() {
+    String configured = settings.getString(ApplicationSettingKey.GENERAL_DEFAULT_LANGUAGE);
+    return configured == null || configured.isBlank() ? FALLBACK_LOCALE : configured;
+  }
+
+  private Map<String, Object> sampleVars() {
+    return Map.of(
+        "siteName", "qnop",
+        "recipientName", "Jane Doe",
+        "actionUrl", "https://qnop.example/action?token=SAMPLE");
+  }
+
+  private MailTemplateView toView(MailTemplate row, MailTemplateView.Source source) {
+    return new MailTemplateView(
+        row.getTemplateKey(),
+        row.getLocale(),
+        row.getSubject(),
+        row.getBodyPlain(),
+        row.getBodyHtml(),
+        source,
+        row.getUpdatedAt(),
+        row.getUpdatedBy());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateView.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateView.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import java.time.Instant;
+
+/**
+ * A web-safe view of one template's effective content for the admin API: either a stored per-locale
+ * row ({@code source = DATABASE}) or the built-in catalog fallback ({@code source = DEFAULT}). No
+ * JPA entity leaks to the web layer (ADR-0004).
+ */
+public record MailTemplateView(
+    String key,
+    String locale,
+    String subject,
+    String bodyPlain,
+    String bodyHtml,
+    Source source,
+    Instant updatedAt,
+    String updatedBy) {
+
+  /** Where the effective content came from. */
+  public enum Source {
+    /** A stored, admin-editable {@code mail_template} row. */
+    DATABASE,
+    /** The built-in {@link MailTemplateKey} fallback (no stored row). */
+    DEFAULT
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/RenderedMail.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/RenderedMail.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+/**
+ * A fully rendered mail: the resolved {@code subject} and {@code bodyPlain} (always present) plus
+ * an optional {@code bodyHtml} alternative. Produced by {@link MailTemplateService#render} and
+ * consumed by {@link MailService}.
+ */
+public record RenderedMail(String subject, String bodyPlain, String bodyHtml) {
+
+  /** Whether an HTML alternative is available (a multipart/alternative message should be sent). */
+  public boolean hasHtml() {
+    return bodyHtml != null && !bodyHtml.isBlank();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailSenderProviderTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailSenderProviderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import java.util.EnumSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@ExtendWith(MockitoExtension.class)
+class MailSenderProviderTest {
+
+  @Mock private ApplicationSettingsService settings;
+
+  private MailSenderProvider provider;
+
+  @BeforeEach
+  void setUp() {
+    provider = new MailSenderProvider(settings);
+  }
+
+  private void configureSmtp() {
+    lenient()
+        .when(settings.getString(ApplicationSettingKey.SMTP_HOST))
+        .thenReturn("smtp.example.com");
+    lenient().when(settings.getInteger(ApplicationSettingKey.SMTP_PORT)).thenReturn(587);
+    lenient().when(settings.getString(ApplicationSettingKey.SMTP_USERNAME)).thenReturn("user");
+    lenient().when(settings.getString(ApplicationSettingKey.SMTP_PASSWORD)).thenReturn("secret");
+    lenient().when(settings.getBoolean(ApplicationSettingKey.SMTP_TLS_ENABLED)).thenReturn(true);
+  }
+
+  @Test
+  @DisplayName("current() is null and isEnabled() false when the host is blank")
+  void disabledWhenHostBlank() {
+    when(settings.getString(ApplicationSettingKey.SMTP_HOST)).thenReturn("");
+
+    assertThat(provider.isEnabled()).isFalse();
+    assertThat(provider.current()).isNull();
+  }
+
+  @Test
+  @DisplayName("builds and caches a JavaMailSender from the SMTP settings")
+  void buildsAndCachesSender() {
+    configureSmtp();
+
+    JavaMailSender first = provider.current();
+
+    assertThat(first).isInstanceOf(JavaMailSenderImpl.class);
+    assertThat(((JavaMailSenderImpl) first).getHost()).isEqualTo("smtp.example.com");
+    assertThat(((JavaMailSenderImpl) first).getPort()).isEqualTo(587);
+    assertThat(provider.current()).isSameAs(first); // cached
+  }
+
+  @Test
+  @DisplayName("invalidates the cached sender when an SMTP setting changes")
+  void invalidatesOnSmtpChange() {
+    configureSmtp();
+    JavaMailSender first = provider.current();
+
+    provider.onSettingsChanged(EnumSet.of(ApplicationSettingKey.SMTP_HOST));
+
+    assertThat(provider.current()).isNotSameAs(first);
+  }
+
+  @Test
+  @DisplayName("ignores changes to non-SMTP settings")
+  void ignoresUnrelatedChange() {
+    configureSmtp();
+    JavaMailSender first = provider.current();
+
+    provider.onSettingsChanged(EnumSet.of(ApplicationSettingKey.GENERAL_APPLICATION_NAME));
+
+    assertThat(provider.current()).isSameAs(first);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailServiceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.service.mail.MailService.SendResult;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@ExtendWith(MockitoExtension.class)
+class MailServiceTest {
+
+  @Mock private MailSenderProvider senderProvider;
+  @Mock private MailTemplateService templates;
+  @Mock private JavaMailSender sender;
+
+  private MailService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new MailService(senderProvider, templates);
+  }
+
+  @Test
+  @DisplayName("returns Skipped when SMTP is not configured")
+  void skippedWhenNotConfigured() {
+    when(senderProvider.current()).thenReturn(null);
+
+    SendResult result = service.sendMail("to@example.com", "s", "p", null);
+
+    assertThat(result).isInstanceOf(SendResult.Skipped.class);
+  }
+
+  @Test
+  @DisplayName("returns Sent and hands the message to the transport on success")
+  void sentOnSuccess() {
+    when(senderProvider.current()).thenReturn(sender);
+    when(senderProvider.from()).thenReturn("from@qnop.example");
+    when(sender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
+
+    SendResult result = service.sendMail("to@example.com", "Subject", "Body", null);
+
+    assertThat(result).isInstanceOf(SendResult.Sent.class);
+    verify(sender).send(any(MimeMessage.class));
+  }
+
+  @Test
+  @DisplayName("returns Failed (never throws) when delivery fails")
+  void failedOnDeliveryError() {
+    when(senderProvider.current()).thenReturn(sender);
+    when(senderProvider.from()).thenReturn("from@qnop.example");
+    when(sender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
+    doThrow(new MailSendException("boom")).when(sender).send(any(MimeMessage.class));
+
+    SendResult result = service.sendMail("to@example.com", "Subject", "Body", null);
+
+    assertThat(result).isInstanceOf(SendResult.Failed.class);
+  }
+
+  @Test
+  @DisplayName("returns Failed when template rendering fails, without attempting delivery")
+  void failedWhenRenderThrows() {
+    when(templates.render(any(), any(), any())).thenThrow(new RuntimeException("missing var"));
+
+    SendResult result =
+        service.sendMailFromTemplate(
+            MailTemplateKey.PASSWORD_RESET, "to@example.com", Map.of(), "en");
+
+    assertThat(result).isInstanceOf(SendResult.Failed.class);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.MailTemplate;
+import io.qnop.repository.MailTemplateRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MailTemplateServiceTest {
+
+  @Mock private MailTemplateRepository repository;
+  @Mock private ApplicationSettingsService settings;
+
+  private MailTemplateService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new MailTemplateService(repository, settings);
+    lenient()
+        .when(settings.getString(ApplicationSettingKey.GENERAL_DEFAULT_LANGUAGE))
+        .thenReturn("en");
+  }
+
+  @Test
+  @DisplayName("renders subject + plain + html from a stored row, substituting variables")
+  void rendersFromDatabaseRow() {
+    MailTemplate row =
+        new MailTemplate("auth.password_reset", "en", "Reset {{siteName}}", "Hi {{recipientName}}");
+    row.setBodyHtml("<p>Hi {{recipientName}}</p>");
+    when(repository.findByTemplateKeyAndLocale("auth.password_reset", "en"))
+        .thenReturn(Optional.of(row));
+
+    RenderedMail mail =
+        service.render(
+            MailTemplateKey.PASSWORD_RESET,
+            Map.of("siteName", "qnop", "recipientName", "Jane"),
+            "en");
+
+    assertThat(mail.subject()).isEqualTo("Reset qnop");
+    assertThat(mail.bodyPlain()).isEqualTo("Hi Jane");
+    assertThat(mail.bodyHtml()).isEqualTo("<p>Hi Jane</p>");
+  }
+
+  @Test
+  @DisplayName("falls back to the catalog defaults when no row exists for any locale")
+  void fallsBackToCatalogDefaults() {
+    when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
+
+    RenderedMail mail =
+        service.render(
+            MailTemplateKey.PASSWORD_RESET,
+            Map.of("siteName", "qnop", "recipientName", "Jane", "actionUrl", "https://x"),
+            "de");
+
+    assertThat(mail.subject()).isEqualTo("Reset your qnop password");
+    assertThat(mail.bodyPlain()).contains("Jane");
+    assertThat(mail.bodyHtml()).isNull();
+  }
+
+  @Test
+  @DisplayName("HTML body escapes variables; plain body does not")
+  void escapesHtmlVariables() {
+    MailTemplate row = new MailTemplate("auth.password_reset", "en", "s", "plain {{x}}");
+    row.setBodyHtml("<p>{{x}}</p>");
+    when(repository.findByTemplateKeyAndLocale("auth.password_reset", "en"))
+        .thenReturn(Optional.of(row));
+
+    RenderedMail mail =
+        service.render(MailTemplateKey.PASSWORD_RESET, Map.of("x", "<b>hi</b>"), "en");
+
+    assertThat(mail.bodyPlain()).isEqualTo("plain <b>hi</b>");
+    assertThat(mail.bodyHtml()).contains("&lt;b&gt;hi&lt;/b&gt;").doesNotContain("<b>hi</b>");
+  }
+
+  @Test
+  @DisplayName("a missing variable raises (strict rendering)")
+  void missingVariableThrows() {
+    when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.render(MailTemplateKey.PASSWORD_RESET, Map.of(), "en"))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  @DisplayName("preview uses representative sample data when no variables are supplied")
+  void previewUsesSampleVars() {
+    when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
+
+    RenderedMail mail = service.preview(MailTemplateKey.REGISTRATION_VERIFICATION, "en", Map.of());
+
+    assertThat(mail.subject()).isEqualTo("Verify your qnop account");
+    assertThat(mail.bodyPlain()).contains("Jane Doe");
+  }
+
+  @Test
+  @DisplayName("getEffective reports DEFAULT source when no row is stored")
+  void getEffectiveReportsDefaultSource() {
+    when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
+
+    MailTemplateView view = service.getEffective(MailTemplateKey.PASSWORD_RESET, "en");
+
+    assertThat(view.source()).isEqualTo(MailTemplateView.Source.DEFAULT);
+    assertThat(view.subject()).isEqualTo(MailTemplateKey.PASSWORD_RESET.defaultSubject());
+  }
+}


### PR DESCRIPTION
## Summary

Implements the mail subsystem (issue #19), modelled on plugwerk and adapted to qnop's conventions (Java, OpenAPI-first, the #16 settings service and #17 security). Built on #14 (`mail_template`), #16 (settings), #17 (auth).

### Engine (`io.qnop.service.mail`, qnop-core)
- **`MailSenderProvider`** — builds a `JavaMailSender` from the runtime `smtp.*` settings (#16), caches it, and rebuilds on change via `SettingsChangeListener`; `current()` is `null` (no-op) when `smtp.host` is blank.
- **`MailTemplateService`** — logic-less Mustache (strict: a missing variable raises), separate plain/HTML compilers, locale fallback chain (requested → default language → `en` → built-in catalog defaults); admin CRUD + preview returning web-safe `MailTemplateView`s.
- **`MailTemplateKey`** — registry of known templates with default content (distinct from the `#14` `MailTemplate` JPA entity).
- **`EmailLayoutBuilder`** — responsive, inline-styled HTML wrapper.
- **`MailService.sendMail`** — sealed `SendResult` (`Sent`/`Skipped`/`Failed`), **never throws**; multipart/alternative.

### Admin endpoints (OpenAPI-first, `/api/v1/admin/email/**`)
`AdminEmailController` implements the generated `AdminEmailApi`: `POST /test`, `GET/PUT/DELETE /templates[/{key}]`, `POST /templates/{key}/preview`. Already superadmin-secured by the existing `/api/v1/admin/**` → `SUPERADMIN` matcher (#17). Render errors → 400, unknown keys → 404, delivery failures reported in the body (never 5xx).

### Deps
`spring-boot-starter-mail` + `com.samskivert:jmustache` (1.16).

## Test plan
- [x] `./gradlew build -x test` — green (compile, Spotless, OpenAPI generation, ArchUnit, `bootJar`)
- [x] `:qnop-core:test` — mail engine unit tests green: rendering + variable substitution, locale/default fallback, HTML escaping, strict missing-variable, sealed `SendResult` paths (Skipped/Sent/Failed), sender build/cache/invalidate
- [ ] CI: full `./gradlew build` incl. the Testcontainers schema ITs (Docker, ADR-0020)

### Notes / follow-ups
- Admin-endpoint coverage is via compile + the engine unit tests; a `@WebMvcTest` slice for `AdminEmailController` (with a mocked superadmin) is a sensible follow-up.
- `MailTemplateKey` deliberately renames plugwerk's `MailTemplate` enum to avoid clashing with the #14 `MailTemplate` entity.

Closes #19 · Part of #7

🤖 Co-Author: Claude (Opus 4.x) via Claude Code