### PR TITLE
feat: OIDC/OAuth2 browser login flow (#21)

### DIFF
--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -27,6 +27,11 @@ dependencies {
     // Resource-server filter that validates the bearer JWT on each request, plus
     // the JWT (Nimbus) types used by the web-layer decoder/cookie glue (issue #17).
     implementation(libs.spring.boot.starter.oauth2.resource.server)
+    // OIDC/OAuth2 browser login chain (io.qnop.web.security, issue #21): the
+    // oauth2Login DSL + authorized-client types. (qnop-core also uses the client
+    // library, but that is an implementation dep and does not reach this compile
+    // classpath.)
+    implementation(libs.spring.boot.starter.oauth2.client)
     // Auth-endpoint rate limiting (io.qnop.web.security.ratelimit, issue #18 / ADR-0027):
     // Bucket4j token buckets in a Caffeine cache. Caffeine is BOM-managed (also used by the
     // #17 revocation denylist in qnop-core); declared here too because that is an

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -22,11 +22,14 @@ package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.ServerConfigApi;
 import io.qnop.api.v1.model.Edition;
+import io.qnop.api.v1.model.OidcProviderLoginInfo;
 import io.qnop.api.v1.model.ServerConfigAuth;
 import io.qnop.api.v1.model.ServerConfigGeneral;
 import io.qnop.api.v1.model.ServerConfigResponse;
 import io.qnop.api.v1.model.ServerConfigUpload;
 import io.qnop.api.v1.model.SupportedFormat;
+import io.qnop.service.oidc.OidcProviderService;
+import io.qnop.service.oidc.OidcProviderView;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +54,12 @@ public class ConfigController implements ServerConfigApi {
   /** Reported when no build manifest is available (e.g. when running from exploded classes). */
   private static final String UNKNOWN_VERSION = "unknown";
 
+  private final OidcProviderService oidcProviders;
+
+  public ConfigController(OidcProviderService oidcProviders) {
+    this.oidcProviders = oidcProviders;
+  }
+
   @Override
   public ResponseEntity<ServerConfigResponse> getServerConfig() {
     ServerConfigResponse body =
@@ -58,11 +67,27 @@ public class ConfigController implements ServerConfigApi {
             .version(resolveVersion())
             .edition(Edition.COMMUNITY)
             .general(new ServerConfigGeneral().siteName("qnop").defaultTimezone("UTC"))
-            .auth(new ServerConfigAuth().oidcProviders(List.of()).selfRegistrationEnabled(false))
+            .auth(
+                new ServerConfigAuth()
+                    .oidcProviders(enabledOidcProviders())
+                    .selfRegistrationEnabled(false))
             .upload(new ServerConfigUpload().maxDocumentSizeMb(DEFAULT_MAX_DOCUMENT_SIZE_MB))
             .supportedFormats(
                 List.of(SupportedFormat.PDF, SupportedFormat.DOCX, SupportedFormat.MD));
     return ResponseEntity.ok(body);
+  }
+
+  /** The enabled providers as login buttons for the SPA (issue #21). */
+  private List<OidcProviderLoginInfo> enabledOidcProviders() {
+    return oidcProviders.findAll().stream()
+        .filter(OidcProviderView::enabled)
+        .map(
+            v ->
+                new OidcProviderLoginInfo()
+                    .id(v.id().toString())
+                    .name(v.name())
+                    .loginUrl("/oauth2/authorization/" + v.id()))
+        .toList();
   }
 
   /** Reads the server version from the JAR manifest, falling back to {@code "unknown"}. */

--- a/qnop-app/src/main/java/io/qnop/web/security/OidcLoginSuccessHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/OidcLoginSuccessHandler.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import io.qnop.security.QnopProperties;
+import io.qnop.service.RefreshTokenService;
+import io.qnop.service.RefreshTokenService.IssuedRefreshToken;
+import io.qnop.service.oidc.OidcLoginService;
+import io.qnop.service.oidc.OidcLoginService.LoginResult;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * Completes an OIDC/OAuth2 browser login (issue #21): provisions/links the local user, mints a qnop
+ * refresh session (reusing the issue-#17 refresh-token + cookie machinery), and redirects to the
+ * SPA. The access token is delivered by the SPA's subsequent {@code /api/v1/auth/refresh} call, so
+ * it never travels in a URL. The provider's access token (used only for the GitHub email fallback)
+ * is read from the {@link OAuth2AuthorizedClientService}.
+ */
+@Component
+public class OidcLoginSuccessHandler implements AuthenticationSuccessHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(OidcLoginSuccessHandler.class);
+
+  private final OidcLoginService oidcLoginService;
+  private final RefreshTokenService refreshTokenService;
+  private final RefreshTokenCookieFactory cookieFactory;
+  private final OAuth2AuthorizedClientService authorizedClientService;
+  private final QnopProperties properties;
+
+  public OidcLoginSuccessHandler(
+      OidcLoginService oidcLoginService,
+      RefreshTokenService refreshTokenService,
+      RefreshTokenCookieFactory cookieFactory,
+      OAuth2AuthorizedClientService authorizedClientService,
+      QnopProperties properties) {
+    this.oidcLoginService = oidcLoginService;
+    this.refreshTokenService = refreshTokenService;
+    this.cookieFactory = cookieFactory;
+    this.authorizedClientService = authorizedClientService;
+    this.properties = properties;
+  }
+
+  @Override
+  public void onAuthenticationSuccess(
+      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+      throws IOException {
+    OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+    try {
+      LoginResult result = oidcLoginService.completeLogin(token, providerAccessToken(token));
+      IssuedRefreshToken refresh = refreshTokenService.issue(result.userId());
+      response.addHeader(
+          HttpHeaders.SET_COOKIE,
+          cookieFactory.build(refresh.plaintext(), refresh.maxAge()).toString());
+      response.sendRedirect(frontendBase());
+    } catch (RuntimeException e) {
+      log.warn("OIDC login could not be completed: {}", e.getMessage());
+      response.sendRedirect(frontendBase() + "/login?error=oidc");
+    }
+  }
+
+  private String providerAccessToken(OAuth2AuthenticationToken token) {
+    OAuth2AuthorizedClient client =
+        authorizedClientService.loadAuthorizedClient(
+            token.getAuthorizedClientRegistrationId(), token.getName());
+    return client == null || client.getAccessToken() == null
+        ? null
+        : client.getAccessToken().getTokenValue();
+  }
+
+  private String frontendBase() {
+    List<String> origins = properties.cors().allowedOrigins();
+    if (origins == null || origins.isEmpty()) {
+      return "";
+    }
+    String base = origins.get(0);
+    return base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -29,12 +29,18 @@ import io.qnop.web.security.ratelimit.RegisterRateLimitFilter;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
@@ -74,6 +80,7 @@ public class SecurityConfiguration {
                   || "/api/v1/auth/logout".equals(request.getRequestURI()));
 
   @Bean
+  @Order(2)
   SecurityFilterChain securityFilterChain(
       HttpSecurity http,
       AuthenticationEntryPoint authenticationEntryPoint,
@@ -148,6 +155,49 @@ public class SecurityConfiguration {
                         hsts ->
                             hsts.includeSubDomains(true).maxAgeInSeconds(HSTS_MAX_AGE_SECONDS)));
     return http.build();
+  }
+
+  /**
+   * Dedicated chain for the OIDC/OAuth2 browser login handshake (issue #21). It is scoped to the
+   * authorization-start and callback URLs only, so the main API chain above stays STATELESS. A
+   * session may be created here (IF_REQUIRED) to hold the in-flight authorization request between
+   * the redirect to the IdP and the callback — this avoids storing (and deserializing) the
+   * authorization request in a cookie. On success, {@link OidcLoginSuccessHandler} sets the qnop
+   * refresh cookie and redirects to the SPA; the session is irrelevant to the token-based API.
+   */
+  @Bean
+  @Order(1)
+  SecurityFilterChain oidcLoginSecurityChain(
+      HttpSecurity http,
+      ClientRegistrationRepository clientRegistrationRepository,
+      OidcLoginSuccessHandler oidcLoginSuccessHandler,
+      CorsConfigurationSource corsConfigurationSource)
+      throws Exception {
+    http.securityMatcher("/oauth2/authorization/**", "/login/oauth2/code/**")
+        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+        .oauth2Login(
+            oauth2 ->
+                oauth2
+                    .clientRegistrationRepository(clientRegistrationRepository)
+                    .successHandler(oidcLoginSuccessHandler))
+        .cors(cors -> cors.configurationSource(corsConfigurationSource))
+        .csrf(csrf -> csrf.disable())
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+    return http.build();
+  }
+
+  /** Persists the OAuth2 access token (app-wide, in memory) so the success handler can read it. */
+  @Bean
+  OAuth2AuthorizedClientService oauth2AuthorizedClientService(
+      ClientRegistrationRepository clientRegistrationRepository) {
+    return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+  }
+
+  @Bean
+  OAuth2AuthorizedClientRepository oauth2AuthorizedClientRepository(
+      OAuth2AuthorizedClientService authorizedClientService) {
+    return new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(authorizedClientService);
   }
 
   /** Returns a bare JSON {@code 401} instead of redirecting to a login form (this is an API). */

--- a/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
@@ -20,15 +20,20 @@
  */
 package io.qnop.web;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.qnop.service.oidc.OidcProviderService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -46,6 +51,14 @@ class ConfigControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
+  @MockitoBean private OidcProviderService oidcProviders;
+
+  @BeforeEach
+  void setUp() {
+    // No providers configured: auth.oidcProviders should serialize as an empty list.
+    when(oidcProviders.findAll()).thenReturn(List.of());
+  }
+
   @Test
   @DisplayName("GET /api/v1/config returns the public Community configuration")
   void getConfig_returnsCommunityConfig() throws Exception {
@@ -56,6 +69,8 @@ class ConfigControllerTest {
         .andExpect(jsonPath("$.version").exists())
         .andExpect(jsonPath("$.general.siteName").value("qnop"))
         .andExpect(jsonPath("$.auth.selfRegistrationEnabled").value(false))
+        .andExpect(jsonPath("$.auth.oidcProviders").isArray())
+        .andExpect(jsonPath("$.auth.oidcProviders").isEmpty())
         .andExpect(jsonPath("$.upload.maxDocumentSizeMb").value(50))
         .andExpect(jsonPath("$.supportedFormats[0]").value("PDF"));
   }

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -87,6 +87,22 @@ public class UserService {
     return user;
   }
 
+  /** Records a successful-login timestamp (issue #21 OIDC login, and local login). */
+  @Transactional
+  public User bumpLastLogin(UUID id, Instant at) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    user.setLastLoginAt(at);
+    return user;
+  }
+
+  /** Provisions an enabled external (OIDC) user — no local credentials (issue #21). */
+  @Transactional
+  public User provisionExternal(String displayName, String email) {
+    User user = User.external(displayName, normalizeEmail(email));
+    user.setEnabled(true);
+    return users.save(user);
+  }
+
   /**
    * Applies a reset/new password: re-hashes, clears any forced-change flag, and stamps {@code
    * password_invalidated_before} so previously issued access tokens are rejected (issue #17).

--- a/qnop-core/src/main/java/io/qnop/service/oidc/DbClientRegistrationRepository.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/DbClientRegistrationRepository.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import io.qnop.entity.OidcProvider;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Spring Security {@link ClientRegistrationRepository} backed by the {@code oidc_provider} table
+ * (issue #21). One {@link ClientRegistration} is built per {@code enabled} row, keyed by the
+ * provider's UUID ({@link OidcRegistrationIds}). The cache is rebuilt on demand via {@link
+ * #refresh()} (called by {@code OidcProviderService} after any change), so providers come and go
+ * without a restart. Build failures (e.g. an unreachable issuer for discovery) are logged and the
+ * provider is skipped rather than failing the whole refresh.
+ */
+@Component
+public class DbClientRegistrationRepository
+    implements ClientRegistrationRepository, Iterable<ClientRegistration> {
+
+  private static final String REDIRECT_URI = "{baseUrl}/login/oauth2/code/{registrationId}";
+  private static final String GOOGLE_ISSUER = "https://accounts.google.com";
+  private static final Logger log = LoggerFactory.getLogger(DbClientRegistrationRepository.class);
+
+  private final io.qnop.repository.OidcProviderRepository providers;
+  private final AtomicReference<Map<String, ClientRegistration>> cache =
+      new AtomicReference<>(Map.of());
+
+  public DbClientRegistrationRepository(io.qnop.repository.OidcProviderRepository providers) {
+    this.providers = providers;
+  }
+
+  @PostConstruct
+  public void init() {
+    refresh();
+  }
+
+  /** Rebuilds the cache once a provider change has committed (issue #21). */
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onProvidersChanged(OidcProvidersChangedEvent event) {
+    refresh();
+  }
+
+  @Override
+  public ClientRegistration findByRegistrationId(String registrationId) {
+    return cache.get().get(registrationId);
+  }
+
+  @Override
+  public java.util.Iterator<ClientRegistration> iterator() {
+    return cache.get().values().iterator();
+  }
+
+  /** Rebuilds the registration cache from the enabled provider rows. */
+  @Transactional(readOnly = true)
+  public void refresh() {
+    Map<String, ClientRegistration> built = new LinkedHashMap<>();
+    for (OidcProvider provider : providers.findAll()) {
+      if (!provider.isEnabled()) {
+        continue;
+      }
+      String registrationId = OidcRegistrationIds.of(provider.getId());
+      try {
+        built.put(registrationId, buildRegistration(provider, registrationId));
+      } catch (RuntimeException e) {
+        log.warn(
+            "Skipping OIDC provider {} (registrationId={}): {}",
+            provider.getName(),
+            registrationId,
+            e.getMessage());
+      }
+    }
+    cache.set(Map.copyOf(built));
+  }
+
+  private ClientRegistration buildRegistration(OidcProvider provider, String registrationId) {
+    ClientRegistration.Builder builder =
+        switch (provider.getProviderType()) {
+          case OIDC ->
+              ClientRegistrations.fromIssuerLocation(requireIssuer(provider))
+                  .registrationId(registrationId);
+          case GOOGLE ->
+              ClientRegistrations.fromIssuerLocation(GOOGLE_ISSUER).registrationId(registrationId);
+          case GITHUB ->
+              ClientRegistration.withRegistrationId(registrationId)
+                  .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                  .authorizationUri("https://github.com/login/oauth/authorize")
+                  .tokenUri("https://github.com/login/oauth/access_token")
+                  .userInfoUri("https://api.github.com/user")
+                  .userNameAttributeName("id");
+          case FACEBOOK ->
+              ClientRegistration.withRegistrationId(registrationId)
+                  .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                  .authorizationUri("https://www.facebook.com/v18.0/dialog/oauth")
+                  .tokenUri("https://graph.facebook.com/v18.0/oauth/access_token")
+                  .userInfoUri("https://graph.facebook.com/me?fields=id,name,email")
+                  .userNameAttributeName("id");
+          case OAUTH2 ->
+              ClientRegistration.withRegistrationId(registrationId)
+                  .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                  .authorizationUri(require(provider.getAuthorizationUri(), "authorizationUri"))
+                  .tokenUri(require(provider.getTokenUri(), "tokenUri"))
+                  .userInfoUri(require(provider.getUserInfoUri(), "userInfoUri"))
+                  .jwkSetUri(provider.getJwkSetUri())
+                  .userNameAttributeName(orDefault(provider.getUserNameAttribute(), "sub"));
+        };
+    return builder
+        .clientId(provider.getClientId())
+        .clientSecret(provider.getClientSecret())
+        .redirectUri(REDIRECT_URI)
+        .scope(scopes(provider))
+        .build();
+  }
+
+  private static List<String> scopes(OidcProvider provider) {
+    return switch (provider.getProviderType()) {
+      case GITHUB -> List.of("read:user", "user:email");
+      case FACEBOOK -> List.of("public_profile", "email");
+      default -> {
+        String configured = provider.getScope();
+        if (configured == null || configured.isBlank()) {
+          yield List.of("openid", "email", "profile");
+        }
+        List<String> parsed = new ArrayList<>(Arrays.asList(configured.trim().split("\\s+")));
+        yield parsed;
+      }
+    };
+  }
+
+  private static String requireIssuer(OidcProvider provider) {
+    return require(provider.getIssuerUri(), "issuerUri");
+  }
+
+  private static String require(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " is required");
+    }
+    return value.trim();
+  }
+
+  private static String orDefault(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/GitHubEmailFetcher.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/GitHubEmailFetcher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Fetches a GitHub user's primary, verified email via {@code GET /user/emails} (issue #21). GitHub
+ * omits the email from userinfo unless it is public, so when the login principal carries no email
+ * this is the fallback. The user's OAuth2 access token authorizes the call (needs {@code
+ * user:email} scope).
+ */
+@Component
+public class GitHubEmailFetcher {
+
+  private static final String EMAILS_ENDPOINT = "https://api.github.com/user/emails";
+  private static final ParameterizedTypeReference<List<Map<String, Object>>> EMAIL_LIST =
+      new ParameterizedTypeReference<>() {};
+  private static final Logger log = LoggerFactory.getLogger(GitHubEmailFetcher.class);
+
+  private final RestClient restClient = RestClient.create();
+
+  /** The primary verified email for the token's user, or {@code null} if none is available. */
+  public String fetchPrimaryEmail(String accessToken) {
+    try {
+      List<Map<String, Object>> emails =
+          restClient
+              .get()
+              .uri(EMAILS_ENDPOINT)
+              .header("Authorization", "Bearer " + accessToken)
+              .header("Accept", "application/vnd.github+json")
+              .retrieve()
+              .body(EMAIL_LIST);
+      if (emails == null) {
+        return null;
+      }
+      String firstVerified = null;
+      for (Map<String, Object> entry : emails) {
+        if (!Boolean.TRUE.equals(entry.get("verified"))) {
+          continue;
+        }
+        Object email = entry.get("email");
+        if (email == null) {
+          continue;
+        }
+        if (Boolean.TRUE.equals(entry.get("primary"))) {
+          return email.toString();
+        }
+        if (firstVerified == null) {
+          firstVerified = email.toString();
+        }
+      }
+      return firstVerified;
+    } catch (RuntimeException e) {
+      log.warn("Failed to fetch GitHub primary email: {}", e.getMessage());
+      return null;
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcEmailMissingException.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcEmailMissingException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+/**
+ * Raised when an OIDC/OAuth2 login resolves to a principal with no usable email. qnop requires an
+ * email per account ({@code qnop_user.email} is {@code NOT NULL}, issue #11), so such a login
+ * cannot provision a new user.
+ */
+public class OidcEmailMissingException extends RuntimeException {
+
+  public OidcEmailMissingException(String message) {
+    super(message);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcIdentityService.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcIdentityService.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import io.qnop.entity.OidcIdentity;
+import io.qnop.entity.OidcProvider;
+import io.qnop.entity.User;
+import io.qnop.repository.OidcIdentityRepository;
+import io.qnop.service.UserService;
+import java.time.Instant;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Resolves an OIDC/OAuth2 login to a local user (issue #21), auto-provisioning on first sight.
+ *
+ * <p>Linking is <strong>strictly by ({@code provider}, {@code subject})</strong> — there is no
+ * cross-provider linking by email, which would let a compromised secondary IdP take over an
+ * account. An existing identity bumps {@code last_login_at}; a new one provisions a fresh {@code
+ * EXTERNAL} user (requires a usable email — see {@link OidcEmailMissingException}) and the linking
+ * row.
+ */
+@Service
+@Transactional
+public class OidcIdentityService {
+
+  private static final Logger log = LoggerFactory.getLogger(OidcIdentityService.class);
+
+  private final OidcIdentityRepository identities;
+  private final UserService userService;
+
+  public OidcIdentityService(OidcIdentityRepository identities, UserService userService) {
+    this.identities = identities;
+    this.userService = userService;
+  }
+
+  /** Returns the local user for this login, provisioning + linking on first sight. */
+  public User upsertOnLogin(OidcProvider provider, ResolvedPrincipal principal) {
+    UUID providerId = provider.getId();
+    Instant now = Instant.now();
+    return identities
+        .findByOidcProviderIdAndSubject(providerId, principal.subject())
+        .map(identity -> userService.bumpLastLogin(identity.getUserId(), now))
+        .orElseGet(() -> provision(provider, principal, now));
+  }
+
+  private User provision(OidcProvider provider, ResolvedPrincipal principal, Instant now) {
+    String email = trimToNull(principal.email());
+    if (email == null) {
+      throw new OidcEmailMissingException(
+          "The '" + provider.getName() + "' login returned no usable email address.");
+    }
+    String displayName = orElse(trimToNull(principal.displayName()), principal.subject());
+    User user = userService.provisionExternal(displayName, email);
+    identities.save(new OidcIdentity(provider.getId(), principal.subject(), user.getId()));
+    log.info(
+        "Provisioned new OIDC identity: provider={} userId={}", provider.getName(), user.getId());
+    return userService.bumpLastLogin(user.getId(), now);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private static String orElse(String value, String fallback) {
+    return value == null ? fallback : value;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcLoginService.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcLoginService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import io.qnop.entity.OidcProvider;
+import io.qnop.entity.User;
+import io.qnop.repository.OidcProviderRepository;
+import java.util.UUID;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Bridges a completed Spring Security OAuth2 login to a local qnop user (issue #21), keeping the
+ * {@code OidcProvider}/{@code User} entities inside the service layer (ADR-0004). The web success
+ * handler calls {@link #completeLogin} and mints the qnop session from the returned {@link
+ * LoginResult#userId()}.
+ */
+@Service
+public class OidcLoginService {
+
+  private final OidcProviderRepository providers;
+  private final OidcPrincipalResolver principalResolver;
+  private final OidcIdentityService identityService;
+
+  public OidcLoginService(
+      OidcProviderRepository providers,
+      OidcPrincipalResolver principalResolver,
+      OidcIdentityService identityService) {
+    this.providers = providers;
+    this.principalResolver = principalResolver;
+    this.identityService = identityService;
+  }
+
+  /** Resolves + provisions the user behind a successful OAuth2 login. */
+  @Transactional
+  public LoginResult completeLogin(OAuth2AuthenticationToken authentication, String accessToken) {
+    String registrationId = authentication.getAuthorizedClientRegistrationId();
+    UUID providerId =
+        OidcRegistrationIds.toProviderId(registrationId)
+            .orElseThrow(
+                () -> new IllegalStateException("Unknown OIDC registrationId: " + registrationId));
+    OidcProvider provider =
+        providers
+            .findById(providerId)
+            .filter(OidcProvider::isEnabled)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "OIDC provider not found or disabled: " + providerId));
+
+    ResolvedPrincipal principal = principalResolver.resolve(authentication, provider, accessToken);
+    if (principal.subject() == null || principal.subject().isBlank()) {
+      throw new IllegalStateException("OIDC login returned no subject for provider " + providerId);
+    }
+    User user = identityService.upsertOnLogin(provider, principal);
+    return new LoginResult(user.getId(), principal.upstreamIdToken());
+  }
+
+  /** The local user behind a completed login, plus the upstream id_token (for future RP logout). */
+  public record LoginResult(UUID userId, String upstreamIdToken) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcPrincipalResolver.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcPrincipalResolver.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import io.qnop.entity.OidcProvider;
+import io.qnop.entity.OidcProviderType;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+/**
+ * Maps a Spring Security OAuth2/OIDC principal onto the provider-agnostic {@link ResolvedPrincipal}
+ * (issue #21), applying the provider's attribute mappings and per-type conventions:
+ *
+ * <ul>
+ *   <li><b>OIDC / GOOGLE</b> — the {@link OidcUser} carries a standard {@code sub}/{@code
+ *       email}/{@code name} and the upstream id_token.
+ *   <li><b>GITHUB</b> — userinfo uses {@code id}; the email is often absent and is then fetched via
+ *       {@link GitHubEmailFetcher} using the user's access token.
+ *   <li><b>FACEBOOK / OAUTH2 (generic)</b> — resolved from the configured attribute names.
+ * </ul>
+ */
+@Component
+public class OidcPrincipalResolver {
+
+  private final GitHubEmailFetcher gitHubEmailFetcher;
+
+  public OidcPrincipalResolver(GitHubEmailFetcher gitHubEmailFetcher) {
+    this.gitHubEmailFetcher = gitHubEmailFetcher;
+  }
+
+  /** Resolves the principal; {@code accessToken} is used only for the GitHub email fallback. */
+  public ResolvedPrincipal resolve(
+      OAuth2AuthenticationToken authentication, OidcProvider provider, String accessToken) {
+    OAuth2User user = authentication.getPrincipal();
+    if (user instanceof OidcUser oidc) {
+      return resolveOidc(oidc, provider);
+    }
+    return resolveOAuth2(user, provider, accessToken);
+  }
+
+  private ResolvedPrincipal resolveOidc(OidcUser oidc, OidcProvider provider) {
+    String subject = firstNonBlank(attr(oidc, provider.getUserNameAttribute()), oidc.getSubject());
+    String email = firstNonBlank(oidc.getEmail(), attr(oidc, provider.getEmailAttribute()));
+    String displayName =
+        firstNonBlank(
+            oidc.getFullName(),
+            attr(oidc, provider.getDisplayNameAttribute()),
+            oidc.getPreferredUsername());
+    String idToken = oidc.getIdToken() == null ? null : oidc.getIdToken().getTokenValue();
+    return new ResolvedPrincipal(subject, email, displayName, idToken);
+  }
+
+  private ResolvedPrincipal resolveOAuth2(
+      OAuth2User user, OidcProvider provider, String accessToken) {
+    String subjectAttr = orDefault(provider.getUserNameAttribute(), defaultSubjectAttr(provider));
+    Object rawSubject = user.getAttributes().get(subjectAttr);
+    String subject = rawSubject == null ? null : String.valueOf(rawSubject);
+
+    String email = attr(user, orDefault(provider.getEmailAttribute(), "email"));
+    if (email == null && provider.getProviderType() == OidcProviderType.GITHUB) {
+      email = gitHubEmailFetcher.fetchPrimaryEmail(accessToken);
+    }
+    String displayName =
+        firstNonBlank(
+            attr(user, orDefault(provider.getDisplayNameAttribute(), "name")), attr(user, "login"));
+    return new ResolvedPrincipal(subject, email, displayName, null);
+  }
+
+  private static String defaultSubjectAttr(OidcProvider provider) {
+    return switch (provider.getProviderType()) {
+      case GITHUB, FACEBOOK -> "id";
+      default -> "sub";
+    };
+  }
+
+  private static String attr(OAuth2User user, String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
+    Object value = user.getAttributes().get(name);
+    return value == null ? null : String.valueOf(value);
+  }
+
+  private static String orDefault(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  private static String firstNonBlank(String... values) {
+    for (String value : values) {
+      if (value != null && !value.isBlank()) {
+        return value;
+      }
+    }
+    return null;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import org.springframework.stereotype.Service;
@@ -52,10 +53,15 @@ public class OidcProviderService {
 
   private final OidcProviderRepository providers;
   private final OidcSsrfPolicy ssrfPolicy;
+  private final ApplicationEventPublisher events;
 
-  public OidcProviderService(OidcProviderRepository providers, OidcSsrfPolicy ssrfPolicy) {
+  public OidcProviderService(
+      OidcProviderRepository providers,
+      OidcSsrfPolicy ssrfPolicy,
+      ApplicationEventPublisher events) {
     this.providers = providers;
     this.ssrfPolicy = ssrfPolicy;
+    this.events = events;
   }
 
   @Transactional(readOnly = true)
@@ -133,7 +139,9 @@ public class OidcProviderService {
     provider.setUserNameAttribute(trimToNull(userNameAttribute));
     provider.setEmailAttribute(trimToNull(emailAttribute));
     provider.setDisplayNameAttribute(trimToNull(displayNameAttribute));
-    return toView(providers.save(provider));
+    OidcProviderView view = toView(providers.save(provider));
+    events.publishEvent(new OidcProvidersChangedEvent());
+    return view;
   }
 
   /**
@@ -185,7 +193,9 @@ public class OidcProviderService {
     if (patch.displayNameAttribute() != null) {
       provider.setDisplayNameAttribute(trimToNull(patch.displayNameAttribute()));
     }
-    return toView(provider);
+    OidcProviderView view = toView(provider);
+    events.publishEvent(new OidcProvidersChangedEvent());
+    return view;
   }
 
   public void delete(UUID id) {
@@ -193,6 +203,7 @@ public class OidcProviderService {
       throw new OidcProviderNotFoundException(id);
     }
     providers.deleteById(id);
+    events.publishEvent(new OidcProvidersChangedEvent());
   }
 
   private OidcProvider require(UUID id) {

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcProvidersChangedEvent.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcProvidersChangedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+/**
+ * Published after any OIDC provider create/update/delete (issue #21) so the {@link
+ * DbClientRegistrationRepository} rebuilds its cache after the change commits — providers come and
+ * go without a server restart.
+ */
+public record OidcProvidersChangedEvent() {}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcRegistrationIds.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcRegistrationIds.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Single source of truth for Spring Security {@code registrationId} values (issue #21): the
+ * provider row's immutable UUID, used verbatim. The {@code /config} endpoint, the {@link
+ * DbClientRegistrationRepository}, and Spring Security's redirect URIs ({@code
+ * /oauth2/authorization/{id}}, {@code /login/oauth2/code/{id}}) must all agree on it. The UUID is
+ * used (not the editable name) so renaming a provider never changes its registered redirect URI.
+ */
+public final class OidcRegistrationIds {
+
+  private OidcRegistrationIds() {}
+
+  /** The registrationId for a persisted provider id. */
+  public static String of(UUID providerId) {
+    return providerId.toString();
+  }
+
+  /** Parses a registrationId back to a provider id, if it is a valid UUID. */
+  public static Optional<UUID> toProviderId(String registrationId) {
+    try {
+      return Optional.of(UUID.fromString(registrationId));
+    } catch (IllegalArgumentException e) {
+      return Optional.empty();
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/ResolvedPrincipal.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/ResolvedPrincipal.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+/**
+ * Provider-agnostic snapshot of the facts a successful OIDC/OAuth2 login yields (issue #21).
+ * Downstream provisioning ({@link OidcIdentityService}) works uniformly off this record regardless
+ * of provider type. {@code email == null} is the explicit "no usable email" signal.
+ */
+public record ResolvedPrincipal(
+    String subject, String email, String displayName, String upstreamIdToken) {}

--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcIdentityServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcIdentityServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.OidcIdentity;
+import io.qnop.entity.OidcProvider;
+import io.qnop.entity.User;
+import io.qnop.repository.OidcIdentityRepository;
+import io.qnop.service.UserService;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OidcIdentityServiceTest {
+
+  @Mock private OidcIdentityRepository identities;
+  @Mock private UserService userService;
+
+  private OidcIdentityService service;
+  private final OidcProvider provider = mock(OidcProvider.class);
+  private final UUID providerId = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    service = new OidcIdentityService(identities, userService);
+    when(provider.getId()).thenReturn(providerId);
+  }
+
+  @Test
+  @DisplayName("an existing identity just bumps last-login and returns the linked user")
+  void existingIdentity() {
+    UUID userId = UUID.randomUUID();
+    User user = mock(User.class);
+    when(identities.findByOidcProviderIdAndSubject(providerId, "sub-1"))
+        .thenReturn(Optional.of(new OidcIdentity(providerId, "sub-1", userId)));
+    when(userService.bumpLastLogin(eq(userId), any())).thenReturn(user);
+
+    User result = service.upsertOnLogin(provider, principal("sub-1", "a@example.com"));
+
+    assertThat(result).isSameAs(user);
+    verify(userService, never()).provisionExternal(any(), any());
+  }
+
+  @Test
+  @DisplayName("a new identity provisions an external user and links it by (provider, subject)")
+  void newIdentity() {
+    UUID newUserId = UUID.randomUUID();
+    User newUser = mock(User.class);
+    when(newUser.getId()).thenReturn(newUserId);
+    when(identities.findByOidcProviderIdAndSubject(providerId, "sub-2"))
+        .thenReturn(Optional.empty());
+    when(userService.provisionExternal("Jane", "jane@example.com")).thenReturn(newUser);
+    when(userService.bumpLastLogin(eq(newUserId), any())).thenReturn(newUser);
+
+    User result = service.upsertOnLogin(provider, principal("sub-2", "jane@example.com", "Jane"));
+
+    assertThat(result).isSameAs(newUser);
+    verify(identities).save(any(OidcIdentity.class));
+  }
+
+  @Test
+  @DisplayName("a new identity without an email is rejected (no provisioning)")
+  void newIdentityWithoutEmail() {
+    when(provider.getName()).thenReturn("Google");
+    when(identities.findByOidcProviderIdAndSubject(providerId, "sub-3"))
+        .thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.upsertOnLogin(provider, principal("sub-3", null)))
+        .isInstanceOf(OidcEmailMissingException.class);
+    verify(userService, never()).provisionExternal(any(), any());
+  }
+
+  private static ResolvedPrincipal principal(String subject, String email) {
+    return new ResolvedPrincipal(subject, email, null, null);
+  }
+
+  private static ResolvedPrincipal principal(String subject, String email, String displayName) {
+    return new ResolvedPrincipal(subject, email, displayName, null);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcProviderServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcProviderServiceTest.java
@@ -36,18 +36,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class OidcProviderServiceTest {
 
   @Mock private OidcProviderRepository providers;
+  @Mock private ApplicationEventPublisher events;
 
   private OidcProviderService service;
 
   @BeforeEach
   void setUp() {
     // Use the real SSRF policy so its rules are exercised through the service.
-    service = new OidcProviderService(providers, new OidcSsrfPolicy(false));
+    service = new OidcProviderService(providers, new OidcSsrfPolicy(false), events);
   }
 
   @Test

--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcRegistrationIdsTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcRegistrationIdsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class OidcRegistrationIdsTest {
+
+  @Test
+  void roundTrips() {
+    UUID id = UUID.randomUUID();
+    assertThat(OidcRegistrationIds.of(id)).isEqualTo(id.toString());
+    assertThat(OidcRegistrationIds.toProviderId(id.toString())).contains(id);
+  }
+
+  @Test
+  void rejectsNonUuid() {
+    assertThat(OidcRegistrationIds.toProviderId("not-a-uuid")).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

Completes the OIDC login handshake on top of the provider admin + SSRF guard merged in PR #40 (PR A of issue #21). With this PR, an operator-configured provider becomes a working SSO button: the SPA redirects the browser to the IdP, the callback provisions/links a local user, and a qnop refresh session is minted.

A **dedicated session-based filter chain** (`@Order(1)`, scoped to `/oauth2/authorization/**` + `/login/oauth2/code/**`) runs the `oauth2Login` DSL, while the main API chain (`@Order(2)`) stays **stateless**. A session may be created here only to hold the in-flight authorization request between redirect and callback — deliberately avoiding a cookie-based `AuthorizationRequestRepository` (and the Java-deserialization risk that comes with it). On success the provider's tokens stay server-side; the SPA receives only the qnop HttpOnly refresh cookie (issue #17 machinery) and obtains its access token via the existing `/api/v1/auth/refresh` call.

## What's included

- **`DbClientRegistrationRepository`** — builds `ClientRegistration`s from the DB OIDC providers; `registrationId` = provider UUID (immutable across renames). Cached in an `AtomicReference`, refreshed on an `AFTER_COMMIT` provider-change event. OIDC/GOOGLE discover via the issuer; GITHUB/FACEBOOK use hardcoded endpoints; OAUTH2 is fully explicit.
- **`OidcPrincipalResolver`** — extracts subject/email/displayName from `OidcUser` or `OAuth2User` per provider type, including the GitHub primary-verified-email fallback (`GitHubEmailFetcher`, Spring `RestClient`).
- **`OidcIdentityService`** — links strictly by `(provider, subject)`; first login provisions an enabled `EXTERNAL` user, later logins bump last-login. No cross-provider linking; a missing email is rejected (`OidcEmailMissingException`).
- **`OidcLoginService`** keeps all entity-touching logic in the core service layer; **`OidcLoginSuccessHandler`** (web) deals only with UUIDs/cookies/redirects — layering stays clean (ArchUnit green).
- **`ConfigController`** exposes the enabled providers as SPA login buttons (`/oauth2/authorization/{uuid}`).

## Test plan

- [x] `./gradlew build` green (Spotless + ArchUnit + unit tests)
- [x] Unit tests: `OidcRegistrationIdsTest`, `OidcIdentityServiceTest` (provisioning / existing-link / missing-email paths)
- [ ] **Manual / CI only:** the redirect handshake is only end-to-end verifiable against a live IdP.

## Deferred (follow-ups)

- RP-initiated logout + upstream `id_token` storage (needs a `RefreshTokenService` change).
- Per-provider resource-server JWT validators — not needed, since qnop mints its own session tokens.

Closes #21. Part of #7.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code