### PR TITLE
fix: rate-limit hardening — trusted-proxy warning + bounded bucket cache

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/BucketRateLimitService.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/BucketRateLimitService.java
@@ -43,15 +43,18 @@ public class BucketRateLimitService {
   /** Upper bound on how long an idle bucket lingers, independent of the caller's window. */
   private static final long MAX_BUCKET_TTL_SECONDS = 3_600;
 
-  private static final long MAX_BUCKETS = 100_000;
+  private final java.util.concurrent.ConcurrentMap<String, Bucket> buckets;
 
-  private final Caffeine<Object, Object> cacheBuilder =
-      Caffeine.newBuilder()
-          .expireAfterAccess(MAX_BUCKET_TTL_SECONDS, TimeUnit.SECONDS)
-          .maximumSize(MAX_BUCKETS);
-
-  private final java.util.concurrent.ConcurrentMap<String, Bucket> buckets =
-      cacheBuilder.<String, Bucket>build().asMap();
+  public BucketRateLimitService(RateLimitProperties properties) {
+    // Size-cap the bucket store so a high-cardinality key space (e.g. a spoofable client IP when
+    // no trusted proxy is configured) cannot grow it without bound (issue #49).
+    this.buckets =
+        Caffeine.newBuilder()
+            .expireAfterAccess(MAX_BUCKET_TTL_SECONDS, TimeUnit.SECONDS)
+            .maximumSize(properties.maxBuckets())
+            .<String, Bucket>build()
+            .asMap();
+  }
 
   /**
    * Attempts to consume one token from the bucket identified by {@code scope + key}.

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/HttpClientIpResolver.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/HttpClientIpResolver.java
@@ -22,6 +22,8 @@ package io.qnop.web.security.ratelimit;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
 import org.springframework.stereotype.Component;
 
@@ -53,6 +55,8 @@ public class HttpClientIpResolver {
 
   private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
+  private static final Logger log = LoggerFactory.getLogger(HttpClientIpResolver.class);
+
   private final List<IpAddressMatcher> trustedProxyMatchers;
 
   public HttpClientIpResolver(RateLimitProperties properties) {
@@ -61,6 +65,14 @@ public class HttpClientIpResolver {
             .map(String::trim)
             .map(IpAddressMatcher::new)
             .toList();
+    if (trustedProxyMatchers.isEmpty()) {
+      log.warn(
+          "Rate limiting is active but qnop.auth.rate-limit.trusted-proxy-cidrs is empty:"
+              + " X-Forwarded-For is ignored and the connection IP is used. This is the secure"
+              + " default for a direct deployment. If qnop runs behind a reverse proxy, set it to"
+              + " the proxy's egress CIDRs, or every client shares one per-IP bucket and the limit"
+              + " is effectively bypassable.");
+    }
   }
 
   /** Returns the best-trusted client IP for the request. */

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RateLimitProperties.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/RateLimitProperties.java
@@ -42,6 +42,9 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  * @param refresh IP-keyed limit for {@code POST /api/v1/auth/refresh} (default 30 / 60s)
  * @param changePassword subject-keyed limit for {@code POST /api/v1/auth/change-password} (default
  *     5 / 300s)
+ * @param maxBuckets upper bound on the number of live token buckets held in memory (default
+ *     100&nbsp;000). Bounds memory under a high-cardinality key space — e.g. a spoofable client IP
+ *     when no trusted proxy is configured (issue #49).
  */
 @ConfigurationProperties(prefix = "qnop.auth.rate-limit")
 public record RateLimitProperties(
@@ -50,7 +53,8 @@ public record RateLimitProperties(
     Limit refresh,
     Limit changePassword,
     Limit register,
-    Limit forgotPassword) {
+    Limit forgotPassword,
+    @DefaultValue("100000") long maxBuckets) {
 
   // A whole scope absent from config arrives as null here; substitute its per-scope default. The
   // Limit components themselves carry @DefaultValue, so a partially-specified scope keeps the

--- a/qnop-app/src/test/java/io/qnop/web/security/ratelimit/BucketRateLimitServiceTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/ratelimit/BucketRateLimitServiceTest.java
@@ -22,12 +22,15 @@ package io.qnop.web.security.ratelimit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for the shared Bucket4j limiter — no Spring context, no Docker. */
 class BucketRateLimitServiceTest {
 
-  private final BucketRateLimitService service = new BucketRateLimitService();
+  private final BucketRateLimitService service =
+      new BucketRateLimitService(
+          new RateLimitProperties(List.of(), null, null, null, null, null, 100_000L));
 
   @Test
   void allowsUpToCapacityThenRejects() {

--- a/qnop-app/src/test/java/io/qnop/web/security/ratelimit/HttpClientIpResolverTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/ratelimit/HttpClientIpResolverTest.java
@@ -44,7 +44,7 @@ class HttpClientIpResolverTest {
 
   private static HttpClientIpResolver resolver(List<String> trustedCidrs) {
     return new HttpClientIpResolver(
-        new RateLimitProperties(trustedCidrs, null, null, null, null, null));
+        new RateLimitProperties(trustedCidrs, null, null, null, null, null, 100_000L));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two MEDIUM findings from the Phase 1 review (#49).

- **Silent trusted-proxy misconfiguration.** `HttpClientIpResolver` now logs a `WARN` at startup when rate limiting is active but `qnop.auth.rate-limit.trusted-proxy-cidrs` is empty. Behind a reverse proxy without configured trust, `X-Forwarded-For` is ignored and every client collapses into one per-IP bucket (limit effectively bypassable) — now visible in the logs. The empty list remains the secure default for a direct deployment.
- **Hardcoded bucket-cache cap.** `BucketRateLimitService`'s Caffeine `maximumSize` is now configurable via `qnop.auth.rate-limit.max-buckets` (default `100000`) instead of a constant, so the memory bound against a spoofable high-cardinality key space is tunable per deployment.

No schema change.

## Test plan

- [x] `BucketRateLimitServiceTest`, `HttpClientIpResolverTest` (unit, run locally) updated for the new constructors and green.
- [x] `:qnop-app` compile + ArchUnit green.
- [ ] `RateLimitIT` (Testcontainers, CI) — unchanged limiting behaviour.

Closes #49

🤖 Co-Author: Claude (Opus 4.x) via Claude Code