### PR TITLE
chore: auto-load .env in bootRun for local dev

### DIFF
--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -7,11 +7,36 @@
 // Hosts the architecture-conformance tests. This module carries the Spring Boot
 // plugin and is the bootable server (Phase 1, ADR-0020).
 
+import org.springframework.boot.gradle.tasks.run.BootRun
+
 plugins {
     id("qnop.java-conventions")
     // Version comes from the root `plugins {}` block (declared there `apply false`
     // to keep a single shared plugin classloader — see the root build script).
     id("org.springframework.boot")
+}
+
+// Local-dev convenience (issue #110): load the repo-root `.env` into bootRun's
+// forked JVM so `./gradlew :qnop-app:bootRun` starts without `set -a; source .env`
+// first — matching how docker-compose already consumes the same file. Spring does
+// not read `.env` itself. Shell-exported variables win (we only fill keys absent
+// from the process environment), a missing `.env` is a no-op, and this never
+// affects tests or CI (they supply real environment / Testcontainers secrets).
+tasks.named<BootRun>("bootRun") {
+    val dotenv = rootProject.layout.projectDirectory.file(".env").asFile
+    if (dotenv.exists()) {
+        dotenv.readLines().forEach { rawLine ->
+            val line = rawLine.trim().removePrefix("export ").trim()
+            if (line.isEmpty() || line.startsWith("#")) return@forEach
+            val separator = line.indexOf('=')
+            if (separator <= 0) return@forEach
+            val key = line.substring(0, separator).trim()
+            val value = line.substring(separator + 1).trim().trim('"', '\'')
+            if (System.getenv(key) == null) {
+                environment(key, value)
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Closes #110.

## What & why

`./gradlew :qnop-app:bootRun` did not read the repo-root `.env`, so a fresh local run tripped the `@ValidSecret` fail-fast (ADR-0022) on `qnop.auth.*` unless the developer first ran `set -a; source .env; set +a`. `docker-compose` already loads `.env`, so the two run paths were inconsistent. This bridges the gap (Spring itself does not read `.env`).

## Change

`bootRun` (only) now loads the repo-root `.env` into the forked JVM's environment:

- Parses `KEY=VALUE` lines; skips blanks / `#` comments; strips an optional `export ` prefix and surrounding quotes (split on the first `=`, so base64 secrets are safe).
- **Shell-exported variables win** — only keys absent from the process environment are filled.
- A missing `.env` is a no-op; nothing in tests/CI is affected (they use the real environment / Testcontainers secrets).

## Test plan

- [x] Fresh shell (no `QNOP_AUTH_*` exported) + populated `.env`: `./gradlew :qnop-app:bootRun` → **Started QnopApplication in 3.2s** (previously failed validation).
- [x] `./gradlew build` green (Spotless + ArchUnit + tests); the build script configures cleanly.
- [x] `.env` remains gitignored; no secrets committed.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code