### PR TITLE
ci: override Renovate schedule so PRs are actually opened (#64)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>qnophq/.github"],
+  "comment:schedule": "Override the org preset's 'before 6am every weekday' window. This is a self-hosted single-repo instance whose cadence is already set by the weekday cron in .github/workflows/renovate.yml; the in-config window only fights GitHub's best-effort cron delay (the 04:00 UTC run actually fires ~09:00 UTC, outside the window), so every update sat in 'Awaiting Schedule' and no PR was ever opened. See issue #64.",
+  "schedule": ["at any time"],
   "packageRules": [
     {
       "description": "Spring Boot starters, BOM, security, and dependency-management plugin",


### PR DESCRIPTION
## Summary

Renovate runs successfully but **never opens PRs** — every update sits under *Awaiting Schedule* in the Dependency Dashboard (#36).

**Root cause:** the org preset (`qnophq/.github`) restricts PR creation to `"before 6am every weekday"` / `Europe/Berlin` (= before 04:00 UTC). The weekday cron is `0 4 * * 1-5` (04:00 UTC = 06:00 Berlin, already at the edge), and GitHub Actions delays scheduled runs by hours — actual runs start ~09:00 UTC (~11:00 Berlin), far outside the window. Renovate honors its in-config `schedule` regardless of when the job fires, so all updates defer indefinitely.

**Fix:** this is a self-hosted single-repo instance whose cadence is already controlled by the weekday cron in `.github/workflows/renovate.yml`, so the in-config schedule window is redundant and only fights GitHub's cron delay. Override it:

```json
"schedule": ["at any time"]
```

`prHourlyLimit: 2` / `prConcurrentLimit: 5` from the preset are unchanged and continue to throttle the backlog gracefully.

## Test plan

- [x] `renovate.json` is valid JSON
- [ ] After merge: the next Renovate run opens PRs instead of parking them under *Awaiting Schedule* (also force-unblocked now via the dashboard #36 checkboxes)

Closes #64.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code