### PR TITLE
feat: branding asset upload, SVG sanitization, public serving

### DIFF
--- a/docs/adr/0028-branding-upload-and-svg-sanitization.md
+++ b/docs/adr/0028-branding-upload-and-svg-sanitization.md
@@ -1,0 +1,28 @@
+# ADR-0028: Branding upload pipeline & SVG sanitization
+
+- **Status:** Accepted
+- **Date:** 2026-06-15
+- **Deciders:** qnop core team (with Claude)
+
+## Context
+
+Issue #15 introduced the `application_asset` storage (one row per `BrandingSlot`, bytes in Postgres `bytea`, ADR-0024). Issue #23 adds the upload pipeline and the public read path. Two things make this security-sensitive: operator-uploaded **SVG is XML that browsers execute** (XSS/XXE), and the read path is served on **authentication-free** surfaces (the login page, OG metadata).
+
+## Decision
+
+- **Validation pipeline (`BrandingService`).** On upload: sniff the real content type from the **bytes** (PNG/WebP magic, `<svg` for SVG) — the client-declared `Content-Type` is never trusted; enforce the byte-size cap (512 KiB, `BrandingLimits`); **sanitize SVG**; bound the pixel dimensions (`ImageDimensions`: ImageIO for raster, `viewBox` for SVG); SHA-256; then **delete-then-insert** so a slot holds exactly one current asset.
+- **SVG sanitizer (`SvgSanitizer`).** An **allowlist** sanitizer over an **XXE-hardened** parser: DOCTYPEs are rejected outright (`disallow-doctype-decl`) and all external DTD/entity/stylesheet access is disabled, so entity expansion and file/SSRF disclosure are impossible. Only presentational elements survive; `<script>`, `<foreignObject>`, `<style>`, `<image>`, `<a>` and anything else are dropped, along with `on*` handlers, inline `style`, and any `href`/`xlink:href` that is not a local `#fragment`.
+- **Endpoints are hand-written controllers, not generated from the OpenAPI JSON contract.** `POST`/`DELETE /api/v1/admin/branding/{slot}` (superadmin) carry multipart uploads; `GET /api/v1/branding/{slot}` returns binary with an **ETag (the SHA-256) + 304** and `Cache-Control: no-cache` (revalidate-always). Multipart and binary-with-caching sit outside the published JSON surface (ADR-0021), so they are plain `@RestController`s — still web→service only (ArchUnit-clean). The read path is `permitAll`; the admin namespace is covered by the existing `/api/v1/admin/**` → `SUPERADMIN` rule.
+
+## Consequences
+
+- An uploaded SVG cannot carry script, event handlers, external entities, or external references; combined with the strict CSP (ADR-0022) the login page is safe to render branding inline.
+- Re-uploading a slot replaces it; the new SHA-256 changes the ETag, busting caches.
+- WebP dimensions are best-effort (stock ImageIO has no WebP reader) — the size cap still bounds the payload; only the pixel-dimension check is skipped when dimensions are unknown.
+- These two controllers are the first that do not implement a generated interface; the deviation is scoped to binary/multipart I/O and documented here.
+
+## Alternatives considered
+
+- **A third-party SVG/HTML sanitizer.** Rejected: no well-maintained permissive-licensed pure-Java SVG sanitizer fits, and an allowlist over the JAXP parser is small, auditable, and dependency-free (keeps the AGPL/commercial boundary clean, ADR-0007).
+- **Object storage for branding bytes.** Already rejected in ADR-0024 (branding is config-like; keep it in Postgres).
+- **Generating the endpoints from OpenAPI.** Rejected for these two: multipart upload and binary ETag/304 responses are awkward to express and add no value to the JSON contract consumers.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0025](0025-application-settings-architecture.md) | Application settings — registry-authoritative, snapshot-backed runtime | Accepted |
 | [0026](0026-jwt-session-and-revocation.md) | JWT access tokens, rotating refresh tokens, and revocation | Accepted |
 | [0027](0027-auth-rate-limiting.md) | Auth rate limiting & trusted-proxy IP resolution | Accepted |
+| [0028](0028-branding-upload-and-svg-sanitization.md) | Branding upload pipeline & SVG sanitization | Accepted |
 
 ## Template
 

--- a/qnop-app/src/main/java/io/qnop/web/BrandingController.java
+++ b/qnop-app/src/main/java/io/qnop/web/BrandingController.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.service.branding.BrandingService;
+import io.qnop.service.branding.BrandingValidationException;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Branding asset endpoints (issue #23). Admin upload/delete live under {@code
+ * /api/v1/admin/branding/**} (superadmin, enforced centrally in the security filter chain); the
+ * read path {@code GET /api/v1/branding/{slot}} is public (login page, OG metadata).
+ *
+ * <p>These are deliberately hand-written controllers rather than generated from the OpenAPI JSON
+ * contract: they carry multipart uploads and binary responses with ETag/304 caching, which sit
+ * outside the published JSON surface (ADR-0028). The {@code slot} is the kebab-case URL form (e.g.
+ * {@code logo-light}); resolving it to a domain slot happens in the service, so this web layer
+ * never touches the entity model.
+ */
+@RestController
+public class BrandingController {
+
+  private final BrandingService branding;
+
+  public BrandingController(BrandingService branding) {
+    this.branding = branding;
+  }
+
+  @PostMapping(value = "/admin/branding/{slot}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<BrandingService.StoredAsset> upload(
+      @PathVariable String slot, @RequestParam("file") MultipartFile file) throws IOException {
+    return ResponseEntity.ok(branding.store(slot, file.getBytes(), CurrentUser.requireUserId()));
+  }
+
+  @DeleteMapping("/admin/branding/{slot}")
+  public ResponseEntity<Void> delete(@PathVariable String slot) {
+    branding.delete(slot);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/branding/{slot}")
+  public ResponseEntity<byte[]> serve(
+      @PathVariable String slot,
+      @RequestHeader(value = "If-None-Match", required = false) String ifNoneMatch) {
+    BrandingService.BrandingAsset asset =
+        branding.get(slot).orElseThrow(() -> BrandingValidationException.notFound("no asset"));
+    String etag = "\"" + asset.sha256() + "\"";
+    if (etag.equals(ifNoneMatch)) {
+      return ResponseEntity.status(304).eTag(etag).cacheControl(CacheControl.noCache()).build();
+    }
+    return ResponseEntity.ok()
+        .eTag(etag)
+        .cacheControl(CacheControl.noCache())
+        .contentType(MediaType.parseMediaType(asset.contentType()))
+        .body(asset.content());
+  }
+
+  @ExceptionHandler(BrandingValidationException.class)
+  public ResponseEntity<ErrorResponse> onBrandingError(BrandingValidationException ex) {
+    return ResponseEntity.status(ex.getStatus())
+        .body(
+            new ErrorResponse()
+                .code(ex.getCode())
+                .message(ex.getMessage())
+                .timestamp(OffsetDateTime.now()));
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -129,6 +130,8 @@ public class SecurityConfiguration {
                         "/api/v1/auth/verify-email",
                         "/api/v1/auth/forgot-password",
                         "/api/v1/auth/reset-password")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/branding/**")
                     .permitAll()
                     .requestMatchers("/api/v1/admin/**")
                     .hasRole("SUPERADMIN")

--- a/qnop-app/src/test/java/io/qnop/branding/BrandingControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/branding/BrandingControllerIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.branding;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.ApplicationAssetRepository;
+import io.qnop.repository.UserRepository;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Verifies the branding endpoints (issue #23) through the real security filter chain: superadmin
+ * upload/delete, public ETag/304 serving, 404 for unknown/absent slots, and 403 for non-superadmin.
+ * Requires Docker.
+ */
+class BrandingControllerIT extends AbstractIntegrationTest {
+
+  @Autowired WebApplicationContext context;
+  @Autowired UserRepository users;
+  @Autowired ApplicationAssetRepository assets;
+
+  private MockMvc mockMvc;
+  private UUID userId;
+  private byte[] png;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    userId =
+        users.saveAndFlush(User.internal("Admin", "admin@example.com", "admin", "hash")).getId();
+    BufferedImage image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ImageIO.write(image, "png", out);
+    png = out.toByteArray();
+  }
+
+  @AfterEach
+  void tearDown() {
+    assets.deleteAll(); // application_asset.uploaded_by does not cascade — clear before the user
+    users.deleteById(userId);
+  }
+
+  private JwtRequestPostProcessor superadmin() {
+    return jwt()
+        .jwt(j -> j.subject(userId.toString()))
+        .authorities(new SimpleGrantedAuthority("ROLE_SUPERADMIN"));
+  }
+
+  private MockMultipartFile logo() {
+    return new MockMultipartFile("file", "logo.png", "image/png", png);
+  }
+
+  @Test
+  void superadminUploadsThenAssetIsPubliclyServedWithEtag() throws Exception {
+    mockMvc
+        .perform(multipart("/api/v1/admin/branding/logo-light").file(logo()).with(superadmin()))
+        .andExpect(status().isOk());
+
+    MvcResult served =
+        mockMvc
+            .perform(get("/api/v1/branding/logo-light"))
+            .andExpect(status().isOk())
+            .andExpect(header().exists("ETag"))
+            .andReturn();
+
+    String etag = served.getResponse().getHeader("ETag");
+    mockMvc
+        .perform(get("/api/v1/branding/logo-light").header("If-None-Match", etag))
+        .andExpect(status().isNotModified());
+  }
+
+  @Test
+  void publicGetUnknownSlotReturns404() throws Exception {
+    mockMvc.perform(get("/api/v1/branding/does-not-exist")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void uploadForbiddenForNonSuperadmin() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/admin/branding/logo-light")
+                .file(logo())
+                .with(jwt().jwt(j -> j.subject(userId.toString()))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void deleteRemovesAsset() throws Exception {
+    mockMvc
+        .perform(multipart("/api/v1/admin/branding/logomark").file(logo()).with(superadmin()))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(delete("/api/v1/admin/branding/logomark").with(superadmin()))
+        .andExpect(status().isNoContent());
+
+    mockMvc.perform(get("/api/v1/branding/logomark")).andExpect(status().isNotFound());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/branding/BrandingControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/branding/BrandingControllerIT.java
@@ -66,8 +66,8 @@ class BrandingControllerIT extends AbstractIntegrationTest {
   @BeforeEach
   void setUp() throws Exception {
     mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
-    userId =
-        users.saveAndFlush(User.internal("Admin", "admin@example.com", "admin", "hash")).getId();
+    String tag = "branding-" + UUID.randomUUID();
+    userId = users.saveAndFlush(User.internal("Admin", tag + "@example.com", tag, "hash")).getId();
     BufferedImage image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     ImageIO.write(image, "png", out);

--- a/qnop-app/src/test/java/io/qnop/branding/BrandingServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/branding/BrandingServiceIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.branding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.BrandingSlot;
+import io.qnop.repository.ApplicationAssetRepository;
+import io.qnop.service.branding.BrandingService;
+import io.qnop.service.branding.BrandingValidationException;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies {@link BrandingService} against a real PostgreSQL (ADR-0020, ADR-0028): the validate →
+ * sanitize → store pipeline, delete-then-insert replacement, and rejection of bad input. Requires
+ * Docker.
+ */
+@Transactional
+class BrandingServiceIT extends AbstractIntegrationTest {
+
+  @Autowired BrandingService branding;
+  @Autowired ApplicationAssetRepository assets;
+
+  private static byte[] png(int width, int height) throws Exception {
+    BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ImageIO.write(image, "png", out);
+    return out.toByteArray();
+  }
+
+  @Test
+  void storesAndReadsPng() throws Exception {
+    BrandingService.StoredAsset stored = branding.store("logo-light", png(16, 16), null);
+
+    assertThat(stored.contentType()).isEqualTo("image/png");
+    BrandingService.BrandingAsset asset = branding.get("logo-light").orElseThrow();
+    assertThat(asset.contentType()).isEqualTo("image/png");
+    assertThat(asset.sha256()).isEqualTo(stored.sha256());
+  }
+
+  @Test
+  void sanitizesSvgBeforeStoring() {
+    byte[] svg =
+        ("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\">"
+                + "<script>alert(1)</script><path d=\"M0 0L10 10\"/></svg>")
+            .getBytes(StandardCharsets.UTF_8);
+
+    branding.store("logo-dark", svg, null);
+
+    BrandingService.BrandingAsset asset = branding.get("logo-dark").orElseThrow();
+    assertThat(asset.contentType()).isEqualTo("image/svg+xml");
+    assertThat(new String(asset.content(), StandardCharsets.UTF_8)).doesNotContain("script");
+  }
+
+  @Test
+  void replacesExistingSlot() throws Exception {
+    branding.store("logo-light", png(16, 16), null);
+    branding.store("logo-light", png(20, 20), null);
+
+    long rows =
+        assets.findAll().stream().filter(a -> a.getSlot() == BrandingSlot.LOGO_LIGHT).count();
+    assertThat(rows).isEqualTo(1);
+  }
+
+  @Test
+  void rejectsUnsupportedType() {
+    assertThatThrownBy(() -> branding.store("logomark", new byte[] {1, 2, 3, 4, 5}, null))
+        .isInstanceOfSatisfying(
+            BrandingValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(415));
+  }
+
+  @Test
+  void rejectsOversizedAsset() {
+    byte[] huge =
+        ("<svg xmlns=\"http://www.w3.org/2000/svg\">" + "a".repeat(600 * 1024) + "</svg>")
+            .getBytes(StandardCharsets.UTF_8);
+
+    assertThatThrownBy(() -> branding.store("logo-light", huge, null))
+        .isInstanceOfSatisfying(
+            BrandingValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(413));
+  }
+
+  @Test
+  void deleteRemovesAsset() throws Exception {
+    branding.store("logo-light", png(16, 16), null);
+
+    branding.delete("logo-light");
+
+    assertThat(branding.get("logo-light")).isEmpty();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/branding/BrandingLimits.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/BrandingLimits.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.branding;
+
+import java.util.Set;
+
+/**
+ * Bounds for branding uploads (issue #23). Branding assets are small, config-like blobs (ADR-0024),
+ * so the caps are deliberately tight. The allowed content types match the {@code application_asset}
+ * {@code CHECK} domain (migration 0005).
+ */
+public final class BrandingLimits {
+
+  private BrandingLimits() {}
+
+  public static final String PNG = "image/png";
+  public static final String WEBP = "image/webp";
+  public static final String SVG = "image/svg+xml";
+
+  /** Content types accepted on upload, derived from the bytes (not the client-declared header). */
+  public static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(PNG, WEBP, SVG);
+
+  /** Maximum stored size in bytes (512 KiB) — branding is a small logo, not a document. */
+  public static final long MAX_SIZE_BYTES = 512L * 1024L;
+
+  /** Maximum raster width/height in pixels; logos beyond this are almost certainly a mistake. */
+  public static final int MAX_DIMENSION_PX = 2000;
+}

--- a/qnop-core/src/main/java/io/qnop/service/branding/BrandingService.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/BrandingService.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.branding;
+
+import io.qnop.entity.ApplicationAsset;
+import io.qnop.entity.BrandingSlot;
+import io.qnop.repository.ApplicationAssetRepository;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Validates and stores operator branding assets, and reads them back for public serving (issue
+ * #23). The upload pipeline is: sniff the real content type from the bytes (never trust the
+ * client-declared header) → enforce the size cap → sanitize SVG → bound the pixel dimensions →
+ * SHA-256 → delete-then-insert (one row per slot, ADR-0024).
+ */
+@Service
+public class BrandingService {
+
+  private final ApplicationAssetRepository repository;
+
+  public BrandingService(ApplicationAssetRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Validates the uploaded bytes and replaces the asset in {@code slot}.
+   *
+   * @throws BrandingValidationException if the type is unsupported, the payload too large, the
+   *     image unreadable/oversized, or the SVG unsafe
+   */
+  @Transactional
+  public StoredAsset store(String slot, byte[] bytes, UUID uploadedBy) {
+    BrandingSlot resolved = resolve(slot);
+    String contentType = sniffContentType(bytes);
+
+    if (bytes.length > BrandingLimits.MAX_SIZE_BYTES) {
+      throw BrandingValidationException.tooLarge(
+          "asset exceeds " + BrandingLimits.MAX_SIZE_BYTES + " bytes");
+    }
+
+    byte[] content = bytes;
+    if (BrandingLimits.SVG.equals(contentType)) {
+      try {
+        content = SvgSanitizer.sanitize(bytes);
+      } catch (IllegalArgumentException e) {
+        throw BrandingValidationException.invalidSvg(e.getMessage());
+      }
+    }
+
+    enforceDimensions(contentType, content);
+
+    String sha256 = sha256Hex(content);
+    repository.deleteBySlot(resolved);
+    repository.saveAndFlush(
+        ApplicationAsset.create(
+            resolved, contentType, content, sha256, content.length, uploadedBy));
+    return new StoredAsset(contentType, sha256, content.length);
+  }
+
+  /** The current asset for a slot, for public serving. */
+  @Transactional(readOnly = true)
+  public Optional<BrandingAsset> get(String slot) {
+    return repository
+        .findBySlot(resolve(slot))
+        .map(
+            asset ->
+                new BrandingAsset(asset.getContent(), asset.getContentType(), asset.getSha256()));
+  }
+
+  /** Removes the asset for a slot (idempotent). */
+  @Transactional
+  public void delete(String slot) {
+    repository.deleteBySlot(resolve(slot));
+  }
+
+  private static BrandingSlot resolve(String slot) {
+    BrandingSlot resolved = BrandingSlot.fromUrlValue(slot);
+    if (resolved == null) {
+      throw BrandingValidationException.unknownSlot("unknown branding slot: " + slot);
+    }
+    return resolved;
+  }
+
+  private void enforceDimensions(String contentType, byte[] content) {
+    Optional<ImageDimensions> dimensions = ImageDimensions.read(contentType, content);
+    if (BrandingLimits.PNG.equals(contentType) && dimensions.isEmpty()) {
+      throw BrandingValidationException.invalidImage("unreadable PNG");
+    }
+    dimensions.ifPresent(
+        d -> {
+          if (d.width() > BrandingLimits.MAX_DIMENSION_PX
+              || d.height() > BrandingLimits.MAX_DIMENSION_PX) {
+            throw BrandingValidationException.invalidImage(
+                "dimensions exceed " + BrandingLimits.MAX_DIMENSION_PX + "px");
+          }
+        });
+  }
+
+  /** Derives the content type from the magic bytes; the client-declared header is not trusted. */
+  private String sniffContentType(byte[] bytes) {
+    if (isPng(bytes)) {
+      return BrandingLimits.PNG;
+    }
+    if (isWebp(bytes)) {
+      return BrandingLimits.WEBP;
+    }
+    if (looksLikeSvg(bytes)) {
+      return BrandingLimits.SVG;
+    }
+    throw BrandingValidationException.unsupportedType(
+        "only PNG, WebP and (sanitized) SVG are accepted");
+  }
+
+  private static boolean isPng(byte[] b) {
+    byte[] sig = {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    if (b.length < sig.length) {
+      return false;
+    }
+    for (int i = 0; i < sig.length; i++) {
+      if (b[i] != sig[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isWebp(byte[] b) {
+    return b.length >= 12
+        && b[0] == 'R'
+        && b[1] == 'I'
+        && b[2] == 'F'
+        && b[3] == 'F'
+        && b[8] == 'W'
+        && b[9] == 'E'
+        && b[10] == 'B'
+        && b[11] == 'P';
+  }
+
+  private static boolean looksLikeSvg(byte[] b) {
+    String head =
+        new String(b, 0, Math.min(b.length, 1024), java.nio.charset.StandardCharsets.UTF_8);
+    return head.replace("﻿", "").stripLeading().startsWith("<") && head.contains("<svg");
+  }
+
+  private static String sha256Hex(byte[] content) {
+    try {
+      return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+
+  /** Metadata returned after a successful upload. */
+  public record StoredAsset(String contentType, String sha256, long sizeBytes) {}
+
+  /** An asset's bytes and serving metadata, for the public read path. */
+  public record BrandingAsset(byte[] content, String contentType, String sha256) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/branding/BrandingService.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/BrandingService.java
@@ -74,7 +74,10 @@ public class BrandingService {
     enforceDimensions(contentType, content);
 
     String sha256 = sha256Hex(content);
+    // Flush the delete before the insert: a single flush would order the INSERT before the DELETE
+    // (Hibernate's action ordering) and transiently violate the (slot) unique constraint.
     repository.deleteBySlot(resolved);
+    repository.flush();
     repository.saveAndFlush(
         ApplicationAsset.create(
             resolved, contentType, content, sha256, content.length, uploadedBy));

--- a/qnop-core/src/main/java/io/qnop/service/branding/BrandingValidationException.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/BrandingValidationException.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.branding;
+
+/**
+ * Raised when a branding upload (or read) is rejected (issue #23). Carries the HTTP status and a
+ * stable machine-readable code so the web layer can map it directly without a switch.
+ */
+public class BrandingValidationException extends RuntimeException {
+
+  private final int status;
+  private final String code;
+
+  public BrandingValidationException(int status, String code, String message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public static BrandingValidationException unsupportedType(String detail) {
+    return new BrandingValidationException(415, "UNSUPPORTED_MEDIA_TYPE", detail);
+  }
+
+  public static BrandingValidationException tooLarge(String detail) {
+    return new BrandingValidationException(413, "PAYLOAD_TOO_LARGE", detail);
+  }
+
+  public static BrandingValidationException invalidImage(String detail) {
+    return new BrandingValidationException(400, "INVALID_IMAGE", detail);
+  }
+
+  public static BrandingValidationException invalidSvg(String detail) {
+    return new BrandingValidationException(400, "INVALID_SVG", detail);
+  }
+
+  public static BrandingValidationException unknownSlot(String detail) {
+    return new BrandingValidationException(404, "UNKNOWN_SLOT", detail);
+  }
+
+  public static BrandingValidationException notFound(String detail) {
+    return new BrandingValidationException(404, "NOT_FOUND", detail);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/branding/ImageDimensions.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/ImageDimensions.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.branding;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.imageio.ImageIO;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Element;
+
+/**
+ * Best-effort intrinsic dimensions of a branding asset (issue #23): raster formats via {@code
+ * ImageIO}, SVG via its {@code viewBox} (or {@code width}/{@code height}). Returns empty when the
+ * dimensions cannot be determined (e.g. WebP without an ImageIO plugin, or an SVG without a
+ * viewBox) — the caller treats unknown dimensions as "skip the pixel-bound check" and relies on the
+ * byte-size cap.
+ */
+public record ImageDimensions(int width, int height) {
+
+  private static final Pattern VIEW_BOX =
+      Pattern.compile("\\s*[-+0-9.eE]+\\s+[-+0-9.eE]+\\s+([-+0-9.eE]+)\\s+([-+0-9.eE]+)\\s*");
+  private static final Pattern LENGTH = Pattern.compile("([0-9]+(?:\\.[0-9]+)?)");
+
+  public static Optional<ImageDimensions> read(String contentType, byte[] bytes) {
+    return switch (contentType) {
+      case BrandingLimits.PNG, BrandingLimits.WEBP -> readRaster(bytes);
+      case BrandingLimits.SVG -> readSvg(bytes);
+      default -> Optional.empty();
+    };
+  }
+
+  private static Optional<ImageDimensions> readRaster(byte[] bytes) {
+    try {
+      BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+      return image == null
+          ? Optional.empty()
+          : Optional.of(new ImageDimensions(image.getWidth(), image.getHeight()));
+    } catch (IOException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<ImageDimensions> readSvg(byte[] bytes) {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(true);
+      factory.setExpandEntityReferences(false);
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      Element svg =
+          factory.newDocumentBuilder().parse(new ByteArrayInputStream(bytes)).getDocumentElement();
+
+      String viewBox = svg.getAttribute("viewBox");
+      Matcher viewBoxMatcher = VIEW_BOX.matcher(viewBox);
+      if (!viewBox.isBlank() && viewBoxMatcher.matches()) {
+        int w = (int) Math.ceil(Double.parseDouble(viewBoxMatcher.group(1)));
+        int h = (int) Math.ceil(Double.parseDouble(viewBoxMatcher.group(2)));
+        return Optional.of(new ImageDimensions(w, h));
+      }
+      Optional<Integer> width = length(svg.getAttribute("width"));
+      Optional<Integer> height = length(svg.getAttribute("height"));
+      if (width.isPresent() && height.isPresent()) {
+        return Optional.of(new ImageDimensions(width.get(), height.get()));
+      }
+      return Optional.empty();
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<Integer> length(String value) {
+    if (value == null) {
+      return Optional.empty();
+    }
+    Matcher matcher = LENGTH.matcher(value);
+    return matcher.find()
+        ? Optional.of((int) Math.ceil(Double.parseDouble(matcher.group(1))))
+        : Optional.empty();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/branding/SvgSanitizer.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/SvgSanitizer.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.branding;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Allowlist SVG sanitizer (issue #23). SVG is XML that browsers execute, so an uploaded logo is an
+ * XSS/XXE vector unless neutralized. This sanitizer:
+ *
+ * <ul>
+ *   <li>parses with an <strong>XXE-hardened</strong> parser — DOCTYPEs are rejected outright and
+ *       all external entity/DTD/stylesheet access is disabled, so entity-expansion and file/SSRF
+ *       disclosure are impossible;
+ *   <li>keeps only an <strong>allowlist</strong> of presentational elements and drops everything
+ *       else (so {@code <script>}, {@code <foreignObject>}, {@code <style>}, {@code <image>},
+ *       {@code <a>} … never survive);
+ *   <li>strips {@code on*} event-handler attributes, inline {@code style}, and any {@code href} /
+ *       {@code xlink:href} that is not a local {@code #fragment}.
+ * </ul>
+ *
+ * <p>Pure, dependency-free, DB-free logic (ADR-0004). Throws {@link IllegalArgumentException} when
+ * the input is not a well-formed {@code <svg>} document.
+ */
+public final class SvgSanitizer {
+
+  private static final Set<String> ALLOWED_ELEMENTS =
+      Set.of(
+          "svg",
+          "g",
+          "defs",
+          "title",
+          "desc",
+          "path",
+          "rect",
+          "circle",
+          "ellipse",
+          "line",
+          "polyline",
+          "polygon",
+          "text",
+          "tspan",
+          "use",
+          "symbol",
+          "linearGradient",
+          "radialGradient",
+          "stop",
+          "clipPath",
+          "mask",
+          "pattern",
+          "marker");
+
+  private SvgSanitizer() {}
+
+  /**
+   * Returns a sanitized copy of the SVG bytes.
+   *
+   * @throws IllegalArgumentException if the input is not a well-formed, DOCTYPE-free {@code <svg>}
+   */
+  public static byte[] sanitize(byte[] svg) {
+    try {
+      Document document = parseHardened(svg);
+      Element root = document.getDocumentElement();
+      if (root == null || !"svg".equals(localName(root))) {
+        throw new IllegalArgumentException("not an <svg> document");
+      }
+      sanitizeElement(root);
+      return serialize(document);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("invalid or unsafe SVG: " + e.getMessage());
+    }
+  }
+
+  private static Document parseHardened(byte[] svg) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    factory.setExpandEntityReferences(false);
+    factory.setXIncludeAware(false);
+    // The single most important control: no DOCTYPE means no XXE, no entity expansion.
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    return builder.parse(new ByteArrayInputStream(svg));
+  }
+
+  private static void sanitizeElement(Element element) {
+    NamedNodeMap attributes = element.getAttributes();
+    List<Attr> toRemove = new ArrayList<>();
+    for (int i = 0; i < attributes.getLength(); i++) {
+      Attr attribute = (Attr) attributes.item(i);
+      String name = localName(attribute).toLowerCase(Locale.ROOT);
+      if (name.startsWith("on")) {
+        toRemove.add(attribute);
+      } else if (name.equals("style")) {
+        toRemove.add(attribute);
+      } else if (name.equals("href")) {
+        String value = attribute.getValue() == null ? "" : attribute.getValue().trim();
+        if (!value.startsWith("#")) {
+          toRemove.add(attribute); // only local fragment references survive
+        }
+      }
+    }
+    for (Attr attribute : toRemove) {
+      element.removeAttributeNode(attribute);
+    }
+
+    List<Element> childElements = new ArrayList<>();
+    NodeList children = element.getChildNodes();
+    for (int i = 0; i < children.getLength(); i++) {
+      Node child = children.item(i);
+      if (child.getNodeType() == Node.ELEMENT_NODE) {
+        childElements.add((Element) child);
+      }
+    }
+    for (Element child : childElements) {
+      if (ALLOWED_ELEMENTS.contains(localName(child))) {
+        sanitizeElement(child);
+      } else {
+        element.removeChild(child); // drops <script>, <foreignObject>, <style>, <image>, …
+      }
+    }
+  }
+
+  private static String localName(Node node) {
+    return node.getLocalName() != null ? node.getLocalName() : node.getNodeName();
+  }
+
+  private static byte[] serialize(Document document) throws Exception {
+    TransformerFactory transformerFactory = TransformerFactory.newInstance();
+    transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+    Transformer transformer = transformerFactory.newTransformer();
+    transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+    transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    transformer.transform(new DOMSource(document), new StreamResult(out));
+    return out.toByteArray();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/branding/ImageDimensionsTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/branding/ImageDimensionsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.branding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link ImageDimensions} (issue #23). */
+class ImageDimensionsTest {
+
+  @Test
+  void readsPngDimensionsViaImageIo() throws Exception {
+    BufferedImage image = new BufferedImage(12, 34, BufferedImage.TYPE_INT_ARGB);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ImageIO.write(image, "png", out);
+
+    Optional<ImageDimensions> dimensions =
+        ImageDimensions.read(BrandingLimits.PNG, out.toByteArray());
+
+    assertTrue(dimensions.isPresent());
+    assertEquals(12, dimensions.get().width());
+    assertEquals(34, dimensions.get().height());
+  }
+
+  @Test
+  void readsSvgDimensionsFromViewBox() {
+    byte[] svg =
+        ("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 50\"></svg>")
+            .getBytes(StandardCharsets.UTF_8);
+
+    Optional<ImageDimensions> dimensions = ImageDimensions.read(BrandingLimits.SVG, svg);
+
+    assertTrue(dimensions.isPresent());
+    assertEquals(100, dimensions.get().width());
+    assertEquals(50, dimensions.get().height());
+  }
+
+  @Test
+  void returnsEmptyForUnreadableRaster() {
+    assertTrue(ImageDimensions.read(BrandingLimits.PNG, new byte[] {1, 2, 3}).isEmpty());
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/branding/SvgSanitizerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/branding/SvgSanitizerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.branding;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/** Security-focused tests for {@link SvgSanitizer} (issue #23). */
+class SvgSanitizerTest {
+
+  private static String sanitize(String svg) {
+    return new String(
+        SvgSanitizer.sanitize(svg.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void stripsScriptAndEventHandlersButKeepsShapes() {
+    String out =
+        sanitize(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\">"
+                + "<script>alert(1)</script>"
+                + "<rect width=\"10\" height=\"10\" onload=\"alert(2)\"/>"
+                + "<path d=\"M0 0L10 10\"/>"
+                + "</svg>");
+
+    assertFalse(out.contains("script"), out);
+    assertFalse(out.toLowerCase(java.util.Locale.ROOT).contains("onload"), out);
+    assertTrue(out.contains("<path"), out);
+    assertTrue(out.contains("<rect"), out);
+  }
+
+  @Test
+  void stripsUnsafeHrefsButKeepsFragmentReferences() {
+    String out =
+        sanitize(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\""
+                + " viewBox=\"0 0 10 10\">"
+                + "<a xlink:href=\"javascript:alert(1)\"><rect width=\"5\" height=\"5\"/></a>"
+                + "<use xlink:href=\"#icon\"/>"
+                + "</svg>");
+
+    assertFalse(out.toLowerCase(java.util.Locale.ROOT).contains("javascript:"), out);
+    assertFalse(out.contains("<a "), out); // <a> is not on the allowlist
+    assertTrue(out.contains("#icon"), out); // fragment reference on <use> survives
+  }
+
+  @Test
+  void rejectsDoctypeToBlockXxe() {
+    String xxe =
+        "<?xml version=\"1.0\"?>"
+            + "<!DOCTYPE svg [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+            + "<svg xmlns=\"http://www.w3.org/2000/svg\"><desc>&xxe;</desc></svg>";
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SvgSanitizer.sanitize(xxe.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void rejectsNonSvgRoot() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            SvgSanitizer.sanitize("<html><body>x</body></html>".getBytes(StandardCharsets.UTF_8)));
+  }
+}


### PR DESCRIPTION
Closes #23 · part of epic #7 · depends on #15, #16 (both merged).

## What
The upload pipeline and public read path over the `application_asset` storage (#15, ADR-0024).

- **`BrandingService`** — validate → store: sniff the **real** content type from the bytes (PNG/WebP magic, `<svg`) and never trust the client `Content-Type`; enforce the 512 KiB cap; **sanitize SVG**; bound pixel dimensions (`ImageDimensions`: ImageIO for raster, `viewBox` for SVG); SHA-256; **delete-then-insert** (one row per slot).
- **`SvgSanitizer`** (security crux) — an **allowlist** sanitizer over an **XXE-hardened** parser: DOCTYPEs are rejected outright and all external DTD/entity/stylesheet access is disabled. Only presentational elements survive; `<script>`/`<foreignObject>`/`<style>`/`<image>`/`<a>`, `on*` handlers, inline `style`, and any non-`#fragment` `href`/`xlink:href` are stripped.
- **`BrandingLimits`**, **`ImageDimensions`**, **`BrandingValidationException`** (415/413/400/404).
- **Endpoints** — `POST`/`DELETE /api/v1/admin/branding/{slot}` (superadmin); public `GET /api/v1/branding/{slot}` with **ETag (SHA-256) + 304** and `Cache-Control: no-cache`. These are plain `@RestController`s (multipart + binary I/O sit outside the JSON contract); slot resolution lives in the service so the web layer never references entities (ArchUnit-clean). **ADR-0028** records the design.
- **Security** — `GET /api/v1/branding/**` is `permitAll`; admin upload/delete are covered by the existing `/api/v1/admin/**` → `SUPERADMIN` rule.

## Test plan
- [x] Unit (core): `SvgSanitizer` (strips script/handlers/unsafe href; rejects DOCTYPE/XXE & non-svg root), `ImageDimensions` (PNG via ImageIO, SVG viewBox) — green locally
- [x] Compile (core + app), Spotless + SPDX, ArchUnit layering — green locally
- [ ] `BrandingServiceIT` (Testcontainers): store/sanitize/replace, 415/413, delete — **CI only** (no local Docker)
- [ ] `BrandingControllerIT` (MockMvc + `springSecurity()`, JWT RPP): superadmin multipart upload + public ETag/304 serving, 404 unknown slot, 403 non-superadmin, delete — **CI only**

🤖 Co-Author: Claude (Opus 4.x) via Claude Code