### PR TITLE
fix: harden branding upload — SVG depth limit + I/O outside transaction

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/branding/BrandingService.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/BrandingService.java
@@ -29,7 +29,9 @@ import java.util.HexFormat;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Validates and stores operator branding assets, and reads them back for public serving (issue
@@ -41,18 +43,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class BrandingService {
 
   private final ApplicationAssetRepository repository;
+  private final TransactionTemplate transactionTemplate;
 
-  public BrandingService(ApplicationAssetRepository repository) {
+  public BrandingService(
+      ApplicationAssetRepository repository, PlatformTransactionManager transactionManager) {
     this.repository = repository;
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
   }
 
   /**
    * Validates the uploaded bytes and replaces the asset in {@code slot}.
    *
+   * <p>The CPU-bound validation pipeline — content-type sniffing, SVG sanitization (XML parsing)
+   * and pixel-dimension decoding ({@code ImageIO}) — runs <em>outside</em> any transaction so it
+   * does not hold a database connection while parsing potentially adversarial input (issue #48).
+   * Only the delete-then-insert is transactional.
+   *
    * @throws BrandingValidationException if the type is unsupported, the payload too large, the
    *     image unreadable/oversized, or the SVG unsafe
    */
-  @Transactional
   public StoredAsset store(String slot, byte[] bytes, UUID uploadedBy) {
     BrandingSlot resolved = resolve(slot);
     String contentType = sniffContentType(bytes);
@@ -74,14 +83,19 @@ public class BrandingService {
     enforceDimensions(contentType, content);
 
     String sha256 = sha256Hex(content);
-    // Flush the delete before the insert: a single flush would order the INSERT before the DELETE
-    // (Hibernate's action ordering) and transiently violate the (slot) unique constraint.
-    repository.deleteBySlot(resolved);
-    repository.flush();
-    repository.saveAndFlush(
-        ApplicationAsset.create(
-            resolved, contentType, content, sha256, content.length, uploadedBy));
-    return new StoredAsset(contentType, sha256, content.length);
+    byte[] stored = content;
+    return transactionTemplate.execute(
+        status -> {
+          // Flush the delete before the insert: a single flush would order the INSERT before the
+          // DELETE (Hibernate's action ordering) and transiently violate the (slot) unique
+          // constraint.
+          repository.deleteBySlot(resolved);
+          repository.flush();
+          repository.saveAndFlush(
+              ApplicationAsset.create(
+                  resolved, contentType, stored, sha256, stored.length, uploadedBy));
+          return new StoredAsset(contentType, sha256, stored.length);
+        });
   }
 
   /** The current asset for a slot, for public serving. */

--- a/qnop-core/src/main/java/io/qnop/service/branding/SvgSanitizer.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/SvgSanitizer.java
@@ -61,6 +61,13 @@ import org.w3c.dom.NodeList;
  */
 public final class SvgSanitizer {
 
+  /**
+   * Maximum element nesting depth. A legitimate logo is shallow; a pathologically deep tree is a
+   * denial-of-service vector (stack exhaustion in the recursive walk), so it is rejected outright
+   * (issue #48).
+   */
+  private static final int MAX_NESTING_DEPTH = 100;
+
   private static final Set<String> ALLOWED_ELEMENTS =
       Set.of(
           "svg",
@@ -101,7 +108,7 @@ public final class SvgSanitizer {
       if (root == null || !"svg".equals(localName(root))) {
         throw new IllegalArgumentException("not an <svg> document");
       }
-      sanitizeElement(root);
+      sanitizeElement(root, 0);
       return serialize(document);
     } catch (IllegalArgumentException e) {
       throw e;
@@ -126,7 +133,11 @@ public final class SvgSanitizer {
     return builder.parse(new ByteArrayInputStream(svg));
   }
 
-  private static void sanitizeElement(Element element) {
+  private static void sanitizeElement(Element element, int depth) {
+    if (depth > MAX_NESTING_DEPTH) {
+      throw new IllegalArgumentException(
+          "SVG nesting exceeds the maximum depth of " + MAX_NESTING_DEPTH);
+    }
     NamedNodeMap attributes = element.getAttributes();
     List<Attr> toRemove = new ArrayList<>();
     for (int i = 0; i < attributes.getLength(); i++) {
@@ -157,7 +168,7 @@ public final class SvgSanitizer {
     }
     for (Element child : childElements) {
       if (ALLOWED_ELEMENTS.contains(localName(child))) {
-        sanitizeElement(child);
+        sanitizeElement(child, depth + 1);
       } else {
         element.removeChild(child); // drops <script>, <foreignObject>, <style>, <image>, …
       }

--- a/qnop-core/src/test/java/io/qnop/service/branding/SvgSanitizerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/branding/SvgSanitizerTest.java
@@ -85,4 +85,29 @@ class SvgSanitizerTest {
         () ->
             SvgSanitizer.sanitize("<html><body>x</body></html>".getBytes(StandardCharsets.UTF_8)));
   }
+
+  @Test
+  void rejectsPathologicallyDeepNesting() {
+    // A logo is shallow; a very deep tree is a stack-exhaustion DoS vector (issue #48).
+    int depth = 500;
+    String svg =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\">"
+            + "<g>".repeat(depth)
+            + "</g>".repeat(depth)
+            + "</svg>";
+
+    assertThrows(IllegalArgumentException.class, () -> sanitize(svg));
+  }
+
+  @Test
+  void acceptsModeratelyNestedGroups() {
+    int depth = 20;
+    String svg =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\">"
+            + "<g>".repeat(depth)
+            + "</g>".repeat(depth)
+            + "</svg>";
+
+    assertTrue(sanitize(svg).contains("<g"), svg);
+  }
 }


### PR DESCRIPTION
## Summary

Two MEDIUM security findings from the Phase 1 review (#48).

- **SVG stack-exhaustion DoS.** `SvgSanitizer.sanitizeElement` recursed with no depth cap, so a deeply nested SVG could blow the stack. Reject nesting beyond **100** levels (a real logo is shallow); the rejection flows through the existing `IllegalArgumentException` → `BrandingValidationException.invalidSvg` path.
- **Blocking I/O inside `@Transactional`.** `BrandingService.store()` ran the whole CPU-bound validation pipeline — content-type sniff, SVG XML parsing, `ImageIO` pixel-dimension decode, SHA-256 — inside the transaction, holding a DB connection while parsing adversarial input. The validation now runs **outside** any transaction; only the delete-then-insert runs in a `TransactionTemplate`.

No schema change.

## Test plan

- [x] `SvgSanitizerTest` (unit, runs locally): deep nesting (500) is rejected; moderate nesting (20) is accepted. Existing XXE / script / href cases still pass.
- [x] `:qnop-core:build` (compile + Spotless + unit tests) + ArchUnit green.
- [ ] Branding ITs (Testcontainers, CI) — unchanged behaviour for valid uploads/serving.

Closes #48

🤖 Co-Author: Claude (Opus 4.x) via Claude Code