### PR TITLE
ci: raise Renovate prHourlyLimit to 10

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>qnophq/.github"],
   "schedule": ["at any time"],
+  "prHourlyLimit": 10,
   "packageRules": [
     {
       "description": "Spring Boot starters, BOM, security, and dependency-management plugin",


### PR DESCRIPTION
## Summary

The org preset (`qnophq/.github`) sets `prHourlyLimit: 2`, so the ~18-group Renovate backlog surfaces only 2 PRs per run. Override it to **10** for this repo to drain the initial backlog in a couple of runs.

> Note: the org preset's `prConcurrentLimit: 5` still caps simultaneously-open PRs, so PRs continue to flow as earlier ones merge. Say the word if you also want that raised.

## Test plan

- [x] `renovate.json` is valid JSON
- [ ] Next `gh workflow run renovate.yml` opens up to 10 PRs (bounded by prConcurrentLimit: 5 open at a time)

Follow-up to #67.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code