### PR TITLE
feat: GET /users/me profile endpoint + wire /config self-registration

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -38,6 +38,10 @@ tags:
   - name: UserSettings
     description: |
       The authenticated user's own per-user settings (issue #22).
+  - name: Users
+    description: |
+      The authenticated user's own profile — identity, global role and account
+      source — used by the SPA to render the shell and gate role-based UI (#99).
 paths:
   /config:
     get:
@@ -853,6 +857,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /users/me:
+    get:
+      tags:
+        - Users
+      summary: Get the current user's profile
+      description: |
+        Returns the authenticated user's identity, global role and account source.
+        The SPA calls this right after login to render the shell and gate
+        role-based UI. Requires a user (JWT) principal; non-user principals are
+        rejected with 403.
+      operationId: getCurrentUser
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The current user's profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CurrentUserResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /users/me/settings:
     get:
       tags:
@@ -1356,6 +1384,48 @@ components:
           description: Map of setting key to new value.
       required:
         - values
+    UserRole:
+      type: string
+      description: |
+        A user's global system role — exactly one per user (issue #98). `ADMIN`
+        administers the system; `MEMBER` is the standard user; `AUDITOR` has
+        organisation-wide read access to the audit trail and compliance.
+      enum:
+        - ADMIN
+        - MEMBER
+        - AUDITOR
+    UserSource:
+      type: string
+      description: |
+        How the account authenticates: `INTERNAL` (local username + password) or
+        `EXTERNAL` (provisioned from an OIDC/OAuth2 provider).
+      enum:
+        - INTERNAL
+        - EXTERNAL
+    CurrentUserResponse:
+      type: object
+      description: The authenticated user's own profile.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The user's stable id.
+        displayName:
+          type: string
+          description: Human-readable name shown in the UI.
+        email:
+          type: string
+          description: The user's email address.
+        role:
+          $ref: '#/components/schemas/UserRole'
+        source:
+          $ref: '#/components/schemas/UserSource'
+      required:
+        - id
+        - displayName
+        - email
+        - role
+        - source
     RegisterRequest:
       type: object
       description: Self-registration details for a new local account.

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -28,6 +28,8 @@ import io.qnop.api.v1.model.ServerConfigGeneral;
 import io.qnop.api.v1.model.ServerConfigResponse;
 import io.qnop.api.v1.model.ServerConfigUpload;
 import io.qnop.api.v1.model.SupportedFormat;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.oidc.OidcProviderService;
 import io.qnop.service.oidc.OidcProviderView;
 import java.util.List;
@@ -39,11 +41,11 @@ import org.springframework.web.bind.annotation.RestController;
  * Public server configuration endpoint ({@code GET /api/v1/config}), implementing the generated
  * {@link ServerConfigApi} contract (ADR-0015, ADR-0021).
  *
- * <p><strong>Placeholder values (issue #9).</strong> This endpoint proves the OpenAPI-first
+ * <p><strong>Partly placeholder (issue #9/#99).</strong> This endpoint proves the OpenAPI-first
  * toolchain end-to-end: a hand-written {@code @RestController} implements a generated interface and
- * returns a generated DTO. The values are static for now; later issues wire the real sources —
- * {@code edition} from the {@code EditionResolver} SPI (ADR-0012), {@code general}/{@code upload}
- * from application settings (#16), and {@code auth.oidcProviders} from the OIDC registry (#21).
+ * returns a generated DTO. {@code auth.oidcProviders} comes from the OIDC registry (#21) and {@code
+ * auth.selfRegistrationEnabled} from application settings (#99); {@code edition} ({@code
+ * EditionResolver} SPI, ADR-0012) and {@code general}/{@code upload} (#16) are still static.
  */
 @RestController
 public class ConfigController implements ServerConfigApi {
@@ -55,9 +57,11 @@ public class ConfigController implements ServerConfigApi {
   private static final String UNKNOWN_VERSION = "unknown";
 
   private final OidcProviderService oidcProviders;
+  private final ApplicationSettingsService settings;
 
-  public ConfigController(OidcProviderService oidcProviders) {
+  public ConfigController(OidcProviderService oidcProviders, ApplicationSettingsService settings) {
     this.oidcProviders = oidcProviders;
+    this.settings = settings;
   }
 
   @Override
@@ -70,7 +74,8 @@ public class ConfigController implements ServerConfigApi {
             .auth(
                 new ServerConfigAuth()
                     .oidcProviders(enabledOidcProviders())
-                    .selfRegistrationEnabled(false))
+                    .selfRegistrationEnabled(
+                        settings.getBoolean(ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED)))
             .upload(new ServerConfigUpload().maxDocumentSizeMb(DEFAULT_MAX_DOCUMENT_SIZE_MB))
             .supportedFormats(
                 List.of(SupportedFormat.PDF, SupportedFormat.DOCX, SupportedFormat.MD));

--- a/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.UsersApi;
+import io.qnop.api.v1.model.CurrentUserResponse;
+import io.qnop.api.v1.model.UserRole;
+import io.qnop.api.v1.model.UserSource;
+import io.qnop.service.UserService;
+import io.qnop.service.UserService.UserProfileView;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The authenticated user's own profile ({@code GET /api/v1/users/me}), implementing the generated
+ * {@link UsersApi} contract (issue #99). The acting user is the JWT subject ({@link CurrentUser});
+ * non-user (API-key) principals are rejected with 403. The service returns an entity-free {@link
+ * UserProfileView}, mapped here to the API DTO (ADR-0004).
+ */
+@RestController
+public class CurrentUserController implements UsersApi {
+
+  private final UserService users;
+
+  public CurrentUserController(UserService users) {
+    this.users = users;
+  }
+
+  @Override
+  public ResponseEntity<CurrentUserResponse> getCurrentUser() {
+    UserProfileView profile = users.getProfile(CurrentUser.requireUserId());
+    return ResponseEntity.ok(
+        new CurrentUserResponse()
+            .id(profile.id())
+            .displayName(profile.displayName())
+            .email(profile.email())
+            .role(UserRole.fromValue(profile.role()))
+            .source(UserSource.fromValue(profile.source())));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
@@ -191,6 +191,25 @@ class AuthControllerIT extends AbstractIntegrationTest {
         .andExpect(status().isForbidden());
   }
 
+  @Test
+  void currentUserReturnsProfileForRealToken() throws Exception {
+    createUser("ivan", UserRole.AUDITOR);
+    String accessToken = loginAccessToken("ivan");
+
+    mockMvc
+        .perform(get("/api/v1/users/me").header("Authorization", "Bearer " + accessToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("ivan"))
+        .andExpect(jsonPath("$.email").value("ivan@example.com"))
+        .andExpect(jsonPath("$.role").value("AUDITOR"))
+        .andExpect(jsonPath("$.source").value("INTERNAL"));
+  }
+
+  @Test
+  void currentUserUnauthorizedForAnonymous() throws Exception {
+    mockMvc.perform(get("/api/v1/users/me")).andExpect(status().isUnauthorized());
+  }
+
   private User createUser(String username) {
     return createUser(username, UserRole.MEMBER);
   }

--- a/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
@@ -25,6 +25,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.oidc.OidcProviderService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,11 +54,14 @@ class ConfigControllerTest {
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean private OidcProviderService oidcProviders;
+  @MockitoBean private ApplicationSettingsService settings;
 
   @BeforeEach
   void setUp() {
     // No providers configured: auth.oidcProviders should serialize as an empty list.
     when(oidcProviders.findAll()).thenReturn(List.of());
+    when(settings.getBoolean(ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED))
+        .thenReturn(false);
   }
 
   @Test
@@ -73,6 +78,18 @@ class ConfigControllerTest {
         .andExpect(jsonPath("$.auth.oidcProviders").isEmpty())
         .andExpect(jsonPath("$.upload.maxDocumentSizeMb").value(50))
         .andExpect(jsonPath("$.supportedFormats[0]").value("PDF"));
+  }
+
+  @Test
+  @DisplayName("selfRegistrationEnabled reflects the application setting")
+  void getConfig_reflectsSelfRegistrationSetting() throws Exception {
+    when(settings.getBoolean(ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED))
+        .thenReturn(true);
+
+    mockMvc
+        .perform(get("/api/v1/config"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.auth.selfRegistrationEnabled").value(true));
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -81,6 +81,29 @@ public class UserService {
     return users.findById(id);
   }
 
+  /**
+   * The current user's profile for {@code GET /users/me}. Returns a Spring-free, entity-free view
+   * (role and source as their enum names) so the web layer never touches a JPA entity (ADR-0004).
+   */
+  @Transactional(readOnly = true)
+  public UserProfileView getProfile(UUID id) {
+    return users
+        .findById(id)
+        .map(
+            u ->
+                new UserProfileView(
+                    u.getId(),
+                    u.getDisplayName(),
+                    u.getEmail(),
+                    u.getRole().name(),
+                    u.getSource().name()))
+        .orElseThrow(() -> new UserNotFoundException(id));
+  }
+
+  /** A read-only projection of a user's profile (no entity types cross the service boundary). */
+  public record UserProfileView(
+      UUID id, String displayName, String email, String role, String source) {}
+
   /** Activates a user after successful email verification. */
   @Transactional
   public User enable(UUID id) {

--- a/qnop-core/src/test/java/io/qnop/service/UserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/UserServiceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.User;
+import io.qnop.entity.UserRole;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.UserService.UserProfileView;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/** Unit test for {@link UserService#getProfile} (issue #99). */
+class UserServiceTest {
+
+  private final UserRepository users = mock(UserRepository.class);
+  private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+  private final UserService service = new UserService(users, passwordEncoder);
+
+  @Test
+  @DisplayName("getProfile returns an entity-free view with role and source as names")
+  void getProfileReturnsView() {
+    UUID id = UUID.randomUUID();
+    User user = User.internal("Ivan Admin", "ivan@example.com", "ivan", "hash");
+    user.setRole(UserRole.ADMIN);
+    when(users.findById(id)).thenReturn(Optional.of(user));
+
+    UserProfileView view = service.getProfile(id);
+
+    assertThat(view.id()).isEqualTo(user.getId());
+    assertThat(view.displayName()).isEqualTo("Ivan Admin");
+    assertThat(view.email()).isEqualTo("ivan@example.com");
+    assertThat(view.role()).isEqualTo("ADMIN");
+    assertThat(view.source()).isEqualTo("INTERNAL");
+  }
+
+  @Test
+  @DisplayName("getProfile throws for an unknown user")
+  void getProfileRejectsUnknownUser() {
+    UUID id = UUID.randomUUID();
+    when(users.findById(id)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getProfile(id)).isInstanceOf(UserNotFoundException.class);
+  }
+}


### PR DESCRIPTION
Closes #99. Part of epic #97. Builds on #98 (role model).

## What & why

The SPA needs two things this PR provides:

1. **`GET /users/me`** — the authenticated user's own profile (`id`, `displayName`, `email`, `role`, `source`), called right after login to render the shell and gate role-based UI. Until now the client only had the access token (subject UUID); there was no way to fetch name/role.
2. **Real `selfRegistrationEnabled`** — `/config.auth.selfRegistrationEnabled` was hardcoded `false`; it now reflects the `auth.self_registration_enabled` application setting, so the login page can show/hide the register form correctly.

## Changes

- **OpenAPI** (contract-first, ADR-0021): new `GET /users/me` under a `Users` tag → `CurrentUserResponse { id, displayName, email, role, source }`, with new `UserRole` (ADMIN/MEMBER/AUDITOR) and `UserSource` (INTERNAL/EXTERNAL) enum schemas.
- **`UserService.getProfile`** returns an entity-free `UserProfileView` (role/source as their enum names), so the web layer never touches a JPA entity (ADR-0004). **`CurrentUserController`** maps it to the generated DTO; the acting user is the JWT subject (`CurrentUser`), non-user principals get 403.
- **`ConfigController`**: `selfRegistrationEnabled` now read from `ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED`.

## Test plan

- [x] `./gradlew build` green (Spotless + ArchUnit + all tests, Testcontainers).
- [x] **`AuthControllerIT`** — real-token `GET /users/me` returns the profile (role `AUDITOR`, source `INTERNAL`); anonymous → 401.
- [x] **`UserServiceTest`** — `getProfile` returns the view; unknown user → `UserNotFoundException`.
- [x] **`ConfigControllerTest`** — `selfRegistrationEnabled` reflects the setting (false and true).

## Notes

- `GET /users/me` is covered by the default `authenticated()` rule — no `SecurityConfiguration` change needed.
- `general.siteName` / `upload.maxDocumentSizeMb` remain static; wiring those to settings stays with #16, as noted in the updated `ConfigController` Javadoc.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code