### PR TITLE
chore: phase-1 review code-quality follow-ups (issue #50)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/architecture/ArchitectureRulesTest.java
+++ b/qnop-app/src/test/java/io/qnop/architecture/ArchitectureRulesTest.java
@@ -80,6 +80,9 @@ class ArchitectureRulesTest {
             // The published REST contract is used by the service (mapping) and web layers.
             .whereLayer("Api")
             .mayOnlyBeAccessedByLayers("Service", "Web")
+            // Some access checks here are legitimately empty (e.g. Web is accessed by no
+            // layer), so keep the allowance on the layered rule; the purity rules below no
+            // longer need it now that their packages are populated (issue #50, L-8).
             .allowEmptyShould(true);
 
     rule.check(QNOP_CLASSES);
@@ -104,6 +107,8 @@ class ArchitectureRulesTest {
                 "io.qnop.repository..",
                 "io.qnop.service..",
                 "io.qnop.web..")
+            // qnop-spi is still package-info only in Community; keep the empty-should
+            // allowance here until the first published SPI interface lands.
             .allowEmptyShould(true);
 
     rule.check(QNOP_CLASSES);
@@ -129,8 +134,7 @@ class ArchitectureRulesTest {
                 "io.qnop.entity..",
                 "io.qnop.repository..",
                 "io.qnop.service..",
-                "io.qnop.web..")
-            .allowEmptyShould(true);
+                "io.qnop.web..");
 
     rule.check(QNOP_CLASSES);
   }
@@ -151,8 +155,7 @@ class ArchitectureRulesTest {
                 "io.qnop.service..",
                 "io.qnop.repository..",
                 "io.qnop.entity..",
-                "io.qnop.api..")
-            .allowEmptyShould(true);
+                "io.qnop.api..");
 
     rule.check(QNOP_CLASSES);
   }

--- a/qnop-core/src/main/java/io/qnop/entity/ApplicationAsset.java
+++ b/qnop-core/src/main/java/io/qnop/entity/ApplicationAsset.java
@@ -94,7 +94,7 @@ public class ApplicationAsset {
     ApplicationAsset asset = new ApplicationAsset();
     asset.slot = slot;
     asset.contentType = contentType;
-    asset.content = content;
+    asset.content = content == null ? null : content.clone();
     asset.sha256 = sha256;
     asset.sizeBytes = sizeBytes;
     asset.uploadedBy = uploadedBy;
@@ -121,12 +121,16 @@ public class ApplicationAsset {
     this.contentType = contentType;
   }
 
+  /**
+   * Returns a defensive copy so the stored bytes (and their {@code sha256}/{@code size}) stay
+   * intact.
+   */
   public byte[] getContent() {
-    return content;
+    return content == null ? null : content.clone();
   }
 
   public void setContent(byte[] content) {
-    this.content = content;
+    this.content = content == null ? null : content.clone();
   }
 
   public String getSha256() {

--- a/qnop-core/src/main/java/io/qnop/entity/EncryptedStringConverter.java
+++ b/qnop-core/src/main/java/io/qnop/entity/EncryptedStringConverter.java
@@ -45,11 +45,18 @@ public class EncryptedStringConverter implements AttributeConverter<String, Stri
 
   @Override
   public String convertToDatabaseColumn(String attribute) {
-    return attribute == null ? null : encryptor.encrypt(attribute);
+    // Keep null and empty distinct and unencrypted; only real secrets are encrypted.
+    if (attribute == null || attribute.isEmpty()) {
+      return attribute;
+    }
+    return encryptor.encrypt(attribute);
   }
 
   @Override
   public String convertToEntityAttribute(String dbData) {
-    return dbData == null ? null : encryptor.decrypt(dbData);
+    if (dbData == null || dbData.isEmpty()) {
+      return dbData;
+    }
+    return encryptor.decrypt(dbData);
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/RefreshTokenHasher.java
+++ b/qnop-core/src/main/java/io/qnop/service/RefreshTokenHasher.java
@@ -52,12 +52,7 @@ public class RefreshTokenHasher {
       Mac mac = Mac.getInstance(HMAC_ALGORITHM);
       mac.init(key);
       byte[] digest = mac.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
-      StringBuilder hex = new StringBuilder(digest.length * 2);
-      for (byte b : digest) {
-        hex.append(Character.forDigit((b >> 4) & 0xF, 16));
-        hex.append(Character.forDigit(b & 0xF, 16));
-      }
-      return hex.toString();
+      return java.util.HexFormat.of().formatHex(digest);
     } catch (NoSuchAlgorithmException | InvalidKeyException e) {
       throw new IllegalStateException("Unable to compute refresh-token lookup hash", e);
     }

--- a/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
@@ -58,7 +58,7 @@ public class RefreshTokenService {
   private final RefreshTokenRepository repository;
   private final RefreshTokenHasher hasher;
   private final QnopProperties properties;
-  private final SecureRandom secureRandom = new SecureRandom();
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   public RefreshTokenService(
       RefreshTokenRepository repository, RefreshTokenHasher hasher, QnopProperties properties) {
@@ -136,7 +136,7 @@ public class RefreshTokenService {
 
   private String generatePlaintext() {
     byte[] bytes = new byte[TOKEN_BYTES];
-    secureRandom.nextBytes(bytes);
+    SECURE_RANDOM.nextBytes(bytes);
     return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
@@ -128,12 +128,7 @@ public class TokenRevocationService {
     try {
       byte[] digest =
           MessageDigest.getInstance("SHA-256").digest(jti.getBytes(StandardCharsets.UTF_8));
-      StringBuilder hex = new StringBuilder(digest.length * 2);
-      for (byte b : digest) {
-        hex.append(Character.forDigit((b >> 4) & 0xF, 16));
-        hex.append(Character.forDigit(b & 0xF, 16));
-      }
-      return hex.toString();
+      return java.util.HexFormat.of().formatHex(digest);
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException("SHA-256 not available", e);
     }

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -29,3 +29,6 @@ databaseChangeLog:
   - include:
       file: migrations/0006-shedlock-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0007-review-hardening.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0007-review-hardening.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0007-review-hardening.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Phase-1 review follow-ups (issue #50): tighten two existing tables. These are
+# Postgres-only invariants (partial-unique index, CHECK) and live in Liquibase,
+# not JPA annotations (ADR-0020).
+databaseChangeLog:
+  - changeSet:
+      id: 0007-refresh-token-rotated-to-unique
+      author: qnop
+      comment: A refresh token is rotated into at most one successor (issue #50, L-9).
+      changes:
+        - sql:
+            comment: |
+              Partial-unique index so rotated_to_id links predecessor→successor 1:1;
+              NULLs (un-rotated tokens) stay unconstrained.
+            sql: |
+              CREATE UNIQUE INDEX ux_refresh_token_rotated_to
+                ON refresh_token (rotated_to_id) WHERE rotated_to_id IS NOT NULL;
+
+  - changeSet:
+      id: 0007-mail-template-locale-lowercase
+      author: qnop
+      comment: Store mail_template.locale lowercase so (template_key, locale) cannot collide on case (issue #50, L-9).
+      changes:
+        - sql:
+            comment: Enforce a lowercase locale; the seeded rows are already 'en'.
+            sql: |
+              ALTER TABLE mail_template ADD CONSTRAINT ck_mail_template_locale_lowercase
+                CHECK (locale = lower(locale));


### PR DESCRIPTION
Closes #50 (the actionable subset; remaining items deferred with rationale below).

## Done
- **L-1** — `ApplicationAsset.getContent()/setContent()/create()` defensively copy the `byte[]` (`clone()`), so the stored bytes and their `sha256`/`size` can't be mutated through the entity.
- **L-5** — `TokenRevocationService` and `RefreshTokenHasher` use `HexFormat.of().formatHex(...)` instead of a duplicated manual hex loop (behaviour-preserving lowercase hex — the lookup hashes are unchanged).
- **L-7** — `RefreshTokenService`'s `SecureRandom` is `static final`.
- **L-8** — dropped ArchUnit `allowEmptyShould(true)` from `restApiModelStaysPure` and `securityFoundationStaysPure` (their packages are now populated, so emptiness would be a real bug). Kept it on `pluginContractStaysPure` (`io.qnop.spi` is still package-info only) and on the layered rule (some access checks — e.g. "Web accessed by no layer" — are legitimately empty).
- **L-9** — migration `0007`: partial-unique index `ux_refresh_token_rotated_to` (a token rotates into at most one successor) and a `CHECK (locale = lower(locale))` on `mail_template`.
- **L-10** — `EncryptedStringConverter` keeps `null` and `""` distinct and unencrypted; only real secrets are encrypted.

## Deferred (rationale)
- **L-2** — `TokenRevocationService`'s `@Transactional`/`readOnly` annotations are already consistent (write methods plain, the one read method `readOnly=true`); no change needed.
- **L-3/L-4** — the `@Lazy` cycle-break is functional and already documented; swapping to `ObjectProvider` + `@PreDestroy` is a stylistic preference for a LOW item that would churn the mail subsystem and its unit test for no behavioural gain. Left for a focused follow-up if desired.
- **L-11** (HKDF salt deployment hardening) and the larger **L-12** items (filter-chain diagram, blanket `@ConditionalOnMissingBean` on Community beans, OIDC discovery circuit-breaker) are marked future/broader and out of scope for this roundup.

## Test plan
- [x] `:qnop-core:build` (hex behaviour preserved), `:qnop-app` compile, Spotless + SPDX, ArchUnit (incl. the tightened purity rules) — green locally
- [ ] Migration `0007` applies cleanly — verified by the full Testcontainers suite in **CI** (no local Docker)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code