### PR TITLE
fix: ignore generated files in Prettier (unblock Renovate npm PRs) (#80)

### DIFF
--- a/qnop-ui/.prettierignore
+++ b/qnop-ui/.prettierignore
@@ -1,0 +1,8 @@
+# Generated files — not source, must not be reformatted by Prettier.
+# The package manager owns the lockfile's format; running it through
+# `prettier --check` breaks CI whenever the lockfile is regenerated
+# (e.g. on every Renovate dependency update). See issue #80.
+pnpm-lock.yaml
+
+# Build output
+dist


### PR DESCRIPTION
## Summary

All open Renovate **npm** PRs (#75–#79) are red: the Frontend job's `pnpm format:check` (`prettier --check .`) lints the tracked `pnpm-lock.yaml`, which has no `.prettierignore`. The committed lock passes on `main`, but pnpm regenerates it in its own (non-Prettier) format on every dependency update — so every npm update fails.

Add `qnop-ui/.prettierignore` excluding generated files:
- `pnpm-lock.yaml` — package-manager-owned, must not be reformatted
- `dist` — Vite build output

This is a pre-existing repo misconfiguration surfaced by Renovate; the fix is correct independent of Renovate.

## Rollout

After merge, Renovate auto-rebases its open npm PRs onto the new base; their `format:check` then passes. (I'll trigger a run to speed it up.)

## Test plan

- [x] `.prettierignore` valid
- [ ] After merge + rebase: #75–#79 Frontend job goes green

Closes #80. Refs #67.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code