### PR TITLE
feat(ui): auth screen redesign + switch all UI texts to English (#118)

### DIFF
--- a/qnop-ui/src/components/admin/users/UserBadges.tsx
+++ b/qnop-ui/src/components/admin/users/UserBadges.tsx
@@ -63,7 +63,7 @@ function ToneBadge({ tone, label }: { tone: Tone; label: string }) {
 const ROLE_TONE: Record<UserRole, Tone> = { ADMIN: 'blue', AUDITOR: 'amber', MEMBER: 'neutral' };
 const ROLE_LABEL: Record<UserRole, string> = {
   ADMIN: 'Admin',
-  MEMBER: 'Mitglied',
+  MEMBER: 'Member',
   AUDITOR: 'Auditor',
 };
 
@@ -75,8 +75,8 @@ export function UserRoleBadge({ role }: { role: UserRole }) {
 /** Account state: active (green) or disabled (red). */
 export function UserStatusBadge({ enabled }: { enabled: boolean }) {
   return enabled ? (
-    <ToneBadge tone="green" label="Aktiv" />
+    <ToneBadge tone="green" label="Active" />
   ) : (
-    <ToneBadge tone="red" label="Deaktiviert" />
+    <ToneBadge tone="red" label="Disabled" />
   );
 }

--- a/qnop-ui/src/components/admin/users/UserFormDialog.tsx
+++ b/qnop-ui/src/components/admin/users/UserFormDialog.tsx
@@ -49,16 +49,16 @@ interface UserFormDialogProps {
 }
 
 const ROLES: { value: UserRole; label: string }[] = [
-  { value: 'MEMBER', label: 'Mitglied' },
+  { value: 'MEMBER', label: 'Member' },
   { value: 'AUDITOR', label: 'Auditor' },
   { value: 'ADMIN', label: 'Admin' },
 ];
 
-const CONFLICT_DE: Record<string, string> = {
-  EMAIL_TAKEN: 'Diese E-Mail-Adresse ist bereits vergeben.',
-  USERNAME_TAKEN: 'Dieser Benutzername ist bereits vergeben.',
-  SELF_LOCKOUT: 'Du kannst dein eigenes Konto nicht deaktivieren oder herabstufen.',
-  LAST_ADMIN: 'Es muss mindestens ein aktiver Admin verbleiben.',
+const CONFLICT_MESSAGES: Record<string, string> = {
+  EMAIL_TAKEN: 'An account with this email already exists.',
+  USERNAME_TAKEN: 'This username is already taken.',
+  SELF_LOCKOUT: "You can't disable or change the role of your own account.",
+  LAST_ADMIN: 'At least one enabled admin must remain.',
 };
 
 /**
@@ -111,8 +111,8 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
     } catch (err) {
       const code = apiErrorCode(err);
       setError(
-        (code && CONFLICT_DE[code]) ??
-          apiErrorMessage(err, 'Speichern fehlgeschlagen. Bitte erneut versuchen.'),
+        (code && CONFLICT_MESSAGES[code]) ??
+          apiErrorMessage(err, 'Saving failed. Please try again.'),
       );
     }
   };
@@ -122,11 +122,11 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <Box component="form" onSubmit={onSubmit} noValidate>
-        <DialogTitle>{isEdit ? 'Benutzer bearbeiten' : 'Benutzer anlegen'}</DialogTitle>
+        <DialogTitle>{isEdit ? 'Edit user' : 'Add user'}</DialogTitle>
         <DialogContent>
           <Stack spacing={2.5} sx={{ mt: 1 }}>
             <TextField
-              label="Vollständiger Name"
+              label="Full name"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               autoComplete="name"
@@ -137,16 +137,16 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
             {!isEdit && (
               <>
                 <TextField
-                  label="Benutzername"
+                  label="Username"
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
                   autoComplete="off"
                   fullWidth
                   required
-                  helperText="Mindestens 3 Zeichen, eindeutig."
+                  helperText="At least 3 characters, unique."
                 />
                 <TextField
-                  label="E-Mail"
+                  label="Email"
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -158,7 +158,7 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
             )}
 
             <TextField
-              label="Rolle"
+              label="Role"
               select
               value={role}
               onChange={(e) => setRole(e.target.value as UserRole)}
@@ -176,7 +176,7 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
                 control={
                   <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
                 }
-                label={enabled ? 'Konto aktiv' : 'Konto deaktiviert'}
+                label={enabled ? 'Account active' : 'Account disabled'}
               />
             )}
 
@@ -189,18 +189,18 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
                   <FormControlLabel
                     value="invite"
                     control={<Radio size="small" />}
-                    label="Einladung per E-Mail senden (Benutzer setzt eigenes Passwort)"
+                    label="Send an email invitation (the user sets their own password)"
                   />
                   <FormControlLabel
                     value="password"
                     control={<Radio size="small" />}
-                    label="Passwort jetzt setzen (Änderung beim ersten Login erforderlich)"
+                    label="Set a password now (must be changed on first login)"
                   />
                 </RadioGroup>
                 {method === 'password' && (
                   <Box sx={{ mt: 1 }}>
                     <PasswordField
-                      label="Initialpasswort"
+                      label="Initial password"
                       value={password}
                       onChange={setPassword}
                       autoComplete="new-password"
@@ -217,10 +217,10 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2.5 }}>
           <Button onClick={onClose} color="inherit">
-            Abbrechen
+            Cancel
           </Button>
           <Button type="submit" variant="contained" disabled={submitting || !canSubmit}>
-            {isEdit ? 'Speichern' : 'Anlegen'}
+            {isEdit ? 'Save' : 'Create'}
           </Button>
         </DialogActions>
       </Box>

--- a/qnop-ui/src/components/admin/users/UsersTable.tsx
+++ b/qnop-ui/src/components/admin/users/UsersTable.tsx
@@ -60,11 +60,11 @@ export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) 
       <Table size="medium" sx={{ '& td, & th': { borderColor: 'divider' } }}>
         <TableHead>
           <TableRow>
-            <TableCell>Benutzer</TableCell>
-            <TableCell>Rolle</TableCell>
+            <TableCell>User</TableCell>
+            <TableCell>Role</TableCell>
             <TableCell>Status</TableCell>
-            <TableCell>Letzter Login</TableCell>
-            <TableCell align="right">Aktionen</TableCell>
+            <TableCell>Last login</TableCell>
+            <TableCell align="right">Actions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -72,7 +72,7 @@ export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) 
             <TableRow>
               <TableCell colSpan={5}>
                 <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
-                  Keine Benutzer gefunden.
+                  No users found.
                 </Typography>
               </TableCell>
             </TableRow>
@@ -114,7 +114,7 @@ export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) 
               <TableCell align="right">
                 <IconButton
                   size="small"
-                  aria-label={`Aktionen für ${user.displayName}`}
+                  aria-label={`Actions for ${user.displayName}`}
                   onClick={(e) => openMenu(e, user)}
                 >
                   <MoreVertical size={18} />
@@ -135,7 +135,7 @@ export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) 
           <ListItemIcon>
             <SquarePen size={16} />
           </ListItemIcon>
-          <ListItemText>Bearbeiten</ListItemText>
+          <ListItemText>Edit</ListItemText>
         </MenuItem>
         <MenuItem
           disabled={active?.source === 'EXTERNAL'}
@@ -147,7 +147,7 @@ export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) 
           <ListItemIcon>
             <KeyRound size={16} />
           </ListItemIcon>
-          <ListItemText>Passwort-Link senden</ListItemText>
+          <ListItemText>Send password link</ListItemText>
         </MenuItem>
       </Menu>
     </>

--- a/qnop-ui/src/components/auth/AuthLayout.tsx
+++ b/qnop-ui/src/components/auth/AuthLayout.tsx
@@ -35,15 +35,17 @@ const TRUST = [
 interface AuthLayoutProps {
   title: string;
   subtitle?: string;
+  /** Optional slot rendered above the title (e.g. the sign-in/register switch). */
+  headerSlot?: ReactNode;
   children: ReactNode;
 }
 
 /**
  * Two-column shell for the public auth screens (#103): a sovereign-themed brand
  * panel on the left (hidden below `md`) and the form card on the right, matching
- * the design prototype's "Dokumenten-Review, souverän" treatment.
+ * the design prototype's "Sovereign document review" treatment.
  */
-export function AuthLayout({ title, subtitle, children }: AuthLayoutProps) {
+export function AuthLayout({ title, subtitle, headerSlot, children }: AuthLayoutProps) {
   return (
     <Box
       sx={{
@@ -131,22 +133,32 @@ export function AuthLayout({ title, subtitle, children }: AuthLayoutProps) {
         <Box sx={{ position: 'relative', zIndex: 1, mt: 'auto', maxWidth: 460 }}>
           <Typography
             sx={{
-              fontSize: 12,
-              letterSpacing: '0.1em',
+              fontSize: 12.5,
+              letterSpacing: '0.12em',
               textTransform: 'uppercase',
               color: '#61B5F6',
-              fontWeight: 500,
-              mb: 2,
+              fontWeight: 600,
+              mb: 2.5,
             }}
           >
-            Dokumenten-Review, souverän
+            Sovereign document review
           </Typography>
-          <Typography variant="h2" sx={{ color: '#fff', mb: 2 }}>
-            Prüfen, freigeben, vertrauen — alles an einem Ort.
+          <Typography
+            component="h2"
+            sx={{
+              color: '#fff',
+              fontWeight: 700,
+              fontSize: { md: 34, lg: 41 },
+              lineHeight: 1.1,
+              letterSpacing: '-0.025em',
+              mb: 2.5,
+            }}
+          >
+            Review, approve, trust — all in one place.
           </Typography>
-          <Typography sx={{ color: '#B9C6D4', lineHeight: 1.6, maxWidth: 420 }}>
-            Verträge gemeinsam prüfen, Versionen vergleichen und Reviews koordinieren. Ihre Daten
-            bleiben dabei vollständig auf Ihrer Infrastruktur.
+          <Typography sx={{ color: '#B9C6D4', fontSize: 16, lineHeight: 1.65, maxWidth: 430 }}>
+            Review contracts together, compare versions and coordinate reviews — while your data
+            stays entirely on your own infrastructure.
           </Typography>
           <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 1.25, mt: 4 }}>
             {TRUST.map(({ icon: Icon, label }) => (
@@ -173,7 +185,7 @@ export function AuthLayout({ title, subtitle, children }: AuthLayoutProps) {
         </Box>
 
         <Typography sx={{ position: 'relative', zIndex: 1, mt: 5, fontSize: 12, color: '#7A8BA0' }}>
-          © 2026 devtank42 GmbH · Alle Daten verbleiben in der EU
+          © 2026 devtank42 GmbH · All data stays in the EU
         </Typography>
       </Box>
 
@@ -188,11 +200,21 @@ export function AuthLayout({ title, subtitle, children }: AuthLayoutProps) {
         }}
       >
         <Box sx={{ width: '100%', maxWidth: 408 }}>
-          <Typography variant="h4" component="h1" sx={{ mb: subtitle ? 0.5 : 3 }}>
+          {headerSlot}
+          <Typography
+            component="h1"
+            sx={{
+              fontWeight: 700,
+              fontSize: 26,
+              letterSpacing: '-0.02em',
+              lineHeight: 1.15,
+              mb: subtitle ? 0.75 : 3,
+            }}
+          >
             {title}
           </Typography>
           {subtitle && (
-            <Typography color="text.secondary" sx={{ mb: 3 }}>
+            <Typography color="text.secondary" sx={{ fontSize: 14.5, mb: 3 }}>
               {subtitle}
             </Typography>
           )}

--- a/qnop-ui/src/components/auth/AuthModeSwitch.tsx
+++ b/qnop-ui/src/components/auth/AuthModeSwitch.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import { Link as RouterLink } from 'react-router-dom';
+
+type Mode = 'login' | 'register';
+
+const SEGMENTS: { mode: Mode; label: string; to: string }[] = [
+  { mode: 'login', label: 'Sign in', to: '/login' },
+  { mode: 'register', label: 'Create account', to: '/register' },
+];
+
+/**
+ * Segmented sign-in / create-account switch shown above the auth form, matching
+ * the design prototype's two-button toggle. Each segment is a router link, so
+ * the switch navigates between the `/login` and `/register` routes; the active
+ * segment is raised on a white surface.
+ */
+export function AuthModeSwitch({ active }: { active: Mode }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 0.5,
+        p: 0.5,
+        mb: 3.5,
+        borderRadius: 2,
+        bgcolor: (t) => (t.palette.mode === 'dark' ? 'rgba(255,255,255,0.06)' : '#EEF2F7'),
+      }}
+    >
+      {SEGMENTS.map(({ mode, label, to }) => {
+        const isActive = mode === active;
+        return (
+          <Box
+            key={mode}
+            component={RouterLink}
+            to={to}
+            replace
+            aria-current={isActive ? 'page' : undefined}
+            sx={{
+              flex: 1,
+              height: 38,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 1.5,
+              fontSize: 13.5,
+              fontWeight: 600,
+              textDecoration: 'none',
+              letterSpacing: '-0.01em',
+              transition: 'all .15s',
+              color: isActive ? 'text.primary' : 'text.secondary',
+              bgcolor: isActive ? 'background.paper' : 'transparent',
+              boxShadow: isActive ? '0 1px 3px rgba(1,32,66,0.10)' : 'none',
+              '&:hover': { color: isActive ? 'text.primary' : 'text.primary' },
+            }}
+          >
+            {label}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/auth/OidcButtons.tsx
+++ b/qnop-ui/src/components/auth/OidcButtons.tsx
@@ -41,7 +41,7 @@ export function OidcButtons() {
 
   return (
     <>
-      <Divider sx={{ my: 2.5, color: 'text.disabled', fontSize: 12 }}>oder</Divider>
+      <Divider sx={{ my: 2.5, color: 'text.disabled', fontSize: 12 }}>or</Divider>
       <Stack spacing={1.25}>
         {providers.map((p) => (
           <Button
@@ -55,7 +55,7 @@ export function OidcButtons() {
             }}
             sx={{ borderColor: 'divider', color: 'text.primary', justifyContent: 'center' }}
           >
-            Mit {p.name} anmelden
+            Sign in with {p.name}
           </Button>
         ))}
       </Stack>

--- a/qnop-ui/src/components/auth/PasswordField.tsx
+++ b/qnop-ui/src/components/auth/PasswordField.tsx
@@ -23,7 +23,7 @@ import { useState } from 'react';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
-import { Eye, EyeOff } from 'lucide-react';
+import { Eye, EyeOff, Lock } from 'lucide-react';
 
 interface PasswordFieldProps {
   label: string;
@@ -54,13 +54,18 @@ export function PasswordField({
       fullWidth
       slotProps={{
         input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <Lock size={17} />
+            </InputAdornment>
+          ),
           endAdornment: (
             <InputAdornment position="end">
               <IconButton
                 onClick={() => setShow((s) => !s)}
                 edge="end"
                 size="small"
-                aria-label={show ? 'Passwort verbergen' : 'Passwort anzeigen'}
+                aria-label={show ? 'Hide password' : 'Show password'}
                 tabIndex={-1}
               >
                 {show ? <EyeOff size={18} /> : <Eye size={18} />}

--- a/qnop-ui/src/components/shell/Breadcrumbs.tsx
+++ b/qnop-ui/src/components/shell/Breadcrumbs.tsx
@@ -33,7 +33,7 @@ export function Breadcrumbs() {
   return (
     <MuiBreadcrumbs
       separator={<ChevronRight size={13} />}
-      aria-label="Brotkrumen"
+      aria-label="Breadcrumb"
       sx={{ fontSize: 13, '& .MuiBreadcrumbs-separator': { mx: 0.5, color: 'text.disabled' } }}
     >
       {crumbs.map((c, i) => {

--- a/qnop-ui/src/components/shell/TopBar.tsx
+++ b/qnop-ui/src/components/shell/TopBar.tsx
@@ -51,13 +51,8 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
       sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper' }}
     >
       <Toolbar sx={{ gap: 1.5, minHeight: { xs: 56, sm: 56 } }}>
-        <Tooltip title={isMobile ? 'Menü' : 'Menü ein-/ausklappen'}>
-          <IconButton
-            onClick={onToggleSidebar}
-            size="small"
-            edge="start"
-            aria-label="Menü umschalten"
-          >
+        <Tooltip title={isMobile ? 'Menu' : 'Toggle menu'}>
+          <IconButton onClick={onToggleSidebar} size="small" edge="start" aria-label="Toggle menu">
             {isMobile ? <MenuIcon size={18} /> : <PanelLeft size={18} />}
           </IconButton>
         </Tooltip>
@@ -86,26 +81,24 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
         >
           <Search size={15} />
           <InputBase
-            placeholder="Suchen…"
+            placeholder="Search…"
             sx={{ fontSize: 13, flex: 1 }}
-            inputProps={{ 'aria-label': 'Suchen' }}
+            inputProps={{ 'aria-label': 'Search' }}
           />
         </Box>
 
-        <Tooltip title={themeMode === 'dark' ? 'Heller Modus' : 'Dunkler Modus'}>
+        <Tooltip title={themeMode === 'dark' ? 'Light mode' : 'Dark mode'}>
           <IconButton
             onClick={toggleTheme}
             size="small"
-            aria-label={
-              themeMode === 'dark' ? 'Hellen Modus aktivieren' : 'Dunklen Modus aktivieren'
-            }
+            aria-label={themeMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
           >
             {themeMode === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
           </IconButton>
         </Tooltip>
 
-        <Tooltip title="Benachrichtigungen">
-          <IconButton size="small" aria-label="Benachrichtigungen">
+        <Tooltip title="Notifications">
+          <IconButton size="small" aria-label="Notifications">
             <Badge color="primary" variant="dot">
               <Bell size={18} />
             </Badge>
@@ -119,7 +112,7 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
           onClick={() => navigate('/reviews')}
           sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
         >
-          Neuer Review
+          New review
         </Button>
       </Toolbar>
     </AppBar>

--- a/qnop-ui/src/components/shell/UserFooter.tsx
+++ b/qnop-ui/src/components/shell/UserFooter.tsx
@@ -33,7 +33,7 @@ import { UserAvatar } from './UserAvatar';
 
 const ROLE_LABEL: Record<string, string> = {
   ADMIN: 'Administrator',
-  MEMBER: 'Mitglied',
+  MEMBER: 'Member',
   AUDITOR: 'Auditor',
 };
 
@@ -59,7 +59,7 @@ export function UserFooter({ collapsed }: UserFooterProps) {
     <Box sx={{ borderTop: 1, borderColor: 'divider', p: collapsed ? 1 : 1.5 }}>
       <ButtonBase
         onClick={(e: MouseEvent<HTMLElement>) => setAnchor(e.currentTarget)}
-        aria-label="Benutzermenü"
+        aria-label="User menu"
         sx={{
           width: '100%',
           gap: 1.25,
@@ -73,7 +73,7 @@ export function UserFooter({ collapsed }: UserFooterProps) {
         {!collapsed && (
           <Box sx={{ minWidth: 0, textAlign: 'left', flex: 1 }}>
             <Typography noWrap sx={{ fontSize: 13, fontWeight: 500, lineHeight: 1.2 }}>
-              {displayName ?? 'Unbekannt'}
+              {displayName ?? 'Unknown'}
             </Typography>
             <Typography noWrap sx={{ fontSize: 11, color: 'text.disabled' }}>
               {role ? ROLE_LABEL[role] : ''}
@@ -98,13 +98,13 @@ export function UserFooter({ collapsed }: UserFooterProps) {
           <ListItemIcon>
             <KeyRound size={16} />
           </ListItemIcon>
-          Passwort ändern
+          Change password
         </MenuItem>
         <MenuItem onClick={onLogout}>
           <ListItemIcon>
             <LogOut size={16} />
           </ListItemIcon>
-          Abmelden
+          Sign out
         </MenuItem>
       </Menu>
     </Box>

--- a/qnop-ui/src/components/shell/navConfig.test.ts
+++ b/qnop-ui/src/components/shell/navConfig.test.ts
@@ -51,7 +51,7 @@ describe('visibleNavGroups', () => {
 
   it('drops the now-empty admin group for a MEMBER', () => {
     const groups = visibleNavGroups('MEMBER');
-    expect(groups.some((g) => g.label === 'Verwaltung')).toBe(false);
+    expect(groups.some((g) => g.label === 'Administration')).toBe(false);
   });
 
   it('shows only the always-visible items when role is null', () => {
@@ -65,7 +65,7 @@ describe('crumbsFor', () => {
   });
 
   it('builds group > item for an admin path (no Dashboard prefix)', () => {
-    expect(crumbsFor('/admin/users')).toEqual([{ label: 'Verwaltung' }, { label: 'Benutzer' }]);
+    expect(crumbsFor('/admin/users')).toEqual([{ label: 'Administration' }, { label: 'Users' }]);
   });
 
   it('builds just the item for a top-level path', () => {

--- a/qnop-ui/src/components/shell/navConfig.tsx
+++ b/qnop-ui/src/components/shell/navConfig.tsx
@@ -61,7 +61,7 @@ export const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: 'Verwaltung',
+    label: 'Administration',
     items: [
       {
         id: 'compliance',
@@ -70,11 +70,11 @@ export const NAV_GROUPS: NavGroup[] = [
         icon: ShieldCheck,
         roles: ['ADMIN', 'AUDITOR'],
       },
-      { id: 'users', label: 'Benutzer', path: '/admin/users', icon: User, roles: ['ADMIN'] },
+      { id: 'users', label: 'Users', path: '/admin/users', icon: User, roles: ['ADMIN'] },
       { id: 'teams', label: 'Teams', path: '/admin/teams', icon: Users, roles: ['ADMIN'] },
       {
         id: 'settings',
-        label: 'Einstellungen',
+        label: 'Settings',
         path: '/admin/settings',
         icon: Settings,
         roles: ['ADMIN'],

--- a/qnop-ui/src/pages/ComingSoonPage.tsx
+++ b/qnop-ui/src/pages/ComingSoonPage.tsx
@@ -58,7 +58,7 @@ export function ComingSoonPage({ title, description, icon: Icon }: ComingSoonPag
           {title}
         </Typography>
         <Typography color="text.secondary">{description}</Typography>
-        <Chip label="In Vorbereitung" color="primary" variant="outlined" size="small" />
+        <Chip label="Coming soon" color="primary" variant="outlined" size="small" />
       </Stack>
     </Box>
   );

--- a/qnop-ui/src/pages/HomePage.tsx
+++ b/qnop-ui/src/pages/HomePage.tsx
@@ -38,9 +38,9 @@ export function HomePage() {
   return (
     <Stack spacing={3}>
       <Box>
-        <Typography variant="h1">Willkommen{displayName ? `, ${displayName}` : ''}.</Typography>
+        <Typography variant="h1">Welcome{displayName ? `, ${displayName}` : ''}.</Typography>
         <Typography color="text.secondary" sx={{ mt: 1 }}>
-          Dein Review-Arbeitsbereich entsteht hier in den nächsten Schritten.
+          Your review workspace will take shape here over the next steps.
         </Typography>
       </Box>
 
@@ -63,9 +63,9 @@ export function HomePage() {
               <Inbox size={22} />
             </Box>
             <Box>
-              <Typography variant="h6">Noch keine Reviews</Typography>
+              <Typography variant="h6">No reviews yet</Typography>
               <Typography color="text.secondary">
-                Sobald der Dokumenten-Upload steht, erscheinen deine Reviews hier.
+                Once document upload is ready, your reviews will appear here.
               </Typography>
             </Box>
           </Stack>

--- a/qnop-ui/src/pages/admin/UsersPage.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.tsx
@@ -93,10 +93,10 @@ export function UsersPage() {
   const onResetPassword = async (user: AdminUserSummary) => {
     try {
       await sendReset.mutateAsync(user.id);
-      setToast({ message: `Passwort-Link an ${user.email} gesendet.`, severity: 'success' });
+      setToast({ message: `Password link sent to ${user.email}.`, severity: 'success' });
     } catch (err) {
       setToast({
-        message: apiErrorMessage(err, 'Der Link konnte nicht gesendet werden.'),
+        message: apiErrorMessage(err, 'The link could not be sent.'),
         severity: 'error',
       });
     }
@@ -111,14 +111,14 @@ export function UsersPage() {
       >
         <Box>
           <Typography variant="h1" sx={{ fontSize: 28 }}>
-            Benutzer
+            Users
           </Typography>
           <Typography color="text.secondary" sx={{ mt: 0.5 }}>
-            Konten, Rollen und Zugriff verwalten.
+            Manage accounts, roles and access.
           </Typography>
         </Box>
         <Button variant="contained" startIcon={<UserPlus size={18} />} onClick={openCreate}>
-          Benutzer anlegen
+          Add user
         </Button>
       </Stack>
 
@@ -126,7 +126,7 @@ export function UsersPage() {
         <TextField
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Nach Name, E-Mail oder Benutzername suchen"
+          placeholder="Search by name, email or username"
           size="small"
           sx={{ flex: 1, maxWidth: 420 }}
           slotProps={{
@@ -139,7 +139,7 @@ export function UsersPage() {
               endAdornment: search ? (
                 <InputAdornment position="end">
                   <IconButton
-                    aria-label="Suche zurücksetzen"
+                    aria-label="Clear search"
                     size="small"
                     edge="end"
                     onClick={() => setSearch('')}
@@ -153,7 +153,7 @@ export function UsersPage() {
         />
         <TextField
           select
-          label="Rolle"
+          label="Role"
           value={roleFilter}
           onChange={(e) => {
             setRoleFilter(e.target.value as UserRole | '');
@@ -162,9 +162,9 @@ export function UsersPage() {
           size="small"
           sx={{ minWidth: 160 }}
         >
-          <MenuItem value="">Alle Rollen</MenuItem>
+          <MenuItem value="">All roles</MenuItem>
           <MenuItem value="ADMIN">Admin</MenuItem>
-          <MenuItem value="MEMBER">Mitglied</MenuItem>
+          <MenuItem value="MEMBER">Member</MenuItem>
           <MenuItem value="AUDITOR">Auditor</MenuItem>
         </TextField>
       </Stack>
@@ -173,7 +173,7 @@ export function UsersPage() {
         <Box sx={{ height: 3 }}>{isFetching && <LinearProgress />}</Box>
         {isError ? (
           <Alert severity="error" sx={{ m: 2 }}>
-            Die Benutzerliste konnte nicht geladen werden.
+            The user list could not be loaded.
           </Alert>
         ) : (
           <>
@@ -185,13 +185,13 @@ export function UsersPage() {
               rowsPerPage={PAGE_SIZE}
               rowsPerPageOptions={[PAGE_SIZE]}
               onPageChange={(_, next) => setPage(next)}
-              labelDisplayedRows={({ from, to, count }) => `${from}–${to} von ${count}`}
+              labelDisplayedRows={({ from, to, count }) => `${from}–${to} of ${count}`}
             />
           </>
         )}
         {isLoading && (
           <Typography color="text.secondary" sx={{ p: 2, fontSize: 14 }}>
-            Lädt …
+            Loading…
           </Typography>
         )}
       </Paper>

--- a/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
@@ -69,9 +69,7 @@ export function ChangePasswordPage() {
       clearAuth();
       setDone(true);
     } catch (err) {
-      setError(
-        apiErrorMessage(err, 'Das aktuelle Passwort ist falsch oder die Anfrage schlug fehl.'),
-      );
+      setError(apiErrorMessage(err, 'The current password is wrong or the request failed.'));
     } finally {
       setSubmitting(false);
     }
@@ -79,23 +77,23 @@ export function ChangePasswordPage() {
 
   return (
     <AuthLayout
-      title="Passwort ändern"
-      subtitle={forced ? 'Bitte vergib ein neues Passwort, um fortzufahren.' : undefined}
+      title="Change password"
+      subtitle={forced ? 'Please set a new password to continue.' : undefined}
     >
       {done ? (
         <>
           <Alert severity="success" sx={{ mb: 2 }}>
-            Dein Passwort wurde geändert. Bitte melde dich mit dem neuen Passwort an.
+            Your password has been changed. Please sign in with the new password.
           </Alert>
           <Link component={RouterLink} to="/login" underline="hover">
-            Zur Anmeldung
+            To sign in
           </Link>
         </>
       ) : (
         <Box component="form" onSubmit={onSubmit} noValidate>
           <Stack spacing={2}>
             <PasswordField
-              label="Aktuelles Passwort"
+              label="Current password"
               value={current}
               onChange={setCurrent}
               autoComplete="current-password"
@@ -103,7 +101,7 @@ export function ChangePasswordPage() {
             />
             <Box>
               <PasswordField
-                label="Neues Passwort"
+                label="New password"
                 value={password}
                 onChange={setPassword}
                 autoComplete="new-password"
@@ -112,13 +110,13 @@ export function ChangePasswordPage() {
               <PasswordStrengthMeter password={password} />
             </Box>
             <PasswordField
-              label="Neues Passwort bestätigen"
+              label="Confirm new password"
               value={confirm}
               onChange={setConfirm}
               autoComplete="new-password"
               required
             />
-            {mismatch && <Alert severity="warning">Die Passwörter stimmen nicht überein.</Alert>}
+            {mismatch && <Alert severity="warning">The passwords don&apos;t match.</Alert>}
             {error && <Alert severity="error">{error}</Alert>}
             <Button
               type="submit"
@@ -127,12 +125,12 @@ export function ChangePasswordPage() {
               disabled={submitting || !canSubmit}
               fullWidth
             >
-              Passwort ändern
+              Change password
             </Button>
             {!forced && (
               <Typography sx={{ fontSize: 13 }}>
                 <Link component={RouterLink} to="/" underline="hover">
-                  Abbrechen
+                  Cancel
                 </Link>
               </Typography>
             )}

--- a/qnop-ui/src/pages/auth/ForgotPasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ForgotPasswordPage.tsx
@@ -23,9 +23,11 @@ import { useState, type FormEvent } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
+import { Mail } from 'lucide-react';
 import { Link as RouterLink } from 'react-router-dom';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { forgotPassword } from '../../api/auth';
@@ -46,25 +48,21 @@ export function ForgotPasswordPage() {
       await forgotPassword(email);
       setDone(true);
     } catch (err) {
-      setError(apiErrorMessage(err, 'Anfrage fehlgeschlagen. Bitte später erneut versuchen.'));
+      setError(apiErrorMessage(err, 'Request failed. Please try again later.'));
     } finally {
       setSubmitting(false);
     }
   };
 
   return (
-    <AuthLayout
-      title="Passwort zurücksetzen"
-      subtitle="Wir senden dir einen Link zum Zurücksetzen deines Passworts."
-    >
+    <AuthLayout title="Reset password" subtitle="We'll send you a link to reset your password.">
       {done ? (
         <>
           <Alert severity="success" sx={{ mb: 2 }}>
-            Wenn ein Konto mit dieser Adresse existiert, ist eine E-Mail mit einem Reset-Link
-            unterwegs.
+            If an account exists for this address, a reset link is on its way.
           </Alert>
           <Link component={RouterLink} to="/login" underline="hover">
-            Zurück zur Anmeldung
+            Back to sign in
           </Link>
         </>
       ) : (
@@ -72,13 +70,22 @@ export function ForgotPasswordPage() {
           <Box component="form" onSubmit={onSubmit} noValidate>
             <Stack spacing={2}>
               <TextField
-                label="Arbeits-E-Mail"
+                label="Work email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 autoComplete="email"
                 fullWidth
                 required
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <Mail size={17} />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
               />
               {error && <Alert severity="error">{error}</Alert>}
               <Button
@@ -88,13 +95,13 @@ export function ForgotPasswordPage() {
                 disabled={submitting}
                 fullWidth
               >
-                Link senden
+                Send link
               </Button>
             </Stack>
           </Box>
           <Box sx={{ mt: 3 }}>
             <Link component={RouterLink} to="/login" underline="hover" sx={{ fontSize: 13 }}>
-              Zurück zur Anmeldung
+              Back to sign in
             </Link>
           </Box>
         </>

--- a/qnop-ui/src/pages/auth/LoginPage.tsx
+++ b/qnop-ui/src/pages/auth/LoginPage.tsx
@@ -23,12 +23,14 @@ import { useState, type FormEvent } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
+import { AtSign } from 'lucide-react';
 import { Link as RouterLink, useNavigate, useSearchParams } from 'react-router-dom';
 import { AuthLayout } from '../../components/auth/AuthLayout';
+import { AuthModeSwitch } from '../../components/auth/AuthModeSwitch';
 import { OidcButtons } from '../../components/auth/OidcButtons';
 import { PasswordField } from '../../components/auth/PasswordField';
 import { useConfig } from '../../api/hooks/useConfig';
@@ -47,6 +49,8 @@ export function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
+  const canRegister = !!config?.auth?.selfRegistrationEnabled;
+
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
     setError(null);
@@ -59,27 +63,40 @@ export function LoginPage() {
       }
       navigate(safeRedirectPath(params.get('from')), { replace: true });
     } catch (err) {
-      setError(apiErrorMessage(err, 'Anmeldung fehlgeschlagen. Bitte Zugangsdaten prüfen.'));
+      setError(apiErrorMessage(err, 'Sign-in failed. Please check your credentials.'));
     } finally {
       setSubmitting(false);
     }
   };
 
   return (
-    <AuthLayout title="Willkommen zurück" subtitle="Melde dich an, um deine Reviews fortzusetzen.">
+    <AuthLayout
+      title="Welcome back"
+      subtitle="Sign in to continue with your reviews."
+      headerSlot={canRegister ? <AuthModeSwitch active="login" /> : undefined}
+    >
       <Box component="form" onSubmit={onSubmit} noValidate>
         <Stack spacing={2}>
           <TextField
-            label="E-Mail oder Benutzername"
+            label="Email or username"
             value={usernameOrEmail}
             onChange={(e) => setUsernameOrEmail(e.target.value)}
             autoComplete="username"
             fullWidth
             required
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <AtSign size={17} />
+                  </InputAdornment>
+                ),
+              },
+            }}
           />
           <Box>
             <PasswordField
-              label="Passwort"
+              label="Password"
               value={password}
               onChange={setPassword}
               autoComplete="current-password"
@@ -92,7 +109,7 @@ export function LoginPage() {
                 underline="hover"
                 sx={{ fontSize: 13 }}
               >
-                Passwort vergessen?
+                Forgot password?
               </Link>
             </Box>
           </Box>
@@ -100,21 +117,12 @@ export function LoginPage() {
           {error && <Alert severity="error">{error}</Alert>}
 
           <Button type="submit" variant="contained" size="large" disabled={submitting} fullWidth>
-            Anmelden
+            Sign in
           </Button>
         </Stack>
       </Box>
 
       <OidcButtons />
-
-      {config?.auth?.selfRegistrationEnabled && (
-        <Typography sx={{ mt: 3, textAlign: 'center', fontSize: 13, color: 'text.secondary' }}>
-          Noch kein Konto?{' '}
-          <Link component={RouterLink} to="/register" underline="hover" sx={{ fontWeight: 500 }}>
-            Konto erstellen
-          </Link>
-        </Typography>
-      )}
     </AuthLayout>
   );
 }

--- a/qnop-ui/src/pages/auth/RegisterPage.tsx
+++ b/qnop-ui/src/pages/auth/RegisterPage.tsx
@@ -19,18 +19,21 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useState, type FormEvent } from 'react';
+import { useState, type FormEvent, type ReactNode } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
+import InputAdornment from '@mui/material/InputAdornment';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { AtSign, Mail, User } from 'lucide-react';
 import { Link as RouterLink, Navigate } from 'react-router-dom';
 import { AuthLayout } from '../../components/auth/AuthLayout';
+import { AuthModeSwitch } from '../../components/auth/AuthModeSwitch';
 import { OidcButtons } from '../../components/auth/OidcButtons';
 import { PasswordField } from '../../components/auth/PasswordField';
 import { PasswordStrengthMeter } from '../../components/auth/PasswordStrengthMeter';
@@ -38,6 +41,10 @@ import { register } from '../../api/auth';
 import { useConfig } from '../../api/hooks/useConfig';
 import { apiErrorMessage } from '../../utils/apiError';
 import { passwordStrength } from '../../utils/passwordStrength';
+
+const startIcon = (icon: ReactNode) => ({
+  input: { startAdornment: <InputAdornment position="start">{icon}</InputAdornment> },
+});
 
 /** Registration screen, available only when self-registration is enabled. */
 export function RegisterPage() {
@@ -63,9 +70,7 @@ export function RegisterPage() {
       await register({ displayName, username, email, password });
       setDone(true);
     } catch (err) {
-      setError(
-        apiErrorMessage(err, 'Registrierung fehlgeschlagen. Bitte später erneut versuchen.'),
-      );
+      setError(apiErrorMessage(err, 'Registration failed. Please try again later.'));
     } finally {
       setSubmitting(false);
     }
@@ -73,13 +78,13 @@ export function RegisterPage() {
 
   if (done) {
     return (
-      <AuthLayout title="Fast geschafft">
+      <AuthLayout title="Almost there">
         <Alert severity="success" sx={{ mb: 2 }}>
-          Wenn die Angaben gültig sind, haben wir dir eine Bestätigungs-E-Mail geschickt. Bitte
-          bestätige deine Adresse, um die Anmeldung abzuschließen.
+          If the details are valid, we&apos;ve sent you a confirmation email. Please confirm your
+          address to finish signing up.
         </Alert>
         <Link component={RouterLink} to="/login" underline="hover">
-          Zur Anmeldung
+          To sign in
         </Link>
       </AuthLayout>
     );
@@ -88,37 +93,44 @@ export function RegisterPage() {
   const canSubmit = terms && passwordStrength(password).acceptable;
 
   return (
-    <AuthLayout title="Konto erstellen" subtitle="In zwei Minuten startklar.">
+    <AuthLayout
+      title="Create account"
+      subtitle="Ready in two minutes."
+      headerSlot={<AuthModeSwitch active="register" />}
+    >
       <Box component="form" onSubmit={onSubmit} noValidate>
         <Stack spacing={2}>
           <TextField
-            label="Vollständiger Name"
+            label="Full name"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             autoComplete="name"
             fullWidth
             required
+            slotProps={startIcon(<User size={17} />)}
           />
           <TextField
-            label="Benutzername"
+            label="Username"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             autoComplete="username"
             fullWidth
             required
+            slotProps={startIcon(<AtSign size={17} />)}
           />
           <TextField
-            label="Arbeits-E-Mail"
+            label="Work email"
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             autoComplete="email"
             fullWidth
             required
+            slotProps={startIcon(<Mail size={17} />)}
           />
           <Box>
             <PasswordField
-              label="Passwort"
+              label="Password"
               value={password}
               onChange={setPassword}
               autoComplete="new-password"
@@ -133,7 +145,7 @@ export function RegisterPage() {
             }
             label={
               <Typography sx={{ fontSize: 12.5, color: 'text.secondary' }}>
-                Ich akzeptiere die Nutzungsbedingungen und die Datenschutzerklärung (DSGVO).
+                I accept the terms of service and the privacy policy (GDPR).
               </Typography>
             }
           />
@@ -147,19 +159,12 @@ export function RegisterPage() {
             disabled={submitting || !canSubmit}
             fullWidth
           >
-            Konto erstellen
+            Create account
           </Button>
         </Stack>
       </Box>
 
       <OidcButtons />
-
-      <Typography sx={{ mt: 3, textAlign: 'center', fontSize: 13, color: 'text.secondary' }}>
-        Bereits ein Konto?{' '}
-        <Link component={RouterLink} to="/login" underline="hover" sx={{ fontWeight: 500 }}>
-          Anmelden
-        </Link>
-      </Typography>
     </AuthLayout>
   );
 }

--- a/qnop-ui/src/pages/auth/ResetPasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ResetPasswordPage.tsx
@@ -54,30 +54,30 @@ export function ResetPasswordPage() {
       await resetPassword(token, password);
       setDone(true);
     } catch (err) {
-      setError(apiErrorMessage(err, 'Zurücksetzen fehlgeschlagen. Fordere einen neuen Link an.'));
+      setError(apiErrorMessage(err, 'Reset failed. Please request a new link.'));
     } finally {
       setSubmitting(false);
     }
   };
 
   return (
-    <AuthLayout title="Neues Passwort wählen">
+    <AuthLayout title="Choose a new password">
       {done ? (
         <>
           <Alert severity="success" sx={{ mb: 2 }}>
-            Dein Passwort wurde geändert. Du kannst dich jetzt anmelden.
+            Your password has been changed. You can sign in now.
           </Alert>
           <Link component={RouterLink} to="/login" underline="hover">
-            Zur Anmeldung
+            To sign in
           </Link>
         </>
       ) : !token ? (
         <>
           <Alert severity="error" sx={{ mb: 2 }}>
-            Der Link ist ungültig oder unvollständig. Bitte fordere einen neuen an.
+            This link is invalid or incomplete. Please request a new one.
           </Alert>
           <Link component={RouterLink} to="/forgot-password" underline="hover">
-            Neuen Link anfordern
+            Request a new link
           </Link>
         </>
       ) : (
@@ -85,7 +85,7 @@ export function ResetPasswordPage() {
           <Stack spacing={2}>
             <Box>
               <PasswordField
-                label="Neues Passwort"
+                label="New password"
                 value={password}
                 onChange={setPassword}
                 autoComplete="new-password"
@@ -94,13 +94,13 @@ export function ResetPasswordPage() {
               <PasswordStrengthMeter password={password} />
             </Box>
             <PasswordField
-              label="Passwort bestätigen"
+              label="Confirm password"
               value={confirm}
               onChange={setConfirm}
               autoComplete="new-password"
               required
             />
-            {mismatch && <Alert severity="warning">Die Passwörter stimmen nicht überein.</Alert>}
+            {mismatch && <Alert severity="warning">The passwords don&apos;t match.</Alert>}
             {error && <Alert severity="error">{error}</Alert>}
             <Button
               type="submit"
@@ -109,7 +109,7 @@ export function ResetPasswordPage() {
               disabled={submitting || !canSubmit}
               fullWidth
             >
-              Passwort speichern
+              Save password
             </Button>
           </Stack>
         </Box>

--- a/qnop-ui/src/pages/auth/VerifyEmailPage.tsx
+++ b/qnop-ui/src/pages/auth/VerifyEmailPage.tsx
@@ -48,30 +48,30 @@ export function VerifyEmailPage() {
   }, [token]);
 
   return (
-    <AuthLayout title="E-Mail bestätigen">
+    <AuthLayout title="Verify email">
       {status === 'verifying' && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, color: 'text.secondary' }}>
           <CircularProgress size={20} />
-          Adresse wird bestätigt…
+          Confirming your address…
         </Box>
       )}
       {status === 'success' && (
         <>
           <Alert severity="success" sx={{ mb: 2 }}>
-            Deine E-Mail-Adresse ist bestätigt. Du kannst dich jetzt anmelden.
+            Your email address is confirmed. You can sign in now.
           </Alert>
           <Link component={RouterLink} to="/login" underline="hover">
-            Zur Anmeldung
+            To sign in
           </Link>
         </>
       )}
       {status === 'error' && (
         <>
           <Alert severity="error" sx={{ mb: 2 }}>
-            Der Bestätigungslink ist ungültig oder abgelaufen.
+            The confirmation link is invalid or expired.
           </Alert>
           <Link component={RouterLink} to="/login" underline="hover">
-            Zur Anmeldung
+            To sign in
           </Link>
         </>
       )}

--- a/qnop-ui/src/pages/errors/ForbiddenPage.tsx
+++ b/qnop-ui/src/pages/errors/ForbiddenPage.tsx
@@ -25,8 +25,8 @@ export function ForbiddenPage() {
   return (
     <ErrorState
       code="403"
-      title="Kein Zugriff"
-      message="Für diesen Bereich fehlen dir die Berechtigungen."
+      title="No access"
+      message="You don't have permission to view this area."
     />
   );
 }

--- a/qnop-ui/src/pages/errors/NotFoundPage.tsx
+++ b/qnop-ui/src/pages/errors/NotFoundPage.tsx
@@ -23,10 +23,6 @@ import { ErrorState } from './ErrorState';
 
 export function NotFoundPage() {
   return (
-    <ErrorState
-      code="404"
-      title="Seite nicht gefunden"
-      message="Die angeforderte Seite existiert nicht."
-    />
+    <ErrorState code="404" title="Page not found" message="The page you requested doesn't exist." />
   );
 }

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -65,7 +65,7 @@ export const router = createBrowserRouter([
         element: (
           <ComingSoonPage
             title="Reviews"
-            description="Dokumente hochladen, prüfen und freigeben — die Review-Oberfläche entsteht im PDF-Durchstich."
+            description="Upload, review and approve documents — the review surface arrives in the PDF vertical slice."
             icon={FileText}
           />
         ),
@@ -76,7 +76,7 @@ export const router = createBrowserRouter([
           <RoleRoute allow={['ADMIN', 'AUDITOR']}>
             <ComingSoonPage
               title="Compliance"
-              description="Audit-Trail und Compliance-Auswertungen über alle Reviews."
+              description="Audit trail and compliance reporting across all reviews."
               icon={ShieldCheck}
             />
           </RoleRoute>
@@ -96,7 +96,7 @@ export const router = createBrowserRouter([
           <AdminRoute>
             <ComingSoonPage
               title="Teams"
-              description="Prüfer in Teams gruppieren und Reviews an die richtigen Personen leiten."
+              description="Group reviewers into teams and route reviews to the right people."
               icon={Users}
             />
           </AdminRoute>
@@ -107,8 +107,8 @@ export const router = createBrowserRouter([
         element: (
           <AdminRoute>
             <ComingSoonPage
-              title="Einstellungen"
-              description="Arbeitsbereich, Sicherheitsrichtlinie, OIDC, Branding und Mail."
+              title="Settings"
+              description="Workspace, security policy, OIDC, branding and mail."
               icon={Settings}
             />
           </AdminRoute>

--- a/qnop-ui/src/utils/apiError.test.ts
+++ b/qnop-ui/src/utils/apiError.test.ts
@@ -33,15 +33,15 @@ function axiosWithBody(status: number, data: unknown): AxiosError {
 
 describe('apiErrorMessage', () => {
   it('maps a 429 to a rate-limit message', () => {
-    expect(apiErrorMessage(axiosWithStatus(429), 'fallback')).toMatch(/Versuche/i);
+    expect(apiErrorMessage(axiosWithStatus(429), 'fallback')).toMatch(/attempts/i);
   });
 
   it('maps a 400 to an invalid/expired message', () => {
-    expect(apiErrorMessage(axiosWithStatus(400), 'fallback')).toMatch(/ungültig|abgelaufen/i);
+    expect(apiErrorMessage(axiosWithStatus(400), 'fallback')).toMatch(/invalid|expired/i);
   });
 
   it('maps the RATE_LIMITED sentinel error to the rate-limit message', () => {
-    expect(apiErrorMessage(new Error('RATE_LIMITED'), 'fallback')).toMatch(/Versuche/i);
+    expect(apiErrorMessage(new Error('RATE_LIMITED'), 'fallback')).toMatch(/attempts/i);
   });
 
   it('falls back for unknown errors', () => {

--- a/qnop-ui/src/utils/apiError.ts
+++ b/qnop-ui/src/utils/apiError.ts
@@ -21,7 +21,7 @@
 
 import { isAxiosError } from 'axios';
 
-const RATE_LIMITED = 'Zu viele Versuche. Bitte versuche es später erneut.';
+const RATE_LIMITED = 'Too many attempts. Please try again later.';
 
 /**
  * Maps an API/network error to a concise, user-facing German message. Rate
@@ -32,7 +32,7 @@ export function apiErrorMessage(error: unknown, fallback: string): string {
   if (isAxiosError(error)) {
     const status = error.response?.status;
     if (status === 429) return RATE_LIMITED;
-    if (status === 400) return 'Die Anfrage ist ungültig oder der Link ist abgelaufen.';
+    if (status === 400) return 'The request is invalid or the link has expired.';
   }
   if (error instanceof Error && error.message === 'RATE_LIMITED') {
     return RATE_LIMITED;

--- a/qnop-ui/src/utils/passwordStrength.test.ts
+++ b/qnop-ui/src/utils/passwordStrength.test.ts
@@ -41,7 +41,7 @@ describe('passwordStrength', () => {
   it('scores a long mixed password as strong', () => {
     const r = passwordStrength('Str0ng#Pass');
     expect(r.score).toBe(4);
-    expect(r.label).toBe('Stark');
+    expect(r.label).toBe('Strong');
     expect(r.acceptable).toBe(true);
   });
 });

--- a/qnop-ui/src/utils/passwordStrength.ts
+++ b/qnop-ui/src/utils/passwordStrength.ts
@@ -27,7 +27,7 @@ export interface PasswordStrength {
   acceptable: boolean;
 }
 
-const LABELS = ['', 'Schwach', 'Mittel', 'Gut', 'Stark'] as const;
+const LABELS = ['', 'Weak', 'Fair', 'Good', 'Strong'] as const;
 
 /**
  * A lightweight password-strength estimate for the register/reset meters


### PR DESCRIPTION
## What & why

Closes #118. Two related frontend changes.

### 1. Auth screen redesign

Brings the login / register / forgot-password screens closer to the design prototype (`docs/qnop-design-prototype/Login & Register.html`):

- **Typography** — larger, display-weight headings in both the brand panel ("Review, approve, trust — all in one place.") and the form card, with tighter letter-spacing and a bigger lead paragraph.
- **In-field icons** — form text fields now carry a leading icon inside the field (mail, lock, user, at-sign). `PasswordField` gained a lock leading icon next to the existing show/hide eye toggle.
- **Segmented switch** — a new `AuthModeSwitch` renders the sign-in ⇄ create-account toggle as two pill buttons at the top of the form (router links between `/login` and `/register`), shown when self-registration is enabled. `AuthLayout` gained a `headerSlot` for it.

### 2. English UI

All visible strings across the existing frontend are now English (team decision; proper i18n lands later — tracked separately). Converted: auth screens + shared auth components, the app shell (nav, breadcrumbs, top bar, user menu), the user-management screen and its dialogs/badges, and the coming-soon / error / home screens.

## Test plan

- [x] `pnpm lint` / `pnpm build` (tsc + vite) green.
- [x] `pnpm test:coverage` green — 62 tests, coverage 97% (≥80% gate). Updated assertions: `navConfig` labels (Administration / Users), password-strength label (Strong), apiError messages.
- [x] Manual (Playwright): login + register at 1440px and 390px — segmented switch navigates, in-field icons render, brand panel hides on mobile, no German strings remain.

## Notes

- New rule recorded for the team: qnop-ui strings stay English until i18n.
- No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
