### PR TITLE
test: cover TokenRevocationService, JwtTokenService and refresh rotation (#44)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/token/RefreshTokenServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/token/RefreshTokenServiceIT.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.RefreshToken;
+import io.qnop.entity.User;
+import io.qnop.repository.RefreshTokenRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.RefreshTokenHasher;
+import io.qnop.service.RefreshTokenService;
+import io.qnop.service.RefreshTokenService.IssuedRefreshToken;
+import io.qnop.service.RefreshTokenService.RotationResult;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Integration test for {@link RefreshTokenService} rotation against a real PostgreSQL (issue #44,
+ * Testcontainers): the single-use rotation persists the rotation link and revokes the predecessor,
+ * an expired token is indistinguishable from unknown, and replaying a revoked token trips
+ * family-wide reuse detection. Each test runs in a rolled-back transaction. Requires Docker.
+ */
+@Transactional
+class RefreshTokenServiceIT extends AbstractIntegrationTest {
+
+  @Autowired RefreshTokenService refreshTokenService;
+  @Autowired RefreshTokenRepository refreshTokens;
+  @Autowired RefreshTokenHasher hasher;
+  @Autowired UserRepository users;
+
+  private User newUser() {
+    return users.saveAndFlush(
+        User.internal(
+            "Alice",
+            "alice-" + UUID.randomUUID() + "@example.com",
+            "u-" + UUID.randomUUID(),
+            "hash"));
+  }
+
+  @Test
+  void happyPathRotationRevokesPredecessorAndLinksSuccessor() {
+    User user = newUser();
+    IssuedRefreshToken issued = refreshTokenService.issue(user.getId());
+
+    RotationResult result = refreshTokenService.rotate(issued.plaintext());
+
+    assertThat(result).isInstanceOf(RotationResult.Success.class);
+    RotationResult.Success success = (RotationResult.Success) result;
+    assertThat(success.userId()).isEqualTo(user.getId());
+
+    RefreshToken predecessor =
+        refreshTokens.findByTokenLookupHash(hasher.hash(issued.plaintext())).orElseThrow();
+    assertThat(predecessor.getRevokedAt()).isNotNull();
+    assertThat(predecessor.getRevocationReason()).isEqualTo("ROTATED");
+    assertThat(predecessor.getRotatedToId()).isNotNull();
+
+    RefreshToken successor =
+        refreshTokens.findByTokenLookupHash(hasher.hash(success.token().plaintext())).orElseThrow();
+    assertThat(successor.getId()).isEqualTo(predecessor.getRotatedToId());
+    assertThat(successor.getFamilyId()).isEqualTo(predecessor.getFamilyId());
+    assertThat(successor.getRevokedAt()).isNull();
+  }
+
+  @Test
+  void rotatingAnExpiredTokenYieldsUnknown() {
+    User user = newUser();
+    String plaintext = "expired-" + UUID.randomUUID();
+    refreshTokens.saveAndFlush(
+        new RefreshToken(
+            UUID.randomUUID(),
+            user.getId(),
+            hasher.hash(plaintext),
+            Instant.now().minusSeconds(60)));
+
+    RotationResult result = refreshTokenService.rotate(plaintext);
+
+    assertThat(result).isInstanceOf(RotationResult.Unknown.class);
+  }
+
+  @Test
+  void rotatingAnUnknownTokenYieldsUnknown() {
+    RotationResult result = refreshTokenService.rotate("never-issued-" + UUID.randomUUID());
+
+    assertThat(result).isInstanceOf(RotationResult.Unknown.class);
+  }
+
+  @Test
+  void replayingARevokedTokenRevokesTheWholeFamily() {
+    User user = newUser();
+    IssuedRefreshToken issued = refreshTokenService.issue(user.getId());
+    RotationResult first = refreshTokenService.rotate(issued.plaintext());
+    assertThat(first).isInstanceOf(RotationResult.Success.class);
+    RotationResult.Success success = (RotationResult.Success) first;
+
+    // Replay the now-revoked original: reuse detection, indistinguishable from unknown.
+    RotationResult replay = refreshTokenService.rotate(issued.plaintext());
+
+    assertThat(replay).isInstanceOf(RotationResult.Reused.class);
+    RefreshToken successor =
+        refreshTokens.findByTokenLookupHash(hasher.hash(success.token().plaintext())).orElseThrow();
+    assertThat(successor.getRevokedAt()).isNotNull();
+    assertThat(successor.getRevocationReason()).isEqualTo("REUSE_DETECTED");
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/JwtTokenServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/JwtTokenServiceTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import io.qnop.security.JwtKeyService;
+import io.qnop.security.QnopProperties;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+/**
+ * Unit test for {@link JwtTokenService} (issue #44): a minted access token must be a valid HS256
+ * JWT whose claims match the {@code qnop.auth} configuration. Tokens are decoded with a decoder
+ * built from the same HKDF-derived signing key, mirroring {@code JwtConfiguration}.
+ */
+class JwtTokenServiceTest {
+
+  private static final Duration TTL = Duration.ofMinutes(15);
+  private static final String ISSUER = "qnop-test";
+
+  private final SecretKey signingKey = new JwtKeyService(properties()).deriveKey("access-token");
+  private final JwtEncoder encoder = new NimbusJwtEncoder(new ImmutableSecret<>(signingKey));
+  private final JwtDecoder decoder =
+      NimbusJwtDecoder.withSecretKey(signingKey).macAlgorithm(MacAlgorithm.HS256).build();
+  private final JwtTokenService service = new JwtTokenService(encoder, properties());
+
+  @Test
+  @DisplayName("issued token is a valid HS256 JWT carrying the expected claims")
+  void issuesDecodableHs256TokenWithExpectedClaims() {
+    UUID userId = UUID.randomUUID();
+
+    Jwt jwt = decoder.decode(service.issueAccessToken(userId));
+
+    assertThat(jwt.getHeaders()).containsEntry("alg", "HS256");
+    assertThat(jwt.getSubject()).isEqualTo(userId.toString());
+    // Read iss as a raw string: Jwt#getIssuer() coerces the claim to a URL, but the
+    // configured issuer is a bare label ("qnop" by default), not a URL.
+    assertThat(jwt.getClaimAsString("iss")).isEqualTo(ISSUER);
+    assertThat(jwt.getId()).isNotNull();
+    // The jti is a random UUID; parsing it back must succeed.
+    assertThat(UUID.fromString(jwt.getId())).isNotNull();
+    assertThat(jwt.getIssuedAt()).isNotNull();
+    assertThat(jwt.getExpiresAt()).isNotNull();
+    assertThat(Duration.between(jwt.getIssuedAt(), jwt.getExpiresAt())).isEqualTo(TTL);
+  }
+
+  @Test
+  @DisplayName("each token gets a distinct jti so it can be revoked individually")
+  void mintsUniqueJtiPerToken() {
+    UUID userId = UUID.randomUUID();
+
+    Jwt first = decoder.decode(service.issueAccessToken(userId));
+    Jwt second = decoder.decode(service.issueAccessToken(userId));
+
+    assertThat(first.getId()).isNotEqualTo(second.getId());
+  }
+
+  private static QnopProperties properties() {
+    return new QnopProperties(
+        new QnopProperties.Auth(
+            "jwt-token-service-test-secret-0123456789",
+            "jwt-token-service-test-enckey-0123456789",
+            "0123456789abcdef0123456789abcdef",
+            TTL,
+            Duration.ofDays(7),
+            ISSUER,
+            null),
+        new QnopProperties.Cors(List.of()));
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/TokenRevocationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TokenRevocationServiceTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.RevokedToken;
+import io.qnop.entity.User;
+import io.qnop.repository.RevokedTokenRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.security.QnopProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit test for {@link TokenRevocationService} (issue #44): the {@code jti} denylist (cache +
+ * persistence, idempotent), and the {@code issuedAt < passwordInvalidatedBefore} bulk-invalidation
+ * comparison. The Caffeine cache is exercised through a fresh service instance per test.
+ */
+@ExtendWith(MockitoExtension.class)
+class TokenRevocationServiceTest {
+
+  private static final Instant EXPIRES_AT = Instant.now().plus(Duration.ofMinutes(15));
+
+  @Mock private RevokedTokenRepository revokedTokens;
+  @Mock private UserRepository users;
+
+  private final UUID userId = UUID.randomUUID();
+  private TokenRevocationService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new TokenRevocationService(revokedTokens, users, properties());
+  }
+
+  @Test
+  @DisplayName("revokeToken hashes the jti, persists it, and never stores the raw claim")
+  void revokeTokenPersistsHashedJti() {
+    when(revokedTokens.existsByJti(anyString())).thenReturn(false);
+
+    service.revokeToken("raw-jti", userId, EXPIRES_AT);
+
+    ArgumentCaptor<RevokedToken> saved = ArgumentCaptor.forClass(RevokedToken.class);
+    verify(revokedTokens).save(saved.capture());
+    assertThat(saved.getValue().getUserId()).isEqualTo(userId);
+    assertThat(saved.getValue().getExpiresAt()).isEqualTo(EXPIRES_AT);
+    // SHA-256 hex, never the raw jti.
+    assertThat(saved.getValue().getJti()).hasSize(64).isNotEqualTo("raw-jti");
+  }
+
+  @Test
+  @DisplayName("revokeToken is idempotent: an already-denylisted jti is not stored twice")
+  void revokeTokenIsIdempotent() {
+    when(revokedTokens.existsByJti(anyString())).thenReturn(true);
+
+    service.revokeToken("raw-jti", userId, EXPIRES_AT);
+
+    verify(revokedTokens, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("after revokeToken the jti is served from cache without a second DB probe")
+  void revokeTokenCachesSoIsRevokedSkipsDb() {
+    when(revokedTokens.existsByJti(anyString())).thenReturn(false);
+
+    service.revokeToken("raw-jti", userId, EXPIRES_AT);
+    boolean revoked = service.isRevoked("raw-jti", userId.toString(), Instant.now());
+
+    assertThat(revoked).isTrue();
+    // existsByJti only during revokeToken; the cache short-circuits isRevoked.
+    verify(revokedTokens, times(1)).existsByJti(anyString());
+  }
+
+  @Test
+  @DisplayName("isRevoked returns true on a cache/DB denylist hit, before touching the user")
+  void isRevokedTrueForDenylistedJti() {
+    when(revokedTokens.existsByJti(anyString())).thenReturn(true);
+
+    assertThat(service.isRevoked("raw-jti", userId.toString(), Instant.now())).isTrue();
+    verifyNoInteractions(users);
+  }
+
+  @Test
+  @DisplayName("isRevoked returns true when the token predates the password invalidation")
+  void isRevokedTrueWhenIssuedBeforePasswordInvalidation() {
+    Instant invalidatedAt = Instant.now();
+    User user = mockUserInvalidatedAt(invalidatedAt);
+    when(revokedTokens.existsByJti(anyString())).thenReturn(false);
+    when(users.findById(userId)).thenReturn(Optional.of(user));
+
+    boolean revoked =
+        service.isRevoked("raw-jti", userId.toString(), invalidatedAt.minusSeconds(60));
+
+    assertThat(revoked).isTrue();
+  }
+
+  @Test
+  @DisplayName("isRevoked returns false when the token was issued after the invalidation")
+  void isRevokedFalseWhenIssuedAfterPasswordInvalidation() {
+    Instant invalidatedAt = Instant.now();
+    User user = mockUserInvalidatedAt(invalidatedAt);
+    when(revokedTokens.existsByJti(anyString())).thenReturn(false);
+    when(users.findById(userId)).thenReturn(Optional.of(user));
+
+    boolean revoked =
+        service.isRevoked("raw-jti", userId.toString(), invalidatedAt.plusSeconds(60));
+
+    assertThat(revoked).isFalse();
+  }
+
+  @Test
+  @DisplayName("isRevoked returns false for a non-UUID subject without querying users")
+  void isRevokedFalseForNonUuidSubject() {
+    when(revokedTokens.existsByJti(anyString())).thenReturn(false);
+
+    assertThat(service.isRevoked("raw-jti", "not-a-uuid", Instant.now())).isFalse();
+    verifyNoInteractions(users);
+  }
+
+  @Test
+  @DisplayName("isRevoked returns false when the user no longer exists")
+  void isRevokedFalseWhenUserMissing() {
+    when(revokedTokens.existsByJti(anyString())).thenReturn(false);
+    when(users.findById(userId)).thenReturn(Optional.empty());
+
+    assertThat(service.isRevoked("raw-jti", userId.toString(), Instant.now())).isFalse();
+  }
+
+  @Test
+  @DisplayName("isRevoked returns false when the user's password was never invalidated")
+  void isRevokedFalseWhenNeverInvalidated() {
+    User user = mockUserInvalidatedAt(null);
+    when(revokedTokens.existsByJti(anyString())).thenReturn(false);
+    when(users.findById(userId)).thenReturn(Optional.of(user));
+
+    assertThat(service.isRevoked("raw-jti", userId.toString(), Instant.now())).isFalse();
+  }
+
+  @Test
+  @DisplayName("revokeAllForUser bumps passwordInvalidatedBefore and persists the user")
+  void revokeAllForUserBumpsTimestamp() {
+    User user = org.mockito.Mockito.mock(User.class);
+    when(users.findById(userId)).thenReturn(Optional.of(user));
+
+    service.revokeAllForUser(userId);
+
+    verify(user).setPasswordInvalidatedBefore(any(Instant.class));
+    verify(users).save(user);
+  }
+
+  @Test
+  @DisplayName("revokeAllForUser is a no-op when the user does not exist")
+  void revokeAllForUserNoopWhenUserMissing() {
+    when(users.findById(userId)).thenReturn(Optional.empty());
+
+    service.revokeAllForUser(userId);
+
+    verify(users, never()).save(any());
+  }
+
+  private static User mockUserInvalidatedAt(Instant invalidatedAt) {
+    User user = org.mockito.Mockito.mock(User.class);
+    when(user.getPasswordInvalidatedBefore()).thenReturn(invalidatedAt);
+    return user;
+  }
+
+  private static QnopProperties properties() {
+    return new QnopProperties(
+        new QnopProperties.Auth(
+            "token-revocation-test-secret-0123456789",
+            "token-revocation-test-enckey-0123456789",
+            "0123456789abcdef0123456789abcdef",
+            Duration.ofMinutes(15),
+            Duration.ofDays(7),
+            "qnop-test",
+            null),
+        new QnopProperties.Cors(List.of()));
+  }
+}


### PR DESCRIPTION
## Summary

`TokenRevocationService` and `JwtTokenService` (qnop-core `io.qnop.service`) implement the security-critical JWT revocation core — the `jti` denylist and the `issuedAt < passwordInvalidatedBefore` bulk-invalidation comparison — yet had **no tests**. This PR adds the unit coverage plus an integration test for refresh-token rotation, as proposed in #44.

## Tests added

**`JwtTokenServiceTest`** (qnop-core, unit) — builds an encoder/decoder pair from the same HKDF-derived signing key (mirroring `JwtConfiguration`) and asserts a minted token is a valid HS256 JWT: `sub` = user id, the configured `iss`, `exp` = `iat` + TTL, a UUID `jti`, and a distinct `jti` per token.

**`TokenRevocationServiceTest`** (qnop-core, unit, Mockito) — covers:
- `revokeToken` hashes the `jti` (64-hex SHA-256, never the raw claim), persists it, and is idempotent when already denylisted;
- the Caffeine cache short-circuits a second DB probe after `revokeToken`;
- `isRevoked`: denylist hit (without touching the user), issued-before vs issued-after password invalidation, non-UUID subject, missing user, and never-invalidated;
- `revokeAllForUser` bumps `passwordInvalidatedBefore` / no-ops on a missing user.

**`RefreshTokenServiceIT`** (qnop-app, Testcontainers) — exercises the rotation state machine against a real PostgreSQL:
- happy-path rotation persists `rotatedToId`, revokes the predecessor (`ROTATED`), and links an active successor in the same family;
- expired and unknown tokens both yield `Unknown` (indistinguishable to the caller);
- replaying a revoked token trips family-wide `REUSE_DETECTED`.

The IT lives in qnop-app (next to `TokenSchemaIT`), reusing the existing `AbstractIntegrationTest` Testcontainers base — qnop-core has no IT infrastructure and adding it there would mean wiring a `@SpringBootConfiguration` + Testcontainers deps into the framework-light core module.

## Test plan

- [x] `./gradlew :qnop-core:test` green (JwtTokenServiceTest + TokenRevocationServiceTest, 13 tests)
- [x] `./gradlew build -x test` + ArchUnit green; `RefreshTokenServiceIT` compiles
- [ ] **CI only:** `RefreshTokenServiceIT` runs against Testcontainers PostgreSQL (Docker unavailable locally)

Closes #44. Part of #7.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code