### PR TITLE
feat: admin user management — /admin/users CRUD + UI (#104)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -42,6 +42,13 @@ tags:
     description: |
       The authenticated user's own profile — identity, global role and account
       source — used by the SPA to render the shell and gate role-based UI (#99).
+  - name: AdminUsers
+    description: |
+      Admin-only user management (issue #104): list/search with pagination,
+      create (set an initial password or send an invitation), edit display name,
+      global role and enabled state, and trigger a password-setup/reset link.
+      A self-lockout guard prevents an admin from disabling or demoting their own
+      account or the last remaining admin.
 paths:
   /config:
     get:
@@ -605,6 +612,212 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /admin/users:
+    get:
+      tags:
+        - AdminUsers
+      summary: List and search users
+      description: |
+        Returns a page of users (internal and external), most-recent first.
+        Optional `q` matches display name, email or username (case-insensitive);
+        optional `role` filters by global role.
+      operationId: listUsers
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive search over display name, email and username.
+          schema:
+            type: string
+            maxLength: 200
+        - name: role
+          in: query
+          required: false
+          description: Filter by global role.
+          schema:
+            $ref: '#/components/schemas/UserRole'
+        - name: page
+          in: query
+          required: false
+          description: Zero-based page index.
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 0
+        - name: size
+          in: query
+          required: false
+          description: Page size.
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: A page of users
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUserListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags:
+        - AdminUsers
+      summary: Create or invite a user
+      description: |
+        Creates an internal account. If `initialPassword` is provided the account
+        is enabled immediately and must change its password on first login. If it
+        is omitted, the account is created without a password and an invitation
+        link (set-your-password) is emailed to the address.
+      operationId: createUser
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminUserCreateRequest'
+      responses:
+        '201':
+          description: The created user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUserDetail'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: A user with that username or email already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/users/{userId}:
+    get:
+      tags:
+        - AdminUsers
+      summary: Get a user
+      operationId: getUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '200':
+          description: The user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUserDetail'
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    patch:
+      tags:
+        - AdminUsers
+      summary: Update a user
+      description: |
+        Partial update of display name, global role and enabled state. The
+        self-lockout guard rejects (409) an attempt to disable or demote your own
+        account or the last remaining admin.
+      operationId: updateUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminUserUpdateRequest'
+      responses:
+        '200':
+          description: The updated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminUserDetail'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Self-lockout or last-admin guard violated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/users/{userId}/password-reset:
+    post:
+      tags:
+        - AdminUsers
+      summary: Send a password-setup/reset link
+      description: |
+        Issues a password-reset token for the user and emails the set-your-password
+        link. Works for any internal account (e.g. to (re)send an invitation or to
+        help a locked-out user). External (OIDC) accounts have no local password and
+        are rejected with 409.
+      operationId: sendUserPasswordReset
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '202':
+          description: The reset email has been queued
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The account has no local password (external/OIDC)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /auth/register:
     post:
       tags:
@@ -980,6 +1193,14 @@ components:
       description: The template storage key (e.g. `auth.password_reset`).
       schema:
         type: string
+    UserIdParam:
+      name: userId
+      in: path
+      required: true
+      description: The user's id.
+      schema:
+        type: string
+        format: uuid
   responses:
     Unauthorized:
       description: Authentication is required (uniform error envelope, issue #45).
@@ -1426,6 +1647,119 @@ components:
         - email
         - role
         - source
+    AdminUserSummary:
+      type: object
+      description: A user as shown in the admin user list.
+      properties:
+        id:
+          type: string
+          format: uuid
+        displayName:
+          type: string
+        email:
+          type: string
+        username:
+          type: string
+          nullable: true
+          description: The local username; null for external (OIDC) accounts.
+        role:
+          $ref: '#/components/schemas/UserRole'
+        source:
+          $ref: '#/components/schemas/UserSource'
+        enabled:
+          type: boolean
+        lastLoginAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - displayName
+        - email
+        - role
+        - source
+        - enabled
+        - createdAt
+    AdminUserDetail:
+      allOf:
+        - $ref: '#/components/schemas/AdminUserSummary'
+      description: Full detail for a single user (currently the same fields as the summary).
+    AdminUserListResponse:
+      type: object
+      description: A page of users for the admin list.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminUserSummary'
+        total:
+          type: integer
+          format: int64
+          description: Total number of users matching the query.
+        page:
+          type: integer
+          format: int32
+          description: Zero-based page index.
+        size:
+          type: integer
+          format: int32
+          description: Page size.
+      required:
+        - items
+        - total
+        - page
+        - size
+    AdminUserCreateRequest:
+      type: object
+      description: |
+        Create an internal user. Provide `initialPassword` to enable the account
+        immediately (with a forced change on first login), or omit it to send an
+        invitation link instead.
+      properties:
+        displayName:
+          type: string
+          minLength: 1
+          maxLength: 200
+        username:
+          type: string
+          minLength: 3
+          maxLength: 64
+        email:
+          type: string
+          format: email
+          maxLength: 320
+        role:
+          $ref: '#/components/schemas/UserRole'
+        initialPassword:
+          type: string
+          minLength: 8
+          maxLength: 200
+          nullable: true
+          description: Optional. When omitted, an invitation email is sent instead.
+      required:
+        - displayName
+        - username
+        - email
+        - role
+    AdminUserUpdateRequest:
+      type: object
+      description: Partial update; only provided fields change.
+      properties:
+        displayName:
+          type: string
+          minLength: 1
+          maxLength: 200
+          nullable: true
+        role:
+          allOf:
+            - $ref: '#/components/schemas/UserRole'
+          nullable: true
+        enabled:
+          type: boolean
+          nullable: true
     RegisterRequest:
       type: object
       description: Self-registration details for a new local account.

--- a/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AdminUsersApi;
+import io.qnop.api.v1.model.AdminUserCreateRequest;
+import io.qnop.api.v1.model.AdminUserDetail;
+import io.qnop.api.v1.model.AdminUserListResponse;
+import io.qnop.api.v1.model.AdminUserSummary;
+import io.qnop.api.v1.model.AdminUserUpdateRequest;
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.api.v1.model.UserRole;
+import io.qnop.api.v1.model.UserSource;
+import io.qnop.service.AdminUserConflictException;
+import io.qnop.service.AdminUserService;
+import io.qnop.service.AdminUserService.AdminUserPage;
+import io.qnop.service.AdminUserService.AdminUserView;
+import io.qnop.service.UserNotFoundException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin-only user management ({@code /api/v1/admin/users/**}), implementing the generated {@link
+ * AdminUsersApi} contract (issue #104). Authorization is enforced centrally by the security chain
+ * ({@code /api/v1/admin/**} requires {@code ADMIN}). The {@code User} entity never reaches this
+ * layer — {@link AdminUserService} returns entity-free {@link AdminUserView}s (role and source as
+ * their enum names), mapped here to API DTOs (ADR-0004). Unknown users surface as 404, conflicts
+ * (duplicate identity, self-lockout, last-admin, external-account reset) as 409.
+ */
+@RestController
+public class AdminUserController implements AdminUsersApi {
+
+  private final AdminUserService adminUsers;
+
+  public AdminUserController(AdminUserService adminUsers) {
+    this.adminUsers = adminUsers;
+  }
+
+  @Override
+  public ResponseEntity<AdminUserListResponse> listUsers(
+      String q, UserRole role, Integer page, Integer size) {
+    AdminUserPage result = adminUsers.list(q, role == null ? null : role.name(), page, size);
+    return ResponseEntity.ok(
+        new AdminUserListResponse()
+            .items(result.items().stream().map(AdminUserController::toSummary).toList())
+            .total(result.total())
+            .page(result.page())
+            .size(result.size()));
+  }
+
+  @Override
+  public ResponseEntity<AdminUserDetail> createUser(AdminUserCreateRequest request) {
+    AdminUserView created =
+        adminUsers.create(
+            request.getDisplayName(),
+            request.getUsername(),
+            request.getEmail(),
+            request.getRole().name(),
+            request.getInitialPassword());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toDetail(created));
+  }
+
+  @Override
+  public ResponseEntity<AdminUserDetail> getUser(UUID userId) {
+    return ResponseEntity.ok(toDetail(adminUsers.get(userId)));
+  }
+
+  @Override
+  public ResponseEntity<AdminUserDetail> updateUser(UUID userId, AdminUserUpdateRequest request) {
+    AdminUserView updated =
+        adminUsers.update(
+            userId,
+            request.getDisplayName(),
+            request.getRole() == null ? null : request.getRole().name(),
+            request.getEnabled(),
+            CurrentUser.requireUserId());
+    return ResponseEntity.ok(toDetail(updated));
+  }
+
+  @Override
+  public ResponseEntity<Void> sendUserPasswordReset(UUID userId) {
+    adminUsers.sendPasswordReset(userId);
+    return ResponseEntity.accepted().build();
+  }
+
+  @ExceptionHandler(UserNotFoundException.class)
+  public ResponseEntity<ErrorResponse> onUserNotFound(UserNotFoundException ex) {
+    return error(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", ex.getMessage());
+  }
+
+  @ExceptionHandler(AdminUserConflictException.class)
+  public ResponseEntity<ErrorResponse> onConflict(AdminUserConflictException ex) {
+    return error(HttpStatus.CONFLICT, ex.getCode(), ex.getMessage());
+  }
+
+  private static ResponseEntity<ErrorResponse> error(
+      HttpStatus status, String code, String message) {
+    return ResponseEntity.status(status)
+        .body(
+            new ErrorResponse()
+                .code(code)
+                .message(message)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC)));
+  }
+
+  private static AdminUserSummary toSummary(AdminUserView v) {
+    return new AdminUserSummary()
+        .id(v.id())
+        .displayName(v.displayName())
+        .email(v.email())
+        .username(v.username())
+        .role(UserRole.fromValue(v.role()))
+        .source(UserSource.fromValue(v.source()))
+        .enabled(v.enabled())
+        .lastLoginAt(toOffset(v.lastLoginAt()))
+        .createdAt(toOffset(v.createdAt()));
+  }
+
+  private static AdminUserDetail toDetail(AdminUserView v) {
+    return new AdminUserDetail()
+        .id(v.id())
+        .displayName(v.displayName())
+        .email(v.email())
+        .username(v.username())
+        .role(UserRole.fromValue(v.role()))
+        .source(UserSource.fromValue(v.source()))
+        .enabled(v.enabled())
+        .lastLoginAt(toOffset(v.lastLoginAt()))
+        .createdAt(toOffset(v.createdAt()));
+  }
+
+  private static OffsetDateTime toOffset(Instant instant) {
+    return instant == null ? null : instant.atOffset(ZoneOffset.UTC);
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/AdminUserControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AdminUserControllerIT.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.entity.UserRole;
+import io.qnop.repository.UserRepository;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * End-to-end admin user-management flow against a real PostgreSQL and the real security chain
+ * (issue #104): only an ADMIN reaches {@code /admin/users}, create/edit/search work, and the
+ * self-lockout guard rejects an admin disabling their own account.
+ */
+@AutoConfigureMockMvc
+@Transactional
+class AdminUserControllerIT extends AbstractIntegrationTest {
+
+  private static final String PASSWORD = "correct horse battery";
+  private static final Pattern ACCESS_TOKEN =
+      Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+
+  /**
+   * Hands each login a distinct client IP so it gets its own rate-limit bucket (see loginRequest).
+   */
+  private static final AtomicInteger IP_SEQ = new AtomicInteger();
+
+  @Autowired MockMvc mockMvc;
+  @Autowired UserRepository userRepository;
+  @Autowired PasswordEncoder passwordEncoder;
+
+  @Test
+  void anonymousIsUnauthorized() throws Exception {
+    mockMvc.perform(get("/api/v1/admin/users")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void memberIsForbidden() throws Exception {
+    createUser("member", UserRole.MEMBER);
+    String token = loginAccessToken("member");
+
+    mockMvc
+        .perform(get("/api/v1/admin/users").header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void adminListsUsers() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    createUser("alice", UserRole.MEMBER);
+    String token = adminToken();
+
+    // total is >= 2 rather than exactly 2: the context-start bootstrap admin (created outside the
+    // test transaction, so not rolled back) also counts.
+    mockMvc
+        .perform(get("/api/v1/admin/users").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(greaterThanOrEqualTo(2)))
+        .andExpect(jsonPath("$.items").isArray())
+        .andExpect(jsonPath("$.page").value(0));
+  }
+
+  @Test
+  void adminSearchesByQuery() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    createUser("alice", UserRole.MEMBER);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/users")
+                .param("q", "alice")
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(1))
+        .andExpect(jsonPath("$.items[0].username").value("alice"));
+  }
+
+  @Test
+  void adminCreatesUserWithPassword() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    String token = adminToken();
+
+    String body =
+        """
+        {"displayName":"New Person","username":"newbie","email":"New@Example.com",\
+        "role":"MEMBER","initialPassword":"a-strong-pass-1"}""";
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/users")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.username").value("newbie"))
+        .andExpect(jsonPath("$.email").value("new@example.com"))
+        .andExpect(jsonPath("$.role").value("MEMBER"))
+        .andExpect(jsonPath("$.enabled").value(true));
+
+    assertThat(userRepository.findByUsernameAndSource("newbie", io.qnop.entity.UserSource.INTERNAL))
+        .isPresent();
+  }
+
+  @Test
+  void adminCreatesUserByInvitation() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    String token = adminToken();
+
+    String body =
+        """
+        {"displayName":"Invitee","username":"invitee","email":"invitee@example.com",\
+        "role":"AUDITOR"}""";
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/users")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.role").value("AUDITOR"))
+        .andExpect(jsonPath("$.enabled").value(true));
+  }
+
+  @Test
+  void createRejectsDuplicateEmail() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    String token = adminToken();
+    String body =
+        """
+        {"displayName":"Dup","username":"dup","email":"root@example.com",\
+        "role":"MEMBER","initialPassword":"a-strong-pass-1"}""";
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/users")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("EMAIL_TAKEN"));
+  }
+
+  @Test
+  void adminUpdatesRole() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User target = createUser("member", UserRole.MEMBER);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            patch("/api/v1/admin/users/{id}", target.getId())
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"role\":\"AUDITOR\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.role").value("AUDITOR"));
+  }
+
+  @Test
+  void adminCannotDisableOwnAccount() throws Exception {
+    User admin = createUser("root", UserRole.ADMIN);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            patch("/api/v1/admin/users/{id}", admin.getId())
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"enabled\":false}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("SELF_LOCKOUT"));
+  }
+
+  @Test
+  void getUnknownUserIsNotFound() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/users/{id}", UUID.randomUUID())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+  }
+
+  @Test
+  void sendsPasswordReset() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User target = createUser("member", UserRole.MEMBER);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/users/{id}/password-reset", target.getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isAccepted());
+  }
+
+  private String adminToken() throws Exception {
+    return loginAccessToken("root");
+  }
+
+  private User createUser(String username, UserRole role) {
+    User user =
+        User.internal(
+            username, username + "@example.com", username, passwordEncoder.encode(PASSWORD));
+    user.setRole(role);
+    return userRepository.saveAndFlush(user);
+  }
+
+  private MockHttpServletRequestBuilder loginRequest(String usernameOrEmail) {
+    String body =
+        "{\"usernameOrEmail\":\"%s\",\"password\":\"%s\"}".formatted(usernameOrEmail, PASSWORD);
+    // Each login uses a distinct client IP. The login rate limiter (10/60s per IP, issue #18) keeps
+    // in-memory counters in a singleton filter that the cached Spring context shares with the other
+    // IT classes; without unique IPs this class's logins would exhaust the shared 127.0.0.1 bucket.
+    String clientIp = "203.0.113." + (IP_SEQ.incrementAndGet() % 250 + 1);
+    return post("/api/v1/auth/login")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(body)
+        .with(
+            request -> {
+              request.setRemoteAddr(clientIp);
+              return request;
+            });
+  }
+
+  private String loginAccessToken(String username) throws Exception {
+    MvcResult result =
+        mockMvc.perform(loginRequest(username)).andExpect(status().isOk()).andReturn();
+    Matcher matcher = ACCESS_TOKEN.matcher(result.getResponse().getContentAsString());
+    assertThat(matcher.find()).isTrue();
+    return matcher.group(1);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
@@ -21,10 +21,13 @@
 package io.qnop.repository;
 
 import io.qnop.entity.User;
+import io.qnop.entity.UserRole;
 import io.qnop.entity.UserSource;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -38,6 +41,21 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
   /** Finds an internal user by exact username. */
   Optional<User> findByUsernameAndSource(String username, UserSource source);
+
+  /**
+   * Paginated admin search (issue #104): an optional case-insensitive match on display name, email
+   * or username and an optional role filter. {@code q} must be passed pre-lowercased and {@code
+   * LIKE}-wrapped (e.g. {@code %alice%}); a {@code null} {@code q}/{@code role} disables that
+   * filter.
+   */
+  @Query(
+      "SELECT u FROM User u WHERE (:role IS NULL OR u.role = :role)"
+          + " AND (:q IS NULL OR LOWER(u.displayName) LIKE :q OR LOWER(u.email) LIKE :q"
+          + " OR (u.username IS NOT NULL AND LOWER(u.username) LIKE :q))")
+  Page<User> search(@Param("q") String q, @Param("role") UserRole role, Pageable pageable);
+
+  /** Number of enabled users with the given role — guards the last-admin invariant (issue #104). */
+  long countByRoleAndEnabledTrue(UserRole role);
 
   boolean existsByEmailIgnoreCaseAndSource(String email, UserSource source);
 

--- a/qnop-core/src/main/java/io/qnop/service/AdminUserConflictException.java
+++ b/qnop-core/src/main/java/io/qnop/service/AdminUserConflictException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+/**
+ * A conflicting admin user-management request (issue #104): a duplicate username/email, a
+ * self-lockout or last-admin guard violation, or an operation that does not apply to the account
+ * (e.g. a password reset for an external account). Carries a stable {@code code} so the web layer
+ * can surface it in the uniform error envelope; mapped to HTTP 409.
+ */
+public class AdminUserConflictException extends RuntimeException {
+
+  private final String code;
+
+  public AdminUserConflictException(String code, String message) {
+    super(message);
+    this.code = code;
+  }
+
+  public String getCode() {
+    return code;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.User;
+import io.qnop.entity.UserRole;
+import io.qnop.entity.UserSource;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.auth.PasswordResetFlowService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Admin user management (issue #104): paginated search, create-or-invite, edit and password-setup
+ * links. Keeps the {@code User} entity inside the service layer — every result crosses the boundary
+ * as an entity-free {@link AdminUserView} (role and source as their enum names), so the web layer
+ * never touches a JPA entity (ADR-0004).
+ *
+ * <p>Two guards protect against admin lockout: an admin can neither disable nor demote their own
+ * account, and the last enabled admin can never be disabled or demoted — both surface as {@link
+ * AdminUserConflictException} (HTTP 409). Creating with an {@code initialPassword} yields an
+ * enabled account that must change its password on first login; omitting it provisions the account
+ * behind a random, unusable placeholder hash (the {@code INTERNAL ⇒ credentials} DB invariant) and
+ * emails an invitation link the user follows to set their own password.
+ */
+@Service
+public class AdminUserService {
+
+  private final UserRepository users;
+  private final PasswordEncoder passwordEncoder;
+  private final PasswordResetFlowService passwordResetFlow;
+
+  public AdminUserService(
+      UserRepository users,
+      PasswordEncoder passwordEncoder,
+      PasswordResetFlowService passwordResetFlow) {
+    this.users = users;
+    this.passwordEncoder = passwordEncoder;
+    this.passwordResetFlow = passwordResetFlow;
+  }
+
+  /** A paginated, optionally filtered slice of users for the admin list. */
+  @Transactional(readOnly = true)
+  public AdminUserPage list(String query, String roleName, int page, int size) {
+    String like =
+        blankToNull(query) == null ? null : "%" + query.trim().toLowerCase(Locale.ROOT) + "%";
+    UserRole role = parseRoleOrNull(roleName);
+    Page<User> result =
+        users.search(
+            like, role, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+    List<AdminUserView> items = result.getContent().stream().map(AdminUserService::toView).toList();
+    return new AdminUserPage(items, result.getTotalElements(), page, size);
+  }
+
+  @Transactional(readOnly = true)
+  public AdminUserView get(UUID id) {
+    return toView(users.findById(id).orElseThrow(() -> new UserNotFoundException(id)));
+  }
+
+  /**
+   * Creates an internal account. With an {@code initialPassword} the account is enabled and must
+   * change it on first login; without one it is provisioned behind a random placeholder hash and an
+   * invitation (set-your-password) link is emailed.
+   */
+  @Transactional
+  public AdminUserView create(
+      String displayName, String username, String email, String roleName, String initialPassword) {
+    String normalizedEmail = normalizeEmail(email);
+    if (users.existsByEmailIgnoreCaseAndSource(normalizedEmail, UserSource.INTERNAL)) {
+      throw new AdminUserConflictException("EMAIL_TAKEN", "A user with that email already exists.");
+    }
+    if (users.findByUsernameAndSource(username, UserSource.INTERNAL).isPresent()) {
+      throw new AdminUserConflictException(
+          "USERNAME_TAKEN", "A user with that username already exists.");
+    }
+
+    boolean invite = blankToNull(initialPassword) == null;
+    String passwordHash =
+        passwordEncoder.encode(invite ? randomPlaceholderSecret() : initialPassword);
+    User user = User.internal(displayName, normalizedEmail, username, passwordHash);
+    user.setRole(requireRole(roleName));
+    user.setEnabled(true);
+    // Invited users have not chosen a password yet; password-set users must rotate the admin-chosen
+    // one on first login. Either way the account must change its password before normal use.
+    user.setPasswordChangeRequired(true);
+    User saved = users.save(user);
+
+    if (invite) {
+      passwordResetFlow.sendSetupLink(saved);
+    }
+    return toView(saved);
+  }
+
+  /**
+   * Partial update of display name, global role and enabled state. A {@code null} field is left
+   * unchanged. Rejects (409) any change that would disable or demote the acting admin's own account
+   * or remove the last enabled admin.
+   */
+  @Transactional
+  public AdminUserView update(
+      UUID id, String displayName, String roleName, Boolean enabled, UUID actingUserId) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+
+    UserRole newRole = roleName == null ? user.getRole() : requireRole(roleName);
+    boolean newEnabled = enabled == null ? user.isEnabled() : enabled;
+
+    boolean demoting = user.getRole() == UserRole.ADMIN && newRole != UserRole.ADMIN;
+    boolean disabling = user.isEnabled() && !newEnabled;
+
+    if (id.equals(actingUserId) && (demoting || disabling)) {
+      throw new AdminUserConflictException(
+          "SELF_LOCKOUT", "You cannot disable or change the role of your own account.");
+    }
+    if ((demoting || disabling)
+        && user.getRole() == UserRole.ADMIN
+        && user.isEnabled()
+        && users.countByRoleAndEnabledTrue(UserRole.ADMIN) <= 1) {
+      throw new AdminUserConflictException("LAST_ADMIN", "At least one enabled admin must remain.");
+    }
+
+    if (displayName != null) {
+      user.setDisplayName(displayName);
+    }
+    user.setRole(newRole);
+    user.setEnabled(newEnabled);
+    return toView(user);
+  }
+
+  /**
+   * Issues a password-setup/reset token for an internal account and emails the link. External
+   * (OIDC) accounts have no local password and are rejected (409).
+   */
+  @Transactional
+  public void sendPasswordReset(UUID id) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    if (user.getSource() != UserSource.INTERNAL) {
+      throw new AdminUserConflictException(
+          "NO_LOCAL_PASSWORD",
+          "This account signs in via an identity provider; it has no password.");
+    }
+    passwordResetFlow.sendSetupLink(user);
+  }
+
+  private static AdminUserView toView(User u) {
+    return new AdminUserView(
+        u.getId(),
+        u.getDisplayName(),
+        u.getEmail(),
+        u.getUsername(),
+        u.getRole().name(),
+        u.getSource().name(),
+        u.isEnabled(),
+        u.getLastLoginAt(),
+        u.getCreatedAt());
+  }
+
+  private UserRole requireRole(String roleName) {
+    UserRole role = parseRoleOrNull(roleName);
+    if (role == null) {
+      throw new IllegalArgumentException("role is required");
+    }
+    return role;
+  }
+
+  private static UserRole parseRoleOrNull(String roleName) {
+    if (blankToNull(roleName) == null) {
+      return null;
+    }
+    return UserRole.valueOf(roleName.trim().toUpperCase(Locale.ROOT));
+  }
+
+  private static String normalizeEmail(String email) {
+    return email == null ? null : email.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value;
+  }
+
+  private static String randomPlaceholderSecret() {
+    // A single UUIDv4 (122 random bits, 36 chars) is ample for a never-disclosed placeholder and
+    // stays within BCrypt's 72-byte input limit. The account is unusable until the invitee sets a
+    // real password via the emailed link.
+    return UUID.randomUUID().toString();
+  }
+
+  /** A Spring-free, entity-free projection of a user for the admin surface. */
+  public record AdminUserView(
+      UUID id,
+      String displayName,
+      String email,
+      String username,
+      String role,
+      String source,
+      boolean enabled,
+      Instant lastLoginAt,
+      Instant createdAt) {}
+
+  /** One page of {@link AdminUserView}s plus the total count for the admin list. */
+  public record AdminUserPage(List<AdminUserView> items, long total, int page, int size) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
@@ -75,6 +75,17 @@ public class PasswordResetFlowService {
     userService.applyPasswordReset(user.getId(), newPassword);
   }
 
+  /**
+   * Admin action (issue #104): issues a reset token for a known internal account and emails the
+   * set-your-password link. Unlike {@link #requestReset}, this is not gated by the self-service
+   * feature flag or anti-enumeration — the admin already knows the account exists and is acting on
+   * it deliberately (e.g. (re)sending an invitation or unblocking a locked-out user).
+   */
+  @Transactional
+  public void sendSetupLink(User user) {
+    sendResetEmail(user);
+  }
+
   private void sendResetEmail(User user) {
     String rawToken = resetTokens.issue(user).rawToken();
     String actionUrl =

--- a/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.User;
+import io.qnop.entity.UserRole;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.AdminUserService.AdminUserPage;
+import io.qnop.service.AdminUserService.AdminUserView;
+import io.qnop.service.auth.PasswordResetFlowService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/** Unit tests for {@link AdminUserService} (issue #104): create/invite, edit guards, reset. */
+class AdminUserServiceTest {
+
+  private final UserRepository users = mock(UserRepository.class);
+  private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+  private final PasswordResetFlowService passwordResetFlow = mock(PasswordResetFlowService.class);
+  private final AdminUserService service =
+      new AdminUserService(users, passwordEncoder, passwordResetFlow);
+
+  private void noClash() {
+    when(users.existsByEmailIgnoreCaseAndSource(any(), any())).thenReturn(false);
+    when(users.findByUsernameAndSource(any(), any())).thenReturn(Optional.empty());
+    when(users.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(passwordEncoder.encode(any())).thenReturn("hashed");
+  }
+
+  @Test
+  @DisplayName("create with a password enables the account, forces a change and sends no email")
+  void createWithPassword() {
+    noClash();
+
+    AdminUserView view =
+        service.create("Alice", "alice", "Alice@Example.com", "MEMBER", "secretpw12");
+
+    assertThat(view.role()).isEqualTo("MEMBER");
+    assertThat(view.enabled()).isTrue();
+    assertThat(view.email()).isEqualTo("alice@example.com");
+
+    ArgumentCaptor<User> saved = ArgumentCaptor.forClass(User.class);
+    verify(users).save(saved.capture());
+    assertThat(saved.getValue().isPasswordChangeRequired()).isTrue();
+    assertThat(saved.getValue().getPasswordHash()).isEqualTo("hashed");
+    verify(passwordResetFlow, never()).sendSetupLink(any());
+  }
+
+  @Test
+  @DisplayName("create without a password provisions a placeholder and emails an invitation")
+  void createInvite() {
+    noClash();
+
+    service.create("Bob", "bob", "bob@example.com", "AUDITOR", null);
+
+    ArgumentCaptor<User> saved = ArgumentCaptor.forClass(User.class);
+    verify(users).save(saved.capture());
+    assertThat(saved.getValue().getPasswordHash()).isEqualTo("hashed");
+    assertThat(saved.getValue().isEnabled()).isTrue();
+    verify(passwordResetFlow).sendSetupLink(saved.getValue());
+  }
+
+  @Test
+  @DisplayName("create rejects a duplicate email and username")
+  void createRejectsDuplicates() {
+    when(users.existsByEmailIgnoreCaseAndSource(any(), any())).thenReturn(true);
+    assertThatThrownBy(() -> service.create("A", "a", "a@example.com", "MEMBER", "secretpw12"))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("EMAIL_TAKEN");
+
+    when(users.existsByEmailIgnoreCaseAndSource(any(), any())).thenReturn(false);
+    when(users.findByUsernameAndSource(any(), any()))
+        .thenReturn(Optional.of(User.internal("A", "a@example.com", "a", "h")));
+    assertThatThrownBy(() -> service.create("A", "a", "b@example.com", "MEMBER", "secretpw12"))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("USERNAME_TAKEN");
+  }
+
+  @Test
+  @DisplayName("an admin cannot disable or demote their own account")
+  void updateRejectsSelfLockout() {
+    UUID id = UUID.randomUUID();
+    User admin = User.internal("Admin", "admin@example.com", "admin", "h");
+    admin.setRole(UserRole.ADMIN);
+    when(users.findById(id)).thenReturn(Optional.of(admin));
+
+    assertThatThrownBy(() -> service.update(id, null, null, false, id))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("SELF_LOCKOUT");
+
+    assertThatThrownBy(() -> service.update(id, null, "MEMBER", null, id))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("SELF_LOCKOUT");
+  }
+
+  @Test
+  @DisplayName("the last enabled admin cannot be demoted")
+  void updateRejectsLastAdmin() {
+    UUID id = UUID.randomUUID();
+    User admin = User.internal("Admin", "admin@example.com", "admin", "h");
+    admin.setRole(UserRole.ADMIN);
+    when(users.findById(id)).thenReturn(Optional.of(admin));
+    when(users.countByRoleAndEnabledTrue(UserRole.ADMIN)).thenReturn(1L);
+
+    assertThatThrownBy(() -> service.update(id, null, "MEMBER", null, UUID.randomUUID()))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("LAST_ADMIN");
+  }
+
+  @Test
+  @DisplayName("update changes display name and role for a non-admin target")
+  void updateAppliesChanges() {
+    UUID id = UUID.randomUUID();
+    User member = User.internal("Old Name", "m@example.com", "m", "h");
+    member.setRole(UserRole.MEMBER);
+    when(users.findById(id)).thenReturn(Optional.of(member));
+
+    AdminUserView view = service.update(id, "New Name", "AUDITOR", null, UUID.randomUUID());
+
+    assertThat(view.displayName()).isEqualTo("New Name");
+    assertThat(view.role()).isEqualTo("AUDITOR");
+    assertThat(member.getDisplayName()).isEqualTo("New Name");
+  }
+
+  @Test
+  @DisplayName("get throws for an unknown user")
+  void getRejectsUnknown() {
+    UUID id = UUID.randomUUID();
+    when(users.findById(id)).thenReturn(Optional.empty());
+    assertThatThrownBy(() -> service.get(id)).isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("password reset is rejected for an external account and sent for an internal one")
+  void sendPasswordReset() {
+    UUID externalId = UUID.randomUUID();
+    when(users.findById(externalId))
+        .thenReturn(Optional.of(User.external("Ext", "ext@example.com")));
+    assertThatThrownBy(() -> service.sendPasswordReset(externalId))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("NO_LOCAL_PASSWORD");
+
+    UUID internalId = UUID.randomUUID();
+    User internal = User.internal("Int", "int@example.com", "int", "h");
+    when(users.findById(internalId)).thenReturn(Optional.of(internal));
+    service.sendPasswordReset(internalId);
+    verify(passwordResetFlow).sendSetupLink(internal);
+  }
+
+  @Test
+  @DisplayName("list lowercases and wraps the query and maps the page")
+  void listMapsPage() {
+    User user = User.internal("Alice", "alice@example.com", "alice", "h");
+    user.setRole(UserRole.MEMBER);
+    when(users.search(eq("%ali%"), eq(UserRole.MEMBER), any()))
+        .thenReturn(new PageImpl<>(List.of(user), PageRequest.of(0, 20), 1));
+
+    AdminUserPage page = service.list(" Ali ", "MEMBER", 0, 20);
+
+    assertThat(page.items()).hasSize(1);
+    assertThat(page.total()).isEqualTo(1);
+    assertThat(page.items().get(0).email()).isEqualTo("alice@example.com");
+  }
+}

--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -21,6 +21,7 @@
 
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import {
+  AdminUsersApi,
   AuthApi,
   AuthPasswordResetApi,
   AuthRegistrationApi,
@@ -82,3 +83,4 @@ export const usersApi = new UsersApi(undefined, undefined, axiosInstance);
 export const authApi = new AuthApi(undefined, undefined, axiosInstance);
 export const authRegistrationApi = new AuthRegistrationApi(undefined, undefined, axiosInstance);
 export const authPasswordResetApi = new AuthPasswordResetApi(undefined, undefined, axiosInstance);
+export const adminUsersApi = new AdminUsersApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useAdminUsers.test.tsx
+++ b/qnop-ui/src/api/hooks/useAdminUsers.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { AdminUserListResponse } from '../generated';
+import {
+  adminUserKeys,
+  useAdminUsers,
+  useCreateUser,
+  useSendUserPasswordReset,
+  useUpdateUser,
+} from './useAdminUsers';
+import { adminUsersApi } from '../config';
+
+const EMPTY_PAGE: AdminUserListResponse = { items: [], total: 0, page: 0, size: 20 };
+
+vi.mock('../config', () => ({
+  adminUsersApi: {
+    listUsers: vi.fn(),
+    createUser: vi.fn(),
+    updateUser: vi.fn(),
+    sendUserPasswordReset: vi.fn(),
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('adminUserKeys', () => {
+  it('namespaces list keys by params', () => {
+    const params = { q: 'a', page: 1, size: 20 };
+    expect(adminUserKeys.list(params)).toEqual(['admin', 'users', 'list', params]);
+  });
+});
+
+describe('useAdminUsers', () => {
+  it('passes query, role and pagination to the client and returns the page', async () => {
+    vi.mocked(adminUsersApi.listUsers).mockResolvedValue({ data: EMPTY_PAGE } as Awaited<
+      ReturnType<typeof adminUsersApi.listUsers>
+    >);
+
+    const { result } = renderHook(
+      () => useAdminUsers({ q: 'ali', role: 'MEMBER', page: 0, size: 20 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(adminUsersApi.listUsers).toHaveBeenCalledWith({
+      q: 'ali',
+      role: 'MEMBER',
+      page: 0,
+      size: 20,
+    });
+    expect(result.current.data?.total).toBe(0);
+  });
+
+  it('sends an empty query as undefined', async () => {
+    vi.mocked(adminUsersApi.listUsers).mockResolvedValue({ data: EMPTY_PAGE } as Awaited<
+      ReturnType<typeof adminUsersApi.listUsers>
+    >);
+
+    const { result } = renderHook(() => useAdminUsers({ q: '', page: 0, size: 20 }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(adminUsersApi.listUsers).toHaveBeenCalledWith({
+      q: undefined,
+      role: undefined,
+      page: 0,
+      size: 20,
+    });
+  });
+});
+
+describe('useCreateUser', () => {
+  it('forwards the create request to the client', async () => {
+    vi.mocked(adminUsersApi.createUser).mockResolvedValue({
+      data: {},
+    } as Awaited<ReturnType<typeof adminUsersApi.createUser>>);
+
+    const { result } = renderHook(() => useCreateUser(), { wrapper });
+    await result.current.mutateAsync({
+      displayName: 'A',
+      username: 'a',
+      email: 'a@example.com',
+      role: 'MEMBER',
+    });
+
+    expect(adminUsersApi.createUser).toHaveBeenCalledWith({
+      adminUserCreateRequest: {
+        displayName: 'A',
+        username: 'a',
+        email: 'a@example.com',
+        role: 'MEMBER',
+      },
+    });
+  });
+});
+
+describe('useUpdateUser', () => {
+  it('forwards the id and patch to the client', async () => {
+    vi.mocked(adminUsersApi.updateUser).mockResolvedValue({
+      data: {},
+    } as Awaited<ReturnType<typeof adminUsersApi.updateUser>>);
+
+    const { result } = renderHook(() => useUpdateUser(), { wrapper });
+    await result.current.mutateAsync({ id: 'u1', request: { role: 'AUDITOR' } });
+
+    expect(adminUsersApi.updateUser).toHaveBeenCalledWith({
+      userId: 'u1',
+      adminUserUpdateRequest: { role: 'AUDITOR' },
+    });
+  });
+});
+
+describe('useSendUserPasswordReset', () => {
+  it('sends a reset for the given id', async () => {
+    vi.mocked(adminUsersApi.sendUserPasswordReset).mockResolvedValue({
+      data: undefined,
+    } as Awaited<ReturnType<typeof adminUsersApi.sendUserPasswordReset>>);
+
+    const { result } = renderHook(() => useSendUserPasswordReset(), { wrapper });
+    await result.current.mutateAsync('u9');
+
+    expect(adminUsersApi.sendUserPasswordReset).toHaveBeenCalledWith({ userId: 'u9' });
+  });
+});

--- a/qnop-ui/src/api/hooks/useAdminUsers.ts
+++ b/qnop-ui/src/api/hooks/useAdminUsers.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  AdminUserCreateRequest,
+  AdminUserListResponse,
+  AdminUserUpdateRequest,
+  UserRole,
+} from '../generated';
+import { adminUsersApi } from '../config';
+
+/** Query parameters for the admin user list. */
+export interface AdminUserListParams {
+  q?: string;
+  role?: UserRole;
+  page: number;
+  size: number;
+}
+
+export const adminUserKeys = {
+  all: ['admin', 'users'] as const,
+  list: (params: AdminUserListParams) => [...adminUserKeys.all, 'list', params] as const,
+};
+
+/**
+ * A page of users for the admin list. Keeps the previous page visible while the
+ * next one loads, so pagination and search do not flash an empty table.
+ */
+export function useAdminUsers(params: AdminUserListParams) {
+  return useQuery<AdminUserListResponse>({
+    queryKey: adminUserKeys.list(params),
+    queryFn: async () => {
+      const response = await adminUsersApi.listUsers({
+        q: params.q || undefined,
+        role: params.role,
+        page: params.page,
+        size: params.size,
+      });
+      return response.data;
+    },
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** Creates (or invites, when no initialPassword is given) a user, then refreshes the list. */
+export function useCreateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request: AdminUserCreateRequest) => {
+      const response = await adminUsersApi.createUser({ adminUserCreateRequest: request });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: adminUserKeys.all }),
+  });
+}
+
+/** Updates a user's display name, role and/or enabled state, then refreshes the list. */
+export function useUpdateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { id: string; request: AdminUserUpdateRequest }) => {
+      const response = await adminUsersApi.updateUser({
+        userId: vars.id,
+        adminUserUpdateRequest: vars.request,
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: adminUserKeys.all }),
+  });
+}
+
+/** Sends a password-setup/reset link to the given user. */
+export function useSendUserPasswordReset() {
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await adminUsersApi.sendUserPasswordReset({ userId: id });
+    },
+  });
+}

--- a/qnop-ui/src/components/admin/users/UserBadges.tsx
+++ b/qnop-ui/src/components/admin/users/UserBadges.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import type { UserRole } from '../../../api/generated';
+
+type Tone = 'blue' | 'green' | 'amber' | 'red' | 'neutral';
+
+/** A compact, system-coloured pill driven by the shared `qnop.badge` tones. */
+function ToneBadge({ tone, label }: { tone: Tone; label: string }) {
+  const theme = useTheme();
+  const t =
+    tone === 'neutral'
+      ? {
+          bg: theme.qnop.surface2,
+          fg: theme.palette.text.secondary,
+          border: theme.palette.divider,
+        }
+      : theme.qnop.badge[tone];
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        px: 1,
+        py: 0.25,
+        borderRadius: 1,
+        fontSize: 12,
+        fontWeight: 600,
+        lineHeight: 1.6,
+        whiteSpace: 'nowrap',
+        bgcolor: t.bg,
+        color: t.fg,
+        border: '1px solid',
+        borderColor: t.border,
+      }}
+    >
+      {label}
+    </Box>
+  );
+}
+
+const ROLE_TONE: Record<UserRole, Tone> = { ADMIN: 'blue', AUDITOR: 'amber', MEMBER: 'neutral' };
+const ROLE_LABEL: Record<UserRole, string> = {
+  ADMIN: 'Admin',
+  MEMBER: 'Mitglied',
+  AUDITOR: 'Auditor',
+};
+
+/** The user's global role as a coloured pill. */
+export function UserRoleBadge({ role }: { role: UserRole }) {
+  return <ToneBadge tone={ROLE_TONE[role]} label={ROLE_LABEL[role]} />;
+}
+
+/** Account state: active (green) or disabled (red). */
+export function UserStatusBadge({ enabled }: { enabled: boolean }) {
+  return enabled ? (
+    <ToneBadge tone="green" label="Aktiv" />
+  ) : (
+    <ToneBadge tone="red" label="Deaktiviert" />
+  );
+}

--- a/qnop-ui/src/components/admin/users/UserFormDialog.tsx
+++ b/qnop-ui/src/components/admin/users/UserFormDialog.tsx
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type FormEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import type { AdminUserSummary, UserRole } from '../../../api/generated';
+import { PasswordField } from '../../auth/PasswordField';
+import { PasswordStrengthMeter } from '../../auth/PasswordStrengthMeter';
+import { useCreateUser, useUpdateUser } from '../../../api/hooks/useAdminUsers';
+import { apiErrorCode, apiErrorMessage } from '../../../utils/apiError';
+import { passwordStrength } from '../../../utils/passwordStrength';
+
+interface UserFormDialogProps {
+  open: boolean;
+  mode: 'create' | 'edit';
+  user?: AdminUserSummary;
+  onClose: () => void;
+}
+
+const ROLES: { value: UserRole; label: string }[] = [
+  { value: 'MEMBER', label: 'Mitglied' },
+  { value: 'AUDITOR', label: 'Auditor' },
+  { value: 'ADMIN', label: 'Admin' },
+];
+
+const CONFLICT_DE: Record<string, string> = {
+  EMAIL_TAKEN: 'Diese E-Mail-Adresse ist bereits vergeben.',
+  USERNAME_TAKEN: 'Dieser Benutzername ist bereits vergeben.',
+  SELF_LOCKOUT: 'Du kannst dein eigenes Konto nicht deaktivieren oder herabstufen.',
+  LAST_ADMIN: 'Es muss mindestens ein aktiver Admin verbleiben.',
+};
+
+/**
+ * Create/invite a user (mode "create") or edit name, role and status (mode "edit").
+ *
+ * <p>State is seeded once from props via {@code useState} initializers; the parent gives the dialog
+ * a changing {@code key} on every open so it remounts fresh — no reset-via-effect (and no cascading
+ * renders), which is the React-recommended way to reset form state on prop change.
+ */
+export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProps) {
+  const createUser = useCreateUser();
+  const updateUser = useUpdateUser();
+
+  const editing = mode === 'edit' && user;
+  const [displayName, setDisplayName] = useState(editing ? user.displayName : '');
+  const [username, setUsername] = useState(editing ? (user.username ?? '') : '');
+  const [email, setEmail] = useState(editing ? user.email : '');
+  const [role, setRole] = useState<UserRole>(editing ? user.role : 'MEMBER');
+  const [enabled, setEnabled] = useState(editing ? user.enabled : true);
+  const [method, setMethod] = useState<'invite' | 'password'>('invite');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const submitting = createUser.isPending || updateUser.isPending;
+  const passwordOk = method === 'invite' || passwordStrength(password).acceptable;
+  const canSubmit =
+    mode === 'edit'
+      ? displayName.trim().length > 0
+      : displayName.trim().length > 0 &&
+        username.trim().length >= 3 &&
+        email.trim().length > 0 &&
+        passwordOk;
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      if (mode === 'edit' && user) {
+        await updateUser.mutateAsync({ id: user.id, request: { displayName, role, enabled } });
+      } else {
+        await createUser.mutateAsync({
+          displayName,
+          username,
+          email,
+          role,
+          initialPassword: method === 'password' ? password : undefined,
+        });
+      }
+      onClose();
+    } catch (err) {
+      const code = apiErrorCode(err);
+      setError(
+        (code && CONFLICT_DE[code]) ??
+          apiErrorMessage(err, 'Speichern fehlgeschlagen. Bitte erneut versuchen.'),
+      );
+    }
+  };
+
+  const isEdit = mode === 'edit';
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <Box component="form" onSubmit={onSubmit} noValidate>
+        <DialogTitle>{isEdit ? 'Benutzer bearbeiten' : 'Benutzer anlegen'}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ mt: 1 }}>
+            <TextField
+              label="Vollständiger Name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              autoComplete="name"
+              fullWidth
+              required
+            />
+
+            {!isEdit && (
+              <>
+                <TextField
+                  label="Benutzername"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  autoComplete="off"
+                  fullWidth
+                  required
+                  helperText="Mindestens 3 Zeichen, eindeutig."
+                />
+                <TextField
+                  label="E-Mail"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="off"
+                  fullWidth
+                  required
+                />
+              </>
+            )}
+
+            <TextField
+              label="Rolle"
+              select
+              value={role}
+              onChange={(e) => setRole(e.target.value as UserRole)}
+              fullWidth
+            >
+              {ROLES.map((r) => (
+                <MenuItem key={r.value} value={r.value}>
+                  {r.label}
+                </MenuItem>
+              ))}
+            </TextField>
+
+            {isEdit && (
+              <FormControlLabel
+                control={
+                  <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+                }
+                label={enabled ? 'Konto aktiv' : 'Konto deaktiviert'}
+              />
+            )}
+
+            {!isEdit && (
+              <Box>
+                <RadioGroup
+                  value={method}
+                  onChange={(e) => setMethod(e.target.value as 'invite' | 'password')}
+                >
+                  <FormControlLabel
+                    value="invite"
+                    control={<Radio size="small" />}
+                    label="Einladung per E-Mail senden (Benutzer setzt eigenes Passwort)"
+                  />
+                  <FormControlLabel
+                    value="password"
+                    control={<Radio size="small" />}
+                    label="Passwort jetzt setzen (Änderung beim ersten Login erforderlich)"
+                  />
+                </RadioGroup>
+                {method === 'password' && (
+                  <Box sx={{ mt: 1 }}>
+                    <PasswordField
+                      label="Initialpasswort"
+                      value={password}
+                      onChange={setPassword}
+                      autoComplete="new-password"
+                      required
+                    />
+                    <PasswordStrengthMeter password={password} />
+                  </Box>
+                )}
+              </Box>
+            )}
+
+            {error && <Alert severity="error">{error}</Alert>}
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2.5 }}>
+          <Button onClick={onClose} color="inherit">
+            Abbrechen
+          </Button>
+          <Button type="submit" variant="contained" disabled={submitting || !canSubmit}>
+            {isEdit ? 'Speichern' : 'Anlegen'}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/admin/users/UsersTable.tsx
+++ b/qnop-ui/src/components/admin/users/UsersTable.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type MouseEvent } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import { KeyRound, MoreVertical, SquarePen } from 'lucide-react';
+import type { AdminUserSummary } from '../../../api/generated';
+import { UserAvatar } from '../../shell/UserAvatar';
+import { formatDateTime } from '../../../utils/formatDate';
+import { UserRoleBadge, UserStatusBadge } from './UserBadges';
+
+interface UsersTableProps {
+  users: AdminUserSummary[];
+  onEdit: (user: AdminUserSummary) => void;
+  onResetPassword: (user: AdminUserSummary) => void;
+}
+
+export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [active, setActive] = useState<AdminUserSummary | null>(null);
+
+  const openMenu = (event: MouseEvent<HTMLElement>, user: AdminUserSummary) => {
+    setAnchorEl(event.currentTarget);
+    setActive(user);
+  };
+  const closeMenu = () => setAnchorEl(null);
+
+  return (
+    <>
+      <Table size="medium" sx={{ '& td, & th': { borderColor: 'divider' } }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Benutzer</TableCell>
+            <TableCell>Rolle</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Letzter Login</TableCell>
+            <TableCell align="right">Aktionen</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {users.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5}>
+                <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+                  Keine Benutzer gefunden.
+                </Typography>
+              </TableCell>
+            </TableRow>
+          )}
+          {users.map((user) => (
+            <TableRow key={user.id} hover>
+              <TableCell>
+                <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+                  <UserAvatar name={user.displayName} size={36} />
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography sx={{ fontWeight: 600, lineHeight: 1.3 }} noWrap>
+                      {user.displayName}
+                      {user.source === 'EXTERNAL' && (
+                        <Typography
+                          component="span"
+                          sx={{ ml: 1, fontSize: 11, color: 'text.secondary', fontWeight: 500 }}
+                        >
+                          OIDC
+                        </Typography>
+                      )}
+                    </Typography>
+                    <Typography sx={{ fontSize: 13, color: 'text.secondary' }} noWrap>
+                      {user.email}
+                    </Typography>
+                  </Box>
+                </Stack>
+              </TableCell>
+              <TableCell>
+                <UserRoleBadge role={user.role} />
+              </TableCell>
+              <TableCell>
+                <UserStatusBadge enabled={user.enabled} />
+              </TableCell>
+              <TableCell>
+                <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>
+                  {formatDateTime(user.lastLoginAt)}
+                </Typography>
+              </TableCell>
+              <TableCell align="right">
+                <IconButton
+                  size="small"
+                  aria-label={`Aktionen für ${user.displayName}`}
+                  onClick={(e) => openMenu(e, user)}
+                >
+                  <MoreVertical size={18} />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu}>
+        <MenuItem
+          onClick={() => {
+            closeMenu();
+            if (active) onEdit(active);
+          }}
+        >
+          <ListItemIcon>
+            <SquarePen size={16} />
+          </ListItemIcon>
+          <ListItemText>Bearbeiten</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={active?.source === 'EXTERNAL'}
+          onClick={() => {
+            closeMenu();
+            if (active) onResetPassword(active);
+          }}
+        >
+          <ListItemIcon>
+            <KeyRound size={16} />
+          </ListItemIcon>
+          <ListItemText>Passwort-Link senden</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/qnop-ui/src/pages/admin/UsersPage.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
+import LinearProgress from '@mui/material/LinearProgress';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Stack from '@mui/material/Stack';
+import TablePagination from '@mui/material/TablePagination';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { Search, UserPlus } from 'lucide-react';
+import type { AdminUserSummary, UserRole } from '../../api/generated';
+import { useAdminUsers, useSendUserPasswordReset } from '../../api/hooks/useAdminUsers';
+import { UserFormDialog } from '../../components/admin/users/UserFormDialog';
+import { UsersTable } from '../../components/admin/users/UsersTable';
+import { apiErrorMessage } from '../../utils/apiError';
+
+const PAGE_SIZE = 20;
+
+type DialogState =
+  | { open: false }
+  | { open: true; mode: 'create' }
+  | { open: true; mode: 'edit'; user: AdminUserSummary };
+
+type Toast = { message: string; severity: 'success' | 'error' } | null;
+
+/** Admin user management: search, filter, paginate, create/invite, edit and reset (#104). */
+export function UsersPage() {
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState<UserRole | ''>('');
+  const [page, setPage] = useState(0);
+  const [dialog, setDialog] = useState<DialogState>({ open: false });
+  // Bumped on every open so the dialog remounts with fresh state (see UserFormDialog).
+  const [openSeq, setOpenSeq] = useState(0);
+  const [toast, setToast] = useState<Toast>(null);
+
+  const sendReset = useSendUserPasswordReset();
+
+  const openCreate = () => {
+    setDialog({ open: true, mode: 'create' });
+    setOpenSeq((n) => n + 1);
+  };
+  const openEdit = (user: AdminUserSummary) => {
+    setDialog({ open: true, mode: 'edit', user });
+    setOpenSeq((n) => n + 1);
+  };
+
+  // Debounce the search box and reset to the first page when the query changes.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(0);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [search]);
+
+  const { data, isLoading, isFetching, isError } = useAdminUsers({
+    q: debouncedSearch || undefined,
+    role: roleFilter || undefined,
+    page,
+    size: PAGE_SIZE,
+  });
+
+  const users = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  const onResetPassword = async (user: AdminUserSummary) => {
+    try {
+      await sendReset.mutateAsync(user.id);
+      setToast({ message: `Passwort-Link an ${user.email} gesendet.`, severity: 'success' });
+    } catch (err) {
+      setToast({
+        message: apiErrorMessage(err, 'Der Link konnte nicht gesendet werden.'),
+        severity: 'error',
+      });
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        sx={{ justifyContent: 'space-between', alignItems: { sm: 'center' } }}
+      >
+        <Box>
+          <Typography variant="h1" sx={{ fontSize: 28 }}>
+            Benutzer
+          </Typography>
+          <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+            Konten, Rollen und Zugriff verwalten.
+          </Typography>
+        </Box>
+        <Button variant="contained" startIcon={<UserPlus size={18} />} onClick={openCreate}>
+          Benutzer anlegen
+        </Button>
+      </Stack>
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+        <TextField
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Nach Name, E-Mail oder Benutzername suchen"
+          size="small"
+          sx={{ flex: 1, maxWidth: 420 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={16} />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+        <TextField
+          select
+          label="Rolle"
+          value={roleFilter}
+          onChange={(e) => {
+            setRoleFilter(e.target.value as UserRole | '');
+            setPage(0);
+          }}
+          size="small"
+          sx={{ minWidth: 160 }}
+        >
+          <MenuItem value="">Alle Rollen</MenuItem>
+          <MenuItem value="ADMIN">Admin</MenuItem>
+          <MenuItem value="MEMBER">Mitglied</MenuItem>
+          <MenuItem value="AUDITOR">Auditor</MenuItem>
+        </TextField>
+      </Stack>
+
+      <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+        <Box sx={{ height: 3 }}>{isFetching && <LinearProgress />}</Box>
+        {isError ? (
+          <Alert severity="error" sx={{ m: 2 }}>
+            Die Benutzerliste konnte nicht geladen werden.
+          </Alert>
+        ) : (
+          <>
+            <UsersTable users={users} onEdit={openEdit} onResetPassword={onResetPassword} />
+            <TablePagination
+              component="div"
+              count={total}
+              page={page}
+              rowsPerPage={PAGE_SIZE}
+              rowsPerPageOptions={[PAGE_SIZE]}
+              onPageChange={(_, next) => setPage(next)}
+              labelDisplayedRows={({ from, to, count }) => `${from}–${to} von ${count}`}
+            />
+          </>
+        )}
+        {isLoading && (
+          <Typography color="text.secondary" sx={{ p: 2, fontSize: 14 }}>
+            Lädt …
+          </Typography>
+        )}
+      </Paper>
+
+      <UserFormDialog
+        key={openSeq}
+        open={dialog.open}
+        mode={dialog.open ? dialog.mode : 'create'}
+        user={dialog.open && dialog.mode === 'edit' ? dialog.user : undefined}
+        onClose={() => setDialog({ open: false })}
+      />
+
+      <Snackbar
+        open={toast !== null}
+        autoHideDuration={5000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert severity={toast.severity} onClose={() => setToast(null)} variant="filled">
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/admin/UsersPage.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.tsx
@@ -23,6 +23,7 @@ import { useEffect, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import LinearProgress from '@mui/material/LinearProgress';
 import MenuItem from '@mui/material/MenuItem';
@@ -32,7 +33,7 @@ import Stack from '@mui/material/Stack';
 import TablePagination from '@mui/material/TablePagination';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { Search, UserPlus } from 'lucide-react';
+import { Search, UserPlus, X } from 'lucide-react';
 import type { AdminUserSummary, UserRole } from '../../api/generated';
 import { useAdminUsers, useSendUserPasswordReset } from '../../api/hooks/useAdminUsers';
 import { UserFormDialog } from '../../components/admin/users/UserFormDialog';
@@ -135,6 +136,18 @@ export function UsersPage() {
                   <Search size={16} />
                 </InputAdornment>
               ),
+              endAdornment: search ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="Suche zurücksetzen"
+                    size="small"
+                    edge="end"
+                    onClick={() => setSearch('')}
+                  >
+                    <X size={16} />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
             },
           }}
         />

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -20,13 +20,14 @@
  */
 
 import { createBrowserRouter } from 'react-router-dom';
-import { FileText, Settings, ShieldCheck, User, Users } from 'lucide-react';
+import { FileText, Settings, ShieldCheck, Users } from 'lucide-react';
 import { AppShell } from '../components/shell/AppShell';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { ProtectedRoute } from '../components/auth/ProtectedRoute';
 import { RoleRoute } from '../components/auth/RoleRoute';
 import { ComingSoonPage } from '../pages/ComingSoonPage';
 import { HomePage } from '../pages/HomePage';
+import { UsersPage } from '../pages/admin/UsersPage';
 import { ChangePasswordPage } from '../pages/auth/ChangePasswordPage';
 import { ForgotPasswordPage } from '../pages/auth/ForgotPasswordPage';
 import { LoginPage } from '../pages/auth/LoginPage';
@@ -85,11 +86,7 @@ export const router = createBrowserRouter([
         path: 'admin/users',
         element: (
           <AdminRoute>
-            <ComingSoonPage
-              title="Benutzer"
-              description="Konten, Rollen und Zugriff verwalten."
-              icon={User}
-            />
+            <UsersPage />
           </AdminRoute>
         ),
       },

--- a/qnop-ui/src/utils/apiError.test.ts
+++ b/qnop-ui/src/utils/apiError.test.ts
@@ -21,10 +21,14 @@
 
 import { AxiosError, type AxiosResponse } from 'axios';
 import { describe, expect, it } from 'vitest';
-import { apiErrorMessage } from './apiError';
+import { apiErrorCode, apiErrorMessage } from './apiError';
 
 function axiosWithStatus(status: number): AxiosError {
   return new AxiosError('x', 'ERR', undefined, undefined, { status } as AxiosResponse);
+}
+
+function axiosWithBody(status: number, data: unknown): AxiosError {
+  return new AxiosError('x', 'ERR', undefined, undefined, { status, data } as AxiosResponse);
 }
 
 describe('apiErrorMessage', () => {
@@ -43,5 +47,17 @@ describe('apiErrorMessage', () => {
   it('falls back for unknown errors', () => {
     expect(apiErrorMessage(new Error('boom'), 'fallback')).toBe('fallback');
     expect(apiErrorMessage(axiosWithStatus(500), 'fallback')).toBe('fallback');
+  });
+});
+
+describe('apiErrorCode', () => {
+  it('extracts the code from the error envelope', () => {
+    expect(apiErrorCode(axiosWithBody(409, { code: 'EMAIL_TAKEN' }))).toBe('EMAIL_TAKEN');
+  });
+
+  it('returns undefined when there is no code or it is not an axios error', () => {
+    expect(apiErrorCode(axiosWithBody(409, { message: 'x' }))).toBeUndefined();
+    expect(apiErrorCode(axiosWithStatus(500))).toBeUndefined();
+    expect(apiErrorCode(new Error('boom'))).toBeUndefined();
   });
 });

--- a/qnop-ui/src/utils/apiError.ts
+++ b/qnop-ui/src/utils/apiError.ts
@@ -39,3 +39,16 @@ export function apiErrorMessage(error: unknown, fallback: string): string {
   }
   return fallback;
 }
+
+/**
+ * The stable `code` from the uniform API error envelope (e.g. `EMAIL_TAKEN`,
+ * `SELF_LOCKOUT`), or undefined when the error carries none. Callers map known
+ * codes to localized messages instead of surfacing the server's English text.
+ */
+export function apiErrorCode(error: unknown): string | undefined {
+  if (isAxiosError(error)) {
+    const code = (error.response?.data as { code?: unknown } | undefined)?.code;
+    if (typeof code === 'string') return code;
+  }
+  return undefined;
+}

--- a/qnop-ui/src/utils/formatDate.test.ts
+++ b/qnop-ui/src/utils/formatDate.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDateTime } from './formatDate';
+
+describe('formatDateTime', () => {
+  it('returns an em dash for null, undefined or an invalid date', () => {
+    expect(formatDateTime(null)).toBe('—');
+    expect(formatDateTime(undefined)).toBe('—');
+    expect(formatDateTime('not-a-date')).toBe('—');
+  });
+
+  it('formats a valid ISO timestamp to a non-empty localized string', () => {
+    const formatted = formatDateTime('2026-06-21T12:34:00Z');
+    expect(formatted).not.toBe('—');
+    expect(formatted).toMatch(/2026/);
+  });
+});

--- a/qnop-ui/src/utils/formatDate.ts
+++ b/qnop-ui/src/utils/formatDate.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+const DATE_TIME = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+/** Formats an ISO timestamp as a localized date+time, or an em dash when absent/invalid. */
+export function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? '—' : DATE_TIME.format(date);
+}


### PR DESCRIPTION
## What & why

Closes #104. Adds admin-only user management — the prototype "Benutzer" surface — backend and frontend.

An ADMIN can now list/search users, create them (with an initial password or by emailing an invitation), edit name/role/status, and trigger a password-setup/reset link, all from the UI.

## Backend (`AdminUsers` API)

- **OpenAPI**: `GET /admin/users` (paginated, `q` + `role` filters), `POST /admin/users`, `GET`/`PATCH /admin/users/{id}`, `POST /admin/users/{id}/password-reset`. Reuses the shared `Unauthorized`/`Forbidden` responses.
- **`AdminUserService`** keeps the `User` entity in the service layer and returns entity-free views (ADR-0004). Two lockout guards return **409**: an admin cannot disable/demote their own account, and the last enabled admin cannot be removed.
- **Create or invite**: with `initialPassword` the account is enabled and must change it on first login; without one it is provisioned behind a random, unusable BCrypt placeholder (honouring the `INTERNAL ⇒ credentials` DB invariant) and an invitation link is emailed. `PasswordResetFlowService` gained a non-gated `sendSetupLink` for this admin action.
- **`AdminUserController`** maps domain errors to the uniform envelope (404 / 409); authorization stays centralized in the security chain (`/admin/**` ⇒ `ADMIN`).
- **Repository**: paginated search + enabled-admin count.

## Frontend (`/admin/users`)

- TanStack Query hooks (list with `keepPreviousData`; create/update/reset mutations that invalidate the list).
- `UsersPage`: debounced search, role filter, pagination, in-brand table (avatar, role + status badges from `theme.qnop.badge`, per-row actions), snackbar for the reset action.
- `UserFormDialog`: create/invite (toggle) and edit; 409 codes mapped to German messages; state seeded via `useState` initializers + remount-per-open `key` (no reset-via-effect).

## Test plan

- [x] `./gradlew build` green — Spotless, ArchUnit, all tests.
- [x] `AdminUserServiceTest` (unit): create/invite, duplicate guards, self-lockout, last-admin, reset.
- [x] `AdminUserControllerIT` (real PostgreSQL + security chain): ADMIN vs MEMBER (403) vs anonymous (401), create-with-password, create-by-invitation, duplicate (409), role update, self-lockout (409), unknown (404), search, reset (202).
- [x] Frontend `pnpm lint` / `pnpm build` / `pnpm test:coverage` green (coverage 97%, ≥80% gate).
- [x] Manual E2E (Playwright): logged in as admin, listed users, created a user via the dialog — the new row appeared and the list refreshed.

## Notes

- No DB migration: all fields already exist on `qnop_user`.
- Drive-by: the `AdminUserControllerIT` gives each login a distinct client IP so it does not exhaust the login rate-limit bucket shared via the cached Spring context.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code
