### PR TITLE
perf: index application_setting.updated_by FK (issue #46)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/settings/SettingsSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/SettingsSchemaIT.java
@@ -144,4 +144,16 @@ class SettingsSchemaIT extends AbstractIntegrationTest {
     ApplicationSetting reloaded = applicationSettings.findById("custom.audited").orElseThrow();
     assertThat(reloaded.getUpdatedBy()).isNull();
   }
+
+  @Test
+  void indexesTheUpdatedByForeignKey() {
+    // The FK column must be indexed so deletes of a qnop_user (ON DELETE SET NULL) and joins on
+    // updated_by do not sequentially scan application_setting (issue #46).
+    Integer count =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM pg_indexes WHERE tablename = 'application_setting'"
+                + " AND indexname = 'ix_application_setting_updated_by'",
+            Integer.class);
+    assertThat(count).isEqualTo(1);
+  }
 }

--- a/qnop-core/src/main/resources/db/changelog/migrations/0002-settings-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0002-settings-schema.yaml
@@ -37,6 +37,14 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_application_setting_updated_by
             onDelete: SET NULL
+        # Index the FK column: Postgres does not auto-index FKs, so without this a
+        # delete of a qnop_user (ON DELETE SET NULL) and any join on updated_by
+        # would sequentially scan application_setting (issue #46).
+        - createIndex:
+            tableName: application_setting
+            indexName: ix_application_setting_updated_by
+            columns:
+              - column: { name: updated_by }
         - sql:
             comment: Postgres-only CHECK on the value-type enum (not expressible in JPA).
             sql: |


### PR DESCRIPTION
## What

Adds the missing index on the `application_setting.updated_by` foreign key (issue #46). Closes #46.

- `ix_application_setting_updated_by` on `application_setting(updated_by)` — Postgres doesn't auto-index FK columns, so deleting a `qnop_user` (`ON DELETE SET NULL`) and joins on `updated_by` previously sequentially scanned the table.

## Deviation from the issue (mail_template index skipped)
The issue also asked for a `(template_key, locale)` index on `mail_template`. **Not added** — that table already has `UNIQUE(template_key, locale)` (`ux_mail_template_key_locale`), and Postgres backs a unique constraint with a composite btree index that fully serves the `findByTemplateKeyAndLocale` equality lookup. A second index would only add write/storage overhead. (Confirmed with @devtank42.)

## Note
Edited the existing `0002-settings-schema.yaml` changeset in place rather than appending a new changeset — no production database exists yet and CI/tests rebuild the schema from scratch each run, so checksum drift is a non-issue.

## Test plan
- [x] compile, spotlessCheck, ArchUnit (local)
- [ ] `SettingsSchemaIT.indexesTheUpdatedByForeignKey` (Testcontainers, CI) asserts the index exists in `pg_indexes`

🤖 Co-Author: Claude (Opus 4.x) via Claude Code
