### PR TITLE
fix: uniform ErrorResponse envelope for 401/403/429 + global @ControllerAdvice

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -757,6 +757,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /auth/refresh:
     post:
       tags:
@@ -950,6 +952,31 @@ components:
       description: The template storage key (e.g. `auth.password_reset`).
       schema:
         type: string
+  responses:
+    Unauthorized:
+      description: Authentication is required (uniform error envelope, issue #45).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Forbidden:
+      description: The caller lacks permission for this resource (issue #45).
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    TooManyRequests:
+      description: Rate limit exceeded; retry after the Retry-After header (issue #45).
+      headers:
+        Retry-After:
+          description: Seconds to wait before retrying.
+          schema:
+            type: integer
+            format: int32
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
   schemas:
     Edition:
       type: string

--- a/qnop-app/src/main/java/io/qnop/web/ApiErrorWriter.java
+++ b/qnop-app/src/main/java/io/qnop/web/ApiErrorWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+/**
+ * Writes the uniform {@code ErrorResponse} envelope (issue #45) to a raw {@link
+ * HttpServletResponse}. Used by the security entry point (401), the access-denied handler (403),
+ * and the rate-limit filters (429) — the places that short-circuit the request <em>before</em> the
+ * dispatcher, where a {@code @ControllerAdvice} cannot reach. Controller-level errors build the
+ * same {@code ErrorResponse} through the normal MVC pipeline.
+ */
+public final class ApiErrorWriter {
+
+  private ApiErrorWriter() {}
+
+  public static void write(
+      HttpServletResponse response, HttpStatus status, String code, String message)
+      throws IOException {
+    response.setStatus(status.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    String json =
+        "{\"code\":\""
+            + escape(code)
+            + "\",\"message\":\""
+            + escape(message)
+            + "\",\"timestamp\":\""
+            + OffsetDateTime.now()
+            + "\"}";
+    response.getWriter().write(json);
+  }
+
+  private static String escape(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/ApiExceptionHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/ApiExceptionHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.model.ErrorResponse;
+import jakarta.validation.ConstraintViolationException;
+import java.time.OffsetDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+/**
+ * Global error handler (issue #45): maps request-validation failures onto the uniform {@link
+ * ErrorResponse} envelope so every {@code 400} has the same shape as the rest of the API. The
+ * filter-chain errors (401/403/429) are handled at their source via {@link ApiErrorWriter}; domain
+ * errors keep their controller-local handlers, which already return {@link ErrorResponse}.
+ */
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> onBodyValidation(MethodArgumentNotValidException ex) {
+    String message =
+        ex.getBindingResult().getFieldErrors().stream()
+            .findFirst()
+            .map(error -> error.getField() + " " + error.getDefaultMessage())
+            .orElse("request body validation failed");
+    return badRequest(message);
+  }
+
+  @ExceptionHandler(HandlerMethodValidationException.class)
+  public ResponseEntity<ErrorResponse> onParameterValidation(HandlerMethodValidationException ex) {
+    return badRequest("request parameter validation failed");
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ErrorResponse> onConstraintViolation(ConstraintViolationException ex) {
+    return badRequest(ex.getMessage());
+  }
+
+  private static ResponseEntity<ErrorResponse> badRequest(String message) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(
+            new ErrorResponse()
+                .code("VALIDATION_ERROR")
+                .message(message)
+                .timestamp(OffsetDateTime.now()));
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -21,6 +21,7 @@
 package io.qnop.web.security;
 
 import io.qnop.security.QnopProperties;
+import io.qnop.web.ApiErrorWriter;
 import io.qnop.web.security.ratelimit.ChangePasswordRateLimitFilter;
 import io.qnop.web.security.ratelimit.ForgotPasswordRateLimitFilter;
 import io.qnop.web.security.ratelimit.LoginRateLimitFilter;
@@ -32,7 +33,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -44,6 +44,7 @@ import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAut
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfFilter;
@@ -85,6 +86,7 @@ public class SecurityConfiguration {
   SecurityFilterChain securityFilterChain(
       HttpSecurity http,
       AuthenticationEntryPoint authenticationEntryPoint,
+      AccessDeniedHandler accessDeniedHandler,
       CorsConfigurationSource corsConfigurationSource,
       DelegatingJwtDecoder jwtDecoder,
       LoginRateLimitFilter loginRateLimitFilter,
@@ -140,7 +142,10 @@ public class SecurityConfiguration {
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder)))
         .httpBasic(httpBasic -> httpBasic.disable())
         .formLogin(formLogin -> formLogin.disable())
-        .exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryPoint))
+        .exceptionHandling(
+            ex ->
+                ex.authenticationEntryPoint(authenticationEntryPoint)
+                    .accessDeniedHandler(accessDeniedHandler))
         .headers(
             headers ->
                 headers
@@ -203,14 +208,26 @@ public class SecurityConfiguration {
     return new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(authorizedClientService);
   }
 
-  /** Returns a bare JSON {@code 401} instead of redirecting to a login form (this is an API). */
+  /** Writes the uniform {@code ErrorResponse} 401 instead of a login redirect (issue #45). */
   @Bean
   AuthenticationEntryPoint authenticationEntryPoint() {
-    return (request, response, authException) -> {
-      response.setStatus(HttpStatus.UNAUTHORIZED.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      response.getWriter().write("{\"error\":\"unauthorized\"}");
-    };
+    return (request, response, authException) ->
+        ApiErrorWriter.write(
+            response,
+            HttpStatus.UNAUTHORIZED,
+            "UNAUTHENTICATED",
+            "Authentication is required to access this resource.");
+  }
+
+  /** Writes the uniform {@code ErrorResponse} 403 for authorization failures (issue #45). */
+  @Bean
+  AccessDeniedHandler accessDeniedHandler() {
+    return (request, response, accessDeniedException) ->
+        ApiErrorWriter.write(
+            response,
+            HttpStatus.FORBIDDEN,
+            "FORBIDDEN",
+            "You do not have permission to access this resource.");
   }
 
   @Bean

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/AbstractRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/AbstractRateLimitFilter.java
@@ -20,6 +20,7 @@
  */
 package io.qnop.web.security.ratelimit;
 
+import io.qnop.web.ApiErrorWriter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,7 +28,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
@@ -76,17 +76,8 @@ abstract class AbstractRateLimitFilter extends OncePerRequestFilter {
 
   private void writeTooManyRequests(HttpServletResponse response, long retryAfterSeconds)
       throws IOException {
-    response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
     response.setHeader(HttpHeaders.RETRY_AFTER, Long.toString(retryAfterSeconds));
-    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-    response
-        .getWriter()
-        .write(
-            "{\"error\":\"too_many_requests\",\"message\":\""
-                + message
-                + "\",\"retryAfterSeconds\":"
-                + retryAfterSeconds
-                + "}");
+    ApiErrorWriter.write(response, HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMITED", message);
   }
 
   /** Whether this filter applies to the request (method + path match). */

--- a/qnop-app/src/test/java/io/qnop/web/ErrorEnvelopeIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/ErrorEnvelopeIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Verifies the uniform {@code ErrorResponse} envelope (issue #45) across the filter-chain error
+ * paths: 401 (unauthenticated), 403 (authenticated but not permitted), and 400 (request
+ * validation). Each must carry the same {@code code} / {@code message} / {@code timestamp} JSON
+ * shape. Requires Docker (Testcontainers).
+ */
+class ErrorEnvelopeIT extends AbstractIntegrationTest {
+
+  @Autowired WebApplicationContext context;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void unauthenticatedRequestReturns401Envelope() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/admin/settings"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value("UNAUTHENTICATED"))
+        .andExpect(jsonPath("$.message").isNotEmpty())
+        .andExpect(jsonPath("$.timestamp").isNotEmpty());
+  }
+
+  @Test
+  void forbiddenRequestReturns403Envelope() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/admin/settings")
+                .with(
+                    jwt()
+                        .jwt(j -> j.subject(UUID.randomUUID().toString()))
+                        .authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+        .andExpect(status().isForbidden())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+        .andExpect(jsonPath("$.timestamp").isNotEmpty());
+  }
+
+  @Test
+  void bodyValidationReturns400Envelope() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/v1/admin/settings")
+                .with(
+                    jwt()
+                        .jwt(j -> j.subject(UUID.randomUUID().toString()))
+                        .authorities(new SimpleGrantedAuthority("ROLE_SUPERADMIN")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.timestamp").isNotEmpty());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/ErrorEnvelopeIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/ErrorEnvelopeIT.java
@@ -86,7 +86,16 @@ class ErrorEnvelopeIT extends AbstractIntegrationTest {
   void bodyValidationReturns400Envelope() throws Exception {
     // {} omits the required usernameOrEmail/password, tripping @Valid bean validation.
     mockMvc
-        .perform(post("/api/v1/auth/login").contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+                .with(
+                    request -> {
+                      // Distinct client IP so this does not drain RateLimitIT's login bucket.
+                      request.setRemoteAddr("203.0.113.45");
+                      return request;
+                    }))
         .andExpect(status().isBadRequest())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))

--- a/qnop-app/src/test/java/io/qnop/web/ErrorEnvelopeIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/ErrorEnvelopeIT.java
@@ -23,7 +23,7 @@ package io.qnop.web;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -84,15 +84,9 @@ class ErrorEnvelopeIT extends AbstractIntegrationTest {
 
   @Test
   void bodyValidationReturns400Envelope() throws Exception {
+    // {} omits the required usernameOrEmail/password, tripping @Valid bean validation.
     mockMvc
-        .perform(
-            patch("/api/v1/admin/settings")
-                .with(
-                    jwt()
-                        .jwt(j -> j.subject(UUID.randomUUID().toString()))
-                        .authorities(new SimpleGrantedAuthority("ROLE_SUPERADMIN")))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+        .perform(post("/api/v1/auth/login").contentType(MediaType.APPLICATION_JSON).content("{}"))
         .andExpect(status().isBadRequest())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))

--- a/qnop-app/src/test/java/io/qnop/web/security/ratelimit/RateLimitIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/ratelimit/RateLimitIT.java
@@ -71,5 +71,6 @@ class RateLimitIT extends AbstractIntegrationTest {
 
     assertThat(throttled.statusCode()).isEqualTo(429);
     assertThat(throttled.headers().firstValue("Retry-After")).isPresent();
+    assertThat(throttled.body()).contains("\"code\":\"RATE_LIMITED\"");
   }
 }


### PR DESCRIPTION
Closes #45.

## Problem
401 wrote a bare `{"error":"unauthorized"}`, 429 wrote a different hand-built JSON, and 403 had no body — none matched the OpenAPI `ErrorResponse` schema, so clients couldn't parse a uniform error shape.

## Fix
Every error path now emits the same `{code, message, timestamp}` envelope.

- **`ApiErrorWriter`** — writes the `ErrorResponse` shape directly to the raw response, for the filter-chain paths that short-circuit *before* the dispatcher (where `@ControllerAdvice` can't reach).
- **`SecurityConfiguration`** — the 401 `AuthenticationEntryPoint` uses it (`code: UNAUTHENTICATED`); a new `AccessDeniedHandler` covers 403 (`code: FORBIDDEN`) and is wired into `exceptionHandling`.
- **`AbstractRateLimitFilter`** — 429 uses it (`code: RATE_LIMITED`) and keeps `Retry-After`.
- **`ApiExceptionHandler`** (`@RestControllerAdvice`) — maps body/parameter/constraint validation onto a 400 `ErrorResponse` (`code: VALIDATION_ERROR`). Domain `@ExceptionHandler`s (settings/branding) already returned `ErrorResponse` and are unchanged.
- **`openapi.yaml`** — reusable `Unauthorized`/`Forbidden`/`TooManyRequests` responses (→ `ErrorResponse`); `429` documented on `/auth/login`.

## Test plan
- [x] API generation, compile (core + app), Spotless + SPDX, ArchUnit — green locally
- [ ] `ErrorEnvelopeIT` (Testcontainers + MockMvc): 401/403/400 all return the `{code,message,timestamp}` shape — **CI only** (no local Docker)
- [ ] `RateLimitIT`: the throttled 429 body now asserts `"code":"RATE_LIMITED"` — **CI only**

🤖 Co-Author: Claude (Opus 4.x) via Claude Code