### PR TITLE
feat: distributed scheduler locks via ShedLock (Postgres-backed)

### DIFF
--- a/docs/adr/0029-distributed-scheduler-locks.md
+++ b/docs/adr/0029-distributed-scheduler-locks.md
@@ -1,0 +1,69 @@
+# ADR-0029: Distributed scheduler locks for @Scheduled jobs (ShedLock)
+
+- **Status:** Accepted
+- **Date:** 2026-06-16
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+Several maintenance jobs run via Spring `@Scheduled`: the email-verification,
+password-reset, refresh-token (#43) and revoked-token (#43) cleanup sweeps. Spring
+`@Scheduled` fires **per application instance** with no cross-instance
+coordination — in a multi-instance deployment every node runs each job
+concurrently.
+
+Today all four jobs are idempotent bulk `DELETE … WHERE expires_at < now()`, so
+concurrent execution is correct but redundant (wasted DB load, row-lock
+contention). That changes the moment a **non-idempotent** scheduled job lands
+(e.g. mail digests, billing, report generation) — those would be duplicated once
+per instance. The current deployment target is single-node (ADR-0013 defers Redis
+and horizontal scaling), so this is not an active defect, but coordination must be
+in place **before** scaling out or adding the first side-effecting scheduled job.
+
+## Decision
+
+Adopt **ShedLock** to guarantee each scheduled job runs **at most once per tick
+across all instances**, backed by the **existing PostgreSQL** via
+`JdbcTemplateLockProvider` (no Redis, consistent with ADR-0013).
+
+- ShedLock **7.x** — the line tested against Spring 7.0 / Spring Boot 4.x, JVM 17+.
+- A `shedlock` table (Liquibase migration `0006`) holds one row per named job.
+- `SchedulingConfiguration` (qnop-app) declares the `LockProvider` with
+  `usingDbTime()` so the **database clock is authoritative** (no inter-node skew).
+- `@EnableSchedulerLock(interceptMode = PROXY_METHOD)` — wraps the annotated bean
+  methods so the lock applies uniformly (including direct invocation).
+- Each sweep carries `@SchedulerLock(name = …, lockAtMostFor = "PT5M")`. The
+  `@SchedulerLock` annotation lives in `qnop-core` (on the service methods); the
+  `LockProvider` that makes it real is wired in `qnop-app`.
+
+`lockAtMostFor` is a safety net that releases the lock if an instance dies
+mid-job; `lockAtLeastFor` stays at the default `PT0S` because the jobs are
+idempotent, so there is no harm in a fast job releasing early.
+
+## Consequences
+
+- Scheduled jobs are safe under horizontal scaling, and the codebase is ready for
+  non-idempotent scheduled work without a duplicate-execution footgun.
+- One small dependency (ShedLock) and one infrastructure table; no new runtime
+  service (reuses PostgreSQL).
+- New scheduled jobs MUST add `@SchedulerLock` with a unique `name` to be
+  coordinated — an unannotated `@Scheduled` method still runs per instance. This
+  is a convention to enforce in review.
+- `usingDbTime()` requires the lock provider to read DB time; negligible overhead
+  on a once-daily job.
+
+## Alternatives considered
+
+- **PostgreSQL advisory locks** (`pg_try_advisory_lock`). Zero dependencies and
+  Postgres-native, but hand-rolled: no lock metadata/visibility, manual key
+  management, and no framework integration with `@Scheduled`. ShedLock gives the
+  same guarantee with a documented annotation model and is easy to extend to many
+  jobs.
+- **Redis / Redisson lock.** Rejected: pulls in Redis, which ADR-0013 explicitly
+  defers; PostgreSQL already satisfies the requirement.
+- **Externalising jobs** (k8s CronJob / a designated leader instance). Cleaner
+  separation but adds operational surface and couples cleanup to the deployment
+  platform; revisit only if scheduled work grows substantially.
+- **Leaving it (idempotent + single-node).** Correct today but a latent footgun
+  for the first non-idempotent job and for scaling; the chosen option removes the
+  hazard cheaply.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0026](0026-jwt-session-and-revocation.md) | JWT access tokens, rotating refresh tokens, and revocation | Accepted |
 | [0027](0027-auth-rate-limiting.md) | Auth rate limiting & trusted-proxy IP resolution | Accepted |
 | [0028](0028-branding-upload-and-svg-sanitization.md) | Branding upload pipeline & SVG sanitization | Accepted |
+| [0029](0029-distributed-scheduler-locks.md) | Distributed scheduler locks for @Scheduled jobs (ShedLock) | Accepted |
 
 ## Template
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,9 @@ jakartaAnnotation = "3.0.0"
 # so it carries an explicit version; caffeine IS BOM-managed (declared below
 # without a version). bucket4j_jdk17-core targets JDK 17+ (we run JDK 21).
 bucket4j = "8.18.0"
+# Distributed scheduler locks (issue #52, ADR-0029). ShedLock 7.x is the line
+# tested against Spring 7.0 / Spring Boot 4.x and requires JVM 17+ (we run 21).
+shedlock = "7.0.0"
 # Mail subsystem (issue #19): logic-less Mustache for admin-editable templates,
 # safe to render untrusted template bodies. SMTP via spring-boot-starter-mail
 # (version managed by the Spring Boot BOM).
@@ -83,6 +86,11 @@ caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }
 # Boot BOM, so it carries an explicit version. The Caffeine cache above backs the
 # per-key bucket store.
 bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }
+# Distributed scheduler locks (issue #52, ADR-0029). shedlock-spring carries the
+# @SchedulerLock annotation (used in qnop-core service sweeps); the JDBC provider
+# backs the lock on the existing Postgres (no Redis, ADR-0013) and is wired in qnop-app.
+shedlock-spring = { module = "net.javacrumbs.shedlock:shedlock-spring", version.ref = "shedlock" }
+shedlock-provider-jdbc-template = { module = "net.javacrumbs.shedlock:shedlock-provider-jdbc-template", version.ref = "shedlock" }
 # Mail subsystem (issue #19) — JavaMail + logic-less Mustache template rendering.
 spring-boot-starter-mail = { module = "org.springframework.boot:spring-boot-starter-mail" }
 jmustache = { module = "com.samskivert:jmustache", version.ref = "jmustache" }

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -38,6 +38,12 @@ dependencies {
     // implementation dependency and does not reach this module's compile classpath.
     implementation(libs.bucket4j.core)
     implementation(libs.caffeine)
+    // Distributed scheduler locks (io.qnop.bootstrap.SchedulingConfiguration, issue #52 /
+    // ADR-0029): @EnableSchedulerLock + the Postgres JdbcTemplateLockProvider that backs the
+    // @SchedulerLock'd cleanup sweeps. shedlock-spring is declared here too (qnop-core's is an
+    // implementation dep and does not reach this compile classpath).
+    implementation(libs.shedlock.spring)
+    implementation(libs.shedlock.provider.jdbc.template)
     // The bootstrap registers the sibling data packages explicitly via
     // @EntityScan / @EnableJpaRepositories (issue #11), so this module takes a
     // direct JPA dependency for those compile-time symbols (Hibernate itself

--- a/qnop-app/src/main/java/io/qnop/bootstrap/SchedulingConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/SchedulingConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Distributed locking for the {@code @Scheduled} cleanup sweeps (issue #52, ADR-0029).
+ *
+ * <p>Plain Spring {@code @Scheduled} fires per instance with no coordination, so in a
+ * multi-instance deployment every node would run each sweep concurrently. ShedLock fronts each
+ * {@code @SchedulerLock}-annotated sweep with a row in the {@code shedlock} table (migration 0006),
+ * so the job runs at most once per tick across all instances — backed by the existing PostgreSQL,
+ * with no Redis (ADR-0013). {@code usingDbTime()} makes the database clock authoritative, avoiding
+ * skew between application nodes.
+ *
+ * <p>{@code PROXY_METHOD} intercept mode wraps the annotated bean methods directly (rather than the
+ * scheduler), so the lock also applies to any direct invocation — keeping the behaviour uniform.
+ * {@code @EnableScheduling} itself lives on {@link QnopApplication}.
+ */
+@Configuration
+@EnableSchedulerLock(
+    defaultLockAtMostFor = "PT5M",
+    interceptMode = EnableSchedulerLock.InterceptMode.PROXY_METHOD)
+public class SchedulingConfiguration {
+
+  @Bean
+  LockProvider lockProvider(DataSource dataSource) {
+    return new JdbcTemplateLockProvider(
+        JdbcTemplateLockProvider.Configuration.builder()
+            .withJdbcTemplate(new JdbcTemplate(dataSource))
+            .usingDbTime()
+            .build());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/bootstrap/SchedulingLockIT.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/SchedulingLockIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Verifies the ShedLock wiring (issue #52, ADR-0029): the Postgres-backed {@link LockProvider} bean
+ * is present, the {@code shedlock} table exists (Liquibase migration 0006), and the lock provides
+ * mutual exclusion — a second acquisition of a held lock is refused until the first is released.
+ * This is what makes the {@code @Scheduled} sweeps run at most once across instances. Not
+ * {@code @Transactional}: lock state must commit to be observable across acquisitions. Requires
+ * Docker.
+ */
+class SchedulingLockIT extends AbstractIntegrationTest {
+
+  @Autowired LockProvider lockProvider;
+  @Autowired JdbcTemplate jdbc;
+
+  @Test
+  void shedlockTableIsCreatedByLiquibase() {
+    Integer count = jdbc.queryForObject("SELECT count(*) FROM shedlock", Integer.class);
+
+    assertThat(count).isNotNull();
+  }
+
+  @Test
+  void lockIsExclusiveWhileHeldAndReusableAfterRelease() {
+    LockConfiguration config =
+        new LockConfiguration(
+            Instant.now(), "shedlock-it-probe", Duration.ofMinutes(5), Duration.ZERO);
+
+    Optional<SimpleLock> first = lockProvider.lock(config);
+    assertThat(first).as("first acquisition succeeds").isPresent();
+
+    try {
+      assertThat(lockProvider.lock(config)).as("a held lock cannot be re-acquired").isEmpty();
+    } finally {
+      first.orElseThrow().unlock();
+    }
+
+    Optional<SimpleLock> afterRelease = lockProvider.lock(config);
+    assertThat(afterRelease).as("the lock is acquirable again once released").isPresent();
+    afterRelease.ifPresent(SimpleLock::unlock);
+  }
+}

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -48,6 +48,11 @@ dependencies {
     implementation(libs.spring.boot.starter.mail)
     implementation(libs.jmustache)
 
+    // Distributed scheduler locks (issue #52, ADR-0029): the @SchedulerLock
+    // annotation on the @Scheduled cleanup sweeps. The Postgres-backed LockProvider
+    // that makes the lock real is wired in qnop-app.
+    implementation(libs.shedlock.spring)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.UUID;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -119,6 +120,7 @@ public class RefreshTokenService {
    * security purpose (reuse detection) is moot after expiry.
    */
   @Scheduled(cron = "0 40 3 * * *")
+  @SchedulerLock(name = "refreshTokenSweep", lockAtMostFor = "PT5M")
   @Transactional
   public void sweepExpired() {
     repository.deleteExpiredBefore(Instant.now());

--- a/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.UUID;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -120,6 +121,7 @@ public class TokenRevocationService {
    * {@code exp} validation regardless, so dropping its denylist row is safe.
    */
   @Scheduled(cron = "0 45 3 * * *")
+  @SchedulerLock(name = "revokedTokenSweep", lockAtMostFor = "PT5M")
   @Transactional
   public void sweepExpired() {
     revokedTokenRepository.deleteExpiredBefore(Instant.now());

--- a/qnop-core/src/main/java/io/qnop/service/auth/EmailVerificationTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/EmailVerificationTokenService.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.HexFormat;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -88,6 +89,7 @@ public class EmailVerificationTokenService {
 
   /** Daily off-peak purge of expired rows so the table does not grow unbounded. */
   @Scheduled(cron = "0 30 3 * * *")
+  @SchedulerLock(name = "emailVerificationTokenSweep", lockAtMostFor = "PT5M")
   @Transactional
   public void sweep() {
     tokens.deleteByExpiresAtBefore(Instant.now());

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetTokenService.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.HexFormat;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,6 +91,7 @@ public class PasswordResetTokenService {
   }
 
   @Scheduled(cron = "0 35 3 * * *")
+  @SchedulerLock(name = "passwordResetTokenSweep", lockAtMostFor = "PT5M")
   @Transactional
   public void sweep() {
     tokens.deleteByExpiresAtBefore(Instant.now());

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -26,3 +26,6 @@ databaseChangeLog:
   - include:
       file: migrations/0005-application-asset-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0006-shedlock-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0006-shedlock-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0006-shedlock-schema.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# ShedLock coordination table (issue #52, ADR-0029). Backs the distributed lock
+# that makes the @Scheduled cleanup sweeps run at most once per tick across
+# instances. Column shape is mandated by ShedLock's JdbcTemplateLockProvider —
+# name (PK), lock_until, locked_at, locked_by — and uses plain TIMESTAMP because
+# the provider is configured with usingDbTime() (DB clock is authoritative).
+databaseChangeLog:
+  - changeSet:
+      id: 0006-shedlock
+      author: qnop
+      comment: ShedLock distributed-lock table for scheduled jobs.
+      changes:
+        - createTable:
+            tableName: shedlock
+            columns:
+              - column:
+                  name: name
+                  type: VARCHAR(64)
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: lock_until
+                  type: TIMESTAMP
+                  constraints: { nullable: false }
+              - column:
+                  name: locked_at
+                  type: TIMESTAMP
+                  constraints: { nullable: false }
+              - column:
+                  name: locked_by
+                  type: VARCHAR(255)
+                  constraints: { nullable: false }


### PR DESCRIPTION
## Summary

Re-targets ShedLock at `main`. The original PR (#53) was stacked on the #43 branch and got merged **into that branch after it had already merged to `main`** (via #51), so the ShedLock commits never reached `main` — issue #52 was closed but the code is absent. This PR brings it onto `main` directly (rebased; clean).

Spring `@Scheduled` runs per instance with no coordination — every node would run each cleanup sweep concurrently. ShedLock coordinates them via the **existing PostgreSQL** (no Redis, ADR-0013).

## Changes

- ShedLock 7.x (Spring 7 / Boot 4, JVM 17+); `shedlock` table via Liquibase `0006`.
- `SchedulingConfiguration`: `JdbcTemplateLockProvider` (`usingDbTime()`) + `@EnableSchedulerLock(PROXY_METHOD)`.
- `@SchedulerLock` on all four sweeps (refresh, revoked, email-verification, password-reset) — at most once per tick across instances.
- ADR-0029.

## Test plan

- [ ] `SchedulingLockIT` (Testcontainers, CI): `shedlock` table present; lock is exclusive while held and reusable after release.
- [x] `:qnop-core:build` + ArchUnit green; ShedLock 7.0.0 resolves; qnop-app compiles.

Closes #52
Supersedes #53 (merged into an orphaned branch).

🤖 Co-Author: Claude (Opus 4.x) via Claude Code