### PR TITLE
feat: teams subsystem — entity, /admin/teams CRUD, memberships + UI (#105)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -49,6 +49,11 @@ tags:
       global role and enabled state, and trigger a password-setup/reset link.
       A self-lockout guard prevents an admin from disabling or demoting their own
       account or the last remaining admin.
+  - name: AdminTeams
+    description: |
+      Admin-only team management (issue #105): list/search teams with pagination,
+      create / edit / delete teams, and manage memberships with a per-team role
+      (LEAD / MEMBER). Teams group reviewers for the review workflow.
 paths:
   /config:
     get:
@@ -818,6 +823,284 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /admin/teams:
+    get:
+      tags:
+        - AdminTeams
+      summary: List and search teams
+      description: Returns a page of teams ordered by name, with a member count each.
+      operationId: listTeams
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive search over team name and description.
+          schema:
+            type: string
+            maxLength: 200
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 0
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: A page of teams
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTeamListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags:
+        - AdminTeams
+      summary: Create a team
+      operationId: createTeam
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminTeamCreateRequest'
+      responses:
+        '201':
+          description: The created team
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTeamSummary'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: A team with that name already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/teams/{teamId}:
+    get:
+      tags:
+        - AdminTeams
+      summary: Get a team with its members
+      operationId: getTeam
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TeamIdParam'
+      responses:
+        '200':
+          description: The team and its members
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTeamDetail'
+        '404':
+          description: Unknown team
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    patch:
+      tags:
+        - AdminTeams
+      summary: Update a team
+      description: Partial update of name, description and enabled state.
+      operationId: updateTeam
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TeamIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminTeamUpdateRequest'
+      responses:
+        '200':
+          description: The updated team
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTeamSummary'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown team
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: A team with that name already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    delete:
+      tags:
+        - AdminTeams
+      summary: Delete a team
+      description: Deletes the team and, by cascade, its memberships.
+      operationId: deleteTeam
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TeamIdParam'
+      responses:
+        '204':
+          description: Team deleted
+        '404':
+          description: Unknown team
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/teams/{teamId}/members:
+    post:
+      tags:
+        - AdminTeams
+      summary: Add a member to a team
+      operationId: addTeamMember
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TeamIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminTeamMemberRequest'
+      responses:
+        '201':
+          description: The added member
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTeamMember'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown team or user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The user is already a member of the team
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/teams/{teamId}/members/{userId}:
+    patch:
+      tags:
+        - AdminTeams
+      summary: Set a member's team role
+      operationId: setTeamMemberRole
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TeamIdParam'
+        - $ref: '#/components/parameters/UserIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminTeamMemberRoleUpdateRequest'
+      responses:
+        '200':
+          description: The updated member
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminTeamMember'
+        '404':
+          description: The team has no such member
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    delete:
+      tags:
+        - AdminTeams
+      summary: Remove a member from a team
+      operationId: removeTeamMember
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TeamIdParam'
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '204':
+          description: Member removed
+        '404':
+          description: The team has no such member
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /auth/register:
     post:
       tags:
@@ -1198,6 +1481,14 @@ components:
       in: path
       required: true
       description: The user's id.
+      schema:
+        type: string
+        format: uuid
+    TeamIdParam:
+      name: teamId
+      in: path
+      required: true
+      description: The team's id.
       schema:
         type: string
         format: uuid
@@ -1760,6 +2051,167 @@ components:
         enabled:
           type: boolean
           nullable: true
+    TeamRole:
+      type: string
+      description: |
+        A user's role within a team (issue #105) — distinct from the global
+        UserRole. `LEAD` manages the team; `MEMBER` is a regular member.
+      enum:
+        - LEAD
+        - MEMBER
+    AdminTeamMember:
+      type: object
+      description: A team member joined with their user identity.
+      properties:
+        userId:
+          type: string
+          format: uuid
+        displayName:
+          type: string
+        email:
+          type: string
+        teamRole:
+          $ref: '#/components/schemas/TeamRole'
+        joinedAt:
+          type: string
+          format: date-time
+      required:
+        - userId
+        - displayName
+        - email
+        - teamRole
+        - joinedAt
+    AdminTeamSummary:
+      type: object
+      description: A team as shown in the admin team list.
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        enabled:
+          type: boolean
+        memberCount:
+          type: integer
+          format: int64
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - enabled
+        - memberCount
+        - createdAt
+        - updatedAt
+    AdminTeamDetail:
+      type: object
+      description: Full team detail including its members.
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        enabled:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminTeamMember'
+      required:
+        - id
+        - name
+        - enabled
+        - createdAt
+        - updatedAt
+        - members
+    AdminTeamListResponse:
+      type: object
+      description: A page of teams for the admin list.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminTeamSummary'
+        total:
+          type: integer
+          format: int64
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+      required:
+        - items
+        - total
+        - page
+        - size
+    AdminTeamCreateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        description:
+          type: string
+          maxLength: 1000
+          nullable: true
+      required:
+        - name
+    AdminTeamUpdateRequest:
+      type: object
+      description: Partial update; only provided fields change.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+          nullable: true
+        description:
+          type: string
+          maxLength: 1000
+          nullable: true
+        enabled:
+          type: boolean
+          nullable: true
+    AdminTeamMemberRequest:
+      type: object
+      description: Add a user to a team with a team role.
+      properties:
+        userId:
+          type: string
+          format: uuid
+        teamRole:
+          $ref: '#/components/schemas/TeamRole'
+      required:
+        - userId
+        - teamRole
+    AdminTeamMemberRoleUpdateRequest:
+      type: object
+      properties:
+        teamRole:
+          $ref: '#/components/schemas/TeamRole'
+      required:
+        - teamRole
     RegisterRequest:
       type: object
       description: Self-registration details for a new local account.

--- a/qnop-app/src/main/java/io/qnop/web/TeamController.java
+++ b/qnop-app/src/main/java/io/qnop/web/TeamController.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AdminTeamsApi;
+import io.qnop.api.v1.model.AdminTeamCreateRequest;
+import io.qnop.api.v1.model.AdminTeamDetail;
+import io.qnop.api.v1.model.AdminTeamListResponse;
+import io.qnop.api.v1.model.AdminTeamMember;
+import io.qnop.api.v1.model.AdminTeamMemberRequest;
+import io.qnop.api.v1.model.AdminTeamMemberRoleUpdateRequest;
+import io.qnop.api.v1.model.AdminTeamSummary;
+import io.qnop.api.v1.model.AdminTeamUpdateRequest;
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.api.v1.model.TeamRole;
+import io.qnop.service.TeamConflictException;
+import io.qnop.service.TeamNotFoundException;
+import io.qnop.service.TeamService;
+import io.qnop.service.TeamService.TeamDetailView;
+import io.qnop.service.TeamService.TeamMemberView;
+import io.qnop.service.TeamService.TeamPage;
+import io.qnop.service.TeamService.TeamSummaryView;
+import io.qnop.service.UserNotFoundException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin-only team management ({@code /api/v1/admin/teams/**}), implementing the generated {@link
+ * AdminTeamsApi} contract (issue #105). Authorization is enforced centrally by the security chain
+ * ({@code /api/v1/admin/**} requires {@code ADMIN}). The entities never reach this layer — {@link
+ * TeamService} returns entity-free views, mapped here to API DTOs (ADR-0004). Unknown teams/members
+ * surface as 404, conflicts (duplicate name, already a member) as 409.
+ */
+@RestController
+public class TeamController implements AdminTeamsApi {
+
+  private final TeamService teams;
+
+  public TeamController(TeamService teams) {
+    this.teams = teams;
+  }
+
+  @Override
+  public ResponseEntity<AdminTeamListResponse> listTeams(String q, Integer page, Integer size) {
+    TeamPage result = teams.list(q, page, size);
+    return ResponseEntity.ok(
+        new AdminTeamListResponse()
+            .items(result.items().stream().map(TeamController::toSummary).toList())
+            .total(result.total())
+            .page(result.page())
+            .size(result.size()));
+  }
+
+  @Override
+  public ResponseEntity<AdminTeamSummary> createTeam(AdminTeamCreateRequest request) {
+    TeamSummaryView created = teams.create(request.getName(), request.getDescription());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toSummary(created));
+  }
+
+  @Override
+  public ResponseEntity<AdminTeamDetail> getTeam(UUID teamId) {
+    return ResponseEntity.ok(toDetail(teams.get(teamId)));
+  }
+
+  @Override
+  public ResponseEntity<AdminTeamSummary> updateTeam(UUID teamId, AdminTeamUpdateRequest request) {
+    TeamSummaryView updated =
+        teams.update(teamId, request.getName(), request.getDescription(), request.getEnabled());
+    return ResponseEntity.ok(toSummary(updated));
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteTeam(UUID teamId) {
+    teams.delete(teamId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<AdminTeamMember> addTeamMember(
+      UUID teamId, AdminTeamMemberRequest request) {
+    TeamMemberView member =
+        teams.addMember(teamId, request.getUserId(), request.getTeamRole().name());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toMember(member));
+  }
+
+  @Override
+  public ResponseEntity<AdminTeamMember> setTeamMemberRole(
+      UUID teamId, UUID userId, AdminTeamMemberRoleUpdateRequest request) {
+    TeamMemberView member = teams.setMemberRole(teamId, userId, request.getTeamRole().name());
+    return ResponseEntity.ok(toMember(member));
+  }
+
+  @Override
+  public ResponseEntity<Void> removeTeamMember(UUID teamId, UUID userId) {
+    teams.removeMember(teamId, userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @ExceptionHandler(TeamNotFoundException.class)
+  public ResponseEntity<ErrorResponse> onTeamNotFound(TeamNotFoundException ex) {
+    return error(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND", ex.getMessage());
+  }
+
+  @ExceptionHandler(UserNotFoundException.class)
+  public ResponseEntity<ErrorResponse> onUserNotFound(UserNotFoundException ex) {
+    return error(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", ex.getMessage());
+  }
+
+  @ExceptionHandler(TeamConflictException.class)
+  public ResponseEntity<ErrorResponse> onConflict(TeamConflictException ex) {
+    return error(HttpStatus.CONFLICT, ex.getCode(), ex.getMessage());
+  }
+
+  private static ResponseEntity<ErrorResponse> error(
+      HttpStatus status, String code, String message) {
+    return ResponseEntity.status(status)
+        .body(
+            new ErrorResponse()
+                .code(code)
+                .message(message)
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC)));
+  }
+
+  private static AdminTeamSummary toSummary(TeamSummaryView v) {
+    return new AdminTeamSummary()
+        .id(v.id())
+        .name(v.name())
+        .description(v.description())
+        .enabled(v.enabled())
+        .memberCount(v.memberCount())
+        .createdAt(toOffset(v.createdAt()))
+        .updatedAt(toOffset(v.updatedAt()));
+  }
+
+  private static AdminTeamDetail toDetail(TeamDetailView v) {
+    return new AdminTeamDetail()
+        .id(v.id())
+        .name(v.name())
+        .description(v.description())
+        .enabled(v.enabled())
+        .createdAt(toOffset(v.createdAt()))
+        .updatedAt(toOffset(v.updatedAt()))
+        .members(v.members().stream().map(TeamController::toMember).toList());
+  }
+
+  private static AdminTeamMember toMember(TeamMemberView v) {
+    return new AdminTeamMember()
+        .userId(v.userId())
+        .displayName(v.displayName())
+        .email(v.email())
+        .teamRole(TeamRole.fromValue(v.teamRole()))
+        .joinedAt(toOffset(v.joinedAt()));
+  }
+
+  private static OffsetDateTime toOffset(Instant instant) {
+    return instant == null ? null : instant.atOffset(ZoneOffset.UTC);
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/TeamControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/TeamControllerIT.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.entity.UserRole;
+import io.qnop.repository.UserRepository;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * End-to-end team-management flow against a real PostgreSQL and the real security chain (issue
+ * #105): only an ADMIN reaches {@code /admin/teams}, CRUD and membership operations work, and the
+ * constraints (unique name, single membership per user) are enforced.
+ */
+@AutoConfigureMockMvc
+@Transactional
+class TeamControllerIT extends AbstractIntegrationTest {
+
+  private static final String PASSWORD = "correct horse battery";
+  private static final Pattern ID_FIELD = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"");
+  private static final Pattern ACCESS_TOKEN =
+      Pattern.compile("\"accessToken\"\\s*:\\s*\"([^\"]+)\"");
+  private static final AtomicInteger IP_SEQ = new AtomicInteger();
+
+  @Autowired MockMvc mockMvc;
+  @Autowired UserRepository userRepository;
+  @Autowired PasswordEncoder passwordEncoder;
+
+  @Test
+  void anonymousIsUnauthorized() throws Exception {
+    mockMvc.perform(get("/api/v1/admin/teams")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void memberIsForbidden() throws Exception {
+    createUser("member", UserRole.MEMBER);
+    String token = token("member");
+    mockMvc
+        .perform(get("/api/v1/admin/teams").header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void createListAndGetTeam() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    String token = token("root");
+    String teamId = createTeam(token, "Core", "The core team");
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/teams").param("q", "core").header("Authorization", bearer(token)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(1))
+        .andExpect(jsonPath("$.items[0].name").value("Core"))
+        .andExpect(jsonPath("$.items[0].memberCount").value(0));
+
+    mockMvc
+        .perform(get("/api/v1/admin/teams/{id}", teamId).header("Authorization", bearer(token)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("Core"))
+        .andExpect(jsonPath("$.members").isArray())
+        .andExpect(jsonPath("$.members").isEmpty());
+  }
+
+  @Test
+  void rejectsDuplicateName() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    String token = token("root");
+    createTeam(token, "Core", null);
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/teams")
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"core\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("NAME_TAKEN"));
+  }
+
+  @Test
+  void manageMembers() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User alice = createUser("alice", UserRole.MEMBER);
+    String token = token("root");
+    String teamId = createTeam(token, "Core", null);
+
+    // Add a member as LEAD.
+    mockMvc
+        .perform(
+            post("/api/v1/admin/teams/{id}/members", teamId)
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"%s\",\"teamRole\":\"LEAD\"}".formatted(alice.getId())))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.displayName").value("alice"))
+        .andExpect(jsonPath("$.teamRole").value("LEAD"));
+
+    // Adding again conflicts.
+    mockMvc
+        .perform(
+            post("/api/v1/admin/teams/{id}/members", teamId)
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"%s\",\"teamRole\":\"MEMBER\"}".formatted(alice.getId())))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("ALREADY_MEMBER"));
+
+    // Detail now lists the member.
+    mockMvc
+        .perform(get("/api/v1/admin/teams/{id}", teamId).header("Authorization", bearer(token)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.members[0].teamRole").value("LEAD"));
+
+    // Change the role.
+    mockMvc
+        .perform(
+            patch("/api/v1/admin/teams/{id}/members/{uid}", teamId, alice.getId())
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamRole\":\"MEMBER\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.teamRole").value("MEMBER"));
+
+    // Remove the member.
+    mockMvc
+        .perform(
+            delete("/api/v1/admin/teams/{id}/members/{uid}", teamId, alice.getId())
+                .header("Authorization", bearer(token)))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void addMemberRejectsUnknownTeamAndUser() throws Exception {
+    User alice = createUser("alice", UserRole.MEMBER);
+    createUser("root", UserRole.ADMIN);
+    String token = token("root");
+    String teamId = createTeam(token, "Core", null);
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/teams/{id}/members", UUID.randomUUID())
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"%s\",\"teamRole\":\"MEMBER\"}".formatted(alice.getId())))
+        .andExpect(status().isNotFound());
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/teams/{id}/members", teamId)
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"userId\":\"%s\",\"teamRole\":\"MEMBER\"}".formatted(UUID.randomUUID())))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void updateAndDeleteTeam() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    String token = token("root");
+    String teamId = createTeam(token, "Core", null);
+
+    mockMvc
+        .perform(
+            patch("/api/v1/admin/teams/{id}", teamId)
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Platform\",\"enabled\":false}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("Platform"))
+        .andExpect(jsonPath("$.enabled").value(false));
+
+    mockMvc
+        .perform(delete("/api/v1/admin/teams/{id}", teamId).header("Authorization", bearer(token)))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(get("/api/v1/admin/teams/{id}", teamId).header("Authorization", bearer(token)))
+        .andExpect(status().isNotFound());
+  }
+
+  private String createTeam(String token, String name, String description) throws Exception {
+    String body =
+        description == null
+            ? "{\"name\":\"%s\"}".formatted(name)
+            : "{\"name\":\"%s\",\"description\":\"%s\"}".formatted(name, description);
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/v1/admin/teams")
+                    .header("Authorization", bearer(token))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+            .andExpect(status().isCreated())
+            .andReturn();
+    Matcher matcher = ID_FIELD.matcher(result.getResponse().getContentAsString());
+    assertThat(matcher.find()).isTrue();
+    return matcher.group(1);
+  }
+
+  private static String bearer(String token) {
+    return "Bearer " + token;
+  }
+
+  private User createUser(String username, UserRole role) {
+    User user =
+        User.internal(
+            username, username + "@example.com", username, passwordEncoder.encode(PASSWORD));
+    user.setRole(role);
+    return userRepository.saveAndFlush(user);
+  }
+
+  private String token(String username) throws Exception {
+    String clientIp = "203.0.113." + (IP_SEQ.incrementAndGet() % 250 + 1);
+    String body = "{\"usernameOrEmail\":\"%s\",\"password\":\"%s\"}".formatted(username, PASSWORD);
+    MockHttpServletRequestBuilder login =
+        post("/api/v1/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body)
+            .with(
+                request -> {
+                  request.setRemoteAddr(clientIp);
+                  return request;
+                });
+    MvcResult result = mockMvc.perform(login).andExpect(status().isOk()).andReturn();
+    Matcher matcher = ACCESS_TOKEN.matcher(result.getResponse().getContentAsString());
+    assertThat(matcher.find()).isTrue();
+    return matcher.group(1);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/Team.java
+++ b/qnop-core/src/main/java/io/qnop/entity/Team.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * A team groups reviewers (issue #105); membership and per-team roles ({@code LEAD}/{@code MEMBER})
+ * live on {@link TeamMembership}. Teams will later route reviewers in the review workflow.
+ *
+ * <p>The case-insensitive name uniqueness is enforced by a Postgres functional unique index in
+ * Liquibase, not in JPA (ADR-0020). Identifiers are UUIDv7, generated application-side by
+ * Hibernate.
+ */
+@Entity
+@Table(name = "team")
+public class Team {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "name", nullable = false)
+  private String name;
+
+  @Column(name = "description")
+  private String description;
+
+  @Column(name = "enabled", nullable = false)
+  private boolean enabled = true;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @Version
+  @Column(name = "version", nullable = false)
+  private long version;
+
+  protected Team() {
+    // for JPA
+  }
+
+  /** Creates an enabled team with the given name and optional description. */
+  public static Team create(String name, String description) {
+    Team team = new Team();
+    team.name = name;
+    team.description = description;
+    team.enabled = true;
+    return team;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Team other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/TeamMembership.java
+++ b/qnop-core/src/main/java/io/qnop/entity/TeamMembership.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * A user's membership in a {@link Team} with a per-team {@link TeamRole} (issue #105). The team and
+ * user are held as plain UUID foreign keys (not JPA associations) to keep the service logic simple
+ * and DB-free testable; the FKs and the {@code (team_id, user_id)} uniqueness are enforced in
+ * Liquibase (ADR-0020). Deleting a team cascades its memberships. UUIDv7 ids, generated
+ * application-side by Hibernate.
+ */
+@Entity
+@Table(name = "team_membership")
+public class TeamMembership {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "team_id", nullable = false, updatable = false)
+  private UUID teamId;
+
+  @Column(name = "user_id", nullable = false, updatable = false)
+  private UUID userId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "team_role", nullable = false, length = 16)
+  private TeamRole teamRole = TeamRole.MEMBER;
+
+  @CreationTimestamp
+  @Column(name = "joined_at", nullable = false, updatable = false)
+  private Instant joinedAt;
+
+  @Version
+  @Column(name = "version", nullable = false)
+  private long version;
+
+  protected TeamMembership() {
+    // for JPA
+  }
+
+  /** Creates a membership of the given user in the given team with the given role. */
+  public static TeamMembership of(UUID teamId, UUID userId, TeamRole teamRole) {
+    TeamMembership membership = new TeamMembership();
+    membership.teamId = teamId;
+    membership.userId = userId;
+    membership.teamRole = teamRole;
+    return membership;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getTeamId() {
+    return teamId;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public TeamRole getTeamRole() {
+    return teamRole;
+  }
+
+  public void setTeamRole(TeamRole teamRole) {
+    this.teamRole = teamRole;
+  }
+
+  public Instant getJoinedAt() {
+    return joinedAt;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TeamMembership other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/TeamRole.java
+++ b/qnop-core/src/main/java/io/qnop/entity/TeamRole.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+/**
+ * A user's role <em>within a team</em> (issue #105) — distinct from the global {@link UserRole} and
+ * from per-review roles. Carried on {@link TeamMembership}. The allowed set is pinned by a Postgres
+ * {@code CHECK} constraint in Liquibase, not here (ADR-0020).
+ */
+public enum TeamRole {
+  /** Manages the team and its membership; the team's point of contact. */
+  LEAD,
+  /** A regular team member. The default when adding someone to a team. */
+  MEMBER
+}

--- a/qnop-core/src/main/java/io/qnop/repository/TeamMemberCount.java
+++ b/qnop-core/src/main/java/io/qnop/repository/TeamMemberCount.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/** Member count per team, for the team list (avoids an N+1 over the page). Issue #105. */
+public record TeamMemberCount(UUID teamId, long count) {}

--- a/qnop-core/src/main/java/io/qnop/repository/TeamMemberProjection.java
+++ b/qnop-core/src/main/java/io/qnop/repository/TeamMemberProjection.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.TeamRole;
+import java.time.Instant;
+import java.util.UUID;
+
+/** A team member joined with their user identity, for the team detail view (issue #105). */
+public record TeamMemberProjection(
+    UUID membershipId,
+    UUID userId,
+    String displayName,
+    String email,
+    TeamRole teamRole,
+    Instant joinedAt) {}

--- a/qnop-core/src/main/java/io/qnop/repository/TeamMembershipRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/TeamMembershipRepository.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.TeamMembership;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Data access for {@link TeamMembership}. */
+public interface TeamMembershipRepository extends JpaRepository<TeamMembership, UUID> {
+
+  Optional<TeamMembership> findByTeamIdAndUserId(UUID teamId, UUID userId);
+
+  boolean existsByTeamIdAndUserId(UUID teamId, UUID userId);
+
+  /** The members of a team joined with their user identity, ordered by display name. */
+  @Query(
+      "SELECT new io.qnop.repository.TeamMemberProjection("
+          + "m.id, u.id, u.displayName, u.email, m.teamRole, m.joinedAt) "
+          + "FROM TeamMembership m JOIN User u ON u.id = m.userId "
+          + "WHERE m.teamId = :teamId ORDER BY LOWER(u.displayName)")
+  List<TeamMemberProjection> findMembersByTeamId(@Param("teamId") UUID teamId);
+
+  /** Member counts for a set of teams, to populate the list without an N+1. */
+  @Query(
+      "SELECT new io.qnop.repository.TeamMemberCount(m.teamId, COUNT(m)) "
+          + "FROM TeamMembership m WHERE m.teamId IN :teamIds GROUP BY m.teamId")
+  List<TeamMemberCount> countMembersByTeamIds(@Param("teamIds") Collection<UUID> teamIds);
+}

--- a/qnop-core/src/main/java/io/qnop/repository/TeamRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/TeamRepository.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.Team;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Data access for {@link Team}. */
+public interface TeamRepository extends JpaRepository<Team, UUID> {
+
+  /** A team by case-insensitive name (matches the functional unique index). */
+  Optional<Team> findByNameIgnoreCase(String name);
+
+  boolean existsByNameIgnoreCase(String name);
+
+  /**
+   * Paginated admin search (issue #105): an optional case-insensitive match on name or description.
+   * {@code q} must be passed pre-lowercased and {@code LIKE}-wrapped (e.g. {@code %core%}); a
+   * {@code null} {@code q} disables the filter.
+   */
+  @Query(
+      "SELECT t FROM Team t WHERE :q IS NULL OR LOWER(t.name) LIKE :q"
+          + " OR (t.description IS NOT NULL AND LOWER(t.description) LIKE :q)")
+  Page<Team> search(@Param("q") String q, Pageable pageable);
+}

--- a/qnop-core/src/main/java/io/qnop/service/TeamConflictException.java
+++ b/qnop-core/src/main/java/io/qnop/service/TeamConflictException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+/**
+ * A conflicting team request (issue #105): a duplicate team name or adding a user who is already a
+ * member. Carries a stable {@code code} for the uniform error envelope; mapped to HTTP 409.
+ */
+public class TeamConflictException extends RuntimeException {
+
+  private final String code;
+
+  public TeamConflictException(String code, String message) {
+    super(message);
+    this.code = code;
+  }
+
+  public String getCode() {
+    return code;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/TeamNotFoundException.java
+++ b/qnop-core/src/main/java/io/qnop/service/TeamNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import java.util.UUID;
+
+/** Thrown when a team (or team membership) lookup finds no matching row (issue #105). */
+public class TeamNotFoundException extends RuntimeException {
+
+  public TeamNotFoundException(String message) {
+    super(message);
+  }
+
+  public static TeamNotFoundException team(UUID id) {
+    return new TeamNotFoundException("Team not found: " + id);
+  }
+
+  public static TeamNotFoundException membership(UUID teamId, UUID userId) {
+    return new TeamNotFoundException("User " + userId + " is not a member of team " + teamId);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/TeamService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TeamService.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.Team;
+import io.qnop.entity.TeamMembership;
+import io.qnop.entity.TeamRole;
+import io.qnop.entity.User;
+import io.qnop.repository.TeamMemberCount;
+import io.qnop.repository.TeamMembershipRepository;
+import io.qnop.repository.TeamRepository;
+import io.qnop.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Team management (issue #105): teams plus their {@code LEAD}/{@code MEMBER} memberships. Keeps the
+ * entities inside the service layer — every result crosses the boundary as an entity-free view
+ * (team role as its enum name), so the web layer never touches a JPA entity (ADR-0004). Duplicate
+ * team names and duplicate memberships surface as {@link TeamConflictException} (409); unknown
+ * teams or members as {@link TeamNotFoundException} (404); an unknown user being added as {@link
+ * UserNotFoundException} (404). Deleting a team cascades its memberships in the database.
+ */
+@Service
+public class TeamService {
+
+  private final TeamRepository teams;
+  private final TeamMembershipRepository memberships;
+  private final UserRepository users;
+
+  public TeamService(
+      TeamRepository teams, TeamMembershipRepository memberships, UserRepository users) {
+    this.teams = teams;
+    this.memberships = memberships;
+    this.users = users;
+  }
+
+  @Transactional(readOnly = true)
+  public TeamPage list(String query, int page, int size) {
+    String like =
+        blankToNull(query) == null ? null : "%" + query.trim().toLowerCase(Locale.ROOT) + "%";
+    Page<Team> result =
+        teams.search(like, PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "name")));
+    List<UUID> ids = result.getContent().stream().map(Team::getId).toList();
+    Map<UUID, Long> counts =
+        ids.isEmpty()
+            ? Map.of()
+            : memberships.countMembersByTeamIds(ids).stream()
+                .collect(Collectors.toMap(TeamMemberCount::teamId, TeamMemberCount::count));
+    List<TeamSummaryView> items =
+        result.getContent().stream()
+            .map(t -> toSummary(t, counts.getOrDefault(t.getId(), 0L)))
+            .toList();
+    return new TeamPage(items, result.getTotalElements(), page, size);
+  }
+
+  @Transactional(readOnly = true)
+  public TeamDetailView get(UUID id) {
+    Team team = teams.findById(id).orElseThrow(() -> TeamNotFoundException.team(id));
+    List<TeamMemberView> members =
+        memberships.findMembersByTeamId(id).stream()
+            .map(
+                p ->
+                    new TeamMemberView(
+                        p.userId(), p.displayName(), p.email(), p.teamRole().name(), p.joinedAt()))
+            .toList();
+    return new TeamDetailView(
+        team.getId(),
+        team.getName(),
+        team.getDescription(),
+        team.isEnabled(),
+        team.getCreatedAt(),
+        team.getUpdatedAt(),
+        members);
+  }
+
+  @Transactional
+  public TeamSummaryView create(String name, String description) {
+    String trimmed = requireName(name);
+    if (teams.existsByNameIgnoreCase(trimmed)) {
+      throw new TeamConflictException("NAME_TAKEN", "A team with that name already exists.");
+    }
+    Team saved = teams.save(Team.create(trimmed, blankToNull(description)));
+    return toSummary(saved, 0L);
+  }
+
+  @Transactional
+  public TeamSummaryView update(UUID id, String name, String description, Boolean enabled) {
+    Team team = teams.findById(id).orElseThrow(() -> TeamNotFoundException.team(id));
+    if (name != null) {
+      String trimmed = requireName(name);
+      teams
+          .findByNameIgnoreCase(trimmed)
+          .filter(other -> !other.getId().equals(id))
+          .ifPresent(
+              other -> {
+                throw new TeamConflictException(
+                    "NAME_TAKEN", "A team with that name already exists.");
+              });
+      team.setName(trimmed);
+    }
+    if (description != null) {
+      team.setDescription(blankToNull(description));
+    }
+    if (enabled != null) {
+      team.setEnabled(enabled);
+    }
+    long count =
+        memberships.countMembersByTeamIds(List.of(id)).stream()
+            .findFirst()
+            .map(TeamMemberCount::count)
+            .orElse(0L);
+    return toSummary(team, count);
+  }
+
+  @Transactional
+  public void delete(UUID id) {
+    Team team = teams.findById(id).orElseThrow(() -> TeamNotFoundException.team(id));
+    teams.delete(team); // memberships are removed by the ON DELETE CASCADE foreign key
+  }
+
+  @Transactional
+  public TeamMemberView addMember(UUID teamId, UUID userId, String teamRole) {
+    if (!teams.existsById(teamId)) {
+      throw TeamNotFoundException.team(teamId);
+    }
+    User user = users.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+    if (memberships.existsByTeamIdAndUserId(teamId, userId)) {
+      throw new TeamConflictException(
+          "ALREADY_MEMBER", "This user is already a member of the team.");
+    }
+    TeamMembership saved =
+        memberships.save(TeamMembership.of(teamId, userId, requireTeamRole(teamRole)));
+    return toMemberView(user, saved);
+  }
+
+  @Transactional
+  public TeamMemberView setMemberRole(UUID teamId, UUID userId, String teamRole) {
+    TeamMembership membership =
+        memberships
+            .findByTeamIdAndUserId(teamId, userId)
+            .orElseThrow(() -> TeamNotFoundException.membership(teamId, userId));
+    membership.setTeamRole(requireTeamRole(teamRole));
+    User user = users.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+    return toMemberView(user, membership);
+  }
+
+  @Transactional
+  public void removeMember(UUID teamId, UUID userId) {
+    TeamMembership membership =
+        memberships
+            .findByTeamIdAndUserId(teamId, userId)
+            .orElseThrow(() -> TeamNotFoundException.membership(teamId, userId));
+    memberships.delete(membership);
+  }
+
+  private static TeamMemberView toMemberView(User user, TeamMembership membership) {
+    return new TeamMemberView(
+        user.getId(),
+        user.getDisplayName(),
+        user.getEmail(),
+        membership.getTeamRole().name(),
+        membership.getJoinedAt());
+  }
+
+  private static TeamSummaryView toSummary(Team team, long memberCount) {
+    return new TeamSummaryView(
+        team.getId(),
+        team.getName(),
+        team.getDescription(),
+        team.isEnabled(),
+        memberCount,
+        team.getCreatedAt(),
+        team.getUpdatedAt());
+  }
+
+  private static String requireName(String name) {
+    String trimmed = name == null ? "" : name.trim();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException("name is required");
+    }
+    return trimmed;
+  }
+
+  private static TeamRole requireTeamRole(String teamRole) {
+    if (blankToNull(teamRole) == null) {
+      throw new IllegalArgumentException("teamRole is required");
+    }
+    return TeamRole.valueOf(teamRole.trim().toUpperCase(Locale.ROOT));
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value;
+  }
+
+  /** A team as shown in the admin team list. */
+  public record TeamSummaryView(
+      UUID id,
+      String name,
+      String description,
+      boolean enabled,
+      long memberCount,
+      Instant createdAt,
+      Instant updatedAt) {}
+
+  /** A team member joined with their user identity. */
+  public record TeamMemberView(
+      UUID userId, String displayName, String email, String teamRole, Instant joinedAt) {}
+
+  /** Full team detail including its members. */
+  public record TeamDetailView(
+      UUID id,
+      String name,
+      String description,
+      boolean enabled,
+      Instant createdAt,
+      Instant updatedAt,
+      List<TeamMemberView> members) {}
+
+  /** One page of {@link TeamSummaryView}s plus the total count. */
+  public record TeamPage(List<TeamSummaryView> items, long total, int page, int size) {}
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -32,3 +32,6 @@ databaseChangeLog:
   - include:
       file: migrations/0007-review-hardening.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0008-team-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0008-team-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0008-team-schema.yaml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Team schema (issue #105): team + team_membership. Postgres-only CHECK and the
+# case-insensitive name uniqueness live here in Liquibase, NOT in JPA annotations
+# (ADR-0020). JPA runs ddl-auto=none, so the entity mapping must match exactly.
+databaseChangeLog:
+  - changeSet:
+      id: 0008-team
+      author: qnop
+      comment: Teams group reviewers; memberships carry the per-team role.
+      changes:
+        - createTable:
+            tableName: team
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: name
+                  type: VARCHAR(120)
+                  constraints: { nullable: false }
+              - column: { name: description, type: VARCHAR(1000) }
+              - column:
+                  name: enabled
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints: { nullable: false }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints: { nullable: false }
+        - sql:
+            comment: Case-insensitive team-name uniqueness (functional index, not expressible in JPA).
+            sql: |
+              CREATE UNIQUE INDEX ux_team_name_lower ON team (LOWER(name));
+
+  - changeSet:
+      id: 0008-team-membership
+      author: qnop
+      comment: n:m membership of users in teams with a per-team role (LEAD/MEMBER).
+      changes:
+        - createTable:
+            tableName: team_membership
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: team_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: team_role
+                  type: VARCHAR(16)
+                  constraints: { nullable: false }
+              - column:
+                  name: joined_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints: { nullable: false }
+        - addForeignKeyConstraint:
+            constraintName: fk_team_membership_team
+            baseTableName: team_membership
+            baseColumnNames: team_id
+            referencedTableName: team
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: fk_team_membership_user
+            baseTableName: team_membership
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            constraintName: ux_team_membership_team_user
+            tableName: team_membership
+            columnNames: team_id, user_id
+        - createIndex:
+            indexName: ix_team_membership_user
+            tableName: team_membership
+            columns:
+              - column: { name: user_id }
+        - sql:
+            comment: Postgres-only CHECK on the team-role enum.
+            sql: |
+              ALTER TABLE team_membership ADD CONSTRAINT ck_team_membership_role
+                CHECK (team_role IN ('LEAD', 'MEMBER'));

--- a/qnop-core/src/test/java/io/qnop/service/TeamServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TeamServiceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.Team;
+import io.qnop.entity.TeamMembership;
+import io.qnop.entity.TeamRole;
+import io.qnop.entity.User;
+import io.qnop.repository.TeamMembershipRepository;
+import io.qnop.repository.TeamRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.TeamService.TeamMemberView;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link TeamService} (issue #105): name/membership guards and mapping. */
+class TeamServiceTest {
+
+  private final TeamRepository teams = mock(TeamRepository.class);
+  private final TeamMembershipRepository memberships = mock(TeamMembershipRepository.class);
+  private final UserRepository users = mock(UserRepository.class);
+  private final TeamService service = new TeamService(teams, memberships, users);
+
+  @Test
+  @DisplayName("create persists a new team and rejects a duplicate name")
+  void create() {
+    when(teams.existsByNameIgnoreCase("Core")).thenReturn(false);
+    when(teams.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    var view = service.create("  Core  ", "The core team");
+
+    assertThat(view.name()).isEqualTo("Core");
+    assertThat(view.enabled()).isTrue();
+    assertThat(view.memberCount()).isZero();
+
+    when(teams.existsByNameIgnoreCase("Core")).thenReturn(true);
+    assertThatThrownBy(() -> service.create("Core", null))
+        .isInstanceOf(TeamConflictException.class)
+        .extracting("code")
+        .isEqualTo("NAME_TAKEN");
+  }
+
+  @Test
+  @DisplayName("update rejects renaming onto another team's name but allows keeping its own")
+  void updateNameConflict() {
+    UUID id = UUID.randomUUID();
+    Team team = teamWithId(id, "Core");
+    when(teams.findById(id)).thenReturn(Optional.of(team));
+    when(memberships.countMembersByTeamIds(any())).thenReturn(java.util.List.of());
+
+    // Another team already owns "Platform".
+    when(teams.findByNameIgnoreCase("Platform"))
+        .thenReturn(Optional.of(teamWithId(UUID.randomUUID(), "Platform")));
+    assertThatThrownBy(() -> service.update(id, "Platform", null, null))
+        .isInstanceOf(TeamConflictException.class)
+        .extracting("code")
+        .isEqualTo("NAME_TAKEN");
+
+    // Renaming to a name owned by the same team is allowed.
+    when(teams.findByNameIgnoreCase("Core")).thenReturn(Optional.of(team));
+    var view = service.update(id, "Core", "desc", false);
+    assertThat(view.name()).isEqualTo("Core");
+    assertThat(view.enabled()).isFalse();
+  }
+
+  @Test
+  @DisplayName("get and delete throw for an unknown team")
+  void unknownTeam() {
+    UUID id = UUID.randomUUID();
+    when(teams.findById(id)).thenReturn(Optional.empty());
+    assertThatThrownBy(() -> service.get(id)).isInstanceOf(TeamNotFoundException.class);
+    assertThatThrownBy(() -> service.delete(id)).isInstanceOf(TeamNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("addMember validates the team, the user and duplicate membership")
+  void addMember() {
+    UUID teamId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    when(teams.existsById(teamId)).thenReturn(false);
+    assertThatThrownBy(() -> service.addMember(teamId, userId, "MEMBER"))
+        .isInstanceOf(TeamNotFoundException.class);
+
+    when(teams.existsById(teamId)).thenReturn(true);
+    when(users.findById(userId)).thenReturn(Optional.empty());
+    assertThatThrownBy(() -> service.addMember(teamId, userId, "MEMBER"))
+        .isInstanceOf(UserNotFoundException.class);
+
+    User user = User.internal("Alice", "alice@example.com", "alice", "h");
+    when(users.findById(userId)).thenReturn(Optional.of(user));
+    when(memberships.existsByTeamIdAndUserId(teamId, userId)).thenReturn(true);
+    assertThatThrownBy(() -> service.addMember(teamId, userId, "MEMBER"))
+        .isInstanceOf(TeamConflictException.class)
+        .extracting("code")
+        .isEqualTo("ALREADY_MEMBER");
+
+    when(memberships.existsByTeamIdAndUserId(teamId, userId)).thenReturn(false);
+    when(memberships.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    TeamMemberView view = service.addMember(teamId, userId, "LEAD");
+    assertThat(view.displayName()).isEqualTo("Alice");
+    assertThat(view.teamRole()).isEqualTo("LEAD");
+  }
+
+  @Test
+  @DisplayName("setMemberRole and removeMember throw when the membership is missing")
+  void missingMembership() {
+    UUID teamId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    when(memberships.findByTeamIdAndUserId(teamId, userId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.setMemberRole(teamId, userId, "LEAD"))
+        .isInstanceOf(TeamNotFoundException.class);
+    assertThatThrownBy(() -> service.removeMember(teamId, userId))
+        .isInstanceOf(TeamNotFoundException.class);
+    verify(memberships, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("setMemberRole updates the role of an existing member")
+  void setMemberRole() {
+    UUID teamId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    TeamMembership membership = TeamMembership.of(teamId, userId, TeamRole.MEMBER);
+    when(memberships.findByTeamIdAndUserId(teamId, userId)).thenReturn(Optional.of(membership));
+    when(users.findById(userId))
+        .thenReturn(Optional.of(User.internal("Bob", "bob@example.com", "bob", "h")));
+
+    TeamMemberView view = service.setMemberRole(teamId, userId, "LEAD");
+
+    assertThat(membership.getTeamRole()).isEqualTo(TeamRole.LEAD);
+    assertThat(view.teamRole()).isEqualTo("LEAD");
+  }
+
+  private static Team teamWithId(UUID id, String name) {
+    Team team = Team.create(name, null);
+    try {
+      var field = Team.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(team, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+    return team;
+  }
+}

--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -21,6 +21,7 @@
 
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import {
+  AdminTeamsApi,
   AdminUsersApi,
   AuthApi,
   AuthPasswordResetApi,
@@ -84,3 +85,4 @@ export const authApi = new AuthApi(undefined, undefined, axiosInstance);
 export const authRegistrationApi = new AuthRegistrationApi(undefined, undefined, axiosInstance);
 export const authPasswordResetApi = new AuthPasswordResetApi(undefined, undefined, axiosInstance);
 export const adminUsersApi = new AdminUsersApi(undefined, undefined, axiosInstance);
+export const adminTeamsApi = new AdminTeamsApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useTeams.test.tsx
+++ b/qnop-ui/src/api/hooks/useTeams.test.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { AdminTeamDetail, AdminTeamListResponse } from '../generated';
+import {
+  teamKeys,
+  useAddTeamMember,
+  useCreateTeam,
+  useDeleteTeam,
+  useRemoveTeamMember,
+  useSetTeamMemberRole,
+  useTeam,
+  useTeams,
+  useUpdateTeam,
+} from './useTeams';
+import { adminTeamsApi } from '../config';
+
+vi.mock('../config', () => ({
+  adminTeamsApi: {
+    listTeams: vi.fn(),
+    getTeam: vi.fn(),
+    createTeam: vi.fn(),
+    updateTeam: vi.fn(),
+    deleteTeam: vi.fn(),
+    addTeamMember: vi.fn(),
+    setTeamMemberRole: vi.fn(),
+    removeTeamMember: vi.fn(),
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const EMPTY_PAGE: AdminTeamListResponse = { items: [], total: 0, page: 0, size: 20 };
+const TEAM: AdminTeamDetail = {
+  id: 't1',
+  name: 'Core',
+  enabled: true,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  members: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('teamKeys', () => {
+  it('namespaces list and detail keys', () => {
+    expect(teamKeys.list({ page: 0, size: 20 })).toEqual([
+      'admin',
+      'teams',
+      'list',
+      { page: 0, size: 20 },
+    ]);
+    expect(teamKeys.detail('t1')).toEqual(['admin', 'teams', 'detail', 't1']);
+  });
+});
+
+describe('useTeams / useTeam', () => {
+  it('lists teams with query and pagination', async () => {
+    vi.mocked(adminTeamsApi.listTeams).mockResolvedValue({ data: EMPTY_PAGE } as Awaited<
+      ReturnType<typeof adminTeamsApi.listTeams>
+    >);
+
+    const { result } = renderHook(() => useTeams({ q: 'core', page: 1, size: 20 }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(adminTeamsApi.listTeams).toHaveBeenCalledWith({ q: 'core', page: 1, size: 20 });
+  });
+
+  it('fetches a single team', async () => {
+    vi.mocked(adminTeamsApi.getTeam).mockResolvedValue({ data: TEAM } as Awaited<
+      ReturnType<typeof adminTeamsApi.getTeam>
+    >);
+
+    const { result } = renderHook(() => useTeam('t1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(adminTeamsApi.getTeam).toHaveBeenCalledWith({ teamId: 't1' });
+    expect(result.current.data?.name).toBe('Core');
+  });
+});
+
+describe('team mutations', () => {
+  it('creates, updates and deletes a team', async () => {
+    vi.mocked(adminTeamsApi.createTeam).mockResolvedValue({ data: {} } as Awaited<
+      ReturnType<typeof adminTeamsApi.createTeam>
+    >);
+    vi.mocked(adminTeamsApi.updateTeam).mockResolvedValue({ data: {} } as Awaited<
+      ReturnType<typeof adminTeamsApi.updateTeam>
+    >);
+    vi.mocked(adminTeamsApi.deleteTeam).mockResolvedValue({ data: undefined } as Awaited<
+      ReturnType<typeof adminTeamsApi.deleteTeam>
+    >);
+
+    const create = renderHook(() => useCreateTeam(), { wrapper });
+    await create.result.current.mutateAsync({ name: 'Core' });
+    expect(adminTeamsApi.createTeam).toHaveBeenCalledWith({
+      adminTeamCreateRequest: { name: 'Core' },
+    });
+
+    const update = renderHook(() => useUpdateTeam(), { wrapper });
+    await update.result.current.mutateAsync({ id: 't1', request: { enabled: false } });
+    expect(adminTeamsApi.updateTeam).toHaveBeenCalledWith({
+      teamId: 't1',
+      adminTeamUpdateRequest: { enabled: false },
+    });
+
+    const del = renderHook(() => useDeleteTeam(), { wrapper });
+    await del.result.current.mutateAsync('t1');
+    expect(adminTeamsApi.deleteTeam).toHaveBeenCalledWith({ teamId: 't1' });
+  });
+
+  it('adds, re-roles and removes a member', async () => {
+    vi.mocked(adminTeamsApi.addTeamMember).mockResolvedValue({ data: {} } as Awaited<
+      ReturnType<typeof adminTeamsApi.addTeamMember>
+    >);
+    vi.mocked(adminTeamsApi.setTeamMemberRole).mockResolvedValue({ data: {} } as Awaited<
+      ReturnType<typeof adminTeamsApi.setTeamMemberRole>
+    >);
+    vi.mocked(adminTeamsApi.removeTeamMember).mockResolvedValue({ data: undefined } as Awaited<
+      ReturnType<typeof adminTeamsApi.removeTeamMember>
+    >);
+
+    const add = renderHook(() => useAddTeamMember(), { wrapper });
+    await add.result.current.mutateAsync({ teamId: 't1', userId: 'u1', teamRole: 'LEAD' });
+    expect(adminTeamsApi.addTeamMember).toHaveBeenCalledWith({
+      teamId: 't1',
+      adminTeamMemberRequest: { userId: 'u1', teamRole: 'LEAD' },
+    });
+
+    const role = renderHook(() => useSetTeamMemberRole(), { wrapper });
+    await role.result.current.mutateAsync({ teamId: 't1', userId: 'u1', teamRole: 'MEMBER' });
+    expect(adminTeamsApi.setTeamMemberRole).toHaveBeenCalledWith({
+      teamId: 't1',
+      userId: 'u1',
+      adminTeamMemberRoleUpdateRequest: { teamRole: 'MEMBER' },
+    });
+
+    const remove = renderHook(() => useRemoveTeamMember(), { wrapper });
+    await remove.result.current.mutateAsync({ teamId: 't1', userId: 'u1' });
+    expect(adminTeamsApi.removeTeamMember).toHaveBeenCalledWith({ teamId: 't1', userId: 'u1' });
+  });
+});

--- a/qnop-ui/src/api/hooks/useTeams.ts
+++ b/qnop-ui/src/api/hooks/useTeams.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  AdminTeamCreateRequest,
+  AdminTeamDetail,
+  AdminTeamListResponse,
+  AdminTeamUpdateRequest,
+  TeamRole,
+} from '../generated';
+import { adminTeamsApi } from '../config';
+
+export interface TeamListParams {
+  q?: string;
+  page: number;
+  size: number;
+}
+
+export const teamKeys = {
+  all: ['admin', 'teams'] as const,
+  list: (params: TeamListParams) => [...teamKeys.all, 'list', params] as const,
+  detail: (id: string) => [...teamKeys.all, 'detail', id] as const,
+};
+
+/** A page of teams for the admin list (keeps the previous page while loading). */
+export function useTeams(params: TeamListParams) {
+  return useQuery<AdminTeamListResponse>({
+    queryKey: teamKeys.list(params),
+    queryFn: async () => {
+      const response = await adminTeamsApi.listTeams({
+        q: params.q || undefined,
+        page: params.page,
+        size: params.size,
+      });
+      return response.data;
+    },
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** A single team with its members. */
+export function useTeam(id: string) {
+  return useQuery<AdminTeamDetail>({
+    queryKey: teamKeys.detail(id),
+    queryFn: async () => {
+      const response = await adminTeamsApi.getTeam({ teamId: id });
+      return response.data;
+    },
+  });
+}
+
+export function useCreateTeam() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request: AdminTeamCreateRequest) => {
+      const response = await adminTeamsApi.createTeam({ adminTeamCreateRequest: request });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: teamKeys.all }),
+  });
+}
+
+export function useUpdateTeam() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { id: string; request: AdminTeamUpdateRequest }) => {
+      const response = await adminTeamsApi.updateTeam({
+        teamId: vars.id,
+        adminTeamUpdateRequest: vars.request,
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: teamKeys.all }),
+  });
+}
+
+export function useDeleteTeam() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await adminTeamsApi.deleteTeam({ teamId: id });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: teamKeys.all }),
+  });
+}
+
+export function useAddTeamMember() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { teamId: string; userId: string; teamRole: TeamRole }) => {
+      const response = await adminTeamsApi.addTeamMember({
+        teamId: vars.teamId,
+        adminTeamMemberRequest: { userId: vars.userId, teamRole: vars.teamRole },
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: teamKeys.all }),
+  });
+}
+
+export function useSetTeamMemberRole() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { teamId: string; userId: string; teamRole: TeamRole }) => {
+      const response = await adminTeamsApi.setTeamMemberRole({
+        teamId: vars.teamId,
+        userId: vars.userId,
+        adminTeamMemberRoleUpdateRequest: { teamRole: vars.teamRole },
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: teamKeys.all }),
+  });
+}
+
+export function useRemoveTeamMember() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { teamId: string; userId: string }) => {
+      await adminTeamsApi.removeTeamMember({ teamId: vars.teamId, userId: vars.userId });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: teamKeys.all }),
+  });
+}

--- a/qnop-ui/src/components/admin/ConfirmDialog.tsx
+++ b/qnop-ui/src/components/admin/ConfirmDialog.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/** A small reusable confirmation dialog for destructive admin actions (#105). */
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  destructive = false,
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{message}</DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onClose} color="inherit">
+          Cancel
+        </Button>
+        <Button onClick={onConfirm} variant="contained" color={destructive ? 'error' : 'primary'}>
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/admin/ToneBadge.tsx
+++ b/qnop-ui/src/components/admin/ToneBadge.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+
+export type BadgeTone = 'blue' | 'green' | 'amber' | 'red' | 'neutral';
+
+/** A compact, system-coloured pill driven by the shared `qnop.badge` tones (#104/#105). */
+export function ToneBadge({ tone, label }: { tone: BadgeTone; label: string }) {
+  const theme = useTheme();
+  const t =
+    tone === 'neutral'
+      ? {
+          bg: theme.qnop.surface2,
+          fg: theme.palette.text.secondary,
+          border: theme.palette.divider,
+        }
+      : theme.qnop.badge[tone];
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        px: 1,
+        py: 0.25,
+        borderRadius: 1,
+        fontSize: 12,
+        fontWeight: 600,
+        lineHeight: 1.6,
+        whiteSpace: 'nowrap',
+        bgcolor: t.bg,
+        color: t.fg,
+        border: '1px solid',
+        borderColor: t.border,
+      }}
+    >
+      {label}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/admin/teams/AddMemberDialog.tsx
+++ b/qnop-ui/src/components/admin/teams/AddMemberDialog.tsx
@@ -34,7 +34,6 @@ import TextField from '@mui/material/TextField';
 import type { AdminUserSummary, TeamRole } from '../../../api/generated';
 import { useAdminUsers } from '../../../api/hooks/useAdminUsers';
 import { useAddTeamMember } from '../../../api/hooks/useTeams';
-import { apiErrorCode, apiErrorMessage } from '../../../utils/apiError';
 
 interface AddMemberDialogProps {
   open: boolean;
@@ -43,7 +42,11 @@ interface AddMemberDialogProps {
   onClose: () => void;
 }
 
-/** Picks a user (via the admin user search) and adds them to the team with a role. */
+/**
+ * Picks one or more users (via the admin user search) and adds them to the team
+ * with the chosen role. Adds run in parallel; on a partial failure the dialog
+ * stays open with only the users that could not be added still selected.
+ */
 export function AddMemberDialog({
   open,
   teamId,
@@ -53,9 +56,10 @@ export function AddMemberDialog({
   const addMember = useAddTeamMember();
   const [search, setSearch] = useState('');
   const [debounced, setDebounced] = useState('');
-  const [selected, setSelected] = useState<AdminUserSummary | null>(null);
+  const [selected, setSelected] = useState<AdminUserSummary[]>([]);
   const [teamRole, setTeamRole] = useState<TeamRole>('MEMBER');
   const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     const handle = setTimeout(() => setDebounced(search), 300);
@@ -68,27 +72,33 @@ export function AddMemberDialog({
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
-    if (!selected) return;
+    if (selected.length === 0) return;
     setError(null);
-    try {
-      await addMember.mutateAsync({ teamId, userId: selected.id, teamRole });
+    setSubmitting(true);
+    const results = await Promise.allSettled(
+      selected.map((user) => addMember.mutateAsync({ teamId, userId: user.id, teamRole })),
+    );
+    setSubmitting(false);
+
+    const failed = selected.filter((_, i) => results[i].status === 'rejected');
+    if (failed.length === 0) {
       onClose();
-    } catch (err) {
-      const message =
-        apiErrorCode(err) === 'ALREADY_MEMBER'
-          ? 'This user is already a member of the team.'
-          : apiErrorMessage(err, 'Could not add the member. Please try again.');
-      setError(message);
+      return;
     }
+    // Keep only the users that could not be added so the admin can retry them.
+    setSelected(failed);
+    setError(`Could not add: ${failed.map((u) => u.displayName).join(', ')}.`);
   };
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <Box component="form" onSubmit={onSubmit} noValidate>
-        <DialogTitle>Add member</DialogTitle>
+        <DialogTitle>Add members</DialogTitle>
         <DialogContent>
           <Stack spacing={2.5} sx={{ mt: 1 }}>
             <Autocomplete
+              multiple
+              disableCloseOnSelect
               options={options}
               loading={isFetching}
               value={selected}
@@ -99,7 +109,7 @@ export function AddMemberDialog({
               filterOptions={(x) => x}
               noOptionsText="No matching users"
               renderInput={(params) => (
-                <TextField {...params} label="User" placeholder="Search by name or email" />
+                <TextField {...params} label="Users" placeholder="Search by name or email" />
               )}
             />
             <TextField
@@ -108,6 +118,7 @@ export function AddMemberDialog({
               value={teamRole}
               onChange={(e) => setTeamRole(e.target.value as TeamRole)}
               fullWidth
+              helperText="Applied to everyone added in this batch."
             >
               <MenuItem value="MEMBER">Member</MenuItem>
               <MenuItem value="LEAD">Lead</MenuItem>
@@ -119,8 +130,8 @@ export function AddMemberDialog({
           <Button onClick={onClose} color="inherit">
             Cancel
           </Button>
-          <Button type="submit" variant="contained" disabled={addMember.isPending || !selected}>
-            Add
+          <Button type="submit" variant="contained" disabled={submitting || selected.length === 0}>
+            {selected.length > 1 ? `Add ${selected.length}` : 'Add'}
           </Button>
         </DialogActions>
       </Box>

--- a/qnop-ui/src/components/admin/teams/AddMemberDialog.tsx
+++ b/qnop-ui/src/components/admin/teams/AddMemberDialog.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useState, type FormEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import type { AdminUserSummary, TeamRole } from '../../../api/generated';
+import { useAdminUsers } from '../../../api/hooks/useAdminUsers';
+import { useAddTeamMember } from '../../../api/hooks/useTeams';
+import { apiErrorCode, apiErrorMessage } from '../../../utils/apiError';
+
+interface AddMemberDialogProps {
+  open: boolean;
+  teamId: string;
+  existingMemberIds: string[];
+  onClose: () => void;
+}
+
+/** Picks a user (via the admin user search) and adds them to the team with a role. */
+export function AddMemberDialog({
+  open,
+  teamId,
+  existingMemberIds,
+  onClose,
+}: AddMemberDialogProps) {
+  const addMember = useAddTeamMember();
+  const [search, setSearch] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [selected, setSelected] = useState<AdminUserSummary | null>(null);
+  const [teamRole, setTeamRole] = useState<TeamRole>('MEMBER');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(search), 300);
+    return () => clearTimeout(handle);
+  }, [search]);
+
+  const { data, isFetching } = useAdminUsers({ q: debounced || undefined, page: 0, size: 10 });
+  const existing = new Set(existingMemberIds);
+  const options = (data?.items ?? []).filter((u) => !existing.has(u.id));
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!selected) return;
+    setError(null);
+    try {
+      await addMember.mutateAsync({ teamId, userId: selected.id, teamRole });
+      onClose();
+    } catch (err) {
+      const message =
+        apiErrorCode(err) === 'ALREADY_MEMBER'
+          ? 'This user is already a member of the team.'
+          : apiErrorMessage(err, 'Could not add the member. Please try again.');
+      setError(message);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <Box component="form" onSubmit={onSubmit} noValidate>
+        <DialogTitle>Add member</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ mt: 1 }}>
+            <Autocomplete
+              options={options}
+              loading={isFetching}
+              value={selected}
+              onChange={(_, value) => setSelected(value)}
+              onInputChange={(_, value) => setSearch(value)}
+              getOptionLabel={(u) => `${u.displayName} (${u.email})`}
+              isOptionEqualToValue={(a, b) => a.id === b.id}
+              filterOptions={(x) => x}
+              noOptionsText="No matching users"
+              renderInput={(params) => (
+                <TextField {...params} label="User" placeholder="Search by name or email" />
+              )}
+            />
+            <TextField
+              label="Team role"
+              select
+              value={teamRole}
+              onChange={(e) => setTeamRole(e.target.value as TeamRole)}
+              fullWidth
+            >
+              <MenuItem value="MEMBER">Member</MenuItem>
+              <MenuItem value="LEAD">Lead</MenuItem>
+            </TextField>
+            {error && <Alert severity="error">{error}</Alert>}
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2.5 }}>
+          <Button onClick={onClose} color="inherit">
+            Cancel
+          </Button>
+          <Button type="submit" variant="contained" disabled={addMember.isPending || !selected}>
+            Add
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/admin/teams/TeamFormDialog.tsx
+++ b/qnop-ui/src/components/admin/teams/TeamFormDialog.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type FormEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import type { AdminTeamSummary } from '../../../api/generated';
+import { useCreateTeam, useUpdateTeam } from '../../../api/hooks/useTeams';
+import { apiErrorCode, apiErrorMessage } from '../../../utils/apiError';
+
+interface TeamFormDialogProps {
+  open: boolean;
+  mode: 'create' | 'edit';
+  team?: AdminTeamSummary;
+  onClose: () => void;
+}
+
+/**
+ * Create a team (mode "create") or edit its name, description and enabled state
+ * (mode "edit"). State is seeded via useState initializers; the parent remounts
+ * the dialog per open (key) so there is no reset-via-effect.
+ */
+export function TeamFormDialog({ open, mode, team, onClose }: TeamFormDialogProps) {
+  const createTeam = useCreateTeam();
+  const updateTeam = useUpdateTeam();
+
+  const editing = mode === 'edit' && team;
+  const [name, setName] = useState(editing ? team.name : '');
+  const [description, setDescription] = useState(editing ? (team.description ?? '') : '');
+  const [enabled, setEnabled] = useState(editing ? team.enabled : true);
+  const [error, setError] = useState<string | null>(null);
+
+  const submitting = createTeam.isPending || updateTeam.isPending;
+  const canSubmit = name.trim().length > 0;
+  const isEdit = mode === 'edit';
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      if (isEdit && team) {
+        await updateTeam.mutateAsync({ id: team.id, request: { name, description, enabled } });
+      } else {
+        await createTeam.mutateAsync({ name, description: description || undefined });
+      }
+      onClose();
+    } catch (err) {
+      const message =
+        apiErrorCode(err) === 'NAME_TAKEN'
+          ? 'A team with that name already exists.'
+          : apiErrorMessage(err, 'Saving failed. Please try again.');
+      setError(message);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <Box component="form" onSubmit={onSubmit} noValidate>
+        <DialogTitle>{isEdit ? 'Edit team' : 'Create team'}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ mt: 1 }}>
+            <TextField
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              fullWidth
+              required
+            />
+            <TextField
+              label="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              fullWidth
+              multiline
+              minRows={2}
+            />
+            {isEdit && (
+              <FormControlLabel
+                control={
+                  <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+                }
+                label={enabled ? 'Team active' : 'Team disabled'}
+              />
+            )}
+            {error && <Alert severity="error">{error}</Alert>}
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2.5 }}>
+          <Button onClick={onClose} color="inherit">
+            Cancel
+          </Button>
+          <Button type="submit" variant="contained" disabled={submitting || !canSubmit}>
+            {isEdit ? 'Save' : 'Create'}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/admin/teams/TeamRoleBadge.tsx
+++ b/qnop-ui/src/components/admin/teams/TeamRoleBadge.tsx
@@ -19,30 +19,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { UserRole } from '../../../api/generated';
+import type { TeamRole } from '../../../api/generated';
 import { ToneBadge, type BadgeTone } from '../ToneBadge';
 
-const ROLE_TONE: Record<UserRole, BadgeTone> = {
-  ADMIN: 'blue',
-  AUDITOR: 'amber',
-  MEMBER: 'neutral',
-};
-const ROLE_LABEL: Record<UserRole, string> = {
-  ADMIN: 'Admin',
-  MEMBER: 'Member',
-  AUDITOR: 'Auditor',
-};
+const TONE: Record<TeamRole, BadgeTone> = { LEAD: 'blue', MEMBER: 'neutral' };
+const LABEL: Record<TeamRole, string> = { LEAD: 'Lead', MEMBER: 'Member' };
 
-/** The user's global role as a coloured pill. */
-export function UserRoleBadge({ role }: { role: UserRole }) {
-  return <ToneBadge tone={ROLE_TONE[role]} label={ROLE_LABEL[role]} />;
-}
-
-/** Account state: active (green) or disabled (red). */
-export function UserStatusBadge({ enabled }: { enabled: boolean }) {
-  return enabled ? (
-    <ToneBadge tone="green" label="Active" />
-  ) : (
-    <ToneBadge tone="red" label="Disabled" />
-  );
+/** A team member's per-team role as a coloured pill. */
+export function TeamRoleBadge({ role }: { role: TeamRole }) {
+  return <ToneBadge tone={TONE[role]} label={LABEL[role]} />;
 }

--- a/qnop-ui/src/components/shell/Breadcrumbs.tsx
+++ b/qnop-ui/src/components/shell/Breadcrumbs.tsx
@@ -38,7 +38,9 @@ export function Breadcrumbs() {
     >
       {crumbs.map((c, i) => {
         const isLast = i === crumbs.length - 1;
-        if (c.to && !isLast) {
+        // A crumb with a `to` is always a link — even when it is the last crumb,
+        // as on a detail page where the trailing "Teams" links back to the list.
+        if (c.to) {
           return (
             <Link
               key={i}

--- a/qnop-ui/src/components/shell/navConfig.test.ts
+++ b/qnop-ui/src/components/shell/navConfig.test.ts
@@ -71,4 +71,11 @@ describe('crumbsFor', () => {
   it('builds just the item for a top-level path', () => {
     expect(crumbsFor('/reviews')).toEqual([{ label: 'Reviews' }]);
   });
+
+  it('maps a nested detail path to its section, linking back to the list', () => {
+    expect(crumbsFor('/admin/teams/abc-123')).toEqual([
+      { label: 'Administration' },
+      { label: 'Teams', to: '/admin/teams' },
+    ]);
+  });
 });

--- a/qnop-ui/src/components/shell/navConfig.tsx
+++ b/qnop-ui/src/components/shell/navConfig.tsx
@@ -117,13 +117,17 @@ export function crumbsFor(pathname: string): Crumb[] {
     return [{ label: 'Dashboard' }];
   }
   for (const group of NAV_GROUPS) {
-    const item = group.items.find((i) => i.path === pathname);
+    // Exact match, or a detail page nested under an item (e.g. /admin/teams/:id):
+    // both resolve to the item's section context (the id segment is not shown).
+    const item = group.items.find(
+      (i) => i.path === pathname || (i.path !== '/' && pathname.startsWith(`${i.path}/`)),
+    );
     if (item) {
       const trail: Crumb[] = [];
       if (group.label) {
         trail.push({ label: group.label });
       }
-      trail.push({ label: item.label });
+      trail.push({ label: item.label, to: item.path === pathname ? undefined : item.path });
       return trail;
     }
   }

--- a/qnop-ui/src/pages/admin/TeamDetailPage.tsx
+++ b/qnop-ui/src/pages/admin/TeamDetailPage.tsx
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type MouseEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import {
+  ArrowLeft,
+  ArrowLeftRight,
+  MoreVertical,
+  SquarePen,
+  UserMinus,
+  UserPlus,
+} from 'lucide-react';
+import { Link as RouterLink, useParams } from 'react-router-dom';
+import type { AdminTeamMember } from '../../api/generated';
+import { useRemoveTeamMember, useSetTeamMemberRole, useTeam } from '../../api/hooks/useTeams';
+import { AddMemberDialog } from '../../components/admin/teams/AddMemberDialog';
+import { TeamFormDialog } from '../../components/admin/teams/TeamFormDialog';
+import { TeamRoleBadge } from '../../components/admin/teams/TeamRoleBadge';
+import { ConfirmDialog } from '../../components/admin/ConfirmDialog';
+import { UserAvatar } from '../../components/shell/UserAvatar';
+import { UserStatusBadge } from '../../components/admin/users/UserBadges';
+import { formatDateTime } from '../../utils/formatDate';
+
+/** Team detail with member management: add, change role, remove (#105). */
+export function TeamDetailPage() {
+  const { id = '' } = useParams();
+  const { data: team, isLoading, isError } = useTeam(id);
+  const setRole = useSetTeamMemberRole();
+  const removeMember = useRemoveTeamMember();
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [editSeq, setEditSeq] = useState(0);
+  const [addOpen, setAddOpen] = useState(false);
+  const [addSeq, setAddSeq] = useState(0);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [active, setActive] = useState<AdminTeamMember | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<AdminTeamMember | null>(null);
+
+  if (isError) {
+    return (
+      <Alert severity="error">
+        This team could not be loaded.{' '}
+        <Link component={RouterLink} to="/admin/teams" underline="hover">
+          Back to teams
+        </Link>
+      </Alert>
+    );
+  }
+  if (isLoading || !team) {
+    return <Typography color="text.secondary">Loading…</Typography>;
+  }
+
+  const openMenu = (event: MouseEvent<HTMLElement>, member: AdminTeamMember) => {
+    setAnchorEl(event.currentTarget);
+    setActive(member);
+  };
+  const openAdd = () => {
+    setAddOpen(true);
+    setAddSeq((n) => n + 1);
+  };
+  const openEdit = () => {
+    setEditOpen(true);
+    setEditSeq((n) => n + 1);
+  };
+
+  const toggleRole = (member: AdminTeamMember) => {
+    const next = member.teamRole === 'LEAD' ? 'MEMBER' : 'LEAD';
+    setRole.mutate({ teamId: id, userId: member.userId, teamRole: next });
+  };
+
+  const members = team.members ?? [];
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Link
+          component={RouterLink}
+          to="/admin/teams"
+          underline="hover"
+          sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, fontSize: 13, mb: 1 }}
+        >
+          <ArrowLeft size={15} /> Teams
+        </Link>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          sx={{ justifyContent: 'space-between', alignItems: { sm: 'center' } }}
+        >
+          <Box>
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <Typography variant="h1" sx={{ fontSize: 26 }}>
+                {team.name}
+              </Typography>
+              <UserStatusBadge enabled={team.enabled} />
+            </Stack>
+            {team.description && (
+              <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+                {team.description}
+              </Typography>
+            )}
+          </Box>
+          <Stack direction="row" spacing={1.5}>
+            <Button color="inherit" startIcon={<SquarePen size={16} />} onClick={openEdit}>
+              Edit
+            </Button>
+            <Button variant="contained" startIcon={<UserPlus size={18} />} onClick={openAdd}>
+              Add member
+            </Button>
+          </Stack>
+        </Stack>
+      </Box>
+
+      <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+        <Table size="medium" sx={{ '& td, & th': { borderColor: 'divider' } }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Member</TableCell>
+              <TableCell>Role</TableCell>
+              <TableCell>Joined</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {members.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={4}>
+                  <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+                    No members yet. Add the first one.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+            {members.map((member) => (
+              <TableRow key={member.userId} hover>
+                <TableCell>
+                  <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+                    <UserAvatar name={member.displayName} size={36} />
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography sx={{ fontWeight: 600, lineHeight: 1.3 }} noWrap>
+                        {member.displayName}
+                      </Typography>
+                      <Typography sx={{ fontSize: 13, color: 'text.secondary' }} noWrap>
+                        {member.email}
+                      </Typography>
+                    </Box>
+                  </Stack>
+                </TableCell>
+                <TableCell>
+                  <TeamRoleBadge role={member.teamRole} />
+                </TableCell>
+                <TableCell>
+                  <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>
+                    {formatDateTime(member.joinedAt)}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <IconButton
+                    size="small"
+                    aria-label={`Actions for ${member.displayName}`}
+                    onClick={(e) => openMenu(e, member)}
+                  >
+                    <MoreVertical size={18} />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+        <MenuItem
+          onClick={() => {
+            setAnchorEl(null);
+            if (active) toggleRole(active);
+          }}
+        >
+          <ListItemIcon>
+            <ArrowLeftRight size={16} />
+          </ListItemIcon>
+          <ListItemText>{active?.teamRole === 'LEAD' ? 'Make member' : 'Make lead'}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setAnchorEl(null);
+            setRemoveTarget(active);
+          }}
+        >
+          <ListItemIcon>
+            <UserMinus size={16} />
+          </ListItemIcon>
+          <ListItemText>Remove from team</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      <AddMemberDialog
+        key={`add-${addSeq}`}
+        open={addOpen}
+        teamId={id}
+        existingMemberIds={members.map((m) => m.userId)}
+        onClose={() => setAddOpen(false)}
+      />
+
+      <TeamFormDialog
+        key={`edit-${editSeq}`}
+        open={editOpen}
+        mode="edit"
+        team={{
+          id: team.id,
+          name: team.name,
+          description: team.description,
+          enabled: team.enabled,
+          memberCount: members.length,
+          createdAt: team.createdAt,
+          updatedAt: team.updatedAt,
+        }}
+        onClose={() => setEditOpen(false)}
+      />
+
+      <ConfirmDialog
+        open={removeTarget !== null}
+        title="Remove member"
+        message={`Remove ${removeTarget?.displayName} from this team?`}
+        confirmLabel="Remove"
+        destructive
+        onConfirm={() => {
+          if (removeTarget) {
+            removeMember.mutate({ teamId: id, userId: removeTarget.userId });
+          }
+          setRemoveTarget(null);
+        }}
+        onClose={() => setRemoveTarget(null)}
+      />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/admin/TeamDetailPage.tsx
+++ b/qnop-ui/src/pages/admin/TeamDetailPage.tsx
@@ -37,14 +37,7 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
-import {
-  ArrowLeft,
-  ArrowLeftRight,
-  MoreVertical,
-  SquarePen,
-  UserMinus,
-  UserPlus,
-} from 'lucide-react';
+import { ArrowLeftRight, MoreVertical, SquarePen, UserMinus, UserPlus } from 'lucide-react';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import type { AdminTeamMember } from '../../api/generated';
 import { useRemoveTeamMember, useSetTeamMemberRole, useTeam } from '../../api/hooks/useTeams';
@@ -108,14 +101,6 @@ export function TeamDetailPage() {
   return (
     <Stack spacing={3}>
       <Box>
-        <Link
-          component={RouterLink}
-          to="/admin/teams"
-          underline="hover"
-          sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, fontSize: 13, mb: 1 }}
-        >
-          <ArrowLeft size={15} /> Teams
-        </Link>
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           spacing={2}

--- a/qnop-ui/src/pages/admin/TeamsPage.tsx
+++ b/qnop-ui/src/pages/admin/TeamsPage.tsx
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useState, type MouseEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import LinearProgress from '@mui/material/LinearProgress';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { MoreVertical, Search, SquarePen, Trash2, UsersRound, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { AdminTeamSummary } from '../../api/generated';
+import { useDeleteTeam, useTeams } from '../../api/hooks/useTeams';
+import { TeamFormDialog } from '../../components/admin/teams/TeamFormDialog';
+import { ConfirmDialog } from '../../components/admin/ConfirmDialog';
+import { UserStatusBadge } from '../../components/admin/users/UserBadges';
+import { apiErrorMessage } from '../../utils/apiError';
+
+const PAGE_SIZE = 20;
+
+type DialogState =
+  | { open: false }
+  | { open: true; mode: 'create' }
+  | { open: true; mode: 'edit'; team: AdminTeamSummary };
+
+type Toast = { message: string; severity: 'success' | 'error' } | null;
+
+/** Admin team management: search, paginate, create / edit / delete, open a team (#105). */
+export function TeamsPage() {
+  const navigate = useNavigate();
+  const deleteTeam = useDeleteTeam();
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [page, setPage] = useState(0);
+  const [dialog, setDialog] = useState<DialogState>({ open: false });
+  const [openSeq, setOpenSeq] = useState(0);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [active, setActive] = useState<AdminTeamSummary | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AdminTeamSummary | null>(null);
+  const [toast, setToast] = useState<Toast>(null);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(0);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [search]);
+
+  const { data, isLoading, isFetching, isError } = useTeams({
+    q: debouncedSearch || undefined,
+    page,
+    size: PAGE_SIZE,
+  });
+  const teams = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  const openCreate = () => {
+    setDialog({ open: true, mode: 'create' });
+    setOpenSeq((n) => n + 1);
+  };
+  const openEdit = (team: AdminTeamSummary) => {
+    setDialog({ open: true, mode: 'edit', team });
+    setOpenSeq((n) => n + 1);
+  };
+  const openMenu = (event: MouseEvent<HTMLElement>, team: AdminTeamSummary) => {
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget);
+    setActive(team);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteTeam.mutateAsync(deleteTarget.id);
+      setToast({ message: `Team “${deleteTarget.name}” deleted.`, severity: 'success' });
+    } catch (err) {
+      setToast({ message: apiErrorMessage(err, 'Could not delete the team.'), severity: 'error' });
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        sx={{ justifyContent: 'space-between', alignItems: { sm: 'center' } }}
+      >
+        <Box>
+          <Typography variant="h1" sx={{ fontSize: 28 }}>
+            Teams
+          </Typography>
+          <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+            Group reviewers and manage their team roles.
+          </Typography>
+        </Box>
+        <Button variant="contained" startIcon={<UsersRound size={18} />} onClick={openCreate}>
+          Create team
+        </Button>
+      </Stack>
+
+      <TextField
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search by name or description"
+        size="small"
+        sx={{ maxWidth: 420 }}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <Search size={16} />
+              </InputAdornment>
+            ),
+            endAdornment: search ? (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="Clear search"
+                  size="small"
+                  edge="end"
+                  onClick={() => setSearch('')}
+                >
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
+          },
+        }}
+      />
+
+      <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+        <Box sx={{ height: 3 }}>{isFetching && <LinearProgress />}</Box>
+        {isError ? (
+          <Alert severity="error" sx={{ m: 2 }}>
+            The team list could not be loaded.
+          </Alert>
+        ) : (
+          <>
+            <Table size="medium" sx={{ '& td, & th': { borderColor: 'divider' } }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Description</TableCell>
+                  <TableCell>Members</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {teams.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5}>
+                      <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+                        No teams found.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+                {teams.map((team) => (
+                  <TableRow
+                    key={team.id}
+                    hover
+                    sx={{ cursor: 'pointer' }}
+                    onClick={() => navigate(`/admin/teams/${team.id}`)}
+                  >
+                    <TableCell sx={{ fontWeight: 600 }}>{team.name}</TableCell>
+                    <TableCell sx={{ color: 'text.secondary', maxWidth: 320 }}>
+                      <Typography noWrap sx={{ fontSize: 14 }}>
+                        {team.description || '—'}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>{team.memberCount}</TableCell>
+                    <TableCell>
+                      <UserStatusBadge enabled={team.enabled} />
+                    </TableCell>
+                    <TableCell align="right">
+                      <IconButton
+                        size="small"
+                        aria-label={`Actions for ${team.name}`}
+                        onClick={(e) => openMenu(e, team)}
+                      >
+                        <MoreVertical size={18} />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <TablePagination
+              component="div"
+              count={total}
+              page={page}
+              rowsPerPage={PAGE_SIZE}
+              rowsPerPageOptions={[PAGE_SIZE]}
+              onPageChange={(_, next) => setPage(next)}
+              labelDisplayedRows={({ from, to, count }) => `${from}–${to} of ${count}`}
+            />
+          </>
+        )}
+        {isLoading && (
+          <Typography color="text.secondary" sx={{ p: 2, fontSize: 14 }}>
+            Loading…
+          </Typography>
+        )}
+      </Paper>
+
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+        <MenuItem
+          onClick={() => {
+            setAnchorEl(null);
+            if (active) openEdit(active);
+          }}
+        >
+          <ListItemIcon>
+            <SquarePen size={16} />
+          </ListItemIcon>
+          <ListItemText>Edit</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setAnchorEl(null);
+            setDeleteTarget(active);
+          }}
+        >
+          <ListItemIcon>
+            <Trash2 size={16} />
+          </ListItemIcon>
+          <ListItemText>Delete</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      <TeamFormDialog
+        key={openSeq}
+        open={dialog.open}
+        mode={dialog.open ? dialog.mode : 'create'}
+        team={dialog.open && dialog.mode === 'edit' ? dialog.team : undefined}
+        onClose={() => setDialog({ open: false })}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete team"
+        message={`Delete “${deleteTarget?.name}” and all its memberships? This cannot be undone.`}
+        confirmLabel="Delete"
+        destructive
+        onConfirm={confirmDelete}
+        onClose={() => setDeleteTarget(null)}
+      />
+
+      <Snackbar
+        open={toast !== null}
+        autoHideDuration={5000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert severity={toast.severity} onClose={() => setToast(null)} variant="filled">
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -20,7 +20,7 @@
  */
 
 import { createBrowserRouter } from 'react-router-dom';
-import { FileText, Settings, ShieldCheck, Users } from 'lucide-react';
+import { FileText, Settings, ShieldCheck } from 'lucide-react';
 import { AppShell } from '../components/shell/AppShell';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { ProtectedRoute } from '../components/auth/ProtectedRoute';
@@ -28,6 +28,8 @@ import { RoleRoute } from '../components/auth/RoleRoute';
 import { ComingSoonPage } from '../pages/ComingSoonPage';
 import { HomePage } from '../pages/HomePage';
 import { UsersPage } from '../pages/admin/UsersPage';
+import { TeamsPage } from '../pages/admin/TeamsPage';
+import { TeamDetailPage } from '../pages/admin/TeamDetailPage';
 import { ChangePasswordPage } from '../pages/auth/ChangePasswordPage';
 import { ForgotPasswordPage } from '../pages/auth/ForgotPasswordPage';
 import { LoginPage } from '../pages/auth/LoginPage';
@@ -94,11 +96,15 @@ export const router = createBrowserRouter([
         path: 'admin/teams',
         element: (
           <AdminRoute>
-            <ComingSoonPage
-              title="Teams"
-              description="Group reviewers into teams and route reviews to the right people."
-              icon={Users}
-            />
+            <TeamsPage />
+          </AdminRoute>
+        ),
+      },
+      {
+        path: 'admin/teams/:id',
+        element: (
+          <AdminRoute>
+            <TeamDetailPage />
           </AdminRoute>
         ),
       },


### PR DESCRIPTION
## What & why

Closes #105. Adds the teams subsystem — backend and frontend — built from scratch. Teams group reviewers (with per-team roles LEAD/MEMBER) and will later route them in the review workflow.

Data model agreed up front: a `Team` carries `name` (unique, case-insensitive), `description` and an `enabled` flag; removal is a hard delete that cascades memberships.

## Backend

- Entities `Team` + `TeamMembership` (per-team role LEAD/MEMBER), raw UUID FKs. Migration `0008-team-schema.yaml`: functional unique index on `lower(name)`, unique `(team_id, user_id)`, CHECK on `team_role`, FKs `ON DELETE CASCADE`.
- `TeamRepository` / `TeamMembershipRepository` (paginated search, a member projection joined to the user, and per-team member counts to avoid an N+1 over the list).
- `TeamService` keeps entities in the service layer and returns entity-free views (ADR-0004). Guards: duplicate name / duplicate membership → 409; unknown team/member → 404; unknown added user → 404.
- OpenAPI + `TeamController` under `/admin/teams`: CRUD + member add / remove / set-role (ADMIN-only via the security chain).

## Frontend

- `TeamsPage`: search, pagination, create/edit/delete (confirm dialog), status badge, row → detail.
- `TeamDetailPage` (`/admin/teams/:id`): member management — add via a user picker (the admin user search), change role, remove; the list refreshes on change.
- Shared `ToneBadge` (extracted from the user badges) + `TeamRoleBadge`; `ConfirmDialog` for destructive actions. Breadcrumb resolves nested detail paths to their section.

## Test plan

- [x] `./gradlew build` green — Spotless, ArchUnit, all tests.
- [x] `TeamServiceTest` (unit): name/membership guards, role change, mapping.
- [x] `TeamControllerIT` (real PostgreSQL + security chain): ADMIN vs MEMBER (403) vs anonymous (401), CRUD, member add/duplicate(409)/role/remove, unknown team/user (404), duplicate name (409).
- [x] Frontend `pnpm lint` / `pnpm build` / `pnpm test:coverage` green (68 tests, coverage 98%).
- [x] Manual E2E (Playwright): created a team, opened its detail, added a member via the user picker — one click → one add, list refreshed, no console errors; breadcrumb shows "Administration › Teams".

## Notes

- All UI strings English (per the current single-language rule).
- No "must have a lead" invariant is enforced (kept lean; teams may be empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
