### PR TITLE
feat: local-user lifecycle core — registration, verification, password reset (Part of #20)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -386,6 +386,127 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /auth/register:
+    post:
+      tags:
+        - AuthRegistration
+      summary: Register a local account
+      description: |
+        Self-registration of a local user. Public; gated by the
+        `auth.self_registration_enabled` setting. Anti-enumeration: the response is
+        **uniform** whether or not the username/email already exists (no account is
+        created or re-mailed for a duplicate); when registration is disabled the
+        endpoint reports a **disguised 404** so its availability is not revealed.
+      operationId: register
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+      responses:
+        '200':
+          description: Uniform registration acknowledgement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterResponse'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Registration is not available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Too many registration attempts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/verify-email:
+    get:
+      tags:
+        - AuthRegistration
+      summary: Verify a registered email address
+      description: Consumes a single-use verification token and activates the account. Public.
+      operationId: verifyEmail
+      security: []
+      parameters:
+        - name: token
+          in: query
+          required: true
+          description: The raw verification token from the emailed link.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyEmailResponse'
+        '400':
+          description: Unknown, expired, or already-used token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/forgot-password:
+    post:
+      tags:
+        - AuthPasswordReset
+      summary: Request a password-reset email
+      description: |
+        Starts the self-service reset flow. Public. Always returns **204** with
+        constant-time behaviour regardless of whether the address maps to a local
+        account, so it cannot be used to enumerate users.
+      operationId: forgotPassword
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ForgotPasswordRequest'
+      responses:
+        '204':
+          description: Request accepted (no content; outcome intentionally not disclosed)
+        '429':
+          description: Too many reset requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/reset-password:
+    post:
+      tags:
+        - AuthPasswordReset
+      summary: Complete a password reset
+      description: Consumes a single-use reset token and sets the new password. Public.
+      operationId: resetPassword
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetPasswordRequest'
+      responses:
+        '204':
+          description: Password updated
+        '400':
+          description: Unknown/expired/used token or invalid password
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /auth/login:
     post:
       tags:
@@ -985,6 +1106,72 @@ components:
           description: Map of setting key to new value.
       required:
         - values
+    RegisterRequest:
+      type: object
+      description: Self-registration details for a new local account.
+      properties:
+        username:
+          type: string
+          minLength: 3
+          maxLength: 64
+        email:
+          type: string
+          format: email
+          maxLength: 320
+        password:
+          type: string
+          minLength: 8
+          maxLength: 200
+        displayName:
+          type: string
+          maxLength: 255
+      required:
+        - username
+        - email
+        - password
+    RegisterResponse:
+      type: object
+      description: Uniform, non-revealing acknowledgement of a registration request.
+      properties:
+        verificationRequired:
+          type: boolean
+          description: Whether the user must verify their email before logging in.
+        message:
+          type: string
+      required:
+        - verificationRequired
+        - message
+    VerifyEmailResponse:
+      type: object
+      properties:
+        verified:
+          type: boolean
+        message:
+          type: string
+      required:
+        - verified
+        - message
+    ForgotPasswordRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          maxLength: 320
+      required:
+        - email
+    ResetPasswordRequest:
+      type: object
+      properties:
+        token:
+          type: string
+        newPassword:
+          type: string
+          minLength: 8
+          maxLength: 200
+      required:
+        - token
+        - newPassword
     ErrorResponse:
       type: object
       description: |

--- a/qnop-app/src/main/java/io/qnop/bootstrap/AdminInitializationRunner.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/AdminInitializationRunner.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import io.qnop.service.UserService;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.SecureRandom;
+import java.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bootstraps the initial superadmin on first startup (issue #20). If no internal user named {@value
+ * #ADMIN_USERNAME} exists, this runner creates one ({@code is_superadmin = true}, {@code
+ * password_change_required = true}) and surfaces a one-time credential.
+ *
+ * <p>The password comes from {@code QNOP_ADMIN_PASSWORD} when set (CI/smoke tests — then no forced
+ * change); otherwise it is cryptographically random. A random credential is written to {@code
+ * System.err} (bypassing SLF4J, so log forwarders never capture it) and to a {@code 0600} file at
+ * {@value #PASSWORD_FILE}; SLF4J only records that bootstrap happened. Idempotent on later starts.
+ */
+@Component
+public class AdminInitializationRunner implements ApplicationRunner {
+
+  static final String ADMIN_USERNAME = "admin";
+  static final String ADMIN_DEFAULT_EMAIL = "admin@qnop.local";
+  static final String PASSWORD_FILE = "/tmp/qnop-admin-password.txt";
+  private static final String ADMIN_PASSWORD_ENV = "QNOP_ADMIN_PASSWORD";
+  private static final int GENERATED_PASSWORD_BYTES = 24;
+
+  private static final Logger log = LoggerFactory.getLogger(AdminInitializationRunner.class);
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private final UserService userService;
+
+  public AdminInitializationRunner(UserService userService) {
+    this.userService = userService;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    if (userService.internalUsernameExists(ADMIN_USERNAME)) {
+      return;
+    }
+
+    String fixedPassword = blankToNull(System.getenv(ADMIN_PASSWORD_ENV));
+    String initialPassword = fixedPassword != null ? fixedPassword : generatePassword();
+    boolean passwordChangeRequired = fixedPassword == null;
+
+    userService.createSuperadmin(
+        ADMIN_USERNAME,
+        "Administrator",
+        ADMIN_DEFAULT_EMAIL,
+        initialPassword,
+        passwordChangeRequired);
+
+    log.info("Bootstrapped initial superadmin '{}' (first startup).", ADMIN_USERNAME);
+    if (passwordChangeRequired) {
+      surfaceGeneratedPassword(initialPassword);
+    }
+  }
+
+  private void surfaceGeneratedPassword(String password) {
+    System.err.printf(
+        "%n=== qnop initial superadmin ===%nusername: %s%npassword: %s%n"
+            + "Change it on first login. Also written to %s (0600).%n================================%n",
+        ADMIN_USERNAME, password, PASSWORD_FILE);
+    try {
+      Path file = Path.of(PASSWORD_FILE);
+      Files.writeString(file, "username=" + ADMIN_USERNAME + "\npassword=" + password + "\n");
+      try {
+        Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-------"));
+      } catch (UnsupportedOperationException ignored) {
+        // Non-POSIX filesystem: the stderr surface above is the fallback.
+      }
+    } catch (Exception e) {
+      log.warn(
+          "Could not write the initial admin password file at {}: {}",
+          PASSWORD_FILE,
+          e.getMessage());
+    }
+  }
+
+  private static String generatePassword() {
+    byte[] bytes = new byte[GENERATED_PASSWORD_BYTES];
+    RANDOM.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value;
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Spring Boot entry point for the qnop Community server.
@@ -40,6 +41,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableConfigurationProperties({QnopProperties.class, RateLimitProperties.class})
 @EntityScan("io.qnop.entity")
 @EnableJpaRepositories("io.qnop.repository")
+@EnableScheduling
 public class QnopApplication {
 
   public static void main(String[] args) {

--- a/qnop-app/src/main/java/io/qnop/web/AuthPasswordResetController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AuthPasswordResetController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AuthPasswordResetApi;
+import io.qnop.api.v1.model.ForgotPasswordRequest;
+import io.qnop.api.v1.model.ResetPasswordRequest;
+import io.qnop.service.auth.PasswordResetFlowService;
+import io.qnop.service.auth.PasswordResetTokenService.InvalidPasswordResetTokenException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Self-service password-reset endpoints (issue #20), implementing the generated {@link
+ * AuthPasswordResetApi}. Public; the {@code User} entity never reaches this layer — the flow lives
+ * in {@link PasswordResetFlowService} (ADR-0004).
+ *
+ * <p><strong>Anti-enumeration:</strong> {@code forgot-password} always returns {@code 204},
+ * disclosing nothing about whether the address is registered.
+ */
+@RestController
+public class AuthPasswordResetController implements AuthPasswordResetApi {
+
+  private final PasswordResetFlowService passwordResetFlow;
+
+  public AuthPasswordResetController(PasswordResetFlowService passwordResetFlow) {
+    this.passwordResetFlow = passwordResetFlow;
+  }
+
+  @Override
+  public ResponseEntity<Void> forgotPassword(ForgotPasswordRequest request) {
+    passwordResetFlow.requestReset(request.getEmail());
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> resetPassword(ResetPasswordRequest request) {
+    try {
+      passwordResetFlow.reset(request.getToken(), request.getNewPassword());
+    } catch (InvalidPasswordResetTokenException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/AuthRegistrationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AuthRegistrationController.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AuthRegistrationApi;
+import io.qnop.api.v1.model.RegisterRequest;
+import io.qnop.api.v1.model.RegisterResponse;
+import io.qnop.api.v1.model.VerifyEmailResponse;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.auth.EmailVerificationTokenService.InvalidVerificationTokenException;
+import io.qnop.service.auth.RegistrationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Self-registration and email-verification endpoints (issue #20), implementing the generated {@link
+ * AuthRegistrationApi}. Public; the {@code User} entity never reaches this layer — all of it lives
+ * in {@link RegistrationService} (ADR-0004).
+ *
+ * <p><strong>Anti-enumeration:</strong> {@code register} returns a uniform acknowledgement whether
+ * or not the account already exists, and a disguised {@code 404} when self-registration is
+ * disabled.
+ */
+@RestController
+public class AuthRegistrationController implements AuthRegistrationApi {
+
+  private final RegistrationService registrationService;
+  private final ApplicationSettingsService settings;
+
+  public AuthRegistrationController(
+      RegistrationService registrationService, ApplicationSettingsService settings) {
+    this.registrationService = registrationService;
+    this.settings = settings;
+  }
+
+  @Override
+  public ResponseEntity<RegisterResponse> register(RegisterRequest request) {
+    if (!settings.getBoolean(ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Not found");
+    }
+    registrationService.register(
+        request.getUsername(), request.getEmail(), request.getPassword(), request.getDisplayName());
+    return ResponseEntity.ok(
+        new RegisterResponse()
+            .verificationRequired(true)
+            .message("If the details are valid, a verification email has been sent."));
+  }
+
+  @Override
+  public ResponseEntity<VerifyEmailResponse> verifyEmail(String token) {
+    try {
+      registrationService.verify(token);
+    } catch (InvalidVerificationTokenException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+    return ResponseEntity.ok(
+        new VerifyEmailResponse().verified(true).message("Email verified. You can now sign in."));
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/PasswordChangeRequiredFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/PasswordChangeRequiredFilter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import io.qnop.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Forces a password change before any non-auth resource is reachable (issue #20). When the
+ * authenticated JWT subject is a user with {@code password_change_required = true}, every request
+ * outside {@code /api/v1/auth/} is rejected with {@code 403}, so the only thing such a user can do
+ * is change their password (and refresh/logout). Runs after the resource-server authentication has
+ * populated the {@link JwtAuthenticationToken}.
+ */
+@Component
+public class PasswordChangeRequiredFilter extends OncePerRequestFilter {
+
+  private static final String AUTH_PREFIX = "/api/v1/auth/";
+
+  private final UserService userService;
+
+  public PasswordChangeRequiredFilter(UserService userService) {
+    this.userService = userService;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof JwtAuthenticationToken jwt
+        && !request.getRequestURI().startsWith(AUTH_PREFIX)
+        && requiresPasswordChange(jwt.getName())) {
+      response.setStatus(HttpStatus.FORBIDDEN.value());
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response
+          .getWriter()
+          .write(
+              "{\"error\":\"PASSWORD_CHANGE_REQUIRED\",\"message\":\"You must change your password"
+                  + " before accessing this resource.\"}");
+      return;
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * The JWT subject is the {@code qnop_user.id} (issue #17). A non-UUID subject can only come from
+   * a forged/legacy token; treat it as "no change required" so the auth filters reject it on the
+   * correct path rather than bleeding through as a 403.
+   */
+  private boolean requiresPasswordChange(String subject) {
+    final UUID userId;
+    try {
+      userId = UUID.fromString(subject);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+    return userService.passwordChangeRequired(userId);
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -22,8 +22,10 @@ package io.qnop.web.security;
 
 import io.qnop.security.QnopProperties;
 import io.qnop.web.security.ratelimit.ChangePasswordRateLimitFilter;
+import io.qnop.web.security.ratelimit.ForgotPasswordRateLimitFilter;
 import io.qnop.web.security.ratelimit.LoginRateLimitFilter;
 import io.qnop.web.security.ratelimit.RefreshRateLimitFilter;
+import io.qnop.web.security.ratelimit.RegisterRateLimitFilter;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -79,7 +81,10 @@ public class SecurityConfiguration {
       DelegatingJwtDecoder jwtDecoder,
       LoginRateLimitFilter loginRateLimitFilter,
       RefreshRateLimitFilter refreshRateLimitFilter,
-      ChangePasswordRateLimitFilter changePasswordRateLimitFilter)
+      ChangePasswordRateLimitFilter changePasswordRateLimitFilter,
+      RegisterRateLimitFilter registerRateLimitFilter,
+      ForgotPasswordRateLimitFilter forgotPasswordRateLimitFilter,
+      PasswordChangeRequiredFilter passwordChangeRequiredFilter)
       throws Exception {
     http.csrf(
             csrf ->
@@ -96,6 +101,12 @@ public class SecurityConfiguration {
         .addFilterBefore(loginRateLimitFilter, CsrfFilter.class)
         .addFilterBefore(refreshRateLimitFilter, CsrfFilter.class)
         .addFilterBefore(changePasswordRateLimitFilter, AuthorizationFilter.class)
+        // IP-keyed limiters for the public self-service endpoints (issue #20).
+        .addFilterBefore(registerRateLimitFilter, CsrfFilter.class)
+        .addFilterBefore(forgotPasswordRateLimitFilter, CsrfFilter.class)
+        // Force a password change before any non-auth resource (issue #20); needs the
+        // authenticated subject, so it runs after the authorization filter.
+        .addFilterAfter(passwordChangeRequiredFilter, AuthorizationFilter.class)
         .cors(cors -> cors.configurationSource(corsConfigurationSource))
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -105,6 +116,12 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers(
                         "/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/logout")
+                    .permitAll()
+                    .requestMatchers(
+                        "/api/v1/auth/register",
+                        "/api/v1/auth/verify-email",
+                        "/api/v1/auth/forgot-password",
+                        "/api/v1/auth/reset-password")
                     .permitAll()
                     .requestMatchers("/api/v1/admin/**")
                     .hasRole("SUPERADMIN")

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/ForgotPasswordRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/ForgotPasswordRateLimitFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rate-limits {@code POST /api/v1/auth/forgot-password} per client IP (issue #20), throttling
+ * reset-email spam and timing-based enumeration attempts from a single source.
+ */
+@Component
+public class ForgotPasswordRateLimitFilter extends AbstractRateLimitFilter {
+
+  static final String PATH = "/api/v1/auth/forgot-password";
+
+  private final HttpClientIpResolver clientIpResolver;
+  private final RateLimitProperties.Limit limit;
+
+  public ForgotPasswordRateLimitFilter(
+      BucketRateLimitService rateLimitService,
+      HttpClientIpResolver clientIpResolver,
+      RateLimitProperties properties) {
+    super(rateLimitService, "Too many password-reset requests. Please try again later.");
+    this.clientIpResolver = clientIpResolver;
+    this.limit = properties.forgotPassword();
+  }
+
+  @Override
+  protected boolean handles(HttpServletRequest request) {
+    return "POST".equalsIgnoreCase(request.getMethod()) && PATH.equals(request.getRequestURI());
+  }
+
+  @Override
+  protected String resolveKey(HttpServletRequest request) {
+    return clientIpResolver.resolve(request);
+  }
+
+  @Override
+  protected String scope() {
+    return "forgot-password";
+  }
+
+  @Override
+  protected int maxAttempts() {
+    return limit.maxAttempts();
+  }
+
+  @Override
+  protected long windowSeconds() {
+    return limit.windowSeconds();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RateLimitProperties.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RateLimitProperties.java
@@ -45,7 +45,12 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  */
 @ConfigurationProperties(prefix = "qnop.auth.rate-limit")
 public record RateLimitProperties(
-    List<String> trustedProxyCidrs, Limit login, Limit refresh, Limit changePassword) {
+    List<String> trustedProxyCidrs,
+    Limit login,
+    Limit refresh,
+    Limit changePassword,
+    Limit register,
+    Limit forgotPassword) {
 
   // A whole scope absent from config arrives as null here; substitute its per-scope default. The
   // Limit components themselves carry @DefaultValue, so a partially-specified scope keeps the
@@ -55,6 +60,8 @@ public record RateLimitProperties(
     login = login != null ? login : new Limit(10, 60);
     refresh = refresh != null ? refresh : new Limit(30, 60);
     changePassword = changePassword != null ? changePassword : new Limit(5, 300);
+    register = register != null ? register : new Limit(5, 3600);
+    forgotPassword = forgotPassword != null ? forgotPassword : new Limit(5, 3600);
   }
 
   /**

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RegisterRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RegisterRateLimitFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rate-limits {@code POST /api/v1/auth/register} per client IP (issue #20), throttling automated
+ * account-creation/enumeration abuse from a single source.
+ */
+@Component
+public class RegisterRateLimitFilter extends AbstractRateLimitFilter {
+
+  static final String PATH = "/api/v1/auth/register";
+
+  private final HttpClientIpResolver clientIpResolver;
+  private final RateLimitProperties.Limit limit;
+
+  public RegisterRateLimitFilter(
+      BucketRateLimitService rateLimitService,
+      HttpClientIpResolver clientIpResolver,
+      RateLimitProperties properties) {
+    super(rateLimitService, "Too many registration attempts. Please try again later.");
+    this.clientIpResolver = clientIpResolver;
+    this.limit = properties.register();
+  }
+
+  @Override
+  protected boolean handles(HttpServletRequest request) {
+    return "POST".equalsIgnoreCase(request.getMethod()) && PATH.equals(request.getRequestURI());
+  }
+
+  @Override
+  protected String resolveKey(HttpServletRequest request) {
+    return clientIpResolver.resolve(request);
+  }
+
+  @Override
+  protected String scope() {
+    return "register";
+  }
+
+  @Override
+  protected int maxAttempts() {
+    return limit.maxAttempts();
+  }
+
+  @Override
+  protected long windowSeconds() {
+    return limit.windowSeconds();
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/security/ratelimit/HttpClientIpResolverTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/ratelimit/HttpClientIpResolverTest.java
@@ -43,7 +43,8 @@ class HttpClientIpResolverTest {
   }
 
   private static HttpClientIpResolver resolver(List<String> trustedCidrs) {
-    return new HttpClientIpResolver(new RateLimitProperties(trustedCidrs, null, null, null));
+    return new HttpClientIpResolver(
+        new RateLimitProperties(trustedCidrs, null, null, null, null, null));
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/service/UserNotFoundException.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserNotFoundException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import java.util.UUID;
+
+/** Thrown when a user lookup by id finds no matching {@code qnop_user} row. */
+public class UserNotFoundException extends RuntimeException {
+
+  public UserNotFoundException(UUID id) {
+    super("User not found: " + id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.User;
+import io.qnop.entity.UserSource;
+import io.qnop.repository.UserRepository;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Lifecycle operations for local ({@link UserSource#INTERNAL}) users (issue #20):
+ * self-registration, email-verification activation, and password reset. Passwords are BCrypt-hashed
+ * (issue #10); emails are normalized (trimmed, lower-cased) to match the case-insensitive
+ * uniqueness index (issue #11). qnop has no role model — authorization is the {@code is_superadmin}
+ * flag — so a self-registered user is a plain internal account, created disabled until its email is
+ * verified.
+ */
+@Service
+public class UserService {
+
+  private final UserRepository users;
+  private final PasswordEncoder passwordEncoder;
+
+  public UserService(UserRepository users, PasswordEncoder passwordEncoder) {
+    this.users = users;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  /** Creates a disabled internal user pending email verification. */
+  @Transactional
+  public User createSelfRegistered(
+      String username, String email, String rawPassword, String displayName) {
+    String name = displayName == null || displayName.isBlank() ? username : displayName;
+    User user =
+        User.internal(name, normalizeEmail(email), username, passwordEncoder.encode(rawPassword));
+    user.setEnabled(false);
+    return users.save(user);
+  }
+
+  /** An internal user by case-insensitive email, if one exists. */
+  @Transactional(readOnly = true)
+  public Optional<User> findInternalByEmail(String email) {
+    return users.findByEmailIgnoreCaseAndSource(normalizeEmail(email), UserSource.INTERNAL);
+  }
+
+  /** Whether an internal user already exists with the given username or email. */
+  @Transactional(readOnly = true)
+  public boolean internalUserExists(String username, String email) {
+    return users.existsByEmailIgnoreCaseAndSource(normalizeEmail(email), UserSource.INTERNAL)
+        || users.findByUsernameAndSource(username, UserSource.INTERNAL).isPresent();
+  }
+
+  @Transactional(readOnly = true)
+  public Optional<User> findById(UUID id) {
+    return users.findById(id);
+  }
+
+  /** Activates a user after successful email verification. */
+  @Transactional
+  public User enable(UUID id) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    user.setEnabled(true);
+    return user;
+  }
+
+  /**
+   * Applies a reset/new password: re-hashes, clears any forced-change flag, and stamps {@code
+   * password_invalidated_before} so previously issued access tokens are rejected (issue #17).
+   */
+  @Transactional
+  public User applyPasswordReset(UUID id, String rawPassword) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    user.setPasswordHash(passwordEncoder.encode(rawPassword));
+    user.setPasswordChangeRequired(false);
+    user.setPasswordInvalidatedBefore(Instant.now());
+    return user;
+  }
+
+  /** Whether the given user must change their password before using the API (issue #17/#20). */
+  @Transactional(readOnly = true)
+  public boolean passwordChangeRequired(UUID id) {
+    return users.findById(id).map(User::isPasswordChangeRequired).orElse(false);
+  }
+
+  /** Whether an internal user with the given username exists (bootstrap idempotency). */
+  @Transactional(readOnly = true)
+  public boolean internalUsernameExists(String username) {
+    return users.findByUsernameAndSource(username, UserSource.INTERNAL).isPresent();
+  }
+
+  /** Creates an enabled internal superadmin (used by the first-start bootstrap, issue #20). */
+  @Transactional
+  public User createSuperadmin(
+      String username,
+      String displayName,
+      String email,
+      String rawPassword,
+      boolean passwordChangeRequired) {
+    User admin =
+        User.internal(
+            displayName, normalizeEmail(email), username, passwordEncoder.encode(rawPassword));
+    admin.setSuperadmin(true);
+    admin.setEnabled(true);
+    admin.setPasswordChangeRequired(passwordChangeRequired);
+    return users.save(admin);
+  }
+
+  private String normalizeEmail(String email) {
+    return email == null ? null : email.trim().toLowerCase(Locale.ROOT);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/auth/EmailVerificationTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/EmailVerificationTokenService.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import io.qnop.entity.EmailVerificationToken;
+import io.qnop.entity.User;
+import io.qnop.repository.EmailVerificationTokenRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Issues and consumes single-use email-verification tokens (issue #20). A token is 32 random bytes,
+ * surfaced once to the user (in the verification email) and stored only as its SHA-256 hex digest
+ * (issue #12), so a DB leak cannot reconstruct a usable link. Tokens live 24h and are single-use;
+ * issuing a fresh token supersedes any earlier unconsumed one for the same user. A daily scheduled
+ * sweep purges expired rows.
+ */
+@Service
+public class EmailVerificationTokenService {
+
+  static final int TOKEN_BYTES = 32;
+  static final Duration TOKEN_TTL = Duration.ofHours(24);
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private final EmailVerificationTokenRepository tokens;
+
+  public EmailVerificationTokenService(EmailVerificationTokenRepository tokens) {
+    this.tokens = tokens;
+  }
+
+  /** Issues a fresh token for {@code user}, superseding any earlier unconsumed one. */
+  @Transactional
+  public IssuedToken issue(User user) {
+    Instant now = Instant.now();
+    tokens.findUnconsumedTokensForUser(user.getId()).forEach(token -> token.setConsumedAt(now));
+    String rawToken = generateRawToken();
+    Instant expiresAt = now.plus(TOKEN_TTL);
+    tokens.save(new EmailVerificationToken(user, sha256Hex(rawToken), expiresAt));
+    return new IssuedToken(rawToken, expiresAt);
+  }
+
+  /** Validates and consumes a token, returning its owner. Throws if unknown/expired/used. */
+  @Transactional
+  public User consume(String rawToken) {
+    EmailVerificationToken token =
+        tokens
+            .findByTokenHash(sha256Hex(rawToken))
+            .orElseThrow(
+                () ->
+                    new InvalidVerificationTokenException("Unknown or invalid verification token"));
+    if (token.getConsumedAt() != null) {
+      throw new InvalidVerificationTokenException("Verification token already used");
+    }
+    if (token.getExpiresAt().isBefore(Instant.now())) {
+      throw new InvalidVerificationTokenException("Verification token has expired");
+    }
+    token.setConsumedAt(Instant.now());
+    return token.getUser();
+  }
+
+  /** Daily off-peak purge of expired rows so the table does not grow unbounded. */
+  @Scheduled(cron = "0 30 3 * * *")
+  @Transactional
+  public void sweep() {
+    tokens.deleteByExpiresAtBefore(Instant.now());
+  }
+
+  private static String generateRawToken() {
+    byte[] bytes = new byte[TOKEN_BYTES];
+    RANDOM.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  private static String sha256Hex(String input) {
+    try {
+      byte[] digest =
+          MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(digest);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+
+  /** A freshly issued token: the raw value (emailed once) and its absolute expiry. */
+  public record IssuedToken(String rawToken, Instant expiresAt) {}
+
+  /** Raised when a presented verification token is unknown, expired, or already consumed. */
+  public static class InvalidVerificationTokenException extends RuntimeException {
+    public InvalidVerificationTokenException(String message) {
+      super(message);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import io.qnop.entity.User;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.UserService;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Orchestrates the self-service password-reset flow (issue #20), keeping the {@code User} entity
+ * inside the service layer (ADR-0004). {@link #requestReset} is anti-enumeration: it runs only when
+ * the feature is enabled and the email maps to an enabled local account, and the caller returns a
+ * uniform 204 regardless.
+ */
+@Service
+public class PasswordResetFlowService {
+
+  private final UserService userService;
+  private final PasswordResetTokenService resetTokens;
+  private final MailService mailService;
+  private final ApplicationSettingsService settings;
+
+  public PasswordResetFlowService(
+      UserService userService,
+      PasswordResetTokenService resetTokens,
+      MailService mailService,
+      ApplicationSettingsService settings) {
+    this.userService = userService;
+    this.resetTokens = resetTokens;
+    this.mailService = mailService;
+    this.settings = settings;
+  }
+
+  /**
+   * Issues a reset token and emails the link, only for an enabled local account. Silent otherwise.
+   */
+  @Transactional
+  public void requestReset(String email) {
+    if (!settings.getBoolean(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED)) {
+      return;
+    }
+    userService.findInternalByEmail(email).filter(User::isEnabled).ifPresent(this::sendResetEmail);
+  }
+
+  /** Consumes a reset token and applies the new password. Throws on an invalid token. */
+  @Transactional
+  public void reset(String rawToken, String newPassword) {
+    User user = resetTokens.consume(rawToken);
+    userService.applyPasswordReset(user.getId(), newPassword);
+  }
+
+  private void sendResetEmail(User user) {
+    String rawToken = resetTokens.issue(user).rawToken();
+    String actionUrl =
+        baseUrl() + "/reset-password?token=" + URLEncoder.encode(rawToken, StandardCharsets.UTF_8);
+    mailService.sendMailFromTemplate(
+        MailTemplateKey.PASSWORD_RESET,
+        user.getEmail(),
+        Map.of(
+            "siteName", siteName(),
+            "recipientName", user.getDisplayName(),
+            "actionUrl", actionUrl),
+        null);
+  }
+
+  private String siteName() {
+    return settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME);
+  }
+
+  private String baseUrl() {
+    String base = settings.getString(ApplicationSettingKey.GENERAL_BASE_URL);
+    return base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetTokenService.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import io.qnop.entity.PasswordResetToken;
+import io.qnop.entity.User;
+import io.qnop.repository.PasswordResetTokenRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Issues and consumes single-use password-reset tokens (issue #20). Storage mirrors {@link
+ * EmailVerificationTokenService} (32 random bytes, only the SHA-256 hex persisted, single-use); the
+ * difference is the TTL, which is operator-tunable at runtime via {@code
+ * auth.password_reset_token_ttl_minutes} (issue #16) rather than a fixed constant. A daily sweep
+ * purges expired rows.
+ */
+@Service
+public class PasswordResetTokenService {
+
+  static final int TOKEN_BYTES = 32;
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private final PasswordResetTokenRepository tokens;
+  private final ApplicationSettingsService settings;
+
+  public PasswordResetTokenService(
+      PasswordResetTokenRepository tokens, ApplicationSettingsService settings) {
+    this.tokens = tokens;
+    this.settings = settings;
+  }
+
+  /** Issues a fresh reset token for {@code user}, superseding any earlier unconsumed one. */
+  @Transactional
+  public IssuedResetToken issue(User user) {
+    Instant now = Instant.now();
+    tokens.findUnconsumedTokensForUser(user.getId()).forEach(token -> token.setConsumedAt(now));
+    String rawToken = generateRawToken();
+    Instant expiresAt = now.plus(ttl());
+    tokens.save(new PasswordResetToken(user, sha256Hex(rawToken), expiresAt));
+    return new IssuedResetToken(rawToken, expiresAt);
+  }
+
+  /** Validates and consumes a reset token, returning its owner. Throws if unknown/expired/used. */
+  @Transactional
+  public User consume(String rawToken) {
+    PasswordResetToken token =
+        tokens
+            .findByTokenHash(sha256Hex(rawToken))
+            .orElseThrow(
+                () -> new InvalidPasswordResetTokenException("Unknown or invalid reset token"));
+    if (token.getConsumedAt() != null) {
+      throw new InvalidPasswordResetTokenException("Reset token already used");
+    }
+    if (token.getExpiresAt().isBefore(Instant.now())) {
+      throw new InvalidPasswordResetTokenException("Reset token has expired");
+    }
+    token.setConsumedAt(Instant.now());
+    return token.getUser();
+  }
+
+  @Scheduled(cron = "0 35 3 * * *")
+  @Transactional
+  public void sweep() {
+    tokens.deleteByExpiresAtBefore(Instant.now());
+  }
+
+  private Duration ttl() {
+    return Duration.ofMinutes(
+        settings.getInteger(ApplicationSettingKey.AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES));
+  }
+
+  private static String generateRawToken() {
+    byte[] bytes = new byte[TOKEN_BYTES];
+    RANDOM.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  private static String sha256Hex(String input) {
+    try {
+      byte[] digest =
+          MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(digest);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+
+  /** A freshly issued reset token: the raw value (emailed once) and its absolute expiry. */
+  public record IssuedResetToken(String rawToken, Instant expiresAt) {}
+
+  /** Raised when a presented reset token is unknown, expired, or already consumed. */
+  public static class InvalidPasswordResetTokenException extends RuntimeException {
+    public InvalidPasswordResetTokenException(String message) {
+      super(message);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/auth/RegistrationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/RegistrationService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import io.qnop.entity.User;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.UserService;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Orchestrates self-registration and email verification (issue #20): create-or-skip, token issue,
+ * and the verification email — keeping the {@code User} entity inside the service layer (ADR-0004).
+ * The controller stays thin and never touches an entity.
+ */
+@Service
+public class RegistrationService {
+
+  private final UserService userService;
+  private final EmailVerificationTokenService verificationTokens;
+  private final MailService mailService;
+  private final ApplicationSettingsService settings;
+
+  public RegistrationService(
+      UserService userService,
+      EmailVerificationTokenService verificationTokens,
+      MailService mailService,
+      ApplicationSettingsService settings) {
+    this.userService = userService;
+    this.verificationTokens = verificationTokens;
+    this.mailService = mailService;
+    this.settings = settings;
+  }
+
+  /**
+   * Registers a local user and sends a verification email. Anti-enumeration: if an internal user
+   * with the same username/email already exists, this is a silent no-op (no create, no re-mail).
+   */
+  @Transactional
+  public void register(String username, String email, String password, String displayName) {
+    if (userService.internalUserExists(username, email)) {
+      return;
+    }
+    User user = userService.createSelfRegistered(username, email, password, displayName);
+    String rawToken = verificationTokens.issue(user).rawToken();
+    sendVerificationEmail(user, rawToken);
+  }
+
+  /** Consumes a verification token and activates the account. Throws on an invalid token. */
+  @Transactional
+  public void verify(String rawToken) {
+    User user = verificationTokens.consume(rawToken);
+    userService.enable(user.getId());
+  }
+
+  private void sendVerificationEmail(User user, String rawToken) {
+    String actionUrl =
+        baseUrl() + "/verify-email?token=" + URLEncoder.encode(rawToken, StandardCharsets.UTF_8);
+    mailService.sendMailFromTemplate(
+        MailTemplateKey.REGISTRATION_VERIFICATION,
+        user.getEmail(),
+        Map.of(
+            "siteName", siteName(),
+            "recipientName", user.getDisplayName(),
+            "actionUrl", actionUrl),
+        null);
+  }
+
+  private String siteName() {
+    return settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME);
+  }
+
+  private String baseUrl() {
+    String base = settings.getString(ApplicationSettingKey.GENERAL_BASE_URL);
+    return base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/auth/EmailVerificationTokenServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/auth/EmailVerificationTokenServiceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.EmailVerificationToken;
+import io.qnop.entity.User;
+import io.qnop.repository.EmailVerificationTokenRepository;
+import io.qnop.service.auth.EmailVerificationTokenService.InvalidVerificationTokenException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationTokenServiceTest {
+
+  @Mock private EmailVerificationTokenRepository tokens;
+  private EmailVerificationTokenService service;
+  private final User user = User.internal("Jane", "jane@example.com", "jane", "hash");
+
+  @BeforeEach
+  void setUp() {
+    service = new EmailVerificationTokenService(tokens);
+  }
+
+  @Test
+  @DisplayName("issue stores a token with a 24h expiry and returns the raw value")
+  void issueStoresToken() {
+    when(tokens.findUnconsumedTokensForUser(any())).thenReturn(List.of());
+
+    EmailVerificationTokenService.IssuedToken issued = service.issue(user);
+
+    assertThat(issued.rawToken()).isNotBlank();
+    assertThat(issued.expiresAt()).isAfter(Instant.now().plusSeconds(23 * 3600));
+    verify(tokens).save(any(EmailVerificationToken.class));
+  }
+
+  @Test
+  @DisplayName("issue supersedes any earlier unconsumed token for the user")
+  void issueSupersedesPrior() {
+    EmailVerificationToken prior =
+        new EmailVerificationToken(user, "oldhash", Instant.now().plusSeconds(60));
+    when(tokens.findUnconsumedTokensForUser(any())).thenReturn(List.of(prior));
+
+    service.issue(user);
+
+    assertThat(prior.getConsumedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("consume returns the owner and marks the token used")
+  void consumeValid() {
+    EmailVerificationToken token =
+        new EmailVerificationToken(user, "h", Instant.now().plusSeconds(60));
+    when(tokens.findByTokenHash(any())).thenReturn(Optional.of(token));
+
+    User result = service.consume("raw-token");
+
+    assertThat(result).isSameAs(user);
+    assertThat(token.getConsumedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("consume rejects an expired token")
+  void consumeExpired() {
+    EmailVerificationToken token =
+        new EmailVerificationToken(user, "h", Instant.now().minusSeconds(60));
+    when(tokens.findByTokenHash(any())).thenReturn(Optional.of(token));
+
+    assertThatThrownBy(() -> service.consume("raw-token"))
+        .isInstanceOf(InvalidVerificationTokenException.class);
+  }
+
+  @Test
+  @DisplayName("consume rejects an already-used token")
+  void consumeAlreadyUsed() {
+    EmailVerificationToken token =
+        new EmailVerificationToken(user, "h", Instant.now().plusSeconds(60));
+    token.setConsumedAt(Instant.now());
+    when(tokens.findByTokenHash(any())).thenReturn(Optional.of(token));
+
+    assertThatThrownBy(() -> service.consume("raw-token"))
+        .isInstanceOf(InvalidVerificationTokenException.class);
+  }
+
+  @Test
+  @DisplayName("consume rejects an unknown token")
+  void consumeUnknown() {
+    when(tokens.findByTokenHash(any())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.consume("raw-token"))
+        .isInstanceOf(InvalidVerificationTokenException.class);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/auth/PasswordResetFlowServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/auth/PasswordResetFlowServiceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.User;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.UserService;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetFlowServiceTest {
+
+  @Mock private UserService userService;
+  @Mock private PasswordResetTokenService resetTokens;
+  @Mock private MailService mailService;
+  @Mock private ApplicationSettingsService settings;
+
+  private PasswordResetFlowService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new PasswordResetFlowService(userService, resetTokens, mailService, settings);
+    lenient()
+        .when(settings.getString(ApplicationSettingKey.GENERAL_BASE_URL))
+        .thenReturn("https://qnop.example");
+    lenient()
+        .when(settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME))
+        .thenReturn("qnop");
+  }
+
+  @Test
+  @DisplayName("requestReset does nothing when password reset is disabled")
+  void requestResetDisabled() {
+    when(settings.getBoolean(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED)).thenReturn(false);
+
+    service.requestReset("jane@example.com");
+
+    verify(userService, never()).findInternalByEmail(any());
+    verify(resetTokens, never()).issue(any());
+  }
+
+  @Test
+  @DisplayName("requestReset issues a token and emails the link for an enabled local account")
+  void requestResetEnabled() {
+    User user = User.internal("Jane", "jane@example.com", "jane", "hash");
+    when(settings.getBoolean(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED)).thenReturn(true);
+    when(userService.findInternalByEmail("jane@example.com")).thenReturn(Optional.of(user));
+    when(resetTokens.issue(user))
+        .thenReturn(
+            new PasswordResetTokenService.IssuedResetToken("RAW", Instant.now().plusSeconds(60)));
+
+    service.requestReset("jane@example.com");
+
+    verify(mailService)
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.PASSWORD_RESET), eq("jane@example.com"), anyMap(), isNull());
+  }
+
+  @Test
+  @DisplayName("requestReset skips a disabled (unverified) account")
+  void requestResetDisabledUser() {
+    User user = User.internal("Jane", "jane@example.com", "jane", "hash");
+    user.setEnabled(false);
+    when(settings.getBoolean(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED)).thenReturn(true);
+    when(userService.findInternalByEmail("jane@example.com")).thenReturn(Optional.of(user));
+
+    service.requestReset("jane@example.com");
+
+    verify(resetTokens, never()).issue(any());
+  }
+
+  @Test
+  @DisplayName("reset consumes the token and applies the new password")
+  void resetApplies() {
+    User user = User.internal("Jane", "jane@example.com", "jane", "hash");
+    when(resetTokens.consume("tok")).thenReturn(user);
+
+    service.reset("tok", "new-password");
+
+    verify(userService).applyPasswordReset(user.getId(), "new-password");
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/auth/RegistrationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/auth/RegistrationServiceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.User;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.UserService;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationServiceTest {
+
+  @Mock private UserService userService;
+  @Mock private EmailVerificationTokenService verificationTokens;
+  @Mock private MailService mailService;
+  @Mock private ApplicationSettingsService settings;
+
+  private RegistrationService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new RegistrationService(userService, verificationTokens, mailService, settings);
+    lenient()
+        .when(settings.getString(ApplicationSettingKey.GENERAL_BASE_URL))
+        .thenReturn("https://qnop.example/");
+    lenient()
+        .when(settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME))
+        .thenReturn("qnop");
+  }
+
+  @Test
+  @DisplayName("anti-enumeration: an existing account is a silent no-op (no create, no email)")
+  void existingAccountIsNoOp() {
+    when(userService.internalUserExists("jane", "jane@example.com")).thenReturn(true);
+
+    service.register("jane", "jane@example.com", "password1", "Jane");
+
+    verify(userService, never()).createSelfRegistered(any(), any(), any(), any());
+    verify(verificationTokens, never()).issue(any());
+    verify(mailService, never()).sendMailFromTemplate(any(), any(), anyMap(), any());
+  }
+
+  @Test
+  @DisplayName("a new account is created, a token issued, and a verification email sent")
+  void newAccountIsRegistered() {
+    User user = User.internal("Jane", "jane@example.com", "jane", "hash");
+    when(userService.internalUserExists("jane", "jane@example.com")).thenReturn(false);
+    when(userService.createSelfRegistered("jane", "jane@example.com", "password1", "Jane"))
+        .thenReturn(user);
+    when(verificationTokens.issue(user))
+        .thenReturn(
+            new EmailVerificationTokenService.IssuedToken("RAW", Instant.now().plusSeconds(60)));
+
+    service.register("jane", "jane@example.com", "password1", "Jane");
+
+    verify(verificationTokens).issue(user);
+    verify(mailService)
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REGISTRATION_VERIFICATION),
+            eq("jane@example.com"),
+            anyMap(),
+            isNull());
+  }
+
+  @Test
+  @DisplayName("verify consumes the token and activates the account")
+  void verifyActivates() {
+    User user = User.internal("Jane", "jane@example.com", "jane", "hash");
+    when(verificationTokens.consume("tok")).thenReturn(user);
+
+    service.verify("tok");
+
+    verify(userService).enable(user.getId());
+  }
+}


### PR DESCRIPTION
## Summary

**PR 1 of 2 for issue #20** (core self-service lifecycle; the admin user-management half — `AdminUserController` + `AdminPasswordResetService` — follows in PR 2, which will close #20). Modelled on plugwerk and adapted to qnop (Java, OpenAPI-first, the #16 settings service, #17 auth, #18 rate-limiting, #19 mail). qnop has no role model, so a self-registered user is a plain internal account.

### Service layer (qnop-core)
- **`UserService`** — `createSelfRegistered` (disabled until verified), `enable`, `applyPasswordReset` (re-hash + stamp `password_invalidated_before` to revoke outstanding access tokens, #17), `passwordChangeRequired`, superadmin bootstrap helper.
- **`EmailVerificationTokenService`** / **`PasswordResetTokenService`** — 32-byte tokens persisted as SHA-256 hex (single-use, supersede-prior, daily `@Scheduled` sweep); reset TTL operator-tunable (`auth.password_reset_token_ttl_minutes`).
- **`RegistrationService`** / **`PasswordResetFlowService`** — orchestrate create + token + mail so the `User` entity never reaches the web layer (ADR-0004).

### Web layer (qnop-app), OpenAPI-first public endpoints
- `POST /api/v1/auth/register` (gated by `auth.self_registration_enabled`; **anti-enumeration: uniform 200, disguised 404**) + `GET /api/v1/auth/verify-email`.
- `POST /api/v1/auth/forgot-password` (**uniform 204**) + `POST /api/v1/auth/reset-password`.
- **`PasswordChangeRequiredFilter`** (blocks non-`/auth` requests for users with `password_change_required`), **`AdminInitializationRunner`** (first-start superadmin; random password to stderr + `0600` file, never via SLF4J), and IP-keyed rate-limit filters for register/forgot (#18 pattern). `@EnableScheduling` for the sweeps.

## Test plan
- [x] `./gradlew build -x test` — green (compile, Spotless, OpenAPI generation, ArchUnit layering, `bootJar`)
- [x] `:qnop-core:test` — token issue/consume/expiry/single-use, registration anti-enumeration (existing → no-op), reset-flow gating (disabled / disabled-user / apply)
- [ ] CI: full `./gradlew build` incl. the Testcontainers schema/context ITs (Docker, ADR-0020)

### Notes / follow-ups (PR 2)
- `AdminUserController` (`/admin/users` CRUD + reset) and `AdminPasswordResetService` (self/external-reject, SMTP-down fallback) land in PR 2 and will `Closes #20`.
- Controller-level `@WebMvcTest` slices for the new endpoints are a sensible addition; the flows are covered by the service unit tests here + the CI build.

Part of #20 · Part of #7

🤖 Co-Author: Claude (Opus 4.x) via Claude Code