### PR TITLE
fix: schedule cleanup of expired refresh and revoked tokens

### DIFF
--- a/qnop-app/src/test/java/io/qnop/auth/TokenCleanupIT.java
+++ b/qnop-app/src/test/java/io/qnop/auth/TokenCleanupIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.RefreshToken;
+import io.qnop.entity.RevokedToken;
+import io.qnop.entity.User;
+import io.qnop.repository.RefreshTokenRepository;
+import io.qnop.repository.RevokedTokenRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.RefreshTokenService;
+import io.qnop.service.TokenRevocationService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the scheduled cleanup of expired refresh / revoked tokens (issue #43): {@code
+ * sweepExpired()} purges rows past their {@code expires_at} and leaves still-valid rows untouched.
+ * Runs against a real PostgreSQL (Testcontainers); each test rolls back for isolation. Requires
+ * Docker.
+ */
+@Transactional
+class TokenCleanupIT extends AbstractIntegrationTest {
+
+  @Autowired RefreshTokenService refreshTokenService;
+  @Autowired TokenRevocationService tokenRevocationService;
+  @Autowired RefreshTokenRepository refreshTokens;
+  @Autowired RevokedTokenRepository revokedTokens;
+  @Autowired UserRepository users;
+
+  private UUID newUser() {
+    return users
+        .saveAndFlush(User.external("Cleanup", "cleanup-" + UUID.randomUUID() + "@e.com"))
+        .getId();
+  }
+
+  @Test
+  void sweepRemovesExpiredRefreshTokensButKeepsValidOnes() {
+    UUID userId = newUser();
+    Instant past = Instant.now().minus(Duration.ofDays(1));
+    Instant future = Instant.now().plus(Duration.ofDays(1));
+    UUID expired =
+        refreshTokens
+            .saveAndFlush(new RefreshToken(UUID.randomUUID(), userId, "lookup-expired", past))
+            .getId();
+    UUID active =
+        refreshTokens
+            .saveAndFlush(new RefreshToken(UUID.randomUUID(), userId, "lookup-active", future))
+            .getId();
+
+    refreshTokenService.sweepExpired();
+
+    assertThat(refreshTokens.existsById(expired)).isFalse();
+    assertThat(refreshTokens.existsById(active)).isTrue();
+  }
+
+  @Test
+  void sweepRemovesExpiredRevokedTokensButKeepsValidOnes() {
+    UUID userId = newUser();
+    Instant past = Instant.now().minus(Duration.ofDays(1));
+    Instant future = Instant.now().plus(Duration.ofDays(1));
+    UUID expired =
+        revokedTokens.saveAndFlush(new RevokedToken("jti-expired", userId, past)).getId();
+    UUID active =
+        revokedTokens.saveAndFlush(new RevokedToken("jti-active", userId, future)).getId();
+
+    tokenRevocationService.sweepExpired();
+
+    assertThat(revokedTokens.existsById(expired)).isFalse();
+    assertThat(revokedTokens.existsById(active)).isTrue();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.UUID;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -110,6 +111,17 @@ public class RefreshTokenService {
   @Transactional
   public void revokeAllForUser(UUID userId) {
     repository.revokeAllForUser(userId, LOGOUT, Instant.now());
+  }
+
+  /**
+   * Daily off-peak purge of refresh-token rows whose absolute expiry has passed, so the table does
+   * not grow unbounded (issue #43). Rotated/revoked rows are also removed once they expire — their
+   * security purpose (reuse detection) is moot after expiry.
+   */
+  @Scheduled(cron = "0 40 3 * * *")
+  @Transactional
+  public void sweepExpired() {
+    repository.deleteExpiredBefore(Instant.now());
   }
 
   private Minted issueInFamily(UUID userId, UUID familyId) {

--- a/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.UUID;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -111,6 +112,17 @@ public class TokenRevocationService {
               user.setPasswordInvalidatedBefore(Instant.now());
               userRepository.save(user);
             });
+  }
+
+  /**
+   * Daily off-peak purge of denylist entries whose underlying token would have expired anyway, so
+   * {@code revoked_token} does not grow unbounded (issue #43). An expired token is rejected by JWS
+   * {@code exp} validation regardless, so dropping its denylist row is safe.
+   */
+  @Scheduled(cron = "0 45 3 * * *")
+  @Transactional
+  public void sweepExpired() {
+    revokedTokenRepository.deleteExpiredBefore(Instant.now());
   }
 
   private static String hashJti(String jti) {


### PR DESCRIPTION
## Summary

Fixes the pre-production gap from the Phase 1 codebase review: `RefreshTokenRepository.deleteExpiredBefore(...)` and `RevokedTokenRepository.deleteExpiredBefore(...)` existed but were **never called**, so `refresh_token` and `revoked_token` grew unbounded.

Wires each to a `@Scheduled` off-peak sweep, mirroring the existing email-verification (`03:30`) and password-reset (`03:35`) token sweeps:

- `RefreshTokenService.sweepExpired()` — cron `0 40 3 * * *`
- `TokenRevocationService.sweepExpired()` — cron `0 45 3 * * *`

`@EnableScheduling` is already active. An expired token is rejected by expiry / JWS `exp` validation regardless, so dropping its row (incl. rotated/revoked refresh rows and denylist entries) is safe.

## Test plan

- [ ] `TokenCleanupIT` (Testcontainers, CI): seeds one expired + one still-valid row in each table, calls `sweepExpired()`, asserts the expired row is purged and the valid row is kept.
- [x] `:qnop-core:build` (compile + Spotless + ArchUnit) green locally.

Closes #43

🤖 Co-Author: Claude (Opus 4.x) via Claude Code