### PR TITLE
feat: concurrency control for User writes (part 1 of #61)

### DIFF
--- a/docs/adr/0030-concurrency-control-strategy.md
+++ b/docs/adr/0030-concurrency-control-strategy.md
@@ -1,0 +1,81 @@
+# ADR-0030: Concurrency control for entity writes
+
+- **Status:** Accepted
+- **Date:** 2026-06-17
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+PR #56 (issue #47) added `@Version` to `ApplicationSetting` because the review
+flagged that one entity. A systematic look (issue #61) at the other entities' write
+patterns found two genuinely racy ones that #47 did not cover:
+
+- **`User` read-modify-write.** Several flows do `findById → setX → save`:
+  `last_login_at` on every login, `password_invalidated_before` on token revocation
+  (`TokenRevocationService.revokeAllForUser`), the password hash on change/reset, and
+  admin enable/disable. Because a JPA full-entity save writes **every** column, a
+  high-frequency low-value write (a login stamping `last_login_at`) can silently
+  revert a concurrent **security** write (a revocation bumping
+  `password_invalidated_before`) — a lost revocation.
+- **Single-use tokens.** `EmailVerificationToken` / `PasswordResetToken` `consume()`
+  is check-then-act (`if (consumedAt != null) reject; setConsumedAt(now)`), so two
+  concurrent requests with the same token can both succeed — a double-consume
+  (password-reset replay).
+
+## Decision
+
+Match the control to the write shape rather than blanket-applying `@Version`:
+
+1. **Atomic targeted `@Modifying` updates** for the security-critical and
+   high-frequency single-column `User` writes, eliminating the read-modify-write:
+   - `bumpPasswordInvalidatedBefore(id, at)` — sets the column **and** `version =
+     version + 1`. The revocation is always applied, and the version bump makes any
+     concurrently-loaded stale entity's later full save fail optimistically instead
+     of reverting the revocation.
+   - `updatePasswordHash(id, hash)` — same, version-bumping.
+   - `touchLastLogin(id, at)` — best-effort, **no** version bump (a login marker may
+     be overwritten by a concurrent edit; harmless, and it must not make logins
+     fail).
+   `AuthService.changePassword` now reads the user for verification only and applies
+   the hash via the atomic update — it never dirty-saves the entity.
+
+2. **Optimistic locking (`@Version`) on `User`** as the backstop for the remaining
+   genuine multi-field full-entity edits (admin enable/disable, `applyPasswordReset`,
+   registration inserts). A concurrent conflict there is rare and surfaces as a
+   loud failure (correct) rather than a silent lost update. No retry is added for
+   these admin-initiated flows; the security-critical writes don't need it because
+   they are atomic.
+
+3. **Conditional atomic consume** for single-use tokens (follow-up step under #61):
+   `UPDATE … SET consumed_at = now() WHERE id = ? AND consumed_at IS NULL`, checking
+   the affected-row count, so a token is consumed at most once.
+
+`ApplicationSetting` keeps the `@Version` + retry approach from #47 (its writes are
+genuinely multi-field, admin-edited read-modify-writes).
+
+## Consequences
+
+- A token revocation can no longer be silently reverted by a concurrent login or
+  edit — the core security fix.
+- Logins stay cheap and never fail on contention (atomic, no version bump).
+- Admin edits of the same user concurrently now fail loudly (optimistic conflict)
+  instead of losing an update; callers may retry. A future global `@ControllerAdvice`
+  (#45) should map the conflict to `409`.
+- Mixing bulk `version = version + 1` updates with `@Version` requires care: the
+  affected flows must not also dirty-save the same entity in the same transaction
+  (verified for `changePassword`).
+- Config entities (`OidcProvider`, `MailTemplate`, `UserSetting`) are **not** changed
+  — their admin/single-user last-writer-wins edits are low-impact; revisit only if a
+  concrete conflict surfaces.
+
+## Alternatives considered
+
+- **`@Version` + retry everywhere on `User`.** Rejected: would make every login do a
+  version-checked full save and retry on contention — needless overhead on the hot
+  path, and still clobber-prone unless every write is version-checked. Targeted
+  atomic updates are simpler and strictly correct for the single-column writes.
+- **Serializable isolation.** Rejected: heavy, broad performance impact for a
+  localized problem.
+- **`@Version` on the single-use tokens.** Works, but a conditional `UPDATE … WHERE
+  consumed_at IS NULL` expresses "consume once" directly and avoids a load-modify
+  round-trip.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,6 +41,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0027](0027-auth-rate-limiting.md) | Auth rate limiting & trusted-proxy IP resolution | Accepted |
 | [0028](0028-branding-upload-and-svg-sanitization.md) | Branding upload pipeline & SVG sanitization | Accepted |
 | [0029](0029-distributed-scheduler-locks.md) | Distributed scheduler locks for @Scheduled jobs (ShedLock) | Accepted |
+| [0030](0030-concurrency-control-strategy.md) | Concurrency control for entity writes (optimistic locking + atomic updates) | Accepted |
 
 ## Template
 

--- a/qnop-app/src/test/java/io/qnop/auth/UserConcurrencyIT.java
+++ b/qnop-app/src/test/java/io/qnop/auth/UserConcurrencyIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the User concurrency control (issue #61, ADR-0030): {@code @Version} guards full-entity
+ * edits, and the atomic revocation update bumps the version so a stale write cannot revert it. Runs
+ * against a real PostgreSQL (Testcontainers); each test rolls back. Requires Docker.
+ */
+@Transactional
+class UserConcurrencyIT extends AbstractIntegrationTest {
+
+  @Autowired UserRepository users;
+  @PersistenceContext EntityManager em;
+
+  private User newUser() {
+    return users.saveAndFlush(
+        User.internal(
+            "Conc", "conc-" + UUID.randomUUID() + "@e.com", "u-" + UUID.randomUUID(), "h"));
+  }
+
+  @Test
+  void versionStartsAtZeroAndIncrementsOnFullEntitySave() {
+    User saved = newUser();
+    assertThat(saved.getVersion()).isZero();
+
+    saved.setDisplayName("renamed");
+    assertThat(users.saveAndFlush(saved).getVersion()).isEqualTo(1L);
+  }
+
+  @Test
+  void atomicRevocationBumpsVersionAndCannotBeRevertedByAStaleSave() {
+    UUID id = newUser().getId();
+    User stale = users.findById(id).orElseThrow(); // version 0, password_invalidated_before null
+    em.detach(stale);
+
+    // A concurrent revocation: atomic, version-bumping.
+    Instant when = Instant.now();
+    users.bumpPasswordInvalidatedBefore(id, when);
+
+    // The stale full-entity save must now fail rather than reverting the revocation.
+    stale.setDisplayName("changed");
+    assertThatThrownBy(() -> users.saveAndFlush(stale))
+        .isInstanceOf(ObjectOptimisticLockingFailureException.class);
+
+    User fresh = users.findById(id).orElseThrow();
+    assertThat(fresh.getPasswordInvalidatedBefore()).isNotNull();
+    assertThat(fresh.getVersion()).isEqualTo(1L);
+  }
+
+  @Test
+  void touchLastLoginUpdatesTheTimestampAtomically() {
+    UUID id = newUser().getId();
+    Instant when = Instant.now();
+
+    users.touchLastLogin(id, when);
+
+    assertThat(users.findById(id).orElseThrow().getLastLoginAt()).isNotNull();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/User.java
+++ b/qnop-core/src/main/java/io/qnop/entity/User.java
@@ -26,6 +26,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
@@ -89,6 +90,20 @@ public class User {
   @UpdateTimestamp
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt;
+
+  /**
+   * Optimistic-locking guard (issue #61). Concurrent full-entity edits of the same user (e.g. an
+   * admin enable/disable racing a password reset) are rejected instead of silently losing one
+   * another. The security-critical single-field writes — {@code password_invalidated_before} and
+   * {@code password_hash} — go through atomic, version-bumping {@code UPDATE}s in {@link
+   * io.qnop.repository.UserRepository} so a token revocation can never be clobbered by a stale
+   * write; {@code last_login_at} is updated atomically too (best-effort, no version bump). The
+   * backing column ({@code version BIGINT NOT NULL DEFAULT 0}) is defined in Liquibase on {@code
+   * qnop_user} (migration 0001).
+   */
+  @Version
+  @Column(name = "version", nullable = false)
+  private long version;
 
   protected User() {
     // for JPA
@@ -205,6 +220,11 @@ public class User {
 
   public Instant getUpdatedAt() {
     return updatedAt;
+  }
+
+  /** The optimistic-locking version; managed by Hibernate (no setter). */
+  public long getVersion() {
+    return version;
   }
 
   @Override

--- a/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
@@ -22,9 +22,13 @@ package io.qnop.repository;
 
 import io.qnop.entity.User;
 import io.qnop.entity.UserSource;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Data access for {@link User}. */
 public interface UserRepository extends JpaRepository<User, UUID> {
@@ -36,4 +40,32 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByUsernameAndSource(String username, UserSource source);
 
   boolean existsByEmailIgnoreCaseAndSource(String email, UserSource source);
+
+  /**
+   * Atomically stamps the last-login timestamp (issue #61) without a read-modify-write, so a login
+   * never clobbers a concurrent security write. Best-effort: it does not bump {@code version}, so a
+   * concurrent full-entity edit may overwrite the timestamp — harmless for a login marker.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE User u SET u.lastLoginAt = :at WHERE u.id = :id")
+  int touchLastLogin(@Param("id") UUID id, @Param("at") Instant at);
+
+  /**
+   * Atomically bumps {@code password_invalidated_before} (token revocation) and increments {@code
+   * version} (issue #61). The version bump makes any concurrently-loaded stale entity's later
+   * full-entity save fail optimistically rather than reverting the revocation.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "UPDATE User u SET u.passwordInvalidatedBefore = :at, u.version = u.version + 1"
+          + " WHERE u.id = :id")
+  int bumpPasswordInvalidatedBefore(@Param("id") UUID id, @Param("at") Instant at);
+
+  /**
+   * Atomically replaces the password hash and increments {@code version} (issue #61), so a password
+   * change cannot be lost to, or clobber, a concurrent edit.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE User u SET u.passwordHash = :hash, u.version = u.version + 1 WHERE u.id = :id")
+  int updatePasswordHash(@Param("id") UUID id, @Param("hash") String hash);
 }

--- a/qnop-core/src/main/java/io/qnop/service/AuthService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AuthService.java
@@ -94,8 +94,10 @@ public class AuthService {
     if (!passwordEncoder.matches(currentPassword, user.getPasswordHash())) {
       return ChangePasswordOutcome.WRONG_PASSWORD;
     }
-    user.setPasswordHash(passwordEncoder.encode(newPassword));
-    userRepository.save(user);
+    // Atomic, version-bumping updates (issue #61): the loaded `user` is read for verification only
+    // and never dirty-saved, so the hash change and the revocation below can't clobber each other
+    // or a concurrent edit.
+    userRepository.updatePasswordHash(userId, passwordEncoder.encode(newPassword));
     tokenRevocationService.revokeAllForUser(userId);
     refreshTokenService.revokeAllForUser(userId);
     return ChangePasswordOutcome.SUCCESS;

--- a/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
@@ -106,13 +106,10 @@ public class TokenRevocationService {
    */
   @Transactional
   public void revokeAllForUser(UUID userId) {
-    userRepository
-        .findById(userId)
-        .ifPresent(
-            user -> {
-              user.setPasswordInvalidatedBefore(Instant.now());
-              userRepository.save(user);
-            });
+    // Atomic, version-bumping UPDATE (issue #61): the revocation is always applied and cannot be
+    // reverted by a concurrent stale full-entity save of the same user. A no-op if the user is
+    // gone.
+    userRepository.bumpPasswordInvalidatedBefore(userId, Instant.now());
   }
 
   /**

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -87,12 +87,15 @@ public class UserService {
     return user;
   }
 
-  /** Records a successful-login timestamp (issue #21 OIDC login, and local login). */
+  /**
+   * Records a successful-login timestamp (issue #21 OIDC login, and local login). The write is an
+   * atomic {@code UPDATE} (issue #61) so it can never clobber a concurrent security write; the row
+   * is then re-read to return the fresh entity.
+   */
   @Transactional
   public User bumpLastLogin(UUID id, Instant at) {
-    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
-    user.setLastLoginAt(at);
-    return user;
+    users.touchLastLogin(id, at);
+    return users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
   }
 
   /** Provisions an enabled external (OIDC) user — no local credentials (issue #21). */

--- a/qnop-core/src/main/resources/db/changelog/migrations/0001-identity-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0001-identity-schema.yaml
@@ -56,6 +56,12 @@ databaseChangeLog:
                   name: updated_at
                   type: TIMESTAMP WITH TIME ZONE
                   constraints: { nullable: false }
+              # Optimistic-locking guard (issue #61): Hibernate @Version.
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints: { nullable: false }
         - sql:
             comment: Postgres-only CHECK + partial-unique constraints (not expressible in JPA).
             splitStatements: true

--- a/qnop-core/src/test/java/io/qnop/service/TokenRevocationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TokenRevocationServiceTest.java
@@ -23,6 +23,7 @@ package io.qnop.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -172,24 +173,19 @@ class TokenRevocationServiceTest {
   }
 
   @Test
-  @DisplayName("revokeAllForUser bumps passwordInvalidatedBefore and persists the user")
+  @DisplayName("revokeAllForUser atomically bumps passwordInvalidatedBefore")
   void revokeAllForUserBumpsTimestamp() {
-    User user = org.mockito.Mockito.mock(User.class);
-    when(users.findById(userId)).thenReturn(Optional.of(user));
-
     service.revokeAllForUser(userId);
 
-    verify(user).setPasswordInvalidatedBefore(any(Instant.class));
-    verify(users).save(user);
+    verify(users).bumpPasswordInvalidatedBefore(eq(userId), any(Instant.class));
   }
 
   @Test
-  @DisplayName("revokeAllForUser is a no-op when the user does not exist")
-  void revokeAllForUserNoopWhenUserMissing() {
-    when(users.findById(userId)).thenReturn(Optional.empty());
-
+  @DisplayName("revokeAllForUser uses an atomic update, not a read-modify-write (issue #61)")
+  void revokeAllForUserDoesNotReadModifyWrite() {
     service.revokeAllForUser(userId);
 
+    verify(users, never()).findById(any());
     verify(users, never()).save(any());
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #47 (which only covered `ApplicationSetting`). A JPA full-entity `save()` writes **every** column, so a high-frequency low-value `User` write — a login stamping `last_login_at` — could silently revert a concurrent **security** write — a token revocation bumping `password_invalidated_before`. **Part 1** fixes `User`; the single-use token guard (part 2) follows under the same issue.

## Strategy (ADR-0030: match the control to the write shape)

- **`@Version` on `User`** (column folded into the existing `0001` changeset — pre-production, no new migration) as the backstop for genuine multi-field edits (admin enable/disable, password reset): a concurrent conflict now fails loudly instead of losing an update.
- **Atomic, version-bumping `@Modifying` updates** for the security-critical single-field writes, eliminating the read-modify-write:
  - `bumpPasswordInvalidatedBefore` (revocation, `version + 1`) — always applied; the version bump makes a concurrent stale full save fail instead of reverting it.
  - `updatePasswordHash` (`version + 1`).
  - `touchLastLogin` — best-effort, **no** version bump, so logins never fail on contention.
- `TokenRevocationService.revokeAllForUser`, `AuthService.changePassword`, `UserService.bumpLastLogin` now use these atomic updates.

Config entities (OidcProvider/MailTemplate/UserSetting) are intentionally left as last-writer-wins (low impact) — documented in the ADR.

## Test plan

- [x] `TokenRevocationServiceTest` updated to the new atomic contract (unit, green).
- [x] `:qnop-core:build` + ArchUnit green.
- [ ] `UserConcurrencyIT` (Testcontainers, CI): `@Version` increments; an atomic revocation bumps the version and **cannot be reverted by a stale full-entity save**; `touchLastLogin` works.
- [ ] `AuthControllerIT` (CI): change-password flow unchanged end-to-end.

## Follow-up (part 2, #61)

Single-use token conditional consume: `UPDATE … SET consumed_at = now() WHERE id = ? AND consumed_at IS NULL` for `EmailVerificationToken` / `PasswordResetToken`.

Part of #61

🤖 Co-Author: Claude (Opus 4.x) via Claude Code