### PR TITLE
fix: drop invalid comment:schedule key from renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>qnophq/.github"],
-  "comment:schedule": "Override the org preset's 'before 6am every weekday' window. This is a self-hosted single-repo instance whose cadence is already set by the weekday cron in .github/workflows/renovate.yml; the in-config window only fights GitHub's best-effort cron delay (the 04:00 UTC run actually fires ~09:00 UTC, outside the window), so every update sat in 'Awaiting Schedule' and no PR was ever opened. See issue #64.",
   "schedule": ["at any time"],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

With the GitHub App token now working (qnophq/.github#1, #68), the Renovate run surfaced a config error that was previously masked:

```
Invalid configuration option: comment:schedule
WARN: Repository has invalid config → result: config-validation
```

`comment:schedule` was added in #65 as an inline rationale for the `schedule` override, but `renovate.json` has no support for arbitrary comment keys — Renovate treats it as an invalid option and **aborts the entire repository** (no extraction, no PRs).

Remove the key; keep `"schedule": ["at any time"]`. The rationale already lives in #64 and the ADR-0017 amendment.

## Test plan

- [x] `renovate.json` is valid JSON
- [ ] After merge: `gh workflow run renovate.yml` → Renovate extracts deps and opens PRs (no config-validation abort)

Refs #64, #67.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code