### PR TITLE
feat: per-user settings service + /users/me/settings

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -35,6 +35,9 @@ tags:
       rotation, logout, and password change (issue #17). Access tokens are
       short-lived JWTs sent as `Authorization: Bearer`; the rotating refresh
       token lives in an HttpOnly, SameSite=Strict cookie scoped to `/api/v1/auth`.
+  - name: UserSettings
+    description: |
+      The authenticated user's own per-user settings (issue #22).
 paths:
   /config:
     get:
@@ -512,6 +515,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /users/me/settings:
+    get:
+      tags:
+        - UserSettings
+      summary: Get the current user's settings
+      description: |
+        Returns the authenticated user's settings with their values, types and
+        descriptions (registry defaults where unset). Requires a user (JWT)
+        principal; API-key principals are rejected.
+      operationId: getCurrentUserSettings
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The current user's settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSettingsResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Principal is not a user (e.g. an API key)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - UserSettings
+      summary: Update the current user's settings
+      description: |
+        Applies a partial set of changes (`key` to value) for the authenticated
+        user and returns the full, updated settings.
+      operationId: updateCurrentUserSettings
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserSettingsUpdateRequest'
+      responses:
+        '200':
+          description: Updated user settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSettingsResponse'
+        '400':
+          description: Unknown key or type-invalid value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Principal is not a user (e.g. an API key)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -870,6 +945,46 @@ components:
       required:
         - subject
         - bodyPlain
+    UserSettingItem:
+      type: object
+      description: One user setting with its current value.
+      properties:
+        key:
+          type: string
+          description: Stable setting key (e.g. `theme`).
+        value:
+          type: string
+          description: Current value (registry default where the user has not set one).
+        type:
+          $ref: '#/components/schemas/SettingValueType'
+        description:
+          type: string
+          description: Human-readable description of the setting.
+      required:
+        - key
+        - type
+        - description
+    UserSettingsResponse:
+      type: object
+      description: The authenticated user's settings.
+      properties:
+        settings:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserSettingItem'
+      required:
+        - settings
+    UserSettingsUpdateRequest:
+      type: object
+      description: Partial map of user setting key to new value.
+      properties:
+        values:
+          type: object
+          additionalProperties:
+            type: string
+          description: Map of setting key to new value.
+      required:
+        - values
     ErrorResponse:
       type: object
       description: |

--- a/qnop-app/src/main/java/io/qnop/web/CurrentUser.java
+++ b/qnop-app/src/main/java/io/qnop/web/CurrentUser.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import java.util.UUID;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Resolves the authenticated end-user for {@code /users/me/**} endpoints. The principal name is the
+ * JWT {@code sub} claim — a user UUID (issue #17). A principal whose name is not a UUID (e.g. an
+ * API-key principal) is rejected with {@link AccessDeniedException} (HTTP 403), so machine
+ * principals cannot act as a user.
+ */
+public final class CurrentUser {
+
+  private CurrentUser() {}
+
+  public static UUID requireUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String name = authentication == null ? null : authentication.getName();
+    if (name == null) {
+      throw new AccessDeniedException("authentication required");
+    }
+    try {
+      return UUID.fromString(name);
+    } catch (IllegalArgumentException e) {
+      throw new AccessDeniedException("principal is not a user");
+    }
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/UserSettingsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/UserSettingsController.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.UserSettingsApi;
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.api.v1.model.SettingValueType;
+import io.qnop.api.v1.model.UserSettingItem;
+import io.qnop.api.v1.model.UserSettingsResponse;
+import io.qnop.api.v1.model.UserSettingsUpdateRequest;
+import io.qnop.service.SettingValidationException;
+import io.qnop.service.UserSettingsService;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The authenticated user's own settings ({@code GET/PATCH /api/v1/users/me/settings}), implementing
+ * the generated {@link UserSettingsApi} contract (issue #22). The acting user is the JWT subject
+ * ({@link CurrentUser}); non-user (API-key) principals are rejected with 403.
+ */
+@RestController
+public class UserSettingsController implements UserSettingsApi {
+
+  private final UserSettingsService settings;
+
+  public UserSettingsController(UserSettingsService settings) {
+    this.settings = settings;
+  }
+
+  @Override
+  public ResponseEntity<UserSettingsResponse> getCurrentUserSettings() {
+    return ResponseEntity.ok(toResponse(settings.getSettings(CurrentUser.requireUserId())));
+  }
+
+  @Override
+  public ResponseEntity<UserSettingsResponse> updateCurrentUserSettings(
+      UserSettingsUpdateRequest userSettingsUpdateRequest) {
+    return ResponseEntity.ok(
+        toResponse(
+            settings.updateSettings(
+                CurrentUser.requireUserId(), userSettingsUpdateRequest.getValues())));
+  }
+
+  private UserSettingsResponse toResponse(List<UserSettingsService.SettingView> views) {
+    List<UserSettingItem> items =
+        views.stream()
+            .map(
+                view ->
+                    new UserSettingItem()
+                        .key(view.key())
+                        .value(view.value())
+                        .type(SettingValueType.fromValue(view.type()))
+                        .description(view.description()))
+            .toList();
+    return new UserSettingsResponse().settings(items);
+  }
+
+  @ExceptionHandler(SettingValidationException.class)
+  public ResponseEntity<ErrorResponse> onInvalidSetting(SettingValidationException ex) {
+    return ResponseEntity.badRequest()
+        .body(
+            new ErrorResponse()
+                .code("INVALID_SETTING")
+                .message(ex.getMessage())
+                .timestamp(OffsetDateTime.now()));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/settings/UserSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/UserSettingsControllerIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.settings;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.UserRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Verifies the {@code /api/v1/users/me/settings} endpoints (issue #22) through the real security
+ * filter chain. The acting user is a JWT principal whose subject is the user's UUID; an anonymous
+ * caller gets 401 and a non-UUID (API-key) subject gets 403. MockMvc is built with {@code
+ * springSecurity()} so the test JWT reaches the filter chain. Requires Docker.
+ */
+class UserSettingsControllerIT extends AbstractIntegrationTest {
+
+  @Autowired WebApplicationContext context;
+  @Autowired UserRepository users;
+
+  private MockMvc mockMvc;
+  private UUID userId;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    userId = users.saveAndFlush(User.internal("Me", "me@example.com", "me", "hash")).getId();
+  }
+
+  @AfterEach
+  void tearDown() {
+    users.deleteById(userId); // ON DELETE CASCADE removes any user_setting rows
+  }
+
+  @Test
+  void returnsSettingsForAuthenticatedUser() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/users/me/settings").with(jwt().jwt(j -> j.subject(userId.toString()))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.settings").isArray())
+        .andExpect(jsonPath("$.settings.length()").value(3));
+  }
+
+  @Test
+  void unauthorizedForAnonymous() throws Exception {
+    mockMvc.perform(get("/api/v1/users/me/settings")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void forbiddenForNonUserPrincipal() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/users/me/settings").with(jwt().jwt(j -> j.subject("api-key-123"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void patchUpdatesSetting() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/v1/users/me/settings")
+                .with(jwt().jwt(j -> j.subject(userId.toString())))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"theme\":\"dark\"}}"))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.settings[?(@.key=='theme')].value")
+                .value(org.hamcrest.Matchers.hasItem("dark")));
+  }
+
+  @Test
+  void patchRejectsInvalidValue() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/v1/users/me/settings")
+                .with(jwt().jwt(j -> j.subject(userId.toString())))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"theme\":\"neon\"}}"))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/settings/UserSettingsServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/UserSettingsServiceIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.SettingValidationException;
+import io.qnop.service.UserSettingKey;
+import io.qnop.service.UserSettingsService;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies {@link UserSettingsService} against a real PostgreSQL (ADR-0020): registry defaults for
+ * a fresh user, per-user upsert and isolation, and validation. Transactional (rolled back) — the
+ * service does not rely on post-commit behavior. Requires Docker.
+ */
+@Transactional
+class UserSettingsServiceIT extends AbstractIntegrationTest {
+
+  @Autowired UserSettingsService settings;
+  @Autowired UserRepository users;
+
+  private UUID newUser(String tag) {
+    return users.saveAndFlush(User.internal(tag, tag + "@example.com", tag, "hash")).getId();
+  }
+
+  @Test
+  void returnsRegistryDefaultsForFreshUser() {
+    UUID userId = newUser("fresh");
+
+    assertThat(settings.getSettings(userId))
+        .anySatisfy(
+            view -> {
+              assertThat(view.key()).isEqualTo("theme");
+              assertThat(view.value()).isEqualTo("system");
+            });
+  }
+
+  @Test
+  void persistsAndReadsBackUserValue() {
+    UUID userId = newUser("setter");
+
+    settings.updateSettings(userId, Map.of("theme", "dark"));
+
+    assertThat(settings.getSettings(userId))
+        .filteredOn(view -> view.key().equals("theme"))
+        .singleElement()
+        .satisfies(view -> assertThat(view.value()).isEqualTo("dark"));
+  }
+
+  @Test
+  void keepsUsersIsolated() {
+    UUID alice = newUser("alice");
+    UUID bob = newUser("bob");
+
+    settings.updateSettings(alice, Map.of("theme", "dark"));
+
+    assertThat(themeOf(bob)).isEqualTo("system"); // bob still on the default
+    assertThat(themeOf(alice)).isEqualTo("dark");
+  }
+
+  @Test
+  void rejectsUnknownKey() {
+    UUID userId = newUser("unknown");
+    assertThatThrownBy(() -> settings.updateSettings(userId, Map.of("nope", "x")))
+        .isInstanceOf(SettingValidationException.class);
+  }
+
+  @Test
+  void rejectsInvalidEnumValue() {
+    UUID userId = newUser("invalid");
+    assertThatThrownBy(() -> settings.updateSettings(userId, Map.of("theme", "neon")))
+        .isInstanceOf(SettingValidationException.class);
+  }
+
+  private String themeOf(UUID userId) {
+    return settings.getSettings(userId).stream()
+        .filter(view -> view.key().equals(UserSettingKey.THEME.getKey()))
+        .findFirst()
+        .orElseThrow()
+        .value();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.SettingValueType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * The authoritative registry of per-user settings (issue #22): each key carries its {@link
+ * SettingValueType}, default, description, and (for {@code ENUM}) the allowed options.
+ *
+ * <p>Per-user settings live in {@code user_setting} (issue #13) keyed by {@code (user_id,
+ * setting_key)} and are typed by this registry, not by a per-row column (ADR-0025). The set is
+ * deliberately small and UI-facing; none are secrets.
+ */
+public enum UserSettingKey {
+  THEME(
+      "theme",
+      SettingValueType.ENUM,
+      "system",
+      "Preferred UI theme.",
+      List.of("system", "light", "dark")),
+  PREFERRED_LANGUAGE(
+      "preferred_language", SettingValueType.STRING, "en", "Preferred UI language (ISO 639-1)."),
+  TIMEZONE("timezone", SettingValueType.STRING, "UTC", "Preferred display timezone (IANA id).");
+
+  private static final Map<String, UserSettingKey> BY_KEY =
+      Arrays.stream(values())
+          .collect(Collectors.toUnmodifiableMap(UserSettingKey::getKey, Function.identity()));
+
+  private final String key;
+  private final SettingValueType type;
+  private final String defaultValue;
+  private final String description;
+  private final List<String> enumOptions;
+
+  UserSettingKey(String key, SettingValueType type, String defaultValue, String description) {
+    this(key, type, defaultValue, description, List.of());
+  }
+
+  UserSettingKey(
+      String key,
+      SettingValueType type,
+      String defaultValue,
+      String description,
+      List<String> enumOptions) {
+    this.key = key;
+    this.type = type;
+    this.defaultValue = defaultValue;
+    this.description = description;
+    this.enumOptions = List.copyOf(enumOptions);
+  }
+
+  public static Optional<UserSettingKey> fromKey(String key) {
+    return Optional.ofNullable(BY_KEY.get(key));
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public SettingValueType getType() {
+    return type;
+  }
+
+  public String getDefaultValue() {
+    return defaultValue;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public List<String> getEnumOptions() {
+    return enumOptions;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/UserSettingsService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSettingsService.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.UserSetting;
+import io.qnop.repository.UserSettingRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Per-user settings access (issue #22). Each user's values are stored in {@code user_setting} and
+ * typed by the {@link UserSettingKey} registry; missing keys fall back to the registry default.
+ *
+ * <p>Unlike the global application settings (issue #16), there is no in-memory snapshot — per-user
+ * reads are infrequent and indexed by {@code user_id} — and no secrets/encryption.
+ */
+@Service
+public class UserSettingsService {
+
+  private final UserSettingRepository repository;
+
+  public UserSettingsService(UserSettingRepository repository) {
+    this.repository = repository;
+  }
+
+  /** All settings for the user, with stored values overlaid on registry defaults. */
+  @Transactional(readOnly = true)
+  public List<SettingView> getSettings(UUID userId) {
+    Map<String, UserSetting> stored = new HashMap<>();
+    repository.findByUserId(userId).forEach(row -> stored.put(row.getSettingKey(), row));
+
+    List<SettingView> views = new ArrayList<>();
+    for (UserSettingKey key : UserSettingKey.values()) {
+      UserSetting row = stored.get(key.getKey());
+      String value = row != null ? row.getSettingValue() : key.getDefaultValue();
+      views.add(new SettingView(key.getKey(), value, key.getType().name(), key.getDescription()));
+    }
+    return views;
+  }
+
+  /**
+   * Applies a partial set of changes for the user. Unknown keys and type-invalid values are
+   * rejected with {@link SettingValidationException}.
+   */
+  @Transactional
+  public List<SettingView> updateSettings(UUID userId, Map<String, String> changes) {
+    for (Map.Entry<String, String> entry : changes.entrySet()) {
+      UserSettingKey key =
+          UserSettingKey.fromKey(entry.getKey())
+              .orElseThrow(
+                  () -> new SettingValidationException(entry.getKey(), "unknown user setting key"));
+      ValueValidator.validate(key, entry.getValue());
+
+      UserSetting row =
+          repository
+              .findByUserIdAndSettingKey(userId, key.getKey())
+              .orElseGet(() -> new UserSetting(userId, key.getKey(), null));
+      row.setSettingValue(entry.getValue());
+      repository.save(row);
+    }
+    return getSettings(userId);
+  }
+
+  /** A self-contained view of one user setting (no entity types reach the web layer). */
+  public record SettingView(String key, String value, String type, String description) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/ValueValidator.java
+++ b/qnop-core/src/main/java/io/qnop/service/ValueValidator.java
@@ -20,6 +20,9 @@
  */
 package io.qnop.service;
 
+import io.qnop.entity.SettingValueType;
+import java.util.List;
+
 /**
  * Validates a raw setting value string against its key's declared type (issue #16). Shared, plain,
  * DB-free logic (ADR-0004). Throws {@link SettingValidationException} on violation.
@@ -29,36 +32,47 @@ public final class ValueValidator {
   private ValueValidator() {}
 
   public static void validate(ApplicationSettingKey key, String value) {
+    validate(key.getType(), key.getEnumOptions(), value, key.getKey());
+  }
+
+  public static void validate(UserSettingKey key, String value) {
+    validate(key.getType(), key.getEnumOptions(), value, key.getKey());
+  }
+
+  /** Core, key-agnostic validation shared by the application- and user-setting registries. */
+  public static void validate(
+      SettingValueType type, List<String> enumOptions, String value, String keyForError) {
     if (value == null) {
-      throw new SettingValidationException(key.getKey(), "value must not be null");
+      throw new SettingValidationException(keyForError, "value must not be null");
     }
-    switch (key.getType()) {
-      case INTEGER -> requireInteger(key, value);
-      case BOOLEAN -> requireBoolean(key, value);
-      case ENUM -> requireEnumOption(key, value);
+    switch (type) {
+      case INTEGER -> requireInteger(keyForError, value);
+      case BOOLEAN -> requireBoolean(keyForError, value);
+      case ENUM -> requireEnumOption(keyForError, enumOptions, value);
       case STRING, PASSWORD -> {
         // any string is acceptable
       }
     }
   }
 
-  private static void requireInteger(ApplicationSettingKey key, String value) {
+  private static void requireInteger(String keyForError, String value) {
     try {
       Integer.parseInt(value.trim());
     } catch (NumberFormatException e) {
-      throw new SettingValidationException(key.getKey(), "must be an integer");
+      throw new SettingValidationException(keyForError, "must be an integer");
     }
   }
 
-  private static void requireBoolean(ApplicationSettingKey key, String value) {
+  private static void requireBoolean(String keyForError, String value) {
     if (!"true".equals(value) && !"false".equals(value)) {
-      throw new SettingValidationException(key.getKey(), "must be 'true' or 'false'");
+      throw new SettingValidationException(keyForError, "must be 'true' or 'false'");
     }
   }
 
-  private static void requireEnumOption(ApplicationSettingKey key, String value) {
-    if (!key.getEnumOptions().contains(value)) {
-      throw new SettingValidationException(key.getKey(), "must be one of " + key.getEnumOptions());
+  private static void requireEnumOption(
+      String keyForError, List<String> enumOptions, String value) {
+    if (!enumOptions.contains(value)) {
+      throw new SettingValidationException(keyForError, "must be one of " + enumOptions);
     }
   }
 }

--- a/qnop-core/src/test/java/io/qnop/service/UserSettingKeyTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/UserSettingKeyTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.qnop.entity.SettingValueType;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the {@link UserSettingKey} registry and its validation (issue #22). */
+class UserSettingKeyTest {
+
+  @Test
+  void resolvesKnownKeyAndRejectsUnknown() {
+    assertEquals(Optional.of(UserSettingKey.THEME), UserSettingKey.fromKey("theme"));
+    assertTrue(UserSettingKey.fromKey("nope").isEmpty());
+  }
+
+  @Test
+  void themeIsAConstrainedEnum() {
+    assertEquals(SettingValueType.ENUM, UserSettingKey.THEME.getType());
+    assertEquals("system", UserSettingKey.THEME.getDefaultValue());
+    assertDoesNotThrow(() -> ValueValidator.validate(UserSettingKey.THEME, "dark"));
+    assertThrows(
+        SettingValidationException.class,
+        () -> ValueValidator.validate(UserSettingKey.THEME, "neon"));
+  }
+
+  @Test
+  void freeTextKeysAcceptAnyString() {
+    assertDoesNotThrow(() -> ValueValidator.validate(UserSettingKey.PREFERRED_LANGUAGE, "de"));
+    assertDoesNotThrow(() -> ValueValidator.validate(UserSettingKey.TIMEZONE, "Europe/Berlin"));
+  }
+}


### PR DESCRIPTION
Closes #22 · part of epic #7 · depends on #13, #17 (both merged).

## What
Per-user settings over the `user_setting` schema (#13), authenticated via JWT (#17). Mirrors the application-settings service (#16) but simpler — per-user, no global snapshot, no secrets.

- **`UserSettingKey`** — registry of per-user keys: `theme` (ENUM `system`/`light`/`dark`), `preferred_language` (STRING), `timezone` (STRING), with defaults. User settings are registry-typed, not per-row (ADR-0025). `default_workspace` deferred until a workspace concept exists.
- **`UserSettingsService`** — per-user read/upsert; missing keys fall back to registry defaults. No `AtomicReference` snapshot, no encryption.
- **`ValueValidator`** refactored to a shared, key-agnostic core (`validate(SettingValueType, options, value, key)`) used by both the application- and user-setting registries.
- **OpenAPI** — `GET/PATCH /api/v1/users/me/settings` generates `UserSettingsApi` + DTOs (`UserSettingItem`/`UserSettingsResponse`/`UserSettingsUpdateRequest`); `UserSettingsController` maps via the service, so the web layer never references entities (ArchUnit-clean).
- **`CurrentUser`** — resolves the JWT subject as a user UUID; a non-UUID (API-key) principal is rejected with **403**. `/api/v1/users/**` is already `authenticated()` — no security-config change.

## Test plan
- [x] Unit (core): `UserSettingKey` registry + shared `ValueValidator` — green locally
- [x] API generation, compile (core + app), Spotless + SPDX, ArchUnit layering — green locally
- [ ] `UserSettingsServiceIT` (Testcontainers): registry defaults, per-user upsert + isolation, validation — **CI only** (no local Docker)
- [ ] `UserSettingsControllerIT` (MockMvc + `springSecurity()`, JWT request post-processor): GET/PATCH as user, anonymous→401, non-user principal→403, invalid→400 — **CI only**

🤖 Co-Author: Claude (Opus 4.x) via Claude Code