### PR TITLE
feat(ui): application settings screen + admin menu items (#106)

### DIFF
--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -21,6 +21,7 @@
 
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import {
+  AdminSettingsApi,
   AdminTeamsApi,
   AdminUsersApi,
   AuthApi,
@@ -86,3 +87,4 @@ export const authRegistrationApi = new AuthRegistrationApi(undefined, undefined,
 export const authPasswordResetApi = new AuthPasswordResetApi(undefined, undefined, axiosInstance);
 export const adminUsersApi = new AdminUsersApi(undefined, undefined, axiosInstance);
 export const adminTeamsApi = new AdminTeamsApi(undefined, undefined, axiosInstance);
+export const adminSettingsApi = new AdminSettingsApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useSettings.test.tsx
+++ b/qnop-ui/src/api/hooks/useSettings.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { AdminSettingsResponse } from '../generated';
+import { settingsKeys, useSettings, useUpdateSettings } from './useSettings';
+import { adminSettingsApi } from '../config';
+
+const SETTINGS: AdminSettingsResponse = {
+  settings: [
+    {
+      key: 'general.application_name',
+      value: 'qnop',
+      type: 'STRING',
+      description: 'Name',
+      sensitive: false,
+    },
+    {
+      key: 'smtp.password',
+      value: '***',
+      type: 'PASSWORD',
+      description: 'Secret',
+      sensitive: true,
+    },
+  ],
+};
+
+vi.mock('../config', () => ({
+  adminSettingsApi: {
+    getAdminSettings: vi.fn(),
+    updateAdminSettings: vi.fn(),
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('settingsKeys', () => {
+  it('namespaces the settings query', () => {
+    expect(settingsKeys.all).toEqual(['admin', 'settings']);
+  });
+});
+
+describe('useSettings', () => {
+  it('fetches and returns the settings list', async () => {
+    vi.mocked(adminSettingsApi.getAdminSettings).mockResolvedValue({ data: SETTINGS } as Awaited<
+      ReturnType<typeof adminSettingsApi.getAdminSettings>
+    >);
+
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(adminSettingsApi.getAdminSettings).toHaveBeenCalled();
+    expect(result.current.data?.settings).toHaveLength(2);
+  });
+});
+
+describe('useUpdateSettings', () => {
+  it('wraps the changed values in an update request', async () => {
+    vi.mocked(adminSettingsApi.updateAdminSettings).mockResolvedValue({ data: SETTINGS } as Awaited<
+      ReturnType<typeof adminSettingsApi.updateAdminSettings>
+    >);
+
+    const { result } = renderHook(() => useUpdateSettings(), { wrapper });
+    await result.current.mutateAsync({ 'general.application_name': 'Acme' });
+
+    expect(adminSettingsApi.updateAdminSettings).toHaveBeenCalledWith({
+      adminSettingsUpdateRequest: { values: { 'general.application_name': 'Acme' } },
+    });
+  });
+});

--- a/qnop-ui/src/api/hooks/useSettings.ts
+++ b/qnop-ui/src/api/hooks/useSettings.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { AdminSettingsResponse } from '../generated';
+import { adminSettingsApi } from '../config';
+
+export const settingsKeys = {
+  all: ['admin', 'settings'] as const,
+};
+
+/**
+ * The full set of application settings. Window-focus refetch is disabled so a
+ * background refetch never clobbers a half-edited form; the list refreshes on
+ * mount and after a save (which invalidates this query).
+ */
+export function useSettings() {
+  return useQuery<AdminSettingsResponse>({
+    queryKey: settingsKeys.all,
+    queryFn: async () => {
+      const response = await adminSettingsApi.getAdminSettings();
+      return response.data;
+    },
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** Applies a partial map of setting key → raw value, then refreshes the settings. */
+export function useUpdateSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (values: Record<string, string>) => {
+      const response = await adminSettingsApi.updateAdminSettings({
+        adminSettingsUpdateRequest: { values },
+      });
+      return response.data;
+    },
+    onSuccess: (data) => {
+      // Seed the cache with the authoritative response so the form re-bases on
+      // the freshly stored (and re-masked) values without a second round-trip.
+      queryClient.setQueryData(settingsKeys.all, data);
+    },
+  });
+}

--- a/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
+++ b/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMemo, useState, type FormEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import LinearProgress from '@mui/material/LinearProgress';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import type { AdminSetting } from '../../../api/generated';
+import { useSettings, useUpdateSettings } from '../../../api/hooks/useSettings';
+import { apiErrorMessage } from '../../../utils/apiError';
+
+/** Group prefixes in display order; unknown groups are appended alphabetically. */
+const GROUP_ORDER = ['general', 'upload', 'tracking', 'smtp', 'auth'] as const;
+
+const GROUP_LABELS: Record<string, string> = {
+  general: 'General',
+  upload: 'Uploads',
+  tracking: 'Usage tracking',
+  smtp: 'Email (SMTP)',
+  auth: 'Authentication',
+};
+
+/**
+ * Allowed values for ENUM settings. The API does not publish the option list, so
+ * known enum keys are enumerated here; an unknown ENUM key falls back to a plain
+ * text field rather than rendering an empty dropdown.
+ */
+const ENUM_OPTIONS: Record<string, { value: string; label: string }[]> = {
+  'tracking.provider': [
+    { value: 'none', label: 'None' },
+    { value: 'matomo', label: 'Matomo' },
+    { value: 'plausible', label: 'Plausible' },
+    { value: 'umami', label: 'Umami' },
+  ],
+  'auth.self_registration_default_role': [
+    { value: 'MEMBER', label: 'Member' },
+    { value: 'AUDITOR', label: 'Auditor' },
+  ],
+};
+
+type Toast = { message: string; severity: 'success' | 'error' } | null;
+
+/** The baseline value used for dirty-tracking: secrets always start blank. */
+function baseline(setting: AdminSetting): string {
+  return setting.sensitive ? '' : (setting.value ?? '');
+}
+
+/** Humanises the last key segment, e.g. `general.application_name` → "Application name". */
+function fieldLabel(key: string): string {
+  const segment = key.slice(key.lastIndexOf('.') + 1).replace(/_/g, ' ');
+  return segment.charAt(0).toUpperCase() + segment.slice(1);
+}
+
+function groupOf(key: string): string {
+  const dot = key.indexOf('.');
+  return dot === -1 ? key : key.slice(0, dot);
+}
+
+/**
+ * Application settings editor (issue #106): renders the flat settings list as
+ * grouped, type-aware controls and PATCHes only the changed keys. Sensitive
+ * values are write-only — the field stays blank and is sent only when typed.
+ */
+export function ApplicationSettingsForm() {
+  const { data, isLoading, isError } = useSettings();
+  const updateSettings = useUpdateSettings();
+
+  const settings = useMemo(() => data?.settings ?? [], [data]);
+  // Server values are derived (not state); only the user's edits are held as an
+  // overlay, so there is no setState-in-effect to re-seed the form. Clearing the
+  // overlay after a save re-bases the form on the freshly stored values.
+  const baselines = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const setting of settings) {
+      map[setting.key] = baseline(setting);
+    }
+    return map;
+  }, [settings]);
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<Toast>(null);
+
+  const valueOf = (key: string): string => edits[key] ?? baselines[key] ?? '';
+  const changed = useMemo(
+    () => Object.keys(edits).filter((key) => edits[key] !== (baselines[key] ?? '')),
+    [edits, baselines],
+  );
+
+  const groups = useMemo(() => {
+    const byGroup = new Map<string, AdminSetting[]>();
+    for (const setting of settings) {
+      const group = groupOf(setting.key);
+      const list = byGroup.get(group) ?? [];
+      list.push(setting);
+      byGroup.set(group, list);
+    }
+    const known = GROUP_ORDER.filter((group) => byGroup.has(group));
+    const extra = [...byGroup.keys()]
+      .filter((group) => !GROUP_ORDER.includes(group as never))
+      .sort();
+    return [...known, ...extra].map((group) => ({ group, items: byGroup.get(group) ?? [] }));
+  }, [settings]);
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    const patch = Object.fromEntries(changed.map((key) => [key, edits[key]]));
+    try {
+      await updateSettings.mutateAsync(patch);
+      setEdits({});
+      setToast({ message: 'Settings saved.', severity: 'success' });
+    } catch (err) {
+      setError(apiErrorMessage(err, 'The settings could not be saved.'));
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Typography color="text.secondary" sx={{ p: 1, fontSize: 14 }}>
+        Loading…
+      </Typography>
+    );
+  }
+  if (isError) {
+    return <Alert severity="error">The settings could not be loaded.</Alert>;
+  }
+
+  return (
+    <Box component="form" onSubmit={onSubmit} noValidate>
+      <Stack spacing={3}>
+        {groups.map(({ group, items }) => (
+          <Paper key={group} variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+            <Typography variant="h2" sx={{ fontSize: 18, mb: 2 }}>
+              {GROUP_LABELS[group] ?? fieldLabel(group)}
+            </Typography>
+            <Stack spacing={2.5}>
+              {items.map((setting) => (
+                <SettingField
+                  key={setting.key}
+                  setting={setting}
+                  value={valueOf(setting.key)}
+                  onChange={(next) => setEdits((prev) => ({ ...prev, [setting.key]: next }))}
+                />
+              ))}
+            </Stack>
+          </Paper>
+        ))}
+
+        {error && <Alert severity="error">{error}</Alert>}
+
+        <Divider />
+        <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={changed.length === 0 || updateSettings.isPending}
+          >
+            {updateSettings.isPending ? 'Saving…' : 'Save changes'}
+          </Button>
+          <Typography color="text.secondary" sx={{ fontSize: 14 }}>
+            {changed.length === 0
+              ? 'No unsaved changes.'
+              : `${changed.length} unsaved change${changed.length === 1 ? '' : 's'}.`}
+          </Typography>
+          <Box sx={{ flex: 1 }} />
+          {updateSettings.isPending && <LinearProgress sx={{ width: 120 }} />}
+        </Stack>
+      </Stack>
+
+      <Snackbar
+        open={toast !== null}
+        autoHideDuration={4000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert severity={toast.severity} onClose={() => setToast(null)} variant="filled">
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Box>
+  );
+}
+
+interface SettingFieldProps {
+  setting: AdminSetting;
+  value: string;
+  onChange: (next: string) => void;
+}
+
+/** Renders a single setting as the control appropriate to its declared type. */
+function SettingField({ setting, value, onChange }: SettingFieldProps) {
+  const label = fieldLabel(setting.key);
+
+  if (setting.type === 'BOOLEAN') {
+    return (
+      <FormControlLabel
+        control={
+          <Switch
+            checked={value === 'true'}
+            onChange={(e) => onChange(e.target.checked ? 'true' : 'false')}
+          />
+        }
+        label={
+          <Box>
+            <Typography sx={{ fontSize: 15 }}>{label}</Typography>
+            <Typography color="text.secondary" sx={{ fontSize: 13 }}>
+              {setting.description}
+            </Typography>
+          </Box>
+        }
+        sx={{ alignItems: 'flex-start', m: 0, gap: 1 }}
+      />
+    );
+  }
+
+  const enumOptions = setting.type === 'ENUM' ? ENUM_OPTIONS[setting.key] : undefined;
+  if (enumOptions) {
+    return (
+      <TextField
+        select
+        label={label}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        helperText={setting.description}
+        sx={{ maxWidth: 480 }}
+      >
+        {enumOptions.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
+    );
+  }
+
+  const isPassword = setting.type === 'PASSWORD';
+  return (
+    <TextField
+      label={label}
+      type={isPassword ? 'password' : setting.type === 'INTEGER' ? 'number' : 'text'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={isPassword && setting.value === '***' ? '•••••• (unchanged)' : undefined}
+      helperText={
+        isPassword
+          ? `${setting.description} Leave blank to keep the current value.`
+          : setting.description
+      }
+      autoComplete={isPassword ? 'new-password' : undefined}
+      sx={{ maxWidth: 480 }}
+    />
+  );
+}

--- a/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
+++ b/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
@@ -49,11 +49,17 @@ const GROUP_LABELS: Record<string, string> = {
 };
 
 /**
- * Allowed values for ENUM settings. The API does not publish the option list, so
- * known enum keys are enumerated here; an unknown ENUM key falls back to a plain
- * text field rather than rendering an empty dropdown.
+ * Curated dropdown options keyed by setting key. The API does not publish option
+ * lists, so known choices are enumerated here. This covers both ENUM settings
+ * and STRING settings with a known, closed value set (e.g. the default language).
+ * An ENUM key without an entry falls back to a plain text field rather than
+ * rendering an empty dropdown.
  */
-const ENUM_OPTIONS: Record<string, { value: string; label: string }[]> = {
+const SELECT_OPTIONS: Record<string, { value: string; label: string }[]> = {
+  'general.default_language': [
+    { value: 'en', label: 'English' },
+    { value: 'de', label: 'Deutsch' },
+  ],
   'tracking.provider': [
     { value: 'none', label: 'None' },
     { value: 'matomo', label: 'Matomo' },
@@ -243,8 +249,10 @@ function SettingField({ setting, value, onChange }: SettingFieldProps) {
     );
   }
 
-  const enumOptions = setting.type === 'ENUM' ? ENUM_OPTIONS[setting.key] : undefined;
-  if (enumOptions) {
+  // A curated option list turns the field into a dropdown, for ENUM settings and
+  // for STRING settings with a known, closed value set (e.g. the default language).
+  const options = SELECT_OPTIONS[setting.key];
+  if (options) {
     return (
       <TextField
         select
@@ -254,7 +262,7 @@ function SettingField({ setting, value, onChange }: SettingFieldProps) {
         helperText={setting.description}
         sx={{ maxWidth: 480 }}
       >
-        {enumOptions.map((option) => (
+        {options.map((option) => (
           <MenuItem key={option.value} value={option.value}>
             {option.label}
           </MenuItem>

--- a/qnop-ui/src/components/shell/navConfig.test.ts
+++ b/qnop-ui/src/components/shell/navConfig.test.ts
@@ -46,6 +46,9 @@ describe('visibleNavGroups', () => {
       'users',
       'teams',
       'settings',
+      'oidc-providers',
+      'mail-templates',
+      'branding',
     ]);
   });
 

--- a/qnop-ui/src/components/shell/navConfig.tsx
+++ b/qnop-ui/src/components/shell/navConfig.tsx
@@ -21,7 +21,10 @@
 
 import {
   FileText,
+  KeyRound,
   LayoutDashboard,
+  Mail,
+  Palette,
   Settings,
   ShieldCheck,
   User,
@@ -77,6 +80,27 @@ export const NAV_GROUPS: NavGroup[] = [
         label: 'Settings',
         path: '/admin/settings',
         icon: Settings,
+        roles: ['ADMIN'],
+      },
+      {
+        id: 'oidc-providers',
+        label: 'OIDC providers',
+        path: '/admin/oidc-providers',
+        icon: KeyRound,
+        roles: ['ADMIN'],
+      },
+      {
+        id: 'mail-templates',
+        label: 'Mail templates',
+        path: '/admin/mail-templates',
+        icon: Mail,
+        roles: ['ADMIN'],
+      },
+      {
+        id: 'branding',
+        label: 'Branding',
+        path: '/admin/branding',
+        icon: Palette,
         roles: ['ADMIN'],
       },
     ],

--- a/qnop-ui/src/pages/admin/SettingsPage.tsx
+++ b/qnop-ui/src/pages/admin/SettingsPage.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Typography from '@mui/material/Typography';
+import { ApplicationSettingsForm } from '../../components/admin/settings/ApplicationSettingsForm';
+
+interface SettingsTab {
+  readonly id: string;
+  readonly label: string;
+  readonly content: ReactNode;
+}
+
+/** Placeholder for the settings sections that land in the follow-up PRs of #106. */
+function ComingSoon({ what }: { what: string }) {
+  return (
+    <Typography color="text.secondary" sx={{ fontSize: 14 }}>
+      {what} arrives in a follow-up of #106.
+    </Typography>
+  );
+}
+
+const TABS: readonly SettingsTab[] = [
+  { id: 'application', label: 'Application', content: <ApplicationSettingsForm /> },
+  {
+    id: 'oidc',
+    label: 'OIDC providers',
+    content: <ComingSoon what="Single sign-on provider management" />,
+  },
+  { id: 'mail', label: 'Mail templates', content: <ComingSoon what="The mail template editor" /> },
+  { id: 'branding', label: 'Branding', content: <ComingSoon what="Logo and branding uploads" /> },
+];
+
+/**
+ * Admin settings screen (issue #106): a tabbed shell over the application
+ * settings, OIDC providers, mail templates and branding. This change wires the
+ * shell and the Application tab; the remaining tabs follow in separate PRs.
+ */
+export function SettingsPage() {
+  const [active, setActive] = useState(0);
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h1" sx={{ fontSize: 28 }}>
+          Settings
+        </Typography>
+        <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+          Workspace, security policy, single sign-on, branding and mail.
+        </Typography>
+      </Box>
+
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          value={active}
+          onChange={(_, next) => setActive(next)}
+          variant="scrollable"
+          scrollButtons="auto"
+          aria-label="Settings sections"
+        >
+          {TABS.map((tab) => (
+            <Tab key={tab.id} label={tab.label} id={`settings-tab-${tab.id}`} />
+          ))}
+        </Tabs>
+      </Box>
+
+      {TABS.map((tab, index) => (
+        <Box
+          key={tab.id}
+          role="tabpanel"
+          hidden={active !== index}
+          aria-labelledby={`settings-tab-${tab.id}`}
+        >
+          {active === index && tab.content}
+        </Box>
+      ))}
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/admin/SettingsPage.tsx
+++ b/qnop-ui/src/pages/admin/SettingsPage.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { ApplicationSettingsForm } from '../../components/admin/settings/ApplicationSettingsForm';
+
+/**
+ * Admin application settings screen (issue #106): general, upload, tracking,
+ * SMTP and authentication settings. OIDC providers, mail templates and branding
+ * are separate Administration menu items, each with its own screen.
+ */
+export function SettingsPage() {
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="h1" sx={{ fontSize: 28 }}>
+          Settings
+        </Typography>
+        <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+          Workspace, uploads, usage tracking, email and authentication.
+        </Typography>
+      </Box>
+      <ApplicationSettingsForm />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -20,13 +20,14 @@
  */
 
 import { createBrowserRouter } from 'react-router-dom';
-import { FileText, Settings, ShieldCheck } from 'lucide-react';
+import { FileText, KeyRound, Mail, Palette, ShieldCheck } from 'lucide-react';
 import { AppShell } from '../components/shell/AppShell';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { ProtectedRoute } from '../components/auth/ProtectedRoute';
 import { RoleRoute } from '../components/auth/RoleRoute';
 import { ComingSoonPage } from '../pages/ComingSoonPage';
 import { HomePage } from '../pages/HomePage';
+import { SettingsPage } from '../pages/admin/SettingsPage';
 import { UsersPage } from '../pages/admin/UsersPage';
 import { TeamsPage } from '../pages/admin/TeamsPage';
 import { TeamDetailPage } from '../pages/admin/TeamDetailPage';
@@ -112,10 +113,42 @@ export const router = createBrowserRouter([
         path: 'admin/settings',
         element: (
           <AdminRoute>
+            <SettingsPage />
+          </AdminRoute>
+        ),
+      },
+      {
+        path: 'admin/oidc-providers',
+        element: (
+          <AdminRoute>
             <ComingSoonPage
-              title="Settings"
-              description="Workspace, security policy, OIDC, branding and mail."
-              icon={Settings}
+              title="OIDC providers"
+              description="Configure single sign-on identity providers — list, add, discover and enable."
+              icon={KeyRound}
+            />
+          </AdminRoute>
+        ),
+      },
+      {
+        path: 'admin/mail-templates',
+        element: (
+          <AdminRoute>
+            <ComingSoonPage
+              title="Mail templates"
+              description="Edit, preview and test the transactional email templates."
+              icon={Mail}
+            />
+          </AdminRoute>
+        ),
+      },
+      {
+        path: 'admin/branding',
+        element: (
+          <AdminRoute>
+            <ComingSoonPage
+              title="Branding"
+              description="Upload the light/dark logos and logomark shown across the app."
+              icon={Palette}
             />
           </AdminRoute>
         ),

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -20,13 +20,14 @@
  */
 
 import { createBrowserRouter } from 'react-router-dom';
-import { FileText, Settings, ShieldCheck } from 'lucide-react';
+import { FileText, ShieldCheck } from 'lucide-react';
 import { AppShell } from '../components/shell/AppShell';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { ProtectedRoute } from '../components/auth/ProtectedRoute';
 import { RoleRoute } from '../components/auth/RoleRoute';
 import { ComingSoonPage } from '../pages/ComingSoonPage';
 import { HomePage } from '../pages/HomePage';
+import { SettingsPage } from '../pages/admin/SettingsPage';
 import { UsersPage } from '../pages/admin/UsersPage';
 import { TeamsPage } from '../pages/admin/TeamsPage';
 import { TeamDetailPage } from '../pages/admin/TeamDetailPage';
@@ -112,11 +113,7 @@ export const router = createBrowserRouter([
         path: 'admin/settings',
         element: (
           <AdminRoute>
-            <ComingSoonPage
-              title="Settings"
-              description="Workspace, security policy, OIDC, branding and mail."
-              icon={Settings}
-            />
+            <SettingsPage />
           </AdminRoute>
         ),
       },


### PR DESCRIPTION
## Summary

First of four PRs for the admin settings surface (#106). Per review feedback, the four areas are **separate Administration menu items**, not tabs in one screen.

This PR ships the **Application settings** screen and wires the menu structure:

### Application settings (`/admin/settings`)
- **`useSettings` / `useUpdateSettings`** hooks over the generated `AdminSettingsApi` (`GET`/`PATCH /admin/settings`). Window-focus refetch is disabled and the cache is primed from the PATCH response, so a save re-bases the form without a second round-trip or clobbering mid-edit.
- **`ApplicationSettingsForm`** renders the flat settings list grouped by key prefix (General, Uploads, Usage tracking, Email/SMTP, Authentication) with type-aware controls: text, number, `Switch` for booleans, select for known ENUM keys (the API doesn't publish option lists, so `tracking.provider` / `auth.self_registration_default_role` options are client-side; unknown enums fall back to text).
- **Secrets are write-only**: password fields stay blank, sent only when typed. Only changed keys are PATCHed — dirty-tracked against derived server baselines, no `setState`-in-effect.

### Navigation
- **OIDC providers**, **Mail templates** and **Branding** are now standalone ADMIN-only Administration menu items with their own routes (`/admin/oidc-providers`, `/admin/mail-templates`, `/admin/branding`). Their screens arrive in follow-up PRs; for now each routes to the shared "coming soon" placeholder, so the menu and role-gating are fully wired and tested.

## Test plan

- [x] `pnpm test` — 71 unit tests pass (incl. new `useSettings` hooks; nav config updated)
- [x] `pnpm lint`, `pnpm format:check` clean
- [x] `tsc -b` + `vite build` succeed
- [ ] Manual: ADMIN sees Settings / OIDC providers / Mail templates / Branding in the Administration menu; Settings edits persist; secrets stay masked

Part of #106. Part of #97.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code