### PR TITLE
ci: pass App secrets to Renovate via secrets: inherit (#67)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -32,9 +32,16 @@ jobs:
     uses: qnophq/.github/.github/workflows/renovate.yml@94c4381a80ff3297b4017be99f49bb9193f778d1 # main
     # Permissions belong on the calling job, not on the reusable workflow.
     # The reusable workflow inherits these for the duration of the call.
+    # (Renovate now authenticates as a GitHub App, so these GITHUB_TOKEN
+    # scopes are no longer what opens PRs — see ADR-0017 amendment — but
+    # they stay accurate for any GITHUB_TOKEN-based steps.)
     permissions:
       contents: write       # branch + push
       pull-requests: write  # open + label PRs
       issues: write         # update Dependency Dashboard issue
+    # Pass this repo's RENOVATE_APP_ID + RENOVATE_APP_PRIVATE_KEY secrets to
+    # the reusable workflow, which mints the App installation token Renovate
+    # runs as (ADR-0017 amendment, issue #67).
+    secrets: inherit
     with:
       logLevel: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   renovate:
     # Pinned to a qnophq/.github commit SHA; Renovate keeps it current.
-    uses: qnophq/.github/.github/workflows/renovate.yml@94c4381a80ff3297b4017be99f49bb9193f778d1 # main
+    uses: qnophq/.github/.github/workflows/renovate.yml@e5ad31decb2f27b41d76ad27eafe1170087fcf67 # main
     # Permissions belong on the calling job, not on the reusable workflow.
     # The reusable workflow inherits these for the duration of the call.
     # (Renovate now authenticates as a GitHub App, so these GITHUB_TOKEN

--- a/docs/adr/0017-renovate-dependency-automation.md
+++ b/docs/adr/0017-renovate-dependency-automation.md
@@ -1,6 +1,6 @@
 # ADR-0017: Dependency automation via self-hosted Renovate and an org-wide preset
 
-- **Status:** Accepted
+- **Status:** Accepted (amended 2026-06-17 — see [Amendment](#amendment-2026-06-17-github-app-token-model))
 - **Date:** 2026-06-14
 - **Deciders:** bigpuritz, devtank42 (with Claude)
 
@@ -18,7 +18,7 @@ Run **our own Renovate** via GitHub Actions, configured through an **org-wide pr
 
 1. **Org preset** lives in the public repo **`qnophq/.github`** as `default.json`. Repos opt in with `extends: ["github>qnophq/.github"]`. It sets: weekday-morning schedule (Europe/Berlin), dependency dashboard, GitHub Actions + Docker **digest pinning**, grouped minor/patch updates, per-package major-update PRs, and exact npm version pinning (we ship applications, not libraries).
 2. **Reusable workflow** in `qnophq/.github/.github/workflows/renovate.yml` runs `renovatebot/github-action` (SHA-pinned). Consumer repos add a short stub (`.github/workflows/renovate.yml`) that wires their cron + permissions and calls it. This is the "own/self-hosted instance" — no Mend app.
-3. **Single-repo token model.** Each run uses the caller's repo-scoped `GITHUB_TOKEN` (`RENOVATE_REPOSITORIES = github.repository`). No PAT, no cross-repo write access.
+3. **Single-repo token model.** Each run uses the caller's repo-scoped `GITHUB_TOKEN` (`RENOVATE_REPOSITORIES = github.repository`). No PAT, no cross-repo write access. _(Superseded 2026-06-17 — Renovate now authenticates as a GitHub App; see the [Amendment](#amendment-2026-06-17-github-app-token-model). Still single-repo: the installation token is scoped to the calling repo.)_
 4. **Repo-specific rules** for qnop live in `qnophq/qnop/.github/renovate.json`, which extends the org preset and adds Gradle/frontend package groupings.
 5. A **`renovate-config-validator`** workflow in `qnophq/.github` fails the build if `default.json` is syntactically broken, so a bad org preset cannot silently disable updates org-wide.
 
@@ -36,3 +36,22 @@ Run **our own Renovate** via GitHub Actions, configured through an **org-wide pr
 - **Mend-hosted Renovate App.** Zero maintenance, but grants a third-party SaaS write access across the org and moves config out of our control. Rejected for an open-core project that will host a private commercial repo in the same org.
 - **Dependabot.** Native and simple, but weaker grouping/scheduling, no shared org preset of this richness, and no `gradle-wrapper`/`docker-compose` parity with what we want.
 - **Per-repo Renovate config with no org preset.** Duplicates policy across repos and drifts. Rejected in favor of `extends: github>qnophq/.github`.
+
+## Amendment (2026-06-17): GitHub App token model
+
+**Supersedes decision point 3 (single-repo `GITHUB_TOKEN`).**
+
+The original `GITHUB_TOKEN` model could push branches but **never opened PRs** (issue #67). Two reasons:
+
+1. The `qnophq` org enforces **"Allow GitHub Actions to create and approve pull requests = OFF"**, so `GITHUB_TOKEN` gets a 403 on `POST /pulls`. The repo-level toggle returns 409 — it cannot override the org policy.
+2. Even with that enabled, PRs created by `GITHUB_TOKEN` do **not** trigger `pull_request` workflows (GitHub's anti-recursion rule), so Renovate PRs would carry no CI/CLA checks and be un-mergeable under the working rules (ADR-0008).
+
+**Decision:** Renovate authenticates as an **org-installed GitHub App**. The reusable workflow mints a short-lived installation token via `actions/create-github-app-token` (SHA-pinned) and passes it to `renovatebot/github-action`. Each consumer repo:
+
+- installs the App (repository permissions: Contents, Pull requests, Issues, **Workflows** — the last is needed because Renovate edits `.github/workflows/*` to bump pinned action digests);
+- stores `RENOVATE_APP_ID` + `RENOVATE_APP_PRIVATE_KEY` as **repository** secrets (or an org secret scoped to *selected* private repos — never "All repositories", to keep the key off public org repos like `qnophq/.github`);
+- adds `secrets: inherit` to its caller stub so the secrets reach the reusable workflow.
+
+An App installation token is a distinct identity: it is not bound by the Actions-can't-create-PRs policy, and its PRs trigger consumer CI normally. The model stays **single-repo** — the installation token is scoped to the calling repo, preserving the "own/self-hosted instance, no cross-repo write" property. We still avoid the Mend-hosted SaaS App; this is our own App under org control.
+
+**Consequence:** onboarding a new repo to Renovate now also requires installing the App and adding the two secrets, not just the workflow stub. The trade-off buys working PRs *with* CI, which the `GITHUB_TOKEN` model could not provide.


### PR DESCRIPTION
## Summary

Consumer-side half of the Renovate GitHub App switch (issue #67). Pairs with **qnophq/.github#1** (the reusable-workflow change that mints and uses the App token).

- **`.github/workflows/renovate.yml`** — add `secrets: inherit` so this repo's `RENOVATE_APP_ID` + `RENOVATE_APP_PRIVATE_KEY` reach the reusable workflow, which mints the App installation token Renovate runs as. (The `permissions:` block stays — it's still accurate for any `GITHUB_TOKEN` steps.)
- **`docs/adr/0017-renovate-dependency-automation.md`** — amend: supersede decision point 3 (single-repo `GITHUB_TOKEN`) with the GitHub App token model, recording *why* (org forbids Actions from creating PRs; `GITHUB_TOKEN` PRs don't trigger consumer CI).

## Sequencing / rollout

1. Merge **qnophq/.github#1** first.
2. Install the Renovate App on `qnop` and add the two **repository** secrets (org-admin / repo-admin — not code).
3. Merge this PR.
4. Bump the `uses:` SHA in this stub to the post-merge `qnophq/.github` main commit (or let the next Renovate run pin it) so the App-token version of the reusable workflow is actually called.
5. `gh workflow run renovate.yml` → Renovate opens PRs for the already-pushed `renovate/*` branches, and their CI runs.

> Note: this PR is safe to merge before step 4 — until the SHA is bumped, the old reusable workflow simply ignores the inherited secrets. Activation happens at step 4.

Part of #67.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code