### PR TITLE
feat: user-management feature parity — delete, filters/sort, provider name, reset (#124)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -643,6 +643,21 @@ paths:
           description: Filter by global role.
           schema:
             $ref: '#/components/schemas/UserRole'
+        - name: enabled
+          in: query
+          required: false
+          description: Filter by account status; omit for all.
+          schema:
+            type: boolean
+        - name: sort
+          in: query
+          required: false
+          description: |
+            Sort as `field,direction`. Allowed fields: displayName, email,
+            username, role, createdAt, lastLoginAt; direction asc|desc.
+          schema:
+            type: string
+            default: displayName,asc
         - name: page
           in: query
           required: false
@@ -789,24 +804,62 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+    delete:
+      tags:
+        - AdminUsers
+      summary: Delete a user
+      description: |
+        Permanently deletes the user and, by cascade, their tokens, settings,
+        OIDC identity and team memberships. The self-lockout guard rejects (409)
+        deleting your own account or the last enabled admin.
+      operationId: deleteUser
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '204':
+          description: User deleted
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Self-lockout or last-admin guard violated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /admin/users/{userId}/password-reset:
     post:
       tags:
         - AdminUsers
-      summary: Send a password-setup/reset link
+      summary: Reset a user's password (admin)
       description: |
-        Issues a password-reset token for the user and emails the set-your-password
-        link. Works for any internal account (e.g. to (re)send an invitation or to
-        help a locked-out user). External (OIDC) accounts have no local password and
-        are rejected with 409.
+        Revokes the user's active sessions immediately, issues a single-use
+        password-reset token and emails the set-your-password link. Works for any
+        internal account (e.g. to (re)send an invitation or to help a locked-out
+        user). External (OIDC) accounts have no local password and are rejected
+        with 409. When email could not be sent, the response carries `resetUrl`
+        so the operator can deliver it out of band.
       operationId: sendUserPasswordReset
       security:
         - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/UserIdParam'
       responses:
-        '202':
-          description: The reset email has been queued
+        '200':
+          description: The reset was triggered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminPasswordResetResponse'
         '404':
           description: Unknown user
           content:
@@ -1959,6 +2012,13 @@ components:
           $ref: '#/components/schemas/UserSource'
         enabled:
           type: boolean
+        passwordChangeRequired:
+          type: boolean
+          description: Whether the user must change their password before normal use.
+        providerName:
+          type: string
+          nullable: true
+          description: The OIDC provider's name for external accounts; null otherwise.
         lastLoginAt:
           type: string
           format: date-time
@@ -1973,11 +2033,27 @@ components:
         - role
         - source
         - enabled
+        - passwordChangeRequired
         - createdAt
     AdminUserDetail:
       allOf:
         - $ref: '#/components/schemas/AdminUserSummary'
       description: Full detail for a single user (currently the same fields as the summary).
+    AdminPasswordResetResponse:
+      type: object
+      description: Outcome of an admin-triggered password reset.
+      properties:
+        emailSent:
+          type: boolean
+          description: Whether the reset email was delivered.
+        resetUrl:
+          type: string
+          nullable: true
+          description: |
+            The single-use reset link, returned only when the email could not be
+            sent so the operator can deliver it out of band.
+      required:
+        - emailSent
     AdminUserListResponse:
       type: object
       description: A page of users for the admin list.

--- a/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
@@ -21,6 +21,7 @@
 package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.AdminUsersApi;
+import io.qnop.api.v1.model.AdminPasswordResetResponse;
 import io.qnop.api.v1.model.AdminUserCreateRequest;
 import io.qnop.api.v1.model.AdminUserDetail;
 import io.qnop.api.v1.model.AdminUserListResponse;
@@ -33,6 +34,7 @@ import io.qnop.service.AdminUserConflictException;
 import io.qnop.service.AdminUserService;
 import io.qnop.service.AdminUserService.AdminUserPage;
 import io.qnop.service.AdminUserService.AdminUserView;
+import io.qnop.service.AdminUserService.PasswordResetOutcome;
 import io.qnop.service.UserNotFoundException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -62,8 +64,9 @@ public class AdminUserController implements AdminUsersApi {
 
   @Override
   public ResponseEntity<AdminUserListResponse> listUsers(
-      String q, UserRole role, Integer page, Integer size) {
-    AdminUserPage result = adminUsers.list(q, role == null ? null : role.name(), page, size);
+      String q, UserRole role, Boolean enabled, String sort, Integer page, Integer size) {
+    AdminUserPage result =
+        adminUsers.list(q, role == null ? null : role.name(), enabled, sort, page, size);
     return ResponseEntity.ok(
         new AdminUserListResponse()
             .items(result.items().stream().map(AdminUserController::toSummary).toList())
@@ -102,9 +105,18 @@ public class AdminUserController implements AdminUsersApi {
   }
 
   @Override
-  public ResponseEntity<Void> sendUserPasswordReset(UUID userId) {
-    adminUsers.sendPasswordReset(userId);
-    return ResponseEntity.accepted().build();
+  public ResponseEntity<Void> deleteUser(UUID userId) {
+    adminUsers.delete(userId, CurrentUser.requireUserId());
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<AdminPasswordResetResponse> sendUserPasswordReset(UUID userId) {
+    PasswordResetOutcome outcome = adminUsers.sendPasswordReset(userId);
+    return ResponseEntity.ok(
+        new AdminPasswordResetResponse()
+            .emailSent(outcome.emailSent())
+            .resetUrl(outcome.resetUrl()));
   }
 
   @ExceptionHandler(UserNotFoundException.class)
@@ -136,6 +148,8 @@ public class AdminUserController implements AdminUsersApi {
         .role(UserRole.fromValue(v.role()))
         .source(UserSource.fromValue(v.source()))
         .enabled(v.enabled())
+        .passwordChangeRequired(v.passwordChangeRequired())
+        .providerName(v.providerName())
         .lastLoginAt(toOffset(v.lastLoginAt()))
         .createdAt(toOffset(v.createdAt()));
   }
@@ -149,6 +163,8 @@ public class AdminUserController implements AdminUsersApi {
         .role(UserRole.fromValue(v.role()))
         .source(UserSource.fromValue(v.source()))
         .enabled(v.enabled())
+        .passwordChangeRequired(v.passwordChangeRequired())
+        .providerName(v.providerName())
         .lastLoginAt(toOffset(v.lastLoginAt()))
         .createdAt(toOffset(v.createdAt()));
   }

--- a/qnop-app/src/test/java/io/qnop/web/AdminUserControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AdminUserControllerIT.java
@@ -21,7 +21,10 @@
 package io.qnop.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -231,11 +234,83 @@ class AdminUserControllerIT extends AbstractIntegrationTest {
     User target = createUser("member", UserRole.MEMBER);
     String token = adminToken();
 
+    // No SMTP is configured in the IT, so the email is "skipped" and the fallback link is returned.
     mockMvc
         .perform(
             post("/api/v1/admin/users/{id}/password-reset", target.getId())
                 .header("Authorization", "Bearer " + token))
-        .andExpect(status().isAccepted());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.emailSent").value(false))
+        .andExpect(jsonPath("$.resetUrl").isNotEmpty());
+  }
+
+  @Test
+  void adminDeletesUser() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User target = createUser("victim", UserRole.MEMBER);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            delete("/api/v1/admin/users/{id}", target.getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/users/{id}", target.getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void adminCannotDeleteOwnAccount() throws Exception {
+    User admin = createUser("root", UserRole.ADMIN);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            delete("/api/v1/admin/users/{id}", admin.getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("SELF_DELETE"));
+  }
+
+  @Test
+  void filtersByEnabledStatus() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User disabled = createUser("inactive", UserRole.MEMBER);
+    disabled.setEnabled(false);
+    userRepository.saveAndFlush(disabled);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/users")
+                .param("enabled", "false")
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[*].username", everyItem(is("inactive"))))
+        .andExpect(jsonPath("$.items[*].enabled", everyItem(is(false))));
+  }
+
+  @Test
+  void sortsByDisplayNameDescending() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    createUser("sortuser-a", UserRole.MEMBER);
+    createUser("sortuser-b", UserRole.MEMBER);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/users")
+                .param("q", "sortuser")
+                .param("sort", "displayName,desc")
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(2))
+        .andExpect(jsonPath("$.items[0].username").value("sortuser-b"))
+        .andExpect(jsonPath("$.items[1].username").value("sortuser-a"));
   }
 
   private String adminToken() throws Exception {

--- a/qnop-core/src/main/java/io/qnop/repository/OidcIdentityRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/OidcIdentityRepository.java
@@ -21,9 +21,13 @@
 package io.qnop.repository;
 
 import io.qnop.entity.OidcIdentity;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Data access for {@link OidcIdentity}. */
 public interface OidcIdentityRepository extends JpaRepository<OidcIdentity, UUID> {
@@ -32,4 +36,14 @@ public interface OidcIdentityRepository extends JpaRepository<OidcIdentity, UUID
   Optional<OidcIdentity> findByOidcProviderIdAndSubject(UUID oidcProviderId, String subject);
 
   Optional<OidcIdentity> findByUserId(UUID userId);
+
+  /**
+   * The OIDC provider names for a set of users, to label external accounts in the admin list
+   * without an N+1 (issue #124).
+   */
+  @Query(
+      "SELECT new io.qnop.repository.UserProviderName(i.userId, p.name) "
+          + "FROM OidcIdentity i JOIN OidcProvider p ON p.id = i.oidcProviderId "
+          + "WHERE i.userId IN :userIds")
+  List<UserProviderName> findProviderNamesByUserIds(@Param("userIds") Collection<UUID> userIds);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/UserProviderName.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserProviderName.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/** The OIDC provider name an external user is linked to, for the admin user list (issue #124). */
+public record UserProviderName(UUID userId, String providerName) {}

--- a/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
@@ -43,16 +43,21 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByUsernameAndSource(String username, UserSource source);
 
   /**
-   * Paginated admin search (issue #104): an optional case-insensitive match on display name, email
-   * or username and an optional role filter. {@code q} must be passed pre-lowercased and {@code
-   * LIKE}-wrapped (e.g. {@code %alice%}); a {@code null} {@code q}/{@code role} disables that
-   * filter.
+   * Paginated admin search (issues #104/#124): an optional case-insensitive match on display name,
+   * email or username, plus optional role and enabled-status filters. {@code q} must be passed
+   * pre-lowercased and {@code LIKE}-wrapped (e.g. {@code %alice%}); a {@code null} {@code q}/{@code
+   * role}/{@code enabled} disables that filter. Sorting is supplied via {@code Pageable}.
    */
   @Query(
       "SELECT u FROM User u WHERE (:role IS NULL OR u.role = :role)"
+          + " AND (:enabled IS NULL OR u.enabled = :enabled)"
           + " AND (:q IS NULL OR LOWER(u.displayName) LIKE :q OR LOWER(u.email) LIKE :q"
           + " OR (u.username IS NOT NULL AND LOWER(u.username) LIKE :q))")
-  Page<User> search(@Param("q") String q, @Param("role") UserRole role, Pageable pageable);
+  Page<User> search(
+      @Param("q") String q,
+      @Param("role") UserRole role,
+      @Param("enabled") Boolean enabled,
+      Pageable pageable);
 
   /** Number of enabled users with the given role — guards the last-admin invariant (issue #104). */
   long countByRoleAndEnabledTrue(UserRole role);

--- a/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
@@ -23,12 +23,17 @@ package io.qnop.service;
 import io.qnop.entity.User;
 import io.qnop.entity.UserRole;
 import io.qnop.entity.UserSource;
+import io.qnop.repository.OidcIdentityRepository;
+import io.qnop.repository.UserProviderName;
 import io.qnop.repository.UserRepository;
 import io.qnop.service.auth.PasswordResetFlowService;
+import io.qnop.service.auth.PasswordResetFlowService.SetupLinkOutcome;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -37,50 +42,69 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Admin user management (issue #104): paginated search, create-or-invite, edit and password-setup
- * links. Keeps the {@code User} entity inside the service layer — every result crosses the boundary
- * as an entity-free {@link AdminUserView} (role and source as their enum names), so the web layer
- * never touches a JPA entity (ADR-0004).
+ * Admin user management (issues #104/#124): paginated search/filter/sort, create-or-invite, edit,
+ * delete and admin password reset. Keeps the {@code User} entity inside the service layer — every
+ * result crosses the boundary as an entity-free {@link AdminUserView} (role and source as their
+ * enum names), so the web layer never touches a JPA entity (ADR-0004).
  *
- * <p>Two guards protect against admin lockout: an admin can neither disable nor demote their own
- * account, and the last enabled admin can never be disabled or demoted — both surface as {@link
- * AdminUserConflictException} (HTTP 409). Creating with an {@code initialPassword} yields an
- * enabled account that must change its password on first login; omitting it provisions the account
- * behind a random, unusable placeholder hash (the {@code INTERNAL ⇒ credentials} DB invariant) and
- * emails an invitation link the user follows to set their own password.
+ * <p>Lockout guards (all {@link AdminUserConflictException} / HTTP 409): an admin can neither
+ * disable, demote nor delete their own account, and the last enabled admin can never be disabled,
+ * demoted or deleted. Creating with an {@code initialPassword} yields an enabled account that must
+ * change its password on first login; omitting it provisions the account behind a random, unusable
+ * placeholder hash (the {@code INTERNAL ⇒ credentials} DB invariant) and emails an invitation link.
  */
 @Service
 public class AdminUserService {
 
+  /** Whitelist of API sort fields → entity properties (guards the ORDER BY against injection). */
+  private static final Map<String, String> SORTABLE =
+      Map.of(
+          "displayname", "displayName",
+          "email", "email",
+          "username", "username",
+          "role", "role",
+          "createdat", "createdAt",
+          "lastloginat", "lastLoginAt");
+
   private final UserRepository users;
+  private final OidcIdentityRepository oidcIdentities;
   private final PasswordEncoder passwordEncoder;
   private final PasswordResetFlowService passwordResetFlow;
+  private final RefreshTokenService refreshTokens;
 
   public AdminUserService(
       UserRepository users,
+      OidcIdentityRepository oidcIdentities,
       PasswordEncoder passwordEncoder,
-      PasswordResetFlowService passwordResetFlow) {
+      PasswordResetFlowService passwordResetFlow,
+      RefreshTokenService refreshTokens) {
     this.users = users;
+    this.oidcIdentities = oidcIdentities;
     this.passwordEncoder = passwordEncoder;
     this.passwordResetFlow = passwordResetFlow;
+    this.refreshTokens = refreshTokens;
   }
 
-  /** A paginated, optionally filtered slice of users for the admin list. */
+  /** A paginated, optionally filtered/sorted slice of users for the admin list. */
   @Transactional(readOnly = true)
-  public AdminUserPage list(String query, String roleName, int page, int size) {
+  public AdminUserPage list(
+      String query, String roleName, Boolean enabled, String sort, int page, int size) {
     String like =
         blankToNull(query) == null ? null : "%" + query.trim().toLowerCase(Locale.ROOT) + "%";
     UserRole role = parseRoleOrNull(roleName);
     Page<User> result =
-        users.search(
-            like, role, PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
-    List<AdminUserView> items = result.getContent().stream().map(AdminUserService::toView).toList();
+        users.search(like, role, enabled, PageRequest.of(page, size, parseSort(sort)));
+
+    Map<UUID, String> providerNames = providerNamesFor(result.getContent());
+    List<AdminUserView> items =
+        result.getContent().stream().map(u -> toView(u, providerNameOf(u, providerNames))).toList();
     return new AdminUserPage(items, result.getTotalElements(), page, size);
   }
 
   @Transactional(readOnly = true)
   public AdminUserView get(UUID id) {
-    return toView(users.findById(id).orElseThrow(() -> new UserNotFoundException(id)));
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    return toView(user, providerNameOf(user, providerNamesFor(List.of(user))));
   }
 
   /**
@@ -114,7 +138,7 @@ public class AdminUserService {
     if (invite) {
       passwordResetFlow.sendSetupLink(saved);
     }
-    return toView(saved);
+    return toView(saved, null);
   }
 
   /**
@@ -149,25 +173,69 @@ public class AdminUserService {
     }
     user.setRole(newRole);
     user.setEnabled(newEnabled);
-    return toView(user);
+    return toView(user, null);
   }
 
   /**
-   * Issues a password-setup/reset token for an internal account and emails the link. External
-   * (OIDC) accounts have no local password and are rejected (409).
+   * Permanently deletes a user; the database cascades their tokens, settings, OIDC identity and
+   * team memberships. Rejects (409) deleting your own account or the last enabled admin.
    */
   @Transactional
-  public void sendPasswordReset(UUID id) {
+  public void delete(UUID id, UUID actingUserId) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    if (id.equals(actingUserId)) {
+      throw new AdminUserConflictException("SELF_DELETE", "You cannot delete your own account.");
+    }
+    if (user.getRole() == UserRole.ADMIN
+        && user.isEnabled()
+        && users.countByRoleAndEnabledTrue(UserRole.ADMIN) <= 1) {
+      throw new AdminUserConflictException("LAST_ADMIN", "At least one enabled admin must remain.");
+    }
+    users.delete(user);
+  }
+
+  /**
+   * Admin password reset for an internal account: revokes the user's active sessions immediately,
+   * issues a single-use reset token and emails the set-your-password link. External (OIDC) accounts
+   * have no local password and are rejected (409). The reset URL is returned only as a fallback
+   * when the email could not be sent.
+   */
+  @Transactional
+  public PasswordResetOutcome sendPasswordReset(UUID id) {
     User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
     if (user.getSource() != UserSource.INTERNAL) {
       throw new AdminUserConflictException(
           "NO_LOCAL_PASSWORD",
           "This account signs in via an identity provider; it has no password.");
     }
-    passwordResetFlow.sendSetupLink(user);
+    SetupLinkOutcome outcome = passwordResetFlow.sendSetupLink(user);
+    // Revoke active sessions now (the modifying writes clear the persistence context, so do this
+    // after the link has been issued from the still-managed entity).
+    users.bumpPasswordInvalidatedBefore(id, Instant.now());
+    refreshTokens.revokeAllForUser(id);
+    return new PasswordResetOutcome(
+        outcome.emailSent(), outcome.emailSent() ? null : outcome.resetUrl());
   }
 
-  private static AdminUserView toView(User u) {
+  /** The provider name for a user, or null for internal accounts (avoids a null-key map lookup). */
+  private static String providerNameOf(User user, Map<UUID, String> providerNames) {
+    return user.getSource() == UserSource.EXTERNAL ? providerNames.get(user.getId()) : null;
+  }
+
+  /** The provider name per external user id in the given page (empty for all-internal pages). */
+  private Map<UUID, String> providerNamesFor(List<User> page) {
+    List<UUID> externalIds =
+        page.stream().filter(u -> u.getSource() == UserSource.EXTERNAL).map(User::getId).toList();
+    if (externalIds.isEmpty()) {
+      return Map.of();
+    }
+    return oidcIdentities.findProviderNamesByUserIds(externalIds).stream()
+        .collect(
+            Collectors.toMap(
+                UserProviderName::userId, UserProviderName::providerName, (a, b) -> a));
+  }
+
+  private static AdminUserView toView(User u, String providerName) {
     return new AdminUserView(
         u.getId(),
         u.getDisplayName(),
@@ -176,6 +244,8 @@ public class AdminUserService {
         u.getRole().name(),
         u.getSource().name(),
         u.isEnabled(),
+        u.isPasswordChangeRequired(),
+        providerName,
         u.getLastLoginAt(),
         u.getCreatedAt());
   }
@@ -193,6 +263,19 @@ public class AdminUserService {
       return null;
     }
     return UserRole.valueOf(roleName.trim().toUpperCase(Locale.ROOT));
+  }
+
+  /**
+   * Parses a {@code field,direction} string against the whitelist; defaults to display name asc.
+   */
+  private static Sort parseSort(String sort) {
+    String[] parts = (blankToNull(sort) == null ? "displayName,asc" : sort).split(",");
+    String field = SORTABLE.getOrDefault(parts[0].trim().toLowerCase(Locale.ROOT), "displayName");
+    Sort.Direction direction =
+        parts.length > 1 && parts[1].trim().equalsIgnoreCase("desc")
+            ? Sort.Direction.DESC
+            : Sort.Direction.ASC;
+    return Sort.by(direction, field);
   }
 
   private static String normalizeEmail(String email) {
@@ -219,9 +302,14 @@ public class AdminUserService {
       String role,
       String source,
       boolean enabled,
+      boolean passwordChangeRequired,
+      String providerName,
       Instant lastLoginAt,
       Instant createdAt) {}
 
   /** One page of {@link AdminUserView}s plus the total count for the admin list. */
   public record AdminUserPage(List<AdminUserView> items, long total, int page, int size) {}
+
+  /** Outcome of an admin password reset: whether email was sent, and a fallback link if not. */
+  public record PasswordResetOutcome(boolean emailSent, String resetUrl) {}
 }

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
@@ -25,6 +25,7 @@ import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.UserService;
 import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailService.SendResult;
 import io.qnop.service.mail.MailTemplateKey;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -76,29 +77,35 @@ public class PasswordResetFlowService {
   }
 
   /**
-   * Admin action (issue #104): issues a reset token for a known internal account and emails the
-   * set-your-password link. Unlike {@link #requestReset}, this is not gated by the self-service
+   * Admin action (issues #104/#124): issues a reset token for a known internal account and emails
+   * the set-your-password link, returning whether the email was sent and the link itself (for an
+   * out-of-band fallback). Unlike {@link #requestReset}, this is not gated by the self-service
    * feature flag or anti-enumeration — the admin already knows the account exists and is acting on
    * it deliberately (e.g. (re)sending an invitation or unblocking a locked-out user).
    */
   @Transactional
-  public void sendSetupLink(User user) {
-    sendResetEmail(user);
+  public SetupLinkOutcome sendSetupLink(User user) {
+    return sendResetEmail(user);
   }
 
-  private void sendResetEmail(User user) {
+  private SetupLinkOutcome sendResetEmail(User user) {
     String rawToken = resetTokens.issue(user).rawToken();
     String actionUrl =
         baseUrl() + "/reset-password?token=" + URLEncoder.encode(rawToken, StandardCharsets.UTF_8);
-    mailService.sendMailFromTemplate(
-        MailTemplateKey.PASSWORD_RESET,
-        user.getEmail(),
-        Map.of(
-            "siteName", siteName(),
-            "recipientName", user.getDisplayName(),
-            "actionUrl", actionUrl),
-        null);
+    SendResult result =
+        mailService.sendMailFromTemplate(
+            MailTemplateKey.PASSWORD_RESET,
+            user.getEmail(),
+            Map.of(
+                "siteName", siteName(),
+                "recipientName", user.getDisplayName(),
+                "actionUrl", actionUrl),
+            null);
+    return new SetupLinkOutcome(result instanceof SendResult.Sent, actionUrl);
   }
+
+  /** Result of issuing a reset/setup link: whether the email was sent, and the link itself. */
+  public record SetupLinkOutcome(boolean emailSent, String resetUrl) {}
 
   private String siteName() {
     return settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME);

--- a/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
@@ -31,10 +31,13 @@ import static org.mockito.Mockito.when;
 
 import io.qnop.entity.User;
 import io.qnop.entity.UserRole;
+import io.qnop.repository.OidcIdentityRepository;
 import io.qnop.repository.UserRepository;
 import io.qnop.service.AdminUserService.AdminUserPage;
 import io.qnop.service.AdminUserService.AdminUserView;
+import io.qnop.service.AdminUserService.PasswordResetOutcome;
 import io.qnop.service.auth.PasswordResetFlowService;
+import io.qnop.service.auth.PasswordResetFlowService.SetupLinkOutcome;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -45,14 +48,19 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-/** Unit tests for {@link AdminUserService} (issue #104): create/invite, edit guards, reset. */
+/**
+ * Unit tests for {@link AdminUserService} (issues #104/#124): create/invite, edit, delete, reset.
+ */
 class AdminUserServiceTest {
 
   private final UserRepository users = mock(UserRepository.class);
+  private final OidcIdentityRepository oidcIdentities = mock(OidcIdentityRepository.class);
   private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
   private final PasswordResetFlowService passwordResetFlow = mock(PasswordResetFlowService.class);
+  private final RefreshTokenService refreshTokens = mock(RefreshTokenService.class);
   private final AdminUserService service =
-      new AdminUserService(users, passwordEncoder, passwordResetFlow);
+      new AdminUserService(
+          users, oidcIdentities, passwordEncoder, passwordResetFlow, refreshTokens);
 
   private void noClash() {
     when(users.existsByEmailIgnoreCaseAndSource(any(), any())).thenReturn(false);
@@ -162,6 +170,45 @@ class AdminUserServiceTest {
   }
 
   @Test
+  @DisplayName("delete rejects self and the last admin, and removes any other user")
+  void delete() {
+    UUID selfId = UUID.randomUUID();
+    User self = User.internal("Self", "self@example.com", "self", "h");
+    self.setRole(UserRole.ADMIN);
+    when(users.findById(selfId)).thenReturn(Optional.of(self));
+    assertThatThrownBy(() -> service.delete(selfId, selfId))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("SELF_DELETE");
+
+    UUID adminId = UUID.randomUUID();
+    User onlyAdmin = User.internal("Admin", "admin@example.com", "admin", "h");
+    onlyAdmin.setRole(UserRole.ADMIN);
+    when(users.findById(adminId)).thenReturn(Optional.of(onlyAdmin));
+    when(users.countByRoleAndEnabledTrue(UserRole.ADMIN)).thenReturn(1L);
+    assertThatThrownBy(() -> service.delete(adminId, UUID.randomUUID()))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("LAST_ADMIN");
+
+    UUID memberId = UUID.randomUUID();
+    User member = User.internal("Member", "member@example.com", "member", "h");
+    member.setRole(UserRole.MEMBER);
+    when(users.findById(memberId)).thenReturn(Optional.of(member));
+    service.delete(memberId, UUID.randomUUID());
+    verify(users).delete(member);
+  }
+
+  @Test
+  @DisplayName("delete throws for an unknown user")
+  void deleteRejectsUnknown() {
+    UUID id = UUID.randomUUID();
+    when(users.findById(id)).thenReturn(Optional.empty());
+    assertThatThrownBy(() -> service.delete(id, UUID.randomUUID()))
+        .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
   @DisplayName("get throws for an unknown user")
   void getRejectsUnknown() {
     UUID id = UUID.randomUUID();
@@ -170,7 +217,7 @@ class AdminUserServiceTest {
   }
 
   @Test
-  @DisplayName("password reset is rejected for an external account and sent for an internal one")
+  @DisplayName("password reset rejects external accounts; for internal it revokes sessions + sends")
   void sendPasswordReset() {
     UUID externalId = UUID.randomUUID();
     when(users.findById(externalId))
@@ -183,22 +230,46 @@ class AdminUserServiceTest {
     UUID internalId = UUID.randomUUID();
     User internal = User.internal("Int", "int@example.com", "int", "h");
     when(users.findById(internalId)).thenReturn(Optional.of(internal));
-    service.sendPasswordReset(internalId);
+    when(passwordResetFlow.sendSetupLink(internal))
+        .thenReturn(new SetupLinkOutcome(true, "https://app/reset?token=x"));
+
+    PasswordResetOutcome outcome = service.sendPasswordReset(internalId);
+
+    assertThat(outcome.emailSent()).isTrue();
+    assertThat(outcome.resetUrl()).isNull(); // hidden when the email went out
     verify(passwordResetFlow).sendSetupLink(internal);
+    verify(refreshTokens).revokeAllForUser(internalId);
+    verify(users).bumpPasswordInvalidatedBefore(eq(internalId), any());
   }
 
   @Test
-  @DisplayName("list lowercases and wraps the query and maps the page")
+  @DisplayName("password reset returns the fallback url when the email could not be sent")
+  void sendPasswordResetFallbackUrl() {
+    UUID id = UUID.randomUUID();
+    User internal = User.internal("Int", "int@example.com", "int", "h");
+    when(users.findById(id)).thenReturn(Optional.of(internal));
+    when(passwordResetFlow.sendSetupLink(internal))
+        .thenReturn(new SetupLinkOutcome(false, "https://app/reset?token=y"));
+
+    PasswordResetOutcome outcome = service.sendPasswordReset(id);
+
+    assertThat(outcome.emailSent()).isFalse();
+    assertThat(outcome.resetUrl()).isEqualTo("https://app/reset?token=y");
+  }
+
+  @Test
+  @DisplayName("list lowercases/wraps the query, passes the enabled filter, and maps the page")
   void listMapsPage() {
     User user = User.internal("Alice", "alice@example.com", "alice", "h");
     user.setRole(UserRole.MEMBER);
-    when(users.search(eq("%ali%"), eq(UserRole.MEMBER), any()))
+    when(users.search(eq("%ali%"), eq(UserRole.MEMBER), eq(true), any()))
         .thenReturn(new PageImpl<>(List.of(user), PageRequest.of(0, 20), 1));
 
-    AdminUserPage page = service.list(" Ali ", "MEMBER", 0, 20);
+    AdminUserPage page = service.list(" Ali ", "MEMBER", true, "displayName,asc", 0, 20);
 
     assertThat(page.items()).hasSize(1);
     assertThat(page.total()).isEqualTo(1);
     assertThat(page.items().get(0).email()).isEqualTo("alice@example.com");
+    assertThat(page.items().get(0).providerName()).isNull(); // internal user
   }
 }

--- a/qnop-ui/src/api/hooks/useAdminUsers.test.tsx
+++ b/qnop-ui/src/api/hooks/useAdminUsers.test.tsx
@@ -28,6 +28,7 @@ import {
   adminUserKeys,
   useAdminUsers,
   useCreateUser,
+  useDeleteUser,
   useSendUserPasswordReset,
   useUpdateUser,
 } from './useAdminUsers';
@@ -40,6 +41,7 @@ vi.mock('../config', () => ({
     listUsers: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
+    deleteUser: vi.fn(),
     sendUserPasswordReset: vi.fn(),
   },
 }));
@@ -67,7 +69,15 @@ describe('useAdminUsers', () => {
     >);
 
     const { result } = renderHook(
-      () => useAdminUsers({ q: 'ali', role: 'MEMBER', page: 0, size: 20 }),
+      () =>
+        useAdminUsers({
+          q: 'ali',
+          role: 'MEMBER',
+          enabled: false,
+          sort: 'createdAt,desc',
+          page: 0,
+          size: 20,
+        }),
       { wrapper },
     );
 
@@ -75,6 +85,8 @@ describe('useAdminUsers', () => {
     expect(adminUsersApi.listUsers).toHaveBeenCalledWith({
       q: 'ali',
       role: 'MEMBER',
+      enabled: false,
+      sort: 'createdAt,desc',
       page: 0,
       size: 20,
     });
@@ -92,6 +104,8 @@ describe('useAdminUsers', () => {
     expect(adminUsersApi.listUsers).toHaveBeenCalledWith({
       q: undefined,
       role: undefined,
+      enabled: undefined,
+      sort: undefined,
       page: 0,
       size: 20,
     });
@@ -139,15 +153,30 @@ describe('useUpdateUser', () => {
   });
 });
 
-describe('useSendUserPasswordReset', () => {
-  it('sends a reset for the given id', async () => {
-    vi.mocked(adminUsersApi.sendUserPasswordReset).mockResolvedValue({
+describe('useDeleteUser', () => {
+  it('deletes the given id', async () => {
+    vi.mocked(adminUsersApi.deleteUser).mockResolvedValue({
       data: undefined,
+    } as Awaited<ReturnType<typeof adminUsersApi.deleteUser>>);
+
+    const { result } = renderHook(() => useDeleteUser(), { wrapper });
+    await result.current.mutateAsync('u5');
+
+    expect(adminUsersApi.deleteUser).toHaveBeenCalledWith({ userId: 'u5' });
+  });
+});
+
+describe('useSendUserPasswordReset', () => {
+  it('sends a reset for the given id and returns the outcome', async () => {
+    vi.mocked(adminUsersApi.sendUserPasswordReset).mockResolvedValue({
+      data: { emailSent: false, resetUrl: 'https://app/reset?token=x' },
     } as Awaited<ReturnType<typeof adminUsersApi.sendUserPasswordReset>>);
 
     const { result } = renderHook(() => useSendUserPasswordReset(), { wrapper });
-    await result.current.mutateAsync('u9');
+    const outcome = await result.current.mutateAsync('u9');
 
     expect(adminUsersApi.sendUserPasswordReset).toHaveBeenCalledWith({ userId: 'u9' });
+    expect(outcome.emailSent).toBe(false);
+    expect(outcome.resetUrl).toBe('https://app/reset?token=x');
   });
 });

--- a/qnop-ui/src/api/hooks/useAdminUsers.ts
+++ b/qnop-ui/src/api/hooks/useAdminUsers.ts
@@ -21,6 +21,7 @@
 
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
+  AdminPasswordResetResponse,
   AdminUserCreateRequest,
   AdminUserListResponse,
   AdminUserUpdateRequest,
@@ -32,6 +33,8 @@ import { adminUsersApi } from '../config';
 export interface AdminUserListParams {
   q?: string;
   role?: UserRole;
+  enabled?: boolean;
+  sort?: string;
   page: number;
   size: number;
 }
@@ -43,7 +46,8 @@ export const adminUserKeys = {
 
 /**
  * A page of users for the admin list. Keeps the previous page visible while the
- * next one loads, so pagination and search do not flash an empty table.
+ * next one loads, so pagination, search, filtering and sorting do not flash an
+ * empty table.
  */
 export function useAdminUsers(params: AdminUserListParams) {
   return useQuery<AdminUserListResponse>({
@@ -52,6 +56,8 @@ export function useAdminUsers(params: AdminUserListParams) {
       const response = await adminUsersApi.listUsers({
         q: params.q || undefined,
         role: params.role,
+        enabled: params.enabled,
+        sort: params.sort,
         page: params.page,
         size: params.size,
       });
@@ -88,11 +94,27 @@ export function useUpdateUser() {
   });
 }
 
-/** Sends a password-setup/reset link to the given user. */
-export function useSendUserPasswordReset() {
+/** Deletes a user, then refreshes the list. */
+export function useDeleteUser() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (id: string) => {
-      await adminUsersApi.sendUserPasswordReset({ userId: id });
+      await adminUsersApi.deleteUser({ userId: id });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: adminUserKeys.all }),
+  });
+}
+
+/**
+ * Admin password reset: revokes the user's sessions and emails a reset link.
+ * Returns the outcome ({@code emailSent}, and a fallback {@code resetUrl} when
+ * email could not be sent).
+ */
+export function useSendUserPasswordReset() {
+  return useMutation<AdminPasswordResetResponse, unknown, string>({
+    mutationFn: async (id: string) => {
+      const response = await adminUsersApi.sendUserPasswordReset({ userId: id });
+      return response.data;
     },
   });
 }

--- a/qnop-ui/src/components/admin/users/ResetLinkDialog.tsx
+++ b/qnop-ui/src/components/admin/users/ResetLinkDialog.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import { Check, Copy } from 'lucide-react';
+
+interface ResetLinkDialogProps {
+  open: boolean;
+  displayName: string;
+  url: string;
+  onClose: () => void;
+}
+
+/**
+ * Shows the single-use reset link when the email could not be sent (issue #124),
+ * so the operator can deliver it out of band. Sessions are already revoked.
+ */
+export function ResetLinkDialog({ open, displayName, url, onClose }: ResetLinkDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — the field stays selectable.
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Reset link for {displayName}</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>
+          The reset email could not be sent. Copy this single-use link and deliver it to the user.
+          Their existing sessions have already been revoked.
+        </DialogContentText>
+        <TextField
+          value={url}
+          fullWidth
+          size="small"
+          slotProps={{
+            input: {
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip title={copied ? 'Copied' : 'Copy'}>
+                    <IconButton aria-label="Copy reset link" size="small" edge="end" onClick={copy}>
+                      {copied ? <Check size={16} /> : <Copy size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onClose} variant="contained">
+          Done
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/admin/users/UsersTable.tsx
+++ b/qnop-ui/src/components/admin/users/UsersTable.tsx
@@ -27,50 +27,92 @@ import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { KeyRound, MoreVertical, SquarePen } from 'lucide-react';
+import { KeyRound, MoreVertical, SquarePen, Trash2 } from 'lucide-react';
 import type { AdminUserSummary } from '../../../api/generated';
 import { UserAvatar } from '../../shell/UserAvatar';
-import { formatDateTime } from '../../../utils/formatDate';
+import { formatDateTime, formatRelative } from '../../../utils/formatDate';
+import { ToneBadge } from '../ToneBadge';
 import { UserRoleBadge, UserStatusBadge } from './UserBadges';
 
 interface UsersTableProps {
   users: AdminUserSummary[];
+  currentUserId: string | null;
+  /** Active sort as `field,direction`. */
+  sort: string;
+  onSort: (field: string) => void;
   onEdit: (user: AdminUserSummary) => void;
   onResetPassword: (user: AdminUserSummary) => void;
+  onToggleEnabled: (user: AdminUserSummary) => void;
+  onDelete: (user: AdminUserSummary) => void;
 }
 
-export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) {
+const COLUMNS: { key: string; label: string; sortable?: boolean }[] = [
+  { key: 'displayName', label: 'User', sortable: true },
+  { key: 'role', label: 'Role', sortable: true },
+  { key: 'status', label: 'Status' },
+  { key: 'createdAt', label: 'Created', sortable: true },
+  { key: 'lastLoginAt', label: 'Last login', sortable: true },
+  { key: 'actions', label: '' },
+];
+
+export function UsersTable({
+  users,
+  currentUserId,
+  sort,
+  onSort,
+  onEdit,
+  onResetPassword,
+  onToggleEnabled,
+  onDelete,
+}: UsersTableProps) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [active, setActive] = useState<AdminUserSummary | null>(null);
+
+  const [sortField, sortDir] = sort.split(',');
+  const direction = sortDir === 'desc' ? 'desc' : 'asc';
 
   const openMenu = (event: MouseEvent<HTMLElement>, user: AdminUserSummary) => {
     setAnchorEl(event.currentTarget);
     setActive(user);
   };
   const closeMenu = () => setAnchorEl(null);
+  const isSelf = (user: AdminUserSummary) => user.id === currentUserId;
 
   return (
     <>
       <Table size="medium" sx={{ '& td, & th': { borderColor: 'divider' } }}>
         <TableHead>
           <TableRow>
-            <TableCell>User</TableCell>
-            <TableCell>Role</TableCell>
-            <TableCell>Status</TableCell>
-            <TableCell>Last login</TableCell>
-            <TableCell align="right">Actions</TableCell>
+            {COLUMNS.map((col) => (
+              <TableCell key={col.key} align={col.key === 'actions' ? 'right' : 'left'}>
+                {col.sortable ? (
+                  <TableSortLabel
+                    active={sortField === col.key}
+                    direction={sortField === col.key ? direction : 'asc'}
+                    onClick={() => onSort(col.key)}
+                  >
+                    {col.label}
+                  </TableSortLabel>
+                ) : (
+                  col.label
+                )}
+              </TableCell>
+            ))}
           </TableRow>
         </TableHead>
         <TableBody>
           {users.length === 0 && (
             <TableRow>
-              <TableCell colSpan={5}>
+              <TableCell colSpan={COLUMNS.length}>
                 <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
                   No users found.
                 </Typography>
@@ -83,17 +125,26 @@ export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) 
                 <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
                   <UserAvatar name={user.displayName} size={36} />
                   <Box sx={{ minWidth: 0 }}>
-                    <Typography sx={{ fontWeight: 600, lineHeight: 1.3 }} noWrap>
-                      {user.displayName}
+                    <Stack
+                      direction="row"
+                      spacing={0.75}
+                      sx={{ alignItems: 'center', flexWrap: 'wrap' }}
+                    >
+                      <Typography sx={{ fontWeight: 600, lineHeight: 1.3 }} noWrap>
+                        {user.displayName}
+                      </Typography>
                       {user.source === 'EXTERNAL' && (
                         <Typography
                           component="span"
-                          sx={{ ml: 1, fontSize: 11, color: 'text.secondary', fontWeight: 500 }}
+                          sx={{ fontSize: 11, color: 'text.secondary', fontWeight: 500 }}
                         >
-                          OIDC
+                          ({user.providerName ?? 'OIDC'})
                         </Typography>
                       )}
-                    </Typography>
+                      {user.passwordChangeRequired && (
+                        <ToneBadge tone="amber" label="Password change" />
+                      )}
+                    </Stack>
                     <Typography sx={{ fontSize: 13, color: 'text.secondary' }} noWrap>
                       {user.email}
                     </Typography>
@@ -104,11 +155,31 @@ export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) 
                 <UserRoleBadge role={user.role} />
               </TableCell>
               <TableCell>
-                <UserStatusBadge enabled={user.enabled} />
+                <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                  <Tooltip
+                    title={isSelf(user) ? 'You cannot disable your own account' : 'Toggle access'}
+                  >
+                    <span>
+                      <Switch
+                        size="small"
+                        checked={user.enabled}
+                        disabled={isSelf(user)}
+                        onChange={() => onToggleEnabled(user)}
+                        slotProps={{ input: { 'aria-label': `Toggle ${user.displayName}` } }}
+                      />
+                    </span>
+                  </Tooltip>
+                  <UserStatusBadge enabled={user.enabled} />
+                </Stack>
               </TableCell>
               <TableCell>
                 <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>
-                  {formatDateTime(user.lastLoginAt)}
+                  {formatDateTime(user.createdAt)}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>
+                  {formatRelative(user.lastLoginAt)}
                 </Typography>
               </TableCell>
               <TableCell align="right">
@@ -147,7 +218,19 @@ export function UsersTable({ users, onEdit, onResetPassword }: UsersTableProps) 
           <ListItemIcon>
             <KeyRound size={16} />
           </ListItemIcon>
-          <ListItemText>Send password link</ListItemText>
+          <ListItemText>Reset password</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={active ? isSelf(active) : false}
+          onClick={() => {
+            closeMenu();
+            if (active) onDelete(active);
+          }}
+        >
+          <ListItemIcon>
+            <Trash2 size={16} />
+          </ListItemIcon>
+          <ListItemText>Delete</ListItemText>
         </MenuItem>
       </Menu>
     </>

--- a/qnop-ui/src/pages/admin/UsersPage.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.tsx
@@ -35,12 +35,22 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { Search, UserPlus, X } from 'lucide-react';
 import type { AdminUserSummary, UserRole } from '../../api/generated';
-import { useAdminUsers, useSendUserPasswordReset } from '../../api/hooks/useAdminUsers';
+import {
+  useAdminUsers,
+  useDeleteUser,
+  useSendUserPasswordReset,
+  useUpdateUser,
+} from '../../api/hooks/useAdminUsers';
 import { UserFormDialog } from '../../components/admin/users/UserFormDialog';
 import { UsersTable } from '../../components/admin/users/UsersTable';
-import { apiErrorMessage } from '../../utils/apiError';
+import { ResetLinkDialog } from '../../components/admin/users/ResetLinkDialog';
+import { ConfirmDialog } from '../../components/admin/ConfirmDialog';
+import { useAuthStore } from '../../stores/authStore';
+import { apiErrorCode, apiErrorMessage } from '../../utils/apiError';
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_SORT = 'displayName,asc';
 
 type DialogState =
   | { open: false }
@@ -48,19 +58,33 @@ type DialogState =
   | { open: true; mode: 'edit'; user: AdminUserSummary };
 
 type Toast = { message: string; severity: 'success' | 'error' } | null;
+type StatusFilter = '' | 'active' | 'disabled';
 
-/** Admin user management: search, filter, paginate, create/invite, edit and reset (#104). */
+const CONFLICT_MESSAGES: Record<string, string> = {
+  LAST_ADMIN: 'At least one enabled admin must remain.',
+  SELF_LOCKOUT: "You can't disable or change the role of your own account.",
+  SELF_DELETE: "You can't delete your own account.",
+};
+
+/** Admin user management: search/filter/sort, paginate, create, edit, delete and reset (#104/#124). */
 export function UsersPage() {
+  const currentUserId = useAuthStore((s) => s.userId);
+  const updateUser = useUpdateUser();
+  const deleteUser = useDeleteUser();
+  const sendReset = useSendUserPasswordReset();
+
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [roleFilter, setRoleFilter] = useState<UserRole | ''>('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('');
+  const [sort, setSort] = useState(DEFAULT_SORT);
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [dialog, setDialog] = useState<DialogState>({ open: false });
-  // Bumped on every open so the dialog remounts with fresh state (see UserFormDialog).
   const [openSeq, setOpenSeq] = useState(0);
+  const [deleteTarget, setDeleteTarget] = useState<AdminUserSummary | null>(null);
+  const [resetLink, setResetLink] = useState<{ displayName: string; url: string } | null>(null);
   const [toast, setToast] = useState<Toast>(null);
-
-  const sendReset = useSendUserPasswordReset();
 
   const openCreate = () => {
     setDialog({ open: true, mode: 'create' });
@@ -83,22 +107,66 @@ export function UsersPage() {
   const { data, isLoading, isFetching, isError } = useAdminUsers({
     q: debouncedSearch || undefined,
     role: roleFilter || undefined,
+    enabled: statusFilter === '' ? undefined : statusFilter === 'active',
+    sort,
     page,
-    size: PAGE_SIZE,
+    size: pageSize,
   });
 
   const users = data?.items ?? [];
   const total = data?.total ?? 0;
 
-  const onResetPassword = async (user: AdminUserSummary) => {
+  const onSort = (field: string) => {
+    const [currentField, currentDir] = sort.split(',');
+    const nextDir = currentField === field && currentDir === 'asc' ? 'desc' : 'asc';
+    setSort(`${field},${nextDir}`);
+    setPage(0);
+  };
+
+  const onToggleEnabled = async (user: AdminUserSummary) => {
     try {
-      await sendReset.mutateAsync(user.id);
-      setToast({ message: `Password link sent to ${user.email}.`, severity: 'success' });
+      await updateUser.mutateAsync({ id: user.id, request: { enabled: !user.enabled } });
     } catch (err) {
       setToast({
-        message: apiErrorMessage(err, 'The link could not be sent.'),
+        message: conflictOr(err, `Could not update ${user.displayName}.`),
         severity: 'error',
       });
+    }
+  };
+
+  const onResetPassword = async (user: AdminUserSummary) => {
+    try {
+      const outcome = await sendReset.mutateAsync(user.id);
+      if (outcome.emailSent) {
+        setToast({
+          message: `Password reset emailed to ${user.email}. Sessions revoked.`,
+          severity: 'success',
+        });
+      } else if (outcome.resetUrl) {
+        setResetLink({ displayName: user.displayName, url: outcome.resetUrl });
+      } else {
+        setToast({
+          message: `Reset triggered for ${user.displayName}, but no link was returned.`,
+          severity: 'error',
+        });
+      }
+    } catch (err) {
+      setToast({
+        message: conflictOr(err, 'The reset could not be triggered.'),
+        severity: 'error',
+      });
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteUser.mutateAsync(deleteTarget.id);
+      setToast({ message: `User “${deleteTarget.displayName}” deleted.`, severity: 'success' });
+    } catch (err) {
+      setToast({ message: conflictOr(err, 'Could not delete the user.'), severity: 'error' });
+    } finally {
+      setDeleteTarget(null);
     }
   };
 
@@ -122,13 +190,13 @@ export function UsersPage() {
         </Button>
       </Stack>
 
-      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ flexWrap: 'wrap' }}>
         <TextField
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search by name, email or username"
           size="small"
-          sx={{ flex: 1, maxWidth: 420 }}
+          sx={{ flex: 1, minWidth: 240, maxWidth: 420 }}
           slotProps={{
             input: {
               startAdornment: (
@@ -160,12 +228,27 @@ export function UsersPage() {
             setPage(0);
           }}
           size="small"
-          sx={{ minWidth: 160 }}
+          sx={{ minWidth: 150 }}
         >
           <MenuItem value="">All roles</MenuItem>
           <MenuItem value="ADMIN">Admin</MenuItem>
           <MenuItem value="MEMBER">Member</MenuItem>
           <MenuItem value="AUDITOR">Auditor</MenuItem>
+        </TextField>
+        <TextField
+          select
+          label="Status"
+          value={statusFilter}
+          onChange={(e) => {
+            setStatusFilter(e.target.value as StatusFilter);
+            setPage(0);
+          }}
+          size="small"
+          sx={{ minWidth: 150 }}
+        >
+          <MenuItem value="">All statuses</MenuItem>
+          <MenuItem value="active">Active</MenuItem>
+          <MenuItem value="disabled">Disabled</MenuItem>
         </TextField>
       </Stack>
 
@@ -177,14 +260,28 @@ export function UsersPage() {
           </Alert>
         ) : (
           <>
-            <UsersTable users={users} onEdit={openEdit} onResetPassword={onResetPassword} />
+            <UsersTable
+              users={users}
+              currentUserId={currentUserId}
+              sort={sort}
+              onSort={onSort}
+              onEdit={openEdit}
+              onResetPassword={onResetPassword}
+              onToggleEnabled={onToggleEnabled}
+              onDelete={setDeleteTarget}
+            />
             <TablePagination
               component="div"
               count={total}
               page={page}
-              rowsPerPage={PAGE_SIZE}
-              rowsPerPageOptions={[PAGE_SIZE]}
+              rowsPerPage={pageSize}
+              rowsPerPageOptions={PAGE_SIZE_OPTIONS}
               onPageChange={(_, next) => setPage(next)}
+              onRowsPerPageChange={(e) => {
+                setPageSize(parseInt(e.target.value, 10));
+                setPage(0);
+              }}
+              labelRowsPerPage="Users per page"
               labelDisplayedRows={({ from, to, count }) => `${from}–${to} of ${count}`}
             />
           </>
@@ -204,6 +301,23 @@ export function UsersPage() {
         onClose={() => setDialog({ open: false })}
       />
 
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete user"
+        message={`Permanently delete “${deleteTarget?.displayName}”? Their sessions, settings and team memberships are removed. This cannot be undone.`}
+        confirmLabel="Delete"
+        destructive
+        onConfirm={confirmDelete}
+        onClose={() => setDeleteTarget(null)}
+      />
+
+      <ResetLinkDialog
+        open={resetLink !== null}
+        displayName={resetLink?.displayName ?? ''}
+        url={resetLink?.url ?? ''}
+        onClose={() => setResetLink(null)}
+      />
+
       <Snackbar
         open={toast !== null}
         autoHideDuration={5000}
@@ -218,4 +332,10 @@ export function UsersPage() {
       </Snackbar>
     </Stack>
   );
+}
+
+/** Maps a known 409 conflict code to a friendly message, else the generic fallback. */
+function conflictOr(err: unknown, fallback: string): string {
+  const code = apiErrorCode(err);
+  return (code && CONFLICT_MESSAGES[code]) ?? apiErrorMessage(err, fallback);
 }

--- a/qnop-ui/src/utils/formatDate.test.ts
+++ b/qnop-ui/src/utils/formatDate.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { formatDateTime } from './formatDate';
+import { formatDateTime, formatRelative } from './formatDate';
 
 describe('formatDateTime', () => {
   it('returns an em dash for null, undefined or an invalid date', () => {
@@ -33,5 +33,28 @@ describe('formatDateTime', () => {
     const formatted = formatDateTime('2026-06-21T12:34:00Z');
     expect(formatted).not.toBe('—');
     expect(formatted).toMatch(/2026/);
+  });
+});
+
+describe('formatRelative', () => {
+  it('returns an em dash for null, undefined or an invalid date', () => {
+    expect(formatRelative(null)).toBe('—');
+    expect(formatRelative(undefined)).toBe('—');
+    expect(formatRelative('not-a-date')).toBe('—');
+  });
+
+  it('reports a very recent timestamp as "just now"', () => {
+    expect(formatRelative(new Date(Date.now() - 5_000).toISOString())).toBe('just now');
+  });
+
+  it('reports a few hours ago relatively', () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60_000).toISOString();
+    expect(formatRelative(threeHoursAgo)).toMatch(/hour/);
+  });
+
+  it('falls back to an absolute date beyond 30 days', () => {
+    const longAgo = new Date(Date.now() - 200 * 24 * 60 * 60_000).toISOString();
+    expect(formatRelative(longAgo)).not.toBe('—');
+    expect(formatRelative(longAgo)).not.toMatch(/ago|just now/);
   });
 });

--- a/qnop-ui/src/utils/formatDate.ts
+++ b/qnop-ui/src/utils/formatDate.ts
@@ -19,14 +19,37 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-const DATE_TIME = new Intl.DateTimeFormat('de-DE', {
+const DATE_TIME = new Intl.DateTimeFormat('en-GB', {
   dateStyle: 'medium',
   timeStyle: 'short',
 });
+
+const RELATIVE = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
 
 /** Formats an ISO timestamp as a localized date+time, or an em dash when absent/invalid. */
 export function formatDateTime(iso: string | null | undefined): string {
   if (!iso) return '—';
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? '—' : DATE_TIME.format(date);
+}
+
+/**
+ * Formats an ISO timestamp relative to now ("just now", "3 days ago"), falling
+ * back to an absolute date beyond 30 days and to an em dash when absent/invalid.
+ */
+export function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  const diffMs = date.getTime() - Date.now();
+  const absMs = Math.abs(diffMs);
+  if (absMs < MINUTE_MS) return 'just now';
+  if (absMs < HOUR_MS) return RELATIVE.format(Math.round(diffMs / MINUTE_MS), 'minute');
+  if (absMs < DAY_MS) return RELATIVE.format(Math.round(diffMs / HOUR_MS), 'hour');
+  if (absMs < 30 * DAY_MS) return RELATIVE.format(Math.round(diffMs / DAY_MS), 'day');
+  return DATE_TIME.format(date);
 }


### PR DESCRIPTION
Closes #124. Brings QNOP's user management to feature parity with the Plugwerk reference. QNOP was already richer in role modelling, search/filter and create/invite; this closes the remaining gaps.

## Backend

- **`DELETE /admin/users/{id}`** — hard delete (DB cascades tokens/settings/OIDC/team memberships); self-delete and last-admin guards (409).
- **`listUsers`** — adds an `enabled` (status) filter and whitelisted `sort` (displayName/email/username/role/createdAt/lastLoginAt) on top of `q`/`role`.
- **`AdminUserSummary`** — exposes `passwordChangeRequired` and `providerName` (OIDC provider for external accounts, batched join — no N+1).
- **Admin password reset** — revokes the user's sessions immediately (`password_invalidated_before` + refresh tokens) and returns `{ emailSent, resetUrl }`, surfacing the link only as a fallback when SMTP is unavailable. (Covers the admin side of #116.)

## Frontend

- Delete action + confirm dialog; inline enable/disable switch.
- Status filter, selectable page size (10/20/50/100), sortable columns.
- "Created" column + relative "last login"; password-change + provider-name badges.
- Reset surfaces a success toast, or a copy-to-clipboard fallback link dialog when email could not be sent.

## Test plan

- [x] `./gradlew build` green — Spotless, ArchUnit, all tests.
- [x] `AdminUserServiceTest`: delete guards (self/last-admin/unknown), reset outcome (emailed vs fallback url + session revocation), enabled-filter mapping.
- [x] `AdminUserControllerIT`: delete + self-delete 409, enabled filter, sort, reset 200 + fallback url.
- [x] Frontend `pnpm lint` / `pnpm build` / `pnpm test:coverage` green (73 tests, coverage 98%).
- [x] Manual E2E (Playwright): the new columns/badges/filters/sort/page-size render; reset shows the fallback-link dialog (SMTP off); delete removes the user (cascading their team membership) and the list refreshes; no console errors.

## Notes

- Role model stays QNOP's (ADMIN/MEMBER/AUDITOR); Plugwerk's binary superadmin maps to the ADMIN role + self/last-admin guards.
- Date util switched to an English locale to match the single-language UI rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
