### PR TITLE
feat: atomic single-use guard for verification/reset tokens (part 2 of #61)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/auth/TokenConsumeGuardIT.java
+++ b/qnop-app/src/test/java/io/qnop/auth/TokenConsumeGuardIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.EmailVerificationToken;
+import io.qnop.entity.PasswordResetToken;
+import io.qnop.entity.User;
+import io.qnop.repository.EmailVerificationTokenRepository;
+import io.qnop.repository.PasswordResetTokenRepository;
+import io.qnop.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the single-use token guard (issue #61, ADR-0030): the conditional {@code UPDATE … WHERE
+ * consumed_at IS NULL} consumes a token at most once. The first call wins (1 row); a second
+ * concurrent call — the case that the old check-then-act {@code consume()} would have let through —
+ * affects 0 rows. Runs against a real PostgreSQL (Testcontainers); each test rolls back. Requires
+ * Docker.
+ */
+@Transactional
+class TokenConsumeGuardIT extends AbstractIntegrationTest {
+
+  @Autowired UserRepository users;
+  @Autowired EmailVerificationTokenRepository emailTokens;
+  @Autowired PasswordResetTokenRepository resetTokens;
+
+  private User newUser() {
+    return users.saveAndFlush(
+        User.internal("T", "t-" + UUID.randomUUID() + "@e.com", "u-" + UUID.randomUUID(), "h"));
+  }
+
+  @Test
+  void emailVerificationTokenIsConsumedAtMostOnce() {
+    User user = newUser();
+    UUID id =
+        emailTokens
+            .saveAndFlush(
+                new EmailVerificationToken(user, "ev-hash", Instant.now().plusSeconds(3600)))
+            .getId();
+
+    assertThat(emailTokens.markConsumed(id, Instant.now())).isEqualTo(1);
+    assertThat(emailTokens.markConsumed(id, Instant.now())).isZero();
+  }
+
+  @Test
+  void passwordResetTokenIsConsumedAtMostOnce() {
+    User user = newUser();
+    UUID id =
+        resetTokens
+            .saveAndFlush(new PasswordResetToken(user, "pr-hash", Instant.now().plusSeconds(3600)))
+            .getId();
+
+    assertThat(resetTokens.markConsumed(id, Instant.now())).isEqualTo(1);
+    assertThat(resetTokens.markConsumed(id, Instant.now())).isZero();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/EmailVerificationTokenRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/EmailVerificationTokenRepository.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -43,6 +44,16 @@ public interface EmailVerificationTokenRepository
   @Query(
       "SELECT t FROM EmailVerificationToken t WHERE t.user.id = :userId AND t.consumedAt IS NULL")
   List<EmailVerificationToken> findUnconsumedTokensForUser(@Param("userId") UUID userId);
+
+  /**
+   * Atomically consumes a token (issue #61): sets {@code consumed_at} only if it is still null.
+   * Returns 1 if this call won the race, 0 if the token was already consumed — so a verification
+   * token cannot be consumed twice under concurrency.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "UPDATE EmailVerificationToken t SET t.consumedAt = :at WHERE t.id = :id AND t.consumedAt IS NULL")
+  int markConsumed(@Param("id") UUID id, @Param("at") Instant at);
 
   /** Scheduled-sweep target: rows whose {@code expires_at} has passed. */
   long deleteByExpiresAtBefore(Instant cutoff);

--- a/qnop-core/src/main/java/io/qnop/repository/PasswordResetTokenRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/PasswordResetTokenRepository.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -41,6 +42,16 @@ public interface PasswordResetTokenRepository extends JpaRepository<PasswordRese
    */
   @Query("SELECT t FROM PasswordResetToken t WHERE t.user.id = :userId AND t.consumedAt IS NULL")
   List<PasswordResetToken> findUnconsumedTokensForUser(@Param("userId") UUID userId);
+
+  /**
+   * Atomically consumes a token (issue #61): sets {@code consumed_at} only if it is still null.
+   * Returns 1 if this call won the race, 0 if already consumed — so a reset token cannot be
+   * replayed under concurrency.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "UPDATE PasswordResetToken t SET t.consumedAt = :at WHERE t.id = :id AND t.consumedAt IS NULL")
+  int markConsumed(@Param("id") UUID id, @Param("at") Instant at);
 
   /** Scheduled-sweep target: rows whose {@code expires_at} has passed. */
   long deleteByExpiresAtBefore(Instant cutoff);

--- a/qnop-core/src/main/java/io/qnop/service/auth/EmailVerificationTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/EmailVerificationTokenService.java
@@ -82,8 +82,12 @@ public class EmailVerificationTokenService {
     if (token.getExpiresAt().isBefore(Instant.now())) {
       throw new InvalidVerificationTokenException("Verification token has expired");
     }
-    token.setConsumedAt(Instant.now());
-    return token.getUser();
+    User user = token.getUser(); // resolve before the atomic update clears the persistence context
+    // Atomic single-use guard (issue #61): only one concurrent caller flips consumed_at from null.
+    if (tokens.markConsumed(token.getId(), Instant.now()) == 0) {
+      throw new InvalidVerificationTokenException("Verification token already used");
+    }
+    return user;
   }
 
   /** Daily off-peak purge of expired rows so the table does not grow unbounded. */

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetTokenService.java
@@ -85,8 +85,12 @@ public class PasswordResetTokenService {
     if (token.getExpiresAt().isBefore(Instant.now())) {
       throw new InvalidPasswordResetTokenException("Reset token has expired");
     }
-    token.setConsumedAt(Instant.now());
-    return token.getUser();
+    User user = token.getUser(); // resolve before the atomic update clears the persistence context
+    // Atomic single-use guard (issue #61): only one concurrent caller flips consumed_at from null.
+    if (tokens.markConsumed(token.getId(), Instant.now()) == 0) {
+      throw new InvalidPasswordResetTokenException("Reset token already used");
+    }
+    return user;
   }
 
   @Scheduled(cron = "0 35 3 * * *")

--- a/qnop-core/src/test/java/io/qnop/service/auth/EmailVerificationTokenServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/auth/EmailVerificationTokenServiceTest.java
@@ -82,11 +82,24 @@ class EmailVerificationTokenServiceTest {
     EmailVerificationToken token =
         new EmailVerificationToken(user, "h", Instant.now().plusSeconds(60));
     when(tokens.findByTokenHash(any())).thenReturn(Optional.of(token));
+    when(tokens.markConsumed(any(), any())).thenReturn(1);
 
     User result = service.consume("raw-token");
 
     assertThat(result).isSameAs(user);
-    assertThat(token.getConsumedAt()).isNotNull();
+    verify(tokens).markConsumed(any(), any(Instant.class));
+  }
+
+  @Test
+  @DisplayName("consume rejects a token consumed concurrently (atomic guard, issue #61)")
+  void consumeLosesRace() {
+    EmailVerificationToken token =
+        new EmailVerificationToken(user, "h", Instant.now().plusSeconds(60));
+    when(tokens.findByTokenHash(any())).thenReturn(Optional.of(token));
+    when(tokens.markConsumed(any(), any())).thenReturn(0); // another request already won
+
+    assertThatThrownBy(() -> service.consume("raw-token"))
+        .isInstanceOf(InvalidVerificationTokenException.class);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Part 2 of #61 (completes it). `EmailVerificationTokenService` / `PasswordResetTokenService` consumed tokens with a **check-then-act** (`if (consumedAt != null) reject;` then `setConsumedAt(now)`), so two concurrent requests with the same token could both pass the null-check and both succeed — a double-consume / password-reset replay.

## Change (ADR-0030)

Replace the read-modify-write with a **conditional atomic update**:

```sql
UPDATE … SET consumed_at = :at WHERE id = :id AND consumed_at IS NULL
```

and check the affected-row count — only one caller flips the column, so a token is consumed **at most once**.

- `EmailVerificationTokenRepository.markConsumed` / `PasswordResetTokenRepository.markConsumed`.
- Both `consume()` methods resolve the owner before the (clearing) update and reject when `markConsumed` affects 0 rows. The existing `consumedAt != null` / expiry / unknown pre-checks stay for clear error messages.

No schema change.

## Test plan

- [x] `EmailVerificationTokenServiceTest` updated to the atomic contract + a lost-race case (unit, green).
- [x] `:qnop-core:build` + ArchUnit green.
- [ ] `TokenConsumeGuardIT` (Testcontainers, CI): first `markConsumed` affects 1 row, a second affects 0 — for both token types.

Closes #61

🤖 Co-Author: Claude (Opus 4.x) via Claude Code