### PR TITLE
chore: guard qnop-ui against non-pnpm installs (#95)

### DIFF
--- a/qnop-ui/package.json
+++ b/qnop-ui/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@11.8.0",
   "scripts": {
+    "preinstall": "npx only-allow pnpm",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

`qnop-ui` is pnpm-only (`"packageManager": "pnpm@11.6.0"`, only `pnpm-lock.yaml`, CI uses `pnpm install --frozen-lockfile`). Running `npm install` ignores the pnpm lockfile and builds a divergent tree — on npm 11 it crashes with a cryptic `Cannot read properties of null (reading 'matches')`.

Add a `preinstall` guard:

```json
"preinstall": "npx only-allow pnpm"
```

`only-allow` detects the package manager via `npm_config_user_agent` and exits non-zero with a clear message for npm/yarn/bun, passing for pnpm.

## Notes

- Scripts don't affect the lockfile, so `pnpm-lock.yaml` is unchanged and `pnpm install --frozen-lockfile` still passes — CI also exercises the guard under pnpm.
- Caveat: the specific npm-11 crash happens in `buildIdealTree` before lifecycle scripts run, so this mainly catches successful-but-wrong installs and yarn/bun. The repo being pnpm-only remains the primary safeguard.

## Test plan

- [x] `package.json` valid JSON
- [ ] CI: `pnpm install --frozen-lockfile` runs the preinstall under pnpm and passes

Closes #95.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code