### PR TITLE
feat: admin user management — CRUD + admin password reset (Closes #20)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -150,6 +150,241 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /admin/users:
+    get:
+      tags:
+        - AdminUsers
+      summary: List users
+      description: Paged list of all users. Superadmin only.
+      operationId: listUsers
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 20
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: A page of users
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUserListResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - AdminUsers
+      summary: Create a user
+      operationId: createUser
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminCreateUserRequest'
+      responses:
+        '201':
+          description: The created user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUser'
+        '400':
+          description: Invalid input or duplicate username/email
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /admin/users/{userId}:
+    get:
+      tags:
+        - AdminUsers
+      summary: Get a user
+      operationId: getUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '200':
+          description: The user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUser'
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - AdminUsers
+      summary: Update a user
+      description: Partially updates a user (enable/disable, display name, superadmin flag).
+      operationId: updateUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminUpdateUserRequest'
+      responses:
+        '200':
+          description: The updated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUser'
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - AdminUsers
+      summary: Delete a user
+      operationId: deleteUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '204':
+          description: User deleted
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /admin/users/{userId}/reset-password:
+    post:
+      tags:
+        - AdminUsers
+      summary: Admin-trigger a password reset for a user
+      description: |
+        Issues a single-use reset token and emails the link. Rejects resetting the
+        caller's own account (400) and external/OIDC users (400). When SMTP delivery
+        fails, the reset URL is returned in the body so the operator can hand it over.
+      operationId: adminResetUserPassword
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '200':
+          description: Reset triggered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminPasswordResetResponse'
+        '400':
+          description: Self-reset or external-user reset not allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /admin/email/test:
     post:
       tags:
@@ -720,6 +955,14 @@ components:
         itself is introduced in a later issue; the scheme is declared here so the
         contract is complete from the first endpoint.
   parameters:
+    UserIdParam:
+      name: userId
+      in: path
+      required: true
+      description: The target user's id.
+      schema:
+        type: string
+        format: uuid
     MailTemplateKeyParam:
       name: key
       in: path
@@ -1172,6 +1415,118 @@ components:
       required:
         - token
         - newPassword
+    AdminUser:
+      type: object
+      description: A user as seen by the admin API.
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        email:
+          type: string
+        displayName:
+          type: string
+        enabled:
+          type: boolean
+        superadmin:
+          type: boolean
+        source:
+          type: string
+          enum:
+            - INTERNAL
+            - EXTERNAL
+        createdAt:
+          type: string
+          format: date-time
+        lastLoginAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - username
+        - email
+        - displayName
+        - enabled
+        - superadmin
+        - source
+        - createdAt
+    AdminUserListResponse:
+      type: object
+      properties:
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminUser'
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        total:
+          type: integer
+          format: int64
+      required:
+        - users
+        - page
+        - size
+        - total
+    AdminCreateUserRequest:
+      type: object
+      properties:
+        username:
+          type: string
+          minLength: 3
+          maxLength: 64
+        email:
+          type: string
+          format: email
+          maxLength: 320
+        password:
+          type: string
+          minLength: 8
+          maxLength: 200
+        displayName:
+          type: string
+          maxLength: 255
+        superadmin:
+          type: boolean
+          default: false
+      required:
+        - username
+        - email
+        - password
+    AdminUpdateUserRequest:
+      type: object
+      description: Partial update; only the provided fields are changed.
+      properties:
+        enabled:
+          type: boolean
+        displayName:
+          type: string
+          maxLength: 255
+        superadmin:
+          type: boolean
+    AdminPasswordResetResponse:
+      type: object
+      description: Outcome of an admin-triggered reset.
+      properties:
+        tokenIssued:
+          type: boolean
+        emailSent:
+          type: boolean
+        expiresAt:
+          type: string
+          format: date-time
+        resetUrl:
+          type: string
+          description: The reset link; present only when SMTP delivery failed (operator fallback).
+      required:
+        - tokenIssued
+        - emailSent
+        - expiresAt
     ErrorResponse:
       type: object
       description: |

--- a/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AdminUsersApi;
+import io.qnop.api.v1.model.AdminCreateUserRequest;
+import io.qnop.api.v1.model.AdminPasswordResetResponse;
+import io.qnop.api.v1.model.AdminUpdateUserRequest;
+import io.qnop.api.v1.model.AdminUser;
+import io.qnop.api.v1.model.AdminUserListResponse;
+import io.qnop.service.UserNotFoundException;
+import io.qnop.service.UserService;
+import io.qnop.service.UserView;
+import io.qnop.service.auth.AdminPasswordResetService;
+import io.qnop.service.auth.AdminPasswordResetService.ExternalUserResetNotAllowedException;
+import io.qnop.service.auth.AdminPasswordResetService.SelfResetNotAllowedException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Superadmin user-management endpoints ({@code /api/v1/admin/users/**}), implementing the generated
+ * {@link AdminUsersApi} (issue #20, PR 2). Authorization is enforced by the security chain ({@code
+ * /api/v1/admin/**} requires {@code SUPERADMIN}). The {@code User} entity never reaches this layer
+ * — the service returns {@link UserView}s, which are mapped here to the API DTOs (ADR-0004).
+ */
+@RestController
+public class AdminUserController implements AdminUsersApi {
+
+  private final UserService userService;
+  private final AdminPasswordResetService adminPasswordReset;
+
+  public AdminUserController(
+      UserService userService, AdminPasswordResetService adminPasswordReset) {
+    this.userService = userService;
+    this.adminPasswordReset = adminPasswordReset;
+  }
+
+  @Override
+  public ResponseEntity<AdminUserListResponse> listUsers(Integer page, Integer size) {
+    Page<UserView> result = userService.list(PageRequest.of(page, size));
+    AdminUserListResponse body =
+        new AdminUserListResponse()
+            .users(result.getContent().stream().map(this::toDto).toList())
+            .page(result.getNumber())
+            .size(result.getSize())
+            .total(result.getTotalElements());
+    return ResponseEntity.ok(body);
+  }
+
+  @Override
+  public ResponseEntity<AdminUser> createUser(AdminCreateUserRequest request) {
+    final UserView created;
+    try {
+      created =
+          userService.createByAdmin(
+              request.getUsername(),
+              request.getEmail(),
+              request.getPassword(),
+              request.getDisplayName(),
+              Boolean.TRUE.equals(request.getSuperadmin()));
+    } catch (DataIntegrityViolationException e) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "A user with that username or email already exists");
+    }
+    return ResponseEntity.status(HttpStatus.CREATED).body(toDto(created));
+  }
+
+  @Override
+  public ResponseEntity<AdminUser> getUser(UUID userId) {
+    try {
+      return ResponseEntity.ok(toDto(userService.getView(userId)));
+    } catch (UserNotFoundException e) {
+      throw notFound(userId);
+    }
+  }
+
+  @Override
+  public ResponseEntity<AdminUser> updateUser(UUID userId, AdminUpdateUserRequest request) {
+    try {
+      UserView updated =
+          userService.updateByAdmin(
+              userId, request.getEnabled(), request.getDisplayName(), request.getSuperadmin());
+      return ResponseEntity.ok(toDto(updated));
+    } catch (UserNotFoundException e) {
+      throw notFound(userId);
+    }
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteUser(UUID userId) {
+    try {
+      userService.delete(userId);
+    } catch (UserNotFoundException e) {
+      throw notFound(userId);
+    }
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<AdminPasswordResetResponse> adminResetUserPassword(UUID userId) {
+    final AdminPasswordResetService.Result result;
+    try {
+      result = adminPasswordReset.trigger(userId, currentActor());
+    } catch (SelfResetNotAllowedException | ExternalUserResetNotAllowedException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+    } catch (UserNotFoundException e) {
+      throw notFound(userId);
+    }
+    return ResponseEntity.ok(
+        new AdminPasswordResetResponse()
+            .tokenIssued(result.tokenIssued())
+            .emailSent(result.emailSent())
+            .expiresAt(toOffset(result.expiresAt()))
+            .resetUrl(result.resetUrl()));
+  }
+
+  private UUID currentActor() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    return UUID.fromString(auth.getName());
+  }
+
+  private ResponseStatusException notFound(UUID userId) {
+    return new ResponseStatusException(HttpStatus.NOT_FOUND, "Unknown user: " + userId);
+  }
+
+  private AdminUser toDto(UserView view) {
+    return new AdminUser()
+        .id(view.id())
+        .username(view.username())
+        .email(view.email())
+        .displayName(view.displayName())
+        .enabled(view.enabled())
+        .superadmin(view.superadmin())
+        .source(AdminUser.SourceEnum.valueOf(view.source()))
+        .createdAt(toOffset(view.createdAt()))
+        .lastLoginAt(toOffset(view.lastLoginAt()));
+  }
+
+  private OffsetDateTime toOffset(Instant instant) {
+    return instant == null ? null : instant.atOffset(ZoneOffset.UTC);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -27,6 +27,8 @@ import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -127,6 +129,70 @@ public class UserService {
     admin.setEnabled(true);
     admin.setPasswordChangeRequired(passwordChangeRequired);
     return users.save(admin);
+  }
+
+  // --- Admin user management (issue #20, PR 2) ---------------------------------
+
+  /** A page of users as web-safe views (admin listing). */
+  @Transactional(readOnly = true)
+  public Page<UserView> list(Pageable pageable) {
+    return users.findAll(pageable).map(this::toView);
+  }
+
+  /** One user as a web-safe view, or throws {@link UserNotFoundException}. */
+  @Transactional(readOnly = true)
+  public UserView getView(UUID id) {
+    return users.findById(id).map(this::toView).orElseThrow(() -> new UserNotFoundException(id));
+  }
+
+  /** Admin-creates an enabled internal user (optionally a superadmin). */
+  @Transactional
+  public UserView createByAdmin(
+      String username, String email, String password, String displayName, boolean superadmin) {
+    String name = displayName == null || displayName.isBlank() ? username : displayName;
+    User user =
+        User.internal(name, normalizeEmail(email), username, passwordEncoder.encode(password));
+    user.setEnabled(true);
+    user.setSuperadmin(superadmin);
+    return toView(users.save(user));
+  }
+
+  /** Partially updates an internal user (enabled / display name / superadmin). */
+  @Transactional
+  public UserView updateByAdmin(UUID id, Boolean enabled, String displayName, Boolean superadmin) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    if (enabled != null) {
+      user.setEnabled(enabled);
+    }
+    if (displayName != null && !displayName.isBlank()) {
+      user.setDisplayName(displayName);
+    }
+    if (superadmin != null) {
+      user.setSuperadmin(superadmin);
+    }
+    return toView(user);
+  }
+
+  /** Deletes a user; throws {@link UserNotFoundException} if absent. */
+  @Transactional
+  public void delete(UUID id) {
+    if (!users.existsById(id)) {
+      throw new UserNotFoundException(id);
+    }
+    users.deleteById(id);
+  }
+
+  private UserView toView(User user) {
+    return new UserView(
+        user.getId(),
+        user.getUsername(),
+        user.getEmail(),
+        user.getDisplayName(),
+        user.isEnabled(),
+        user.isSuperadmin(),
+        user.getSource().name(),
+        user.getCreatedAt(),
+        user.getLastLoginAt());
   }
 
   private String normalizeEmail(String email) {

--- a/qnop-core/src/main/java/io/qnop/service/UserView.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserView.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A web-safe projection of a user for the admin API (issue #20), so the JPA entity never reaches
+ * the web layer (ADR-0004). {@code source} is a plain string ({@code INTERNAL}/{@code EXTERNAL}) to
+ * keep the entity enum out of the web layer too.
+ */
+public record UserView(
+    UUID id,
+    String username,
+    String email,
+    String displayName,
+    boolean enabled,
+    boolean superadmin,
+    String source,
+    Instant createdAt,
+    Instant lastLoginAt) {}

--- a/qnop-core/src/main/java/io/qnop/service/auth/AdminPasswordResetService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/AdminPasswordResetService.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import io.qnop.entity.User;
+import io.qnop.entity.UserSource;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.UserNotFoundException;
+import io.qnop.service.UserService;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Superadmin-initiated password reset for another user (issue #20). Issues a single-use reset token
+ * and emails the link (reusing the self-service {@link PasswordResetTokenService} + {@link
+ * MailService}). Refuses to reset the actor's own account (they must use change-password) and
+ * refuses external (OIDC) users (their credentials live upstream). When SMTP delivery does not
+ * succeed, the reset URL is returned in the {@link Result} so the operator can hand it over
+ * out-of-band.
+ */
+@Service
+public class AdminPasswordResetService {
+
+  private final UserService userService;
+  private final PasswordResetTokenService resetTokens;
+  private final MailService mailService;
+  private final ApplicationSettingsService settings;
+
+  public AdminPasswordResetService(
+      UserService userService,
+      PasswordResetTokenService resetTokens,
+      MailService mailService,
+      ApplicationSettingsService settings) {
+    this.userService = userService;
+    this.resetTokens = resetTokens;
+    this.mailService = mailService;
+    this.settings = settings;
+  }
+
+  /** Triggers a reset for {@code targetUserId} on behalf of {@code actorUserId}. */
+  @Transactional
+  public Result trigger(UUID targetUserId, UUID actorUserId) {
+    if (targetUserId.equals(actorUserId)) {
+      throw new SelfResetNotAllowedException("Use change-password to update your own password.");
+    }
+    User user =
+        userService
+            .findById(targetUserId)
+            .orElseThrow(() -> new UserNotFoundException(targetUserId));
+    if (user.getSource() == UserSource.EXTERNAL) {
+      throw new ExternalUserResetNotAllowedException(
+          "Cannot reset the password of an external (OIDC) user — credentials live with the"
+              + " upstream provider.");
+    }
+
+    PasswordResetTokenService.IssuedResetToken issued = resetTokens.issue(user);
+    String resetUrl =
+        baseUrl()
+            + "/reset-password?token="
+            + URLEncoder.encode(issued.rawToken(), StandardCharsets.UTF_8);
+    MailService.SendResult send =
+        mailService.sendMailFromTemplate(
+            MailTemplateKey.ADMIN_PASSWORD_RESET,
+            user.getEmail(),
+            Map.of(
+                "siteName", siteName(),
+                "recipientName", user.getDisplayName(),
+                "actionUrl", resetUrl),
+            null);
+    boolean emailSent = send instanceof MailService.SendResult.Sent;
+    // SMTP-down fallback: surface the link to the operator only when it could not be emailed.
+    return new Result(true, emailSent, issued.expiresAt(), emailSent ? null : resetUrl);
+  }
+
+  private String siteName() {
+    return settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME);
+  }
+
+  private String baseUrl() {
+    String base = settings.getString(ApplicationSettingKey.GENERAL_BASE_URL);
+    return base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+  }
+
+  /**
+   * Outcome of an admin-triggered reset. {@code resetUrl} is non-null only on the SMTP fallback.
+   */
+  public record Result(
+      boolean tokenIssued, boolean emailSent, Instant expiresAt, String resetUrl) {}
+
+  /** Raised when an admin tries to reset their own password (use change-password instead). */
+  public static class SelfResetNotAllowedException extends RuntimeException {
+    public SelfResetNotAllowedException(String message) {
+      super(message);
+    }
+  }
+
+  /** Raised when an admin tries to reset an external (OIDC) user's password. */
+  public static class ExternalUserResetNotAllowedException extends RuntimeException {
+    public ExternalUserResetNotAllowedException(String message) {
+      super(message);
+    }
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/auth/AdminPasswordResetServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/auth/AdminPasswordResetServiceTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.User;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.UserNotFoundException;
+import io.qnop.service.UserService;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailService.SendResult;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminPasswordResetServiceTest {
+
+  @Mock private UserService userService;
+  @Mock private PasswordResetTokenService resetTokens;
+  @Mock private MailService mailService;
+  @Mock private ApplicationSettingsService settings;
+
+  private AdminPasswordResetService service;
+  private final UUID actor = UUID.randomUUID();
+  private final UUID target = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    service = new AdminPasswordResetService(userService, resetTokens, mailService, settings);
+    lenient()
+        .when(settings.getString(ApplicationSettingKey.GENERAL_BASE_URL))
+        .thenReturn("https://qnop.example");
+    lenient()
+        .when(settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME))
+        .thenReturn("qnop");
+  }
+
+  @Test
+  @DisplayName("rejects an admin resetting their own account")
+  void rejectsSelfReset() {
+    assertThatThrownBy(() -> service.trigger(actor, actor))
+        .isInstanceOf(AdminPasswordResetService.SelfResetNotAllowedException.class);
+  }
+
+  @Test
+  @DisplayName("rejects resetting an external (OIDC) user")
+  void rejectsExternalUser() {
+    when(userService.findById(target))
+        .thenReturn(Optional.of(User.external("Ext", "ext@example.com")));
+
+    assertThatThrownBy(() -> service.trigger(target, actor))
+        .isInstanceOf(AdminPasswordResetService.ExternalUserResetNotAllowedException.class);
+  }
+
+  @Test
+  @DisplayName("throws when the target user does not exist")
+  void throwsWhenUnknown() {
+    when(userService.findById(target)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.trigger(target, actor))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("emails the reset link and reports no fallback URL when SMTP succeeds")
+  void emailsWhenSmtpUp() {
+    User user = User.internal("Jane", "jane@example.com", "jane", "hash");
+    when(userService.findById(target)).thenReturn(Optional.of(user));
+    when(resetTokens.issue(user))
+        .thenReturn(
+            new PasswordResetTokenService.IssuedResetToken("RAW", Instant.now().plusSeconds(900)));
+    when(mailService.sendMailFromTemplate(any(), eq("jane@example.com"), anyMap(), isNull()))
+        .thenReturn(new SendResult.Sent("jane@example.com"));
+
+    AdminPasswordResetService.Result result = service.trigger(target, actor);
+
+    assertThat(result.tokenIssued()).isTrue();
+    assertThat(result.emailSent()).isTrue();
+    assertThat(result.resetUrl()).isNull();
+  }
+
+  @Test
+  @DisplayName("returns the reset URL as a fallback when SMTP delivery fails")
+  void fallbackWhenSmtpDown() {
+    User user = User.internal("Jane", "jane@example.com", "jane", "hash");
+    when(userService.findById(target)).thenReturn(Optional.of(user));
+    when(resetTokens.issue(user))
+        .thenReturn(
+            new PasswordResetTokenService.IssuedResetToken("RAW", Instant.now().plusSeconds(900)));
+    when(mailService.sendMailFromTemplate(any(), eq("jane@example.com"), anyMap(), isNull()))
+        .thenReturn(new SendResult.Skipped("SMTP is not configured"));
+
+    AdminPasswordResetService.Result result = service.trigger(target, actor);
+
+    assertThat(result.emailSent()).isFalse();
+    assertThat(result.resetUrl()).contains("/reset-password?token=RAW");
+  }
+}


### PR DESCRIPTION
## Summary

**PR 2 of 2 for issue #20**, stacked on #38 (the core-lifecycle PR — base branch is `feat/issue-20-local-user-lifecycle`). Superadmin user administration, modelled on plugwerk. Retarget to `main` once #38 merges.

- **`UserService`** (additions) — paged `list`, `getView`, `createByAdmin`, `updateByAdmin` (partial), `delete`, returning web-safe **`UserView`** projections so the JPA entity stays in the service layer (ADR-0004).
- **`AdminPasswordResetService`** — superadmin triggers a reset for another user; **rejects self-reset and external (OIDC) users** (400); on SMTP failure returns the reset URL as an operator fallback.
- **`AdminUserController`** (`/api/v1/admin/users/**`, `SUPERADMIN` via #17) — list, get, create (201), patch (enable / display name / superadmin), delete, `reset-password`. OpenAPI-first (`AdminUsers` tag → generated `AdminUsersApi`); maps `UserView` → `AdminUser` DTO.

## Test plan
- [x] `./gradlew build -x test` — green (compile, Spotless, OpenAPI generation, ArchUnit layering, `bootJar`)
- [x] `:qnop-core:test` — admin-reset self/external rejection, unknown-user, SMTP-up (no fallback URL) vs SMTP-down (fallback URL returned)
- [ ] CI: full `./gradlew build` incl. Testcontainers ITs (Docker)

### Notes
- Stacked PR: the diff is clean against #38; GitHub will narrow it once #38 merges (then I retarget this PR to `main`).
- `@WebMvcTest` slices for the admin endpoints are a reasonable follow-up; the logic is covered by the service unit tests + CI build.

Closes #20 · Part of #7

🤖 Co-Author: Claude (Opus 4.x) via Claude Code