### PR TITLE
feat: OIDC end-to-end — provider mgmt, login flow, account lifecycle, Keycloak test setup (#106)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,13 @@ QNOP_AUTH_ENCRYPTION_SALT=CHANGE_ME
 # Comma-separated list of exact origins allowed to call the API (the Vite dev server).
 QNOP_CORS_ALLOWED_ORIGINS=http://localhost:5173
 
+# --- Keycloak (local OIDC provider for testing "Sign in with …", issue #106) ---
+# Only used by the `keycloak` compose profile:  docker compose --profile keycloak up -d
+# Admin console + issuer live at http://localhost:8081. LOCAL DEV ONLY.
+QNOP_KEYCLOAK_PORT=8081
+QNOP_KEYCLOAK_ADMIN_USER=admin
+QNOP_KEYCLOAK_ADMIN_PASSWORD=admin
+
 # --- Running the server ---
 # docker-compose loads this file automatically. For `./gradlew :qnop-app:bootRun`
 # export these into your shell first:  set -a; source .env; set +a

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,10 @@ QNOP_CORS_ALLOWED_ORIGINS=http://localhost:5173
 QNOP_KEYCLOAK_PORT=8081
 QNOP_KEYCLOAK_ADMIN_USER=admin
 QNOP_KEYCLOAK_ADMIN_PASSWORD=admin
+# The OIDC SSRF guard blocks discovery against private/loopback issuers by
+# default. The local Keycloak runs on http://localhost, so allow it here.
+# LOCAL DEV ONLY — never set this in production.
+QNOP_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS=true
 
 # --- Running the server ---
 # docker-compose loads this file automatically. For `./gradlew :qnop-app:bootRun`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,53 @@ services:
       timeout: 5s
       retries: 5
 
+  # Keycloak — a local OIDC provider for testing the "Sign in with …" flow (#106).
+  # NOT started by default; enable via the `keycloak` profile:
+  #   docker compose --profile keycloak up -d
+  #
+  # The realm `qnop` is imported from docker/keycloak/qnop-realm.json on first
+  # start. It ships:
+  #   - one confidential OIDC client `qnop-local` (PKCE S256), redirect URIs
+  #     http://localhost:8080|5173/login/oauth2/code/* and matching webOrigins.
+  #   - two verified test users `alice` / `bob`, password `password`.
+  #
+  # Register this in the qnop Admin UI (Administration → OIDC providers):
+  #   Provider type:  Generic OIDC
+  #   Issuer URL:     http://localhost:8081/realms/qnop   (then click Discover)
+  #   Client ID:      qnop-local
+  #   Client secret:  local-dev-secret-do-not-use-in-prod
+  #
+  # Keycloak admin console: http://localhost:8081 (admin/admin). The admin
+  # password, client secret, and user passwords are weak ON PURPOSE — bind to
+  # 127.0.0.1 only and never expose this stack beyond localhost.
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.6
+    profiles: ['keycloak']
+    command: ['start-dev', '--import-realm']
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${QNOP_KEYCLOAK_ADMIN_USER:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${QNOP_KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_HEALTH_ENABLED: 'true'
+    volumes:
+      - ./docker/keycloak:/opt/keycloak/data/import:ro
+      - qnop_keycloakdata:/opt/keycloak/data
+    ports:
+      # Bound to loopback only — this dev IdP must never be reachable off-host.
+      - '127.0.0.1:${QNOP_KEYCLOAK_PORT:-8081}:8080'
+    healthcheck:
+      # Keycloak 26 `start-dev` serves a management endpoint on :9000 once the
+      # realm is loaded — the canonical readiness probe.
+      test:
+        [
+          'CMD-SHELL',
+          "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q '200'",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
 volumes:
   qnop_pgdata:
   qnop_miniodata:
+  qnop_keycloakdata:

--- a/docker/keycloak/qnop-realm.json
+++ b/docker/keycloak/qnop-realm.json
@@ -1,0 +1,64 @@
+{
+  "realm": "qnop",
+  "displayName": "qnop (local development)",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+
+  "clients": [
+    {
+      "clientId": "qnop-local",
+      "name": "qnop (local backend)",
+      "description": "Local-only OIDC client used by qnop-app on http://localhost:8080. The realm, client secret, and user passwords are weak ON PURPOSE — never deploy this beyond localhost.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "local-dev-secret-do-not-use-in-prod",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/login/oauth2/code/*",
+        "http://localhost:5173/login/oauth2/code/*"
+      ],
+      "webOrigins": ["http://localhost:8080", "http://localhost:5173"],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:8080/*##http://localhost:5173/*"
+      },
+      "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email"],
+      "optionalClientScopes": ["address", "phone", "offline_access"]
+    }
+  ],
+
+  "users": [
+    {
+      "username": "alice",
+      "email": "alice@qnop.test",
+      "emailVerified": true,
+      "firstName": "Alice",
+      "lastName": "Example",
+      "enabled": true,
+      "credentials": [{ "type": "password", "value": "password", "temporary": false }]
+    },
+    {
+      "username": "bob",
+      "email": "bob@qnop.test",
+      "emailVerified": true,
+      "firstName": "Bob",
+      "lastName": "Example",
+      "enabled": true,
+      "credentials": [{ "type": "password", "value": "password", "temporary": false }]
+    }
+  ]
+}

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1601,10 +1601,38 @@ components:
         loginUrl:
           type: string
           description: Relative URL the frontend redirects to in order to start login.
+        iconKind:
+          $ref: '#/components/schemas/OidcIconKind'
+        accountPickerLoginUrl:
+          type: string
+          nullable: true
+          description: |
+            Relative login URL that forces the upstream account picker / re-auth
+            screen (adds an allow-listed `prompt`). Null when the provider cannot
+            honour it (e.g. GitHub), in which case the SPA renders a sign-out hint.
+        accountSwitchHintUrl:
+          type: string
+          nullable: true
+          description: |
+            Absolute upstream sign-out URL the SPA links to as a fallback when the
+            provider has no `prompt`-based account picker (today only GitHub). Null
+            otherwise.
       required:
         - id
         - name
         - loginUrl
+        - iconKind
+    OidcIconKind:
+      type: string
+      description: |
+        Which brand glyph the SPA renders on a provider's login button. Decoupled
+        from `OidcProviderTypeDto` so the icon set can evolve independently.
+      enum:
+        - github
+        - google
+        - facebook
+        - oidc
+        - oauth2
     ServerConfigGeneral:
       type: object
       description: General, application-wide public configuration.

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -22,6 +22,7 @@ package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.ServerConfigApi;
 import io.qnop.api.v1.model.Edition;
+import io.qnop.api.v1.model.OidcIconKind;
 import io.qnop.api.v1.model.OidcProviderLoginInfo;
 import io.qnop.api.v1.model.ServerConfigAuth;
 import io.qnop.api.v1.model.ServerConfigGeneral;
@@ -31,7 +32,6 @@ import io.qnop.api.v1.model.SupportedFormat;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.oidc.OidcProviderService;
-import io.qnop.service.oidc.OidcProviderView;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.http.ResponseEntity;
@@ -82,16 +82,18 @@ public class ConfigController implements ServerConfigApi {
     return ResponseEntity.ok(body);
   }
 
-  /** The enabled providers as login buttons for the SPA (issue #21). */
+  /** The enabled providers as login buttons for the SPA (issue #21), with icon + account-switch. */
   private List<OidcProviderLoginInfo> enabledOidcProviders() {
-    return oidcProviders.findAll().stream()
-        .filter(OidcProviderView::enabled)
+    return oidcProviders.enabledLoginViews().stream()
         .map(
             v ->
                 new OidcProviderLoginInfo()
-                    .id(v.id().toString())
+                    .id(v.id())
                     .name(v.name())
-                    .loginUrl("/oauth2/authorization/" + v.id()))
+                    .loginUrl(v.loginUrl())
+                    .iconKind(OidcIconKind.fromValue(v.iconKind()))
+                    .accountPickerLoginUrl(v.accountPickerLoginUrl())
+                    .accountSwitchHintUrl(v.accountSwitchHintUrl()))
         .toList();
   }
 

--- a/qnop-app/src/main/java/io/qnop/web/security/OidcLoginSuccessHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/OidcLoginSuccessHandler.java
@@ -23,6 +23,8 @@ package io.qnop.web.security;
 import io.qnop.security.QnopProperties;
 import io.qnop.service.RefreshTokenService;
 import io.qnop.service.RefreshTokenService.IssuedRefreshToken;
+import io.qnop.service.oidc.OidcAccountDisabledException;
+import io.qnop.service.oidc.OidcEmailMissingException;
 import io.qnop.service.oidc.OidcLoginService;
 import io.qnop.service.oidc.OidcLoginService.LoginResult;
 import jakarta.servlet.http.HttpServletRequest;
@@ -84,8 +86,22 @@ public class OidcLoginSuccessHandler implements AuthenticationSuccessHandler {
       response.sendRedirect(frontendBase());
     } catch (RuntimeException e) {
       log.warn("OIDC login could not be completed: {}", e.getMessage());
-      response.sendRedirect(frontendBase() + "/login?error=oidc");
+      response.sendRedirect(frontendBase() + "/login?error=" + errorCode(e));
     }
+  }
+
+  /**
+   * Maps a login failure to a stable, non-sensitive code the SPA turns into a localized message.
+   * Only the category crosses the redirect URL — never the raw exception text.
+   */
+  private static String errorCode(RuntimeException e) {
+    if (e instanceof OidcAccountDisabledException) {
+      return "account_disabled";
+    }
+    if (e instanceof OidcEmailMissingException) {
+      return "email_missing";
+    }
+    return "oidc";
   }
 
   private String providerAccessToken(OAuth2AuthenticationToken token) {

--- a/qnop-app/src/main/java/io/qnop/web/security/PromptAwareOAuth2AuthorizationRequestResolver.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/PromptAwareOAuth2AuthorizationRequestResolver.java
@@ -40,10 +40,10 @@ import org.springframework.stereotype.Component;
  * /oauth2/authorization/{id}?prompt=…}; this resolver validates that {@code prompt} strictly and
  * forwards it as {@code additionalParameters["prompt"]}.
  *
- * <p><strong>Allow-list:</strong> only {@code select_account} (OIDC/Google/Facebook) and {@code
- * login} (generic OAuth2) reach the upstream — anything else (consent, none, arbitrary or repeated
- * values) is dropped silently. This is the only defence against a caller injecting upstream
- * parameters via the query string.
+ * <p><strong>Allow-list:</strong> only {@code select_account} (Google/Facebook) and {@code login}
+ * (generic OIDC/OAuth2, broadly supported) reach the upstream — anything else (consent, none,
+ * arbitrary or repeated values) is dropped silently. This is the only defence against a caller
+ * injecting upstream parameters via the query string.
  *
  * <p><strong>GitHub carve-out:</strong> GitHub ignores {@code prompt}; for a GitHub provider the
  * request passes through unchanged (the SPA mirrors this by rendering a sign-out hint instead of a

--- a/qnop-app/src/main/java/io/qnop/web/security/PromptAwareOAuth2AuthorizationRequestResolver.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/PromptAwareOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import io.qnop.service.oidc.OidcProviderService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds the OIDC {@code prompt} query parameter to the upstream authorization request when the
+ * operator picked "Use a different account" on the login page (issue #106).
+ *
+ * <p>Spring's default resolver sends no {@code prompt}, so a logged-out qnop user clicking "Sign in
+ * with Google" is silently re-authenticated as the same upstream account (the IdP session cookie is
+ * still valid). The SPA renders a "Use a different account" link pointing at {@code
+ * /oauth2/authorization/{id}?prompt=…}; this resolver validates that {@code prompt} strictly and
+ * forwards it as {@code additionalParameters["prompt"]}.
+ *
+ * <p><strong>Allow-list:</strong> only {@code select_account} (OIDC/Google/Facebook) and {@code
+ * login} (generic OAuth2) reach the upstream — anything else (consent, none, arbitrary or repeated
+ * values) is dropped silently. This is the only defence against a caller injecting upstream
+ * parameters via the query string.
+ *
+ * <p><strong>GitHub carve-out:</strong> GitHub ignores {@code prompt}; for a GitHub provider the
+ * request passes through unchanged (the SPA mirrors this by rendering a sign-out hint instead of a
+ * link). The type lookup is delegated to {@link OidcProviderService#honoursPrompt(UUID)} so the web
+ * layer never touches the repository or the entity enum (ADR-0004).
+ *
+ * <p><strong>PKCE / state preservation:</strong> {@link OAuth2AuthorizationRequest#from} copies
+ * every other field — the PKCE {@code code_verifier} (in {@code attributes}), {@code state}, the
+ * resolved redirect URI, and the scopes — so adding {@code prompt} cannot drop them.
+ */
+@Component
+public class PromptAwareOAuth2AuthorizationRequestResolver
+    implements OAuth2AuthorizationRequestResolver {
+
+  static final String DEFAULT_AUTHORIZATION_REQUEST_BASE_URI = "/oauth2/authorization";
+
+  /** Spring's attribute key carrying the registration id on the resolved request. */
+  static final String REGISTRATION_ID_ATTR = "registration_id";
+
+  /** The closed set of {@code prompt} values forwarded upstream. */
+  static final Set<String> ALLOWED_PROMPT_VALUES = Set.of("select_account", "login");
+
+  private final DefaultOAuth2AuthorizationRequestResolver delegate;
+  private final OidcProviderService providers;
+
+  public PromptAwareOAuth2AuthorizationRequestResolver(
+      ClientRegistrationRepository clientRegistrationRepository, OidcProviderService providers) {
+    this.delegate =
+        new DefaultOAuth2AuthorizationRequestResolver(
+            clientRegistrationRepository, DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+    this.providers = providers;
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+    OAuth2AuthorizationRequest resolved = delegate.resolve(request);
+    return resolved == null ? null : maybeAddPrompt(request, resolved);
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(
+      HttpServletRequest request, String clientRegistrationId) {
+    OAuth2AuthorizationRequest resolved = delegate.resolve(request, clientRegistrationId);
+    return resolved == null ? null : maybeAddPrompt(request, resolved);
+  }
+
+  OAuth2AuthorizationRequest maybeAddPrompt(
+      HttpServletRequest request, OAuth2AuthorizationRequest resolved) {
+    String prompt = whitelistedPrompt(request);
+    if (prompt == null) {
+      return resolved;
+    }
+    if (!(resolved.getAttributes().get(REGISTRATION_ID_ATTR) instanceof String registrationId)) {
+      return resolved;
+    }
+    UUID providerId;
+    try {
+      providerId = UUID.fromString(registrationId);
+    } catch (IllegalArgumentException e) {
+      return resolved;
+    }
+    if (!providers.honoursPrompt(providerId)) {
+      return resolved;
+    }
+    return OAuth2AuthorizationRequest.from(resolved)
+        .additionalParameters(params -> params.put("prompt", prompt))
+        .build();
+  }
+
+  /**
+   * Returns the inbound {@code ?prompt=…} only when it is exactly one allow-listed value. Null for
+   * a missing, unknown, empty, or repeated parameter (pollution defence).
+   */
+  private static String whitelistedPrompt(HttpServletRequest request) {
+    String[] values = request.getParameterValues("prompt");
+    if (values == null || values.length != 1) {
+      return null;
+    }
+    return ALLOWED_PROMPT_VALUES.contains(values[0]) ? values[0] : null;
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -189,6 +189,7 @@ public class SecurityConfiguration {
       HttpSecurity http,
       ClientRegistrationRepository clientRegistrationRepository,
       OidcLoginSuccessHandler oidcLoginSuccessHandler,
+      PromptAwareOAuth2AuthorizationRequestResolver promptAwareResolver,
       CorsConfigurationSource corsConfigurationSource)
       throws Exception {
     http.securityMatcher("/oauth2/authorization/**", "/login/oauth2/code/**")
@@ -197,6 +198,8 @@ public class SecurityConfiguration {
             oauth2 ->
                 oauth2
                     .clientRegistrationRepository(clientRegistrationRepository)
+                    .authorizationEndpoint(
+                        endpoint -> endpoint.authorizationRequestResolver(promptAwareResolver))
                     .successHandler(oidcLoginSuccessHandler))
         .cors(cors -> cors.configurationSource(corsConfigurationSource))
         .csrf(csrf -> csrf.disable())

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -40,5 +40,11 @@ qnop:
     jwt-secret: ${QNOP_AUTH_JWT_SECRET:CHANGE_ME}
     encryption-key: ${QNOP_AUTH_ENCRYPTION_KEY:CHANGE_ME}
     encryption-salt: ${QNOP_AUTH_ENCRYPTION_SALT:CHANGE_ME}
+    # OIDC discovery against a private/loopback issuer (e.g. a local Keycloak on
+    # http://localhost) is blocked by default as an SSRF guard (issue #21). The
+    # local-dev .env turns this on so the bundled Keycloak works out of the box.
+    # NEVER enable in production.
+    oidc:
+      allow-private-discovery-uris: ${QNOP_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS:false}
   cors:
     allowed-origins: ${QNOP_CORS_ALLOWED_ORIGINS:http://localhost:5173}

--- a/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
@@ -27,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.oidc.OidcProviderLoginView;
 import io.qnop.service.oidc.OidcProviderService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,7 +60,7 @@ class ConfigControllerTest {
   @BeforeEach
   void setUp() {
     // No providers configured: auth.oidcProviders should serialize as an empty list.
-    when(oidcProviders.findAll()).thenReturn(List.of());
+    when(oidcProviders.enabledLoginViews()).thenReturn(List.of());
     when(settings.getBoolean(ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED))
         .thenReturn(false);
   }
@@ -90,6 +91,43 @@ class ConfigControllerTest {
         .perform(get("/api/v1/config"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.auth.selfRegistrationEnabled").value(true));
+  }
+
+  @Test
+  @DisplayName("enabled providers expose icon kind and account-switch affordances")
+  void getConfig_mapsOidcLoginInfoFields() throws Exception {
+    String googleLogin = "/oauth2/authorization/11111111-1111-1111-1111-111111111111";
+    String githubLogin = "/oauth2/authorization/22222222-2222-2222-2222-222222222222";
+    when(oidcProviders.enabledLoginViews())
+        .thenReturn(
+            List.of(
+                new OidcProviderLoginView(
+                    "11111111-1111-1111-1111-111111111111",
+                    "Google",
+                    googleLogin,
+                    "google",
+                    googleLogin + "?prompt=select_account",
+                    null),
+                new OidcProviderLoginView(
+                    "22222222-2222-2222-2222-222222222222",
+                    "GitHub",
+                    githubLogin,
+                    "github",
+                    null,
+                    "https://github.com/logout")));
+
+    mockMvc
+        .perform(get("/api/v1/config"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.auth.oidcProviders[0].name").value("Google"))
+        .andExpect(jsonPath("$.auth.oidcProviders[0].iconKind").value("google"))
+        .andExpect(
+            jsonPath("$.auth.oidcProviders[0].accountPickerLoginUrl")
+                .value(googleLogin + "?prompt=select_account"))
+        .andExpect(jsonPath("$.auth.oidcProviders[1].iconKind").value("github"))
+        .andExpect(
+            jsonPath("$.auth.oidcProviders[1].accountSwitchHintUrl")
+                .value("https://github.com/logout"));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/security/PromptAwareOAuth2AuthorizationRequestResolverTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/PromptAwareOAuth2AuthorizationRequestResolverTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+import io.qnop.service.oidc.OidcProviderService;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+
+/**
+ * Unit tests for {@link PromptAwareOAuth2AuthorizationRequestResolver}. Exercises the prompt
+ * allow-list, the GitHub carve-out, and — most importantly — that adding {@code prompt} preserves
+ * the PKCE {@code code_verifier}, {@code state}, redirect URI, and scopes (issue #106).
+ */
+@ExtendWith(MockitoExtension.class)
+class PromptAwareOAuth2AuthorizationRequestResolverTest {
+
+  private static final UUID PROVIDER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+  @Mock private ClientRegistrationRepository clientRegistrationRepository;
+  @Mock private OidcProviderService providers;
+
+  private PromptAwareOAuth2AuthorizationRequestResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    resolver =
+        new PromptAwareOAuth2AuthorizationRequestResolver(clientRegistrationRepository, providers);
+  }
+
+  @Test
+  @DisplayName("forwards an allow-listed prompt and preserves PKCE, state, redirect, and scopes")
+  void addsPrompt_andPreservesCriticalFields() {
+    lenient().when(providers.honoursPrompt(PROVIDER_ID)).thenReturn(true);
+    OAuth2AuthorizationRequest base = baseRequest(PROVIDER_ID.toString());
+
+    OAuth2AuthorizationRequest result =
+        resolver.maybeAddPrompt(requestWithPrompt("select_account"), base);
+
+    assertThat(result.getAdditionalParameters()).containsEntry("prompt", "select_account");
+    assertThat(result.getAttributes()).containsEntry(PkceParameterNames.CODE_VERIFIER, "verifier");
+    assertThat(result.getState()).isEqualTo("state-xyz");
+    assertThat(result.getRedirectUri()).isEqualTo(base.getRedirectUri());
+    assertThat(result.getScopes()).containsExactlyInAnyOrder("openid", "email");
+  }
+
+  @Test
+  @DisplayName("drops a non-allow-listed prompt value")
+  void dropsUnknownPrompt() {
+    OAuth2AuthorizationRequest base = baseRequest(PROVIDER_ID.toString());
+
+    OAuth2AuthorizationRequest result = resolver.maybeAddPrompt(requestWithPrompt("consent"), base);
+
+    assertThat(result).isSameAs(base);
+    assertThat(result.getAdditionalParameters()).doesNotContainKey("prompt");
+  }
+
+  @Test
+  @DisplayName("drops a repeated prompt parameter (pollution defence)")
+  void dropsRepeatedPrompt() {
+    OAuth2AuthorizationRequest base = baseRequest(PROVIDER_ID.toString());
+
+    OAuth2AuthorizationRequest result =
+        resolver.maybeAddPrompt(requestWithPrompt("select_account", "login"), base);
+
+    assertThat(result).isSameAs(base);
+  }
+
+  @Test
+  @DisplayName("passes a GitHub provider through unchanged (it ignores prompt)")
+  void githubPassesThrough() {
+    lenient().when(providers.honoursPrompt(PROVIDER_ID)).thenReturn(false);
+    OAuth2AuthorizationRequest base = baseRequest(PROVIDER_ID.toString());
+
+    OAuth2AuthorizationRequest result =
+        resolver.maybeAddPrompt(requestWithPrompt("select_account"), base);
+
+    assertThat(result).isSameAs(base);
+    assertThat(result.getAdditionalParameters()).doesNotContainKey("prompt");
+  }
+
+  @Test
+  @DisplayName("leaves the request untouched when the registration id is not a UUID")
+  void malformedRegistrationId() {
+    OAuth2AuthorizationRequest base = baseRequest("not-a-uuid");
+
+    OAuth2AuthorizationRequest result =
+        resolver.maybeAddPrompt(requestWithPrompt("select_account"), base);
+
+    assertThat(result).isSameAs(base);
+  }
+
+  private static OAuth2AuthorizationRequest baseRequest(String registrationId) {
+    return OAuth2AuthorizationRequest.authorizationCode()
+        .authorizationUri("https://idp.example.com/authorize")
+        .clientId("client-123")
+        .redirectUri("https://app.example.com/login/oauth2/code/" + registrationId)
+        .scopes(Set.of("openid", "email"))
+        .state("state-xyz")
+        .attributes(
+            attrs -> {
+              attrs.put("registration_id", registrationId);
+              attrs.put(PkceParameterNames.CODE_VERIFIER, "verifier");
+            })
+        .build();
+  }
+
+  private static MockHttpServletRequest requestWithPrompt(String... prompts) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addParameter("prompt", prompts);
+    return request;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
@@ -173,6 +173,17 @@ public class AdminUserService {
     }
     user.setRole(newRole);
     user.setEnabled(newEnabled);
+
+    // Disabling must end access immediately (mirrors the admin password reset): invalidate live
+    // access tokens and revoke refresh families, so a disabled user cannot keep using or refreshing
+    // a session. flush() persists the enabled change before bumpPasswordInvalidatedBefore clears
+    // the
+    // persistence context.
+    if (disabling) {
+      users.flush();
+      users.bumpPasswordInvalidatedBefore(id, Instant.now());
+      refreshTokens.revokeAllForUser(id);
+    }
     return toView(user, null);
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcAccountDisabledException.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcAccountDisabledException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+/**
+ * Raised when an OIDC/OAuth2 login resolves to a local account that is disabled. Mirrors the local
+ * login, which rejects a disabled user, so an admin disabling an account blocks both sign-in paths.
+ */
+public class OidcAccountDisabledException extends RuntimeException {
+
+  public OidcAccountDisabledException(String message) {
+    super(message);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcLoginInfoFactory.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcLoginInfoFactory.java
@@ -71,13 +71,15 @@ public final class OidcLoginInfoFactory {
 
   /**
    * The "use a different account" URL, or {@code null} when the provider cannot honour a {@code
-   * prompt}. {@code select_account} pops the picker (OIDC/Google/Facebook); {@code login} forces a
-   * fresh upstream auth (generic OAuth2); GitHub has neither.
+   * prompt}. Google and Facebook honour {@code select_account} (a real account picker). Generic
+   * OIDC/OAuth2 providers (e.g. Keycloak) frequently ignore {@code select_account} and silently
+   * re-use the session, so they get the universally-supported {@code login} (force re-auth), which
+   * still lets the user sign in as a different account. GitHub honours neither.
    */
   static String accountPickerLoginUrl(OidcProviderType type, String loginUrl) {
     return switch (type) {
-      case OIDC, GOOGLE, FACEBOOK -> loginUrl + "?prompt=select_account";
-      case OAUTH2 -> loginUrl + "?prompt=login";
+      case GOOGLE, FACEBOOK -> loginUrl + "?prompt=select_account";
+      case OIDC, OAUTH2 -> loginUrl + "?prompt=login";
       case GITHUB -> null;
     };
   }

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcLoginInfoFactory.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcLoginInfoFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import io.qnop.entity.OidcProvider;
+import io.qnop.entity.OidcProviderType;
+
+/**
+ * Derives the public login-button projection ({@link OidcProviderLoginView}) for an enabled OIDC
+ * provider (issue #21/#106). Pure, DB-free, and unit-testable per the architecture guardrail —
+ * keeps the icon/account-switch rules out of the {@code @Transactional} service methods.
+ *
+ * <p>The {@code accountPickerLoginUrl} appends an allow-listed {@code prompt} that {@link
+ * io.qnop.web.security.PromptAwareOAuth2AuthorizationRequestResolver} forwards upstream; the
+ * derivation here must stay in lock-step with that resolver's allow-list.
+ */
+public final class OidcLoginInfoFactory {
+
+  /** Spring's OAuth2 authorization-start base path; the registration id is the provider UUID. */
+  private static final String AUTHORIZATION_BASE = "/oauth2/authorization/";
+
+  /**
+   * GitHub honours no {@code prompt} parameter, so there is no in-product account picker; the SPA
+   * instead links to GitHub's sign-out as an honest fallback.
+   */
+  private static final String GITHUB_SIGN_OUT_URL = "https://github.com/logout";
+
+  private OidcLoginInfoFactory() {}
+
+  /** Builds the login-page projection for one (already-enabled) provider. */
+  public static OidcProviderLoginView loginView(OidcProvider provider) {
+    String loginUrl = AUTHORIZATION_BASE + provider.getId();
+    OidcProviderType type = provider.getProviderType();
+    return new OidcProviderLoginView(
+        provider.getId().toString(),
+        provider.getName(),
+        loginUrl,
+        iconKind(type),
+        accountPickerLoginUrl(type, loginUrl),
+        accountSwitchHintUrl(type));
+  }
+
+  /** Brand glyph key for the SPA; decoupled 1:1 from the provider type. */
+  static String iconKind(OidcProviderType type) {
+    return switch (type) {
+      case GITHUB -> "github";
+      case GOOGLE -> "google";
+      case FACEBOOK -> "facebook";
+      case OIDC -> "oidc";
+      case OAUTH2 -> "oauth2";
+    };
+  }
+
+  /**
+   * The "use a different account" URL, or {@code null} when the provider cannot honour a {@code
+   * prompt}. {@code select_account} pops the picker (OIDC/Google/Facebook); {@code login} forces a
+   * fresh upstream auth (generic OAuth2); GitHub has neither.
+   */
+  static String accountPickerLoginUrl(OidcProviderType type, String loginUrl) {
+    return switch (type) {
+      case OIDC, GOOGLE, FACEBOOK -> loginUrl + "?prompt=select_account";
+      case OAUTH2 -> loginUrl + "?prompt=login";
+      case GITHUB -> null;
+    };
+  }
+
+  /** Upstream sign-out URL fallback — today only GitHub, which ignores {@code prompt}. */
+  static String accountSwitchHintUrl(OidcProviderType type) {
+    return type == OidcProviderType.GITHUB ? GITHUB_SIGN_OUT_URL : null;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcLoginService.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcLoginService.java
@@ -72,6 +72,11 @@ public class OidcLoginService {
       throw new IllegalStateException("OIDC login returned no subject for provider " + providerId);
     }
     User user = identityService.upsertOnLogin(provider, principal);
+    // An admin can disable an account; honour it on the OIDC path too, mirroring the local login.
+    if (!user.isEnabled()) {
+      throw new OidcAccountDisabledException(
+          "The account linked to this " + provider.getName() + " login is disabled.");
+    }
     return new LoginResult(user.getId(), principal.upstreamIdToken());
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderLoginView.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderLoginView.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+/**
+ * Public, login-page projection of one enabled OIDC provider (issue #21). Carries only the
+ * non-sensitive fields the SPA renders on a "Sign in with …" button, plus the derived
+ * account-switch affordances. The web layer maps this straight onto the {@code
+ * OidcProviderLoginInfo} DTO, so the entity (and its {@code OidcProviderType} enum) never leaks
+ * past the service boundary (ADR-0004).
+ *
+ * @param accountPickerLoginUrl relative login URL that forces the upstream account picker (adds an
+ *     allow-listed {@code prompt}); {@code null} when the provider cannot honour it (e.g. GitHub).
+ * @param accountSwitchHintUrl absolute upstream sign-out URL used as the GitHub fallback; {@code
+ *     null} otherwise.
+ */
+public record OidcProviderLoginView(
+    String id,
+    String name,
+    String loginUrl,
+    String iconKind,
+    String accountPickerLoginUrl,
+    String accountSwitchHintUrl) {}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
@@ -111,10 +111,18 @@ public class OidcProviderService {
       ssrfPolicy.requirePublicHttpUri(trimmed, "issuerUri", true);
     } catch (IllegalArgumentException e) {
       log.warn("OIDC discovery rejected for issuerUri={}: {}", trimmed, e.getMessage());
-      return OidcDiscoveryOutcome.failure(DISCOVERY_FAILED);
+      return OidcDiscoveryOutcome.failure(e.getMessage());
     }
     try {
-      ClientRegistration registration = ClientRegistrations.fromIssuerLocation(trimmed).build();
+      // fromIssuerLocation fetches the discovery document and pre-fills the endpoints; build()
+      // still validates a registrationId + clientId, which a pure endpoint probe does not have.
+      // Supply throwaway placeholders so the build succeeds without the operator's real
+      // credentials.
+      ClientRegistration registration =
+          ClientRegistrations.fromIssuerLocation(trimmed)
+              .registrationId("discovery")
+              .clientId("discovery")
+              .build();
       ClientRegistration.ProviderDetails details = registration.getProviderDetails();
       return new OidcDiscoveryOutcome(
           true,
@@ -125,8 +133,21 @@ public class OidcProviderService {
           null);
     } catch (RuntimeException e) {
       log.debug("OIDC discovery failed for issuerUri={}: {}", trimmed, e.getMessage());
-      return OidcDiscoveryOutcome.failure(DISCOVERY_FAILED);
+      return OidcDiscoveryOutcome.failure(discoveryFailureMessage(e));
     }
+  }
+
+  /**
+   * A discovery-failure message that keeps the actionable hint and appends the underlying cause.
+   * Discovery is an admin-only probe against an operator-supplied issuer, so the cause (a Spring
+   * {@code ClientRegistrations} message, e.g. an unreachable issuer or a malformed document) aids
+   * diagnosis without leaking qnop internals.
+   */
+  private static String discoveryFailureMessage(Throwable cause) {
+    String detail = cause.getMessage();
+    return detail == null || detail.isBlank()
+        ? DISCOVERY_FAILED
+        : DISCOVERY_FAILED + " (" + detail + ")";
   }
 
   /** Creates a disabled provider (the operator enables it after verifying the configuration). */

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
@@ -74,6 +74,32 @@ public class OidcProviderService {
     return toView(require(id));
   }
 
+  /**
+   * The enabled providers as public login-page button projections (issue #21), each carrying the
+   * derived brand icon and account-switch affordances ({@link OidcLoginInfoFactory}).
+   */
+  @Transactional(readOnly = true)
+  public List<OidcProviderLoginView> enabledLoginViews() {
+    return providers.findAll().stream()
+        .filter(OidcProvider::isEnabled)
+        .map(OidcLoginInfoFactory::loginView)
+        .toList();
+  }
+
+  /**
+   * Whether the provider honours an OIDC {@code prompt} hint, used by {@link
+   * io.qnop.web.security.PromptAwareOAuth2AuthorizationRequestResolver} for the account-switch
+   * affordance. True for every type except GitHub, which silently ignores {@code prompt}; an
+   * unknown id is {@code false} so the resolver leaves the request untouched.
+   */
+  @Transactional(readOnly = true)
+  public boolean honoursPrompt(UUID id) {
+    return providers
+        .findById(id)
+        .map(p -> p.getProviderType() != OidcProviderType.GITHUB)
+        .orElse(false);
+  }
+
   /** Probes an issuer for OIDC discovery support without persisting anything. */
   @Transactional(readOnly = true)
   public OidcDiscoveryOutcome discoverEndpoints(String issuerUri) {

--- a/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
@@ -170,6 +170,37 @@ class AdminUserServiceTest {
   }
 
   @Test
+  @DisplayName("disabling a user revokes their active sessions")
+  void updateDisablingRevokesSessions() {
+    UUID id = UUID.randomUUID();
+    User member = User.internal("Member", "m@example.com", "m", "h");
+    member.setRole(UserRole.MEMBER);
+    member.setEnabled(true);
+    when(users.findById(id)).thenReturn(Optional.of(member));
+
+    service.update(id, null, null, false, UUID.randomUUID());
+
+    assertThat(member.isEnabled()).isFalse();
+    verify(users).bumpPasswordInvalidatedBefore(eq(id), any());
+    verify(refreshTokens).revokeAllForUser(id);
+  }
+
+  @Test
+  @DisplayName("a non-disabling update leaves the user's sessions untouched")
+  void updateWithoutDisablingKeepsSessions() {
+    UUID id = UUID.randomUUID();
+    User member = User.internal("Old", "m@example.com", "m", "h");
+    member.setRole(UserRole.MEMBER);
+    member.setEnabled(true);
+    when(users.findById(id)).thenReturn(Optional.of(member));
+
+    service.update(id, "New", null, null, UUID.randomUUID());
+
+    verify(refreshTokens, never()).revokeAllForUser(any());
+    verify(users, never()).bumpPasswordInvalidatedBefore(any(), any());
+  }
+
+  @Test
   @DisplayName("delete rejects self and the last admin, and removes any other user")
   void delete() {
     UUID selfId = UUID.randomUUID();

--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcLoginInfoFactoryTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcLoginInfoFactoryTest.java
@@ -46,10 +46,8 @@ class OidcLoginInfoFactoryTest {
   }
 
   @Test
-  @DisplayName("OIDC-style providers get a select_account account picker")
-  void accountPicker_selectAccountForIdpStyleProviders() {
-    assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.OIDC, LOGIN_URL))
-        .isEqualTo(LOGIN_URL + "?prompt=select_account");
+  @DisplayName("Google and Facebook get a select_account account picker")
+  void accountPicker_selectAccountForNamedVendors() {
     assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.GOOGLE, LOGIN_URL))
         .isEqualTo(LOGIN_URL + "?prompt=select_account");
     assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.FACEBOOK, LOGIN_URL))
@@ -57,8 +55,10 @@ class OidcLoginInfoFactoryTest {
   }
 
   @Test
-  @DisplayName("generic OAuth2 gets a login (re-auth) prompt instead of a picker")
-  void accountPicker_loginPromptForGenericOauth2() {
+  @DisplayName("generic OIDC/OAuth2 get the broadly-supported login (re-auth) prompt")
+  void accountPicker_loginPromptForGenericProviders() {
+    assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.OIDC, LOGIN_URL))
+        .isEqualTo(LOGIN_URL + "?prompt=login");
     assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.OAUTH2, LOGIN_URL))
         .isEqualTo(LOGIN_URL + "?prompt=login");
   }

--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcLoginInfoFactoryTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcLoginInfoFactoryTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.entity.OidcProviderType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the pure login-button derivation (issue #106). Pins the icon mapping and the
+ * account-switch rules — they must stay in lock-step with {@code
+ * PromptAwareOAuth2AuthorizationRequestResolver}'s prompt allow-list.
+ */
+class OidcLoginInfoFactoryTest {
+
+  private static final String LOGIN_URL = "/oauth2/authorization/p1";
+
+  @Test
+  @DisplayName("iconKind maps each provider type to its brand glyph key")
+  void iconKind_mapsEachType() {
+    assertThat(OidcLoginInfoFactory.iconKind(OidcProviderType.GITHUB)).isEqualTo("github");
+    assertThat(OidcLoginInfoFactory.iconKind(OidcProviderType.GOOGLE)).isEqualTo("google");
+    assertThat(OidcLoginInfoFactory.iconKind(OidcProviderType.FACEBOOK)).isEqualTo("facebook");
+    assertThat(OidcLoginInfoFactory.iconKind(OidcProviderType.OIDC)).isEqualTo("oidc");
+    assertThat(OidcLoginInfoFactory.iconKind(OidcProviderType.OAUTH2)).isEqualTo("oauth2");
+  }
+
+  @Test
+  @DisplayName("OIDC-style providers get a select_account account picker")
+  void accountPicker_selectAccountForIdpStyleProviders() {
+    assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.OIDC, LOGIN_URL))
+        .isEqualTo(LOGIN_URL + "?prompt=select_account");
+    assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.GOOGLE, LOGIN_URL))
+        .isEqualTo(LOGIN_URL + "?prompt=select_account");
+    assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.FACEBOOK, LOGIN_URL))
+        .isEqualTo(LOGIN_URL + "?prompt=select_account");
+  }
+
+  @Test
+  @DisplayName("generic OAuth2 gets a login (re-auth) prompt instead of a picker")
+  void accountPicker_loginPromptForGenericOauth2() {
+    assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.OAUTH2, LOGIN_URL))
+        .isEqualTo(LOGIN_URL + "?prompt=login");
+  }
+
+  @Test
+  @DisplayName("GitHub has no account picker but gets a sign-out hint")
+  void github_noPickerButHasSignOutHint() {
+    assertThat(OidcLoginInfoFactory.accountPickerLoginUrl(OidcProviderType.GITHUB, LOGIN_URL))
+        .isNull();
+    assertThat(OidcLoginInfoFactory.accountSwitchHintUrl(OidcProviderType.GITHUB))
+        .isEqualTo("https://github.com/logout");
+  }
+
+  @Test
+  @DisplayName("non-GitHub providers carry no sign-out hint")
+  void nonGithub_noSignOutHint() {
+    assertThat(OidcLoginInfoFactory.accountSwitchHintUrl(OidcProviderType.OIDC)).isNull();
+    assertThat(OidcLoginInfoFactory.accountSwitchHintUrl(OidcProviderType.GOOGLE)).isNull();
+    assertThat(OidcLoginInfoFactory.accountSwitchHintUrl(OidcProviderType.FACEBOOK)).isNull();
+    assertThat(OidcLoginInfoFactory.accountSwitchHintUrl(OidcProviderType.OAUTH2)).isNull();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcLoginServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcLoginServiceTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.OidcProvider;
+import io.qnop.entity.User;
+import io.qnop.repository.OidcProviderRepository;
+import io.qnop.service.oidc.OidcLoginService.LoginResult;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+
+/**
+ * Unit tests for the OIDC login bridge (issue #21/#106). Pins the security gate: a disabled local
+ * account must be rejected on the OIDC path, mirroring the local login.
+ */
+@ExtendWith(MockitoExtension.class)
+class OidcLoginServiceTest {
+
+  @Mock private OidcProviderRepository providers;
+  @Mock private OidcPrincipalResolver principalResolver;
+  @Mock private OidcIdentityService identityService;
+  @Mock private OAuth2AuthenticationToken authentication;
+
+  private OidcLoginService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new OidcLoginService(providers, principalResolver, identityService);
+  }
+
+  @Test
+  @DisplayName("rejects the login when the linked account is disabled")
+  void rejectsDisabledAccount() {
+    UUID providerId = UUID.randomUUID();
+    OidcProvider provider = mock(OidcProvider.class);
+    when(provider.isEnabled()).thenReturn(true);
+    when(provider.getName()).thenReturn("keycloak");
+    User user = mock(User.class);
+    when(user.isEnabled()).thenReturn(false);
+    ResolvedPrincipal principal = new ResolvedPrincipal("sub-1", "bob@example.com", "Bob", null);
+
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(providerId.toString());
+    when(providers.findById(providerId)).thenReturn(Optional.of(provider));
+    when(principalResolver.resolve(authentication, provider, "tok")).thenReturn(principal);
+    when(identityService.upsertOnLogin(provider, principal)).thenReturn(user);
+
+    assertThatThrownBy(() -> service.completeLogin(authentication, "tok"))
+        .isInstanceOf(OidcAccountDisabledException.class);
+  }
+
+  @Test
+  @DisplayName("completes the login for an enabled account")
+  void completesForEnabledAccount() {
+    UUID providerId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    OidcProvider provider = mock(OidcProvider.class);
+    when(provider.isEnabled()).thenReturn(true);
+    User user = mock(User.class);
+    when(user.isEnabled()).thenReturn(true);
+    when(user.getId()).thenReturn(userId);
+    ResolvedPrincipal principal = new ResolvedPrincipal("sub-1", "bob@example.com", "Bob", "idtok");
+
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(providerId.toString());
+    when(providers.findById(providerId)).thenReturn(Optional.of(provider));
+    when(principalResolver.resolve(authentication, provider, "tok")).thenReturn(principal);
+    when(identityService.upsertOnLogin(provider, principal)).thenReturn(user);
+    lenient().when(provider.getName()).thenReturn("keycloak");
+
+    LoginResult result = service.completeLogin(authentication, "tok");
+
+    assertThat(result.userId()).isEqualTo(userId);
+    assertThat(result.upstreamIdToken()).isEqualTo("idtok");
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcProviderServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcProviderServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 import io.qnop.entity.OidcProvider;
 import io.qnop.repository.OidcProviderRepository;
+import io.qnop.service.oidc.OidcProviderService.OidcDiscoveryOutcome;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -111,5 +112,25 @@ class OidcProviderServiceTest {
     when(providers.existsById(id)).thenReturn(false);
 
     assertThatThrownBy(() -> service.delete(id)).isInstanceOf(OidcProviderNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("discovery rejects a blank issuer with a clear message")
+  void discoverBlankIssuer() {
+    OidcDiscoveryOutcome outcome = service.discoverEndpoints("   ");
+
+    assertThat(outcome.success()).isFalse();
+    assertThat(outcome.error()).contains("must not be blank");
+  }
+
+  @Test
+  @DisplayName("discovery surfaces the SSRF rejection reason instead of a generic message")
+  void discoverBlockedHostSurfacesReason() {
+    // The default policy blocks loopback; the reason must reach the caller (issue #106), not be
+    // swallowed behind a generic "discovery failed" text.
+    OidcDiscoveryOutcome outcome = service.discoverEndpoints("http://localhost:8081/realms/qnop");
+
+    assertThat(outcome.success()).isFalse();
+    assertThat(outcome.error()).contains("blocked");
   }
 }

--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -21,6 +21,7 @@
 
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import {
+  AdminOidcProvidersApi,
   AdminSettingsApi,
   AdminTeamsApi,
   AdminUsersApi,
@@ -88,3 +89,4 @@ export const authPasswordResetApi = new AuthPasswordResetApi(undefined, undefine
 export const adminUsersApi = new AdminUsersApi(undefined, undefined, axiosInstance);
 export const adminTeamsApi = new AdminTeamsApi(undefined, undefined, axiosInstance);
 export const adminSettingsApi = new AdminSettingsApi(undefined, undefined, axiosInstance);
+export const adminOidcProvidersApi = new AdminOidcProvidersApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useOidcProviders.test.tsx
+++ b/qnop-ui/src/api/hooks/useOidcProviders.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { OidcProviderListResponse } from '../generated';
+import {
+  oidcProviderKeys,
+  useCreateOidcProvider,
+  useDeleteOidcProvider,
+  useDiscoverOidcEndpoints,
+  useOidcProviders,
+  useUpdateOidcProvider,
+} from './useOidcProviders';
+import { adminOidcProvidersApi } from '../config';
+
+const EMPTY: OidcProviderListResponse = { providers: [] };
+
+vi.mock('../config', () => ({
+  adminOidcProvidersApi: {
+    listOidcProviders: vi.fn(),
+    createOidcProvider: vi.fn(),
+    updateOidcProvider: vi.fn(),
+    deleteOidcProvider: vi.fn(),
+    discoverOidcEndpoints: vi.fn(),
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('oidcProviderKeys', () => {
+  it('namespaces the providers query', () => {
+    expect(oidcProviderKeys.all).toEqual(['admin', 'oidc-providers']);
+  });
+});
+
+describe('useOidcProviders', () => {
+  it('fetches and returns the providers list', async () => {
+    vi.mocked(adminOidcProvidersApi.listOidcProviders).mockResolvedValue({
+      data: EMPTY,
+    } as Awaited<ReturnType<typeof adminOidcProvidersApi.listOidcProviders>>);
+
+    const { result } = renderHook(() => useOidcProviders(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(adminOidcProvidersApi.listOidcProviders).toHaveBeenCalled();
+    expect(result.current.data?.providers).toEqual([]);
+  });
+});
+
+describe('useCreateOidcProvider', () => {
+  it('wraps the create request', async () => {
+    vi.mocked(adminOidcProvidersApi.createOidcProvider).mockResolvedValue({ data: {} } as Awaited<
+      ReturnType<typeof adminOidcProvidersApi.createOidcProvider>
+    >);
+
+    const { result } = renderHook(() => useCreateOidcProvider(), { wrapper });
+    await result.current.mutateAsync({
+      name: 'Google',
+      providerType: 'GOOGLE',
+      clientId: 'cid',
+      clientSecret: 'secret',
+    });
+
+    expect(adminOidcProvidersApi.createOidcProvider).toHaveBeenCalledWith({
+      oidcProviderCreateRequest: {
+        name: 'Google',
+        providerType: 'GOOGLE',
+        clientId: 'cid',
+        clientSecret: 'secret',
+      },
+    });
+  });
+});
+
+describe('useUpdateOidcProvider', () => {
+  it('forwards the id and patch', async () => {
+    vi.mocked(adminOidcProvidersApi.updateOidcProvider).mockResolvedValue({ data: {} } as Awaited<
+      ReturnType<typeof adminOidcProvidersApi.updateOidcProvider>
+    >);
+
+    const { result } = renderHook(() => useUpdateOidcProvider(), { wrapper });
+    await result.current.mutateAsync({ id: 'p1', request: { enabled: true } });
+
+    expect(adminOidcProvidersApi.updateOidcProvider).toHaveBeenCalledWith({
+      providerId: 'p1',
+      oidcProviderUpdateRequest: { enabled: true },
+    });
+  });
+});
+
+describe('useDeleteOidcProvider', () => {
+  it('deletes by id', async () => {
+    vi.mocked(adminOidcProvidersApi.deleteOidcProvider).mockResolvedValue({
+      data: undefined,
+    } as Awaited<ReturnType<typeof adminOidcProvidersApi.deleteOidcProvider>>);
+
+    const { result } = renderHook(() => useDeleteOidcProvider(), { wrapper });
+    await result.current.mutateAsync('p9');
+
+    expect(adminOidcProvidersApi.deleteOidcProvider).toHaveBeenCalledWith({ providerId: 'p9' });
+  });
+});
+
+describe('useDiscoverOidcEndpoints', () => {
+  it('wraps the issuer URI and returns the discovery outcome', async () => {
+    vi.mocked(adminOidcProvidersApi.discoverOidcEndpoints).mockResolvedValue({
+      data: { success: true, authorizationUri: 'https://idp/auth' },
+    } as Awaited<ReturnType<typeof adminOidcProvidersApi.discoverOidcEndpoints>>);
+
+    const { result } = renderHook(() => useDiscoverOidcEndpoints(), { wrapper });
+    const outcome = await result.current.mutateAsync('https://idp');
+
+    expect(adminOidcProvidersApi.discoverOidcEndpoints).toHaveBeenCalledWith({
+      oidcDiscoveryRequest: { issuerUri: 'https://idp' },
+    });
+    expect(outcome.success).toBe(true);
+  });
+});

--- a/qnop-ui/src/api/hooks/useOidcProviders.ts
+++ b/qnop-ui/src/api/hooks/useOidcProviders.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  OidcDiscoveryResponse,
+  OidcProviderCreateRequest,
+  OidcProviderListResponse,
+  OidcProviderUpdateRequest,
+} from '../generated';
+import { adminOidcProvidersApi } from '../config';
+
+export const oidcProviderKeys = {
+  all: ['admin', 'oidc-providers'] as const,
+};
+
+/** All configured OIDC/OAuth2 identity providers. */
+export function useOidcProviders() {
+  return useQuery<OidcProviderListResponse>({
+    queryKey: oidcProviderKeys.all,
+    queryFn: async () => {
+      const response = await adminOidcProvidersApi.listOidcProviders();
+      return response.data;
+    },
+  });
+}
+
+/** Creates a provider (starts disabled until verified), then refreshes the list. */
+export function useCreateOidcProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request: OidcProviderCreateRequest) => {
+      const response = await adminOidcProvidersApi.createOidcProvider({
+        oidcProviderCreateRequest: request,
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: oidcProviderKeys.all }),
+  });
+}
+
+/** Updates a provider (blank client secret keeps the stored one), then refreshes. */
+export function useUpdateOidcProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { id: string; request: OidcProviderUpdateRequest }) => {
+      const response = await adminOidcProvidersApi.updateOidcProvider({
+        providerId: vars.id,
+        oidcProviderUpdateRequest: vars.request,
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: oidcProviderKeys.all }),
+  });
+}
+
+/** Deletes a provider, then refreshes the list. */
+export function useDeleteOidcProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await adminOidcProvidersApi.deleteOidcProvider({ providerId: id });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: oidcProviderKeys.all }),
+  });
+}
+
+/**
+ * Probes an issuer's discovery document. The endpoint never fails the request —
+ * the outcome is reported in the response's {@code success} flag — so callers
+ * inspect the returned object rather than catching.
+ */
+export function useDiscoverOidcEndpoints() {
+  return useMutation({
+    mutationFn: async (issuerUri: string): Promise<OidcDiscoveryResponse> => {
+      const response = await adminOidcProvidersApi.discoverOidcEndpoints({
+        oidcDiscoveryRequest: { issuerUri },
+      });
+      return response.data;
+    },
+  });
+}

--- a/qnop-ui/src/components/admin/oidc/OidcProviderFormDialog.tsx
+++ b/qnop-ui/src/components/admin/oidc/OidcProviderFormDialog.tsx
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type FormEvent } from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputAdornment from '@mui/material/InputAdornment';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { ChevronDown } from 'lucide-react';
+import type { OidcProviderDto, OidcProviderTypeDto } from '../../../api/generated';
+import { PasswordField } from '../../auth/PasswordField';
+import {
+  useCreateOidcProvider,
+  useDiscoverOidcEndpoints,
+  useUpdateOidcProvider,
+} from '../../../api/hooks/useOidcProviders';
+import { apiErrorMessage } from '../../../utils/apiError';
+import { PROVIDER_TYPES } from './oidcProviderTypes';
+
+interface OidcProviderFormDialogProps {
+  open: boolean;
+  mode: 'create' | 'edit';
+  provider?: OidcProviderDto;
+  onClose: () => void;
+}
+
+/** Trims a field, returning undefined for blank so optional values are omitted. */
+function optional(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Create or edit an OIDC/OAuth2 identity provider. State is seeded once from
+ * props via useState initializers; the parent passes a changing `key` so the
+ * dialog remounts fresh on every open (no reset-via-effect). The client secret
+ * is write-only: blank on edit keeps the stored secret.
+ */
+export function OidcProviderFormDialog({
+  open,
+  mode,
+  provider,
+  onClose,
+}: OidcProviderFormDialogProps) {
+  const createProvider = useCreateOidcProvider();
+  const updateProvider = useUpdateOidcProvider();
+  const discover = useDiscoverOidcEndpoints();
+
+  const editing = mode === 'edit' && provider;
+  const [name, setName] = useState(editing ? provider.name : '');
+  const [providerType, setProviderType] = useState<OidcProviderTypeDto>(
+    editing ? provider.providerType : 'OIDC',
+  );
+  const [clientId, setClientId] = useState(editing ? provider.clientId : '');
+  const [clientSecret, setClientSecret] = useState('');
+  const [issuerUri, setIssuerUri] = useState(editing ? (provider.issuerUri ?? '') : '');
+  const [scope, setScope] = useState(editing ? provider.scope : 'openid email profile');
+  const [authorizationUri, setAuthorizationUri] = useState(
+    editing ? (provider.authorizationUri ?? '') : '',
+  );
+  const [tokenUri, setTokenUri] = useState(editing ? (provider.tokenUri ?? '') : '');
+  const [userInfoUri, setUserInfoUri] = useState(editing ? (provider.userInfoUri ?? '') : '');
+  const [jwkSetUri, setJwkSetUri] = useState(editing ? (provider.jwkSetUri ?? '') : '');
+  const [userNameAttribute, setUserNameAttribute] = useState(
+    editing ? (provider.userNameAttribute ?? '') : '',
+  );
+  const [emailAttribute, setEmailAttribute] = useState(
+    editing ? (provider.emailAttribute ?? '') : '',
+  );
+  const [displayNameAttribute, setDisplayNameAttribute] = useState(
+    editing ? (provider.displayNameAttribute ?? '') : '',
+  );
+  const [enabled, setEnabled] = useState(editing ? provider.enabled : false);
+  const [error, setError] = useState<string | null>(null);
+  const [discoverNote, setDiscoverNote] = useState<string | null>(null);
+
+  const isEdit = mode === 'edit';
+  const submitting = createProvider.isPending || updateProvider.isPending;
+  const canSubmit =
+    name.trim().length > 0 &&
+    clientId.trim().length > 0 &&
+    (isEdit || clientSecret.trim().length > 0);
+
+  const runDiscover = async () => {
+    setDiscoverNote(null);
+    const result = await discover.mutateAsync(issuerUri.trim());
+    if (!result.success) {
+      setDiscoverNote(result.error ?? 'Discovery failed for this issuer.');
+      return;
+    }
+    if (result.authorizationUri) setAuthorizationUri(result.authorizationUri);
+    if (result.tokenUri) setTokenUri(result.tokenUri);
+    if (result.userInfoUri) setUserInfoUri(result.userInfoUri);
+    if (result.jwkSetUri) setJwkSetUri(result.jwkSetUri);
+    setDiscoverNote('Endpoints filled in from the issuer.');
+  };
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    const common = {
+      name: name.trim(),
+      providerType,
+      clientId: clientId.trim(),
+      issuerUri: optional(issuerUri),
+      scope: optional(scope),
+      authorizationUri: optional(authorizationUri),
+      tokenUri: optional(tokenUri),
+      userInfoUri: optional(userInfoUri),
+      jwkSetUri: optional(jwkSetUri),
+      userNameAttribute: optional(userNameAttribute),
+      emailAttribute: optional(emailAttribute),
+      displayNameAttribute: optional(displayNameAttribute),
+    };
+    try {
+      if (isEdit && provider) {
+        await updateProvider.mutateAsync({
+          id: provider.id,
+          request: { ...common, enabled, clientSecret: optional(clientSecret) },
+        });
+      } else {
+        await createProvider.mutateAsync({ ...common, clientSecret: clientSecret.trim() });
+      }
+      onClose();
+    } catch (err) {
+      setError(apiErrorMessage(err, 'Saving the provider failed. Please check the details.'));
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <Box component="form" onSubmit={onSubmit} noValidate>
+        <DialogTitle>{isEdit ? 'Edit provider' : 'Add provider'}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ mt: 1 }}>
+            <TextField
+              label="Display name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              fullWidth
+              required
+              helperText="Shown on the login button, e.g. “Google” or “Company SSO”."
+            />
+            <TextField
+              label="Provider type"
+              select
+              value={providerType}
+              onChange={(e) => setProviderType(e.target.value as OidcProviderTypeDto)}
+              fullWidth
+            >
+              {PROVIDER_TYPES.map((type) => (
+                <MenuItem key={type.value} value={type.value}>
+                  {type.label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Client ID"
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+              fullWidth
+              required
+              autoComplete="off"
+            />
+            <PasswordField
+              label={isEdit ? 'Client secret (leave blank to keep)' : 'Client secret'}
+              value={clientSecret}
+              onChange={setClientSecret}
+              autoComplete="new-password"
+              required={!isEdit}
+            />
+            <TextField
+              label="Issuer URL"
+              value={issuerUri}
+              onChange={(e) => setIssuerUri(e.target.value)}
+              fullWidth
+              placeholder="https://accounts.example.com"
+              helperText="For OIDC issuers, use Discover to fill the endpoints automatically."
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <Button
+                        size="small"
+                        onClick={runDiscover}
+                        disabled={issuerUri.trim().length === 0 || discover.isPending}
+                      >
+                        {discover.isPending ? 'Discovering…' : 'Discover'}
+                      </Button>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+            />
+            {discoverNote && (
+              <Alert severity={discover.data?.success ? 'success' : 'warning'}>
+                {discoverNote}
+              </Alert>
+            )}
+            <TextField
+              label="Scopes"
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              fullWidth
+              helperText="Space-separated, e.g. “openid email profile”."
+            />
+
+            <Accordion disableGutters elevation={0} sx={{ '&:before': { display: 'none' } }}>
+              <AccordionSummary expandIcon={<ChevronDown size={18} />} sx={{ px: 0 }}>
+                <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+                  Endpoints &amp; attribute mapping (advanced)
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails sx={{ px: 0 }}>
+                <Stack spacing={2}>
+                  <Typography color="text.secondary" sx={{ fontSize: 13 }}>
+                    Optional. Required for non-discoverable OAuth2 providers; leave blank for
+                    GitHub/Google/Facebook (qnop knows their endpoints).
+                  </Typography>
+                  <TextField
+                    label="Authorization URL"
+                    value={authorizationUri}
+                    onChange={(e) => setAuthorizationUri(e.target.value)}
+                    fullWidth
+                  />
+                  <TextField
+                    label="Token URL"
+                    value={tokenUri}
+                    onChange={(e) => setTokenUri(e.target.value)}
+                    fullWidth
+                  />
+                  <TextField
+                    label="User info URL"
+                    value={userInfoUri}
+                    onChange={(e) => setUserInfoUri(e.target.value)}
+                    fullWidth
+                  />
+                  <TextField
+                    label="JWK set URL"
+                    value={jwkSetUri}
+                    onChange={(e) => setJwkSetUri(e.target.value)}
+                    fullWidth
+                  />
+                  <TextField
+                    label="Username attribute"
+                    value={userNameAttribute}
+                    onChange={(e) => setUserNameAttribute(e.target.value)}
+                    fullWidth
+                    placeholder="sub"
+                  />
+                  <TextField
+                    label="Email attribute"
+                    value={emailAttribute}
+                    onChange={(e) => setEmailAttribute(e.target.value)}
+                    fullWidth
+                    placeholder="email"
+                  />
+                  <TextField
+                    label="Display-name attribute"
+                    value={displayNameAttribute}
+                    onChange={(e) => setDisplayNameAttribute(e.target.value)}
+                    fullWidth
+                    placeholder="name"
+                  />
+                </Stack>
+              </AccordionDetails>
+            </Accordion>
+
+            {isEdit && (
+              <FormControlLabel
+                control={
+                  <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+                }
+                label={enabled ? 'Enabled for login' : 'Disabled'}
+              />
+            )}
+
+            {error && <Alert severity="error">{error}</Alert>}
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2.5 }}>
+          <Button onClick={onClose} color="inherit">
+            Cancel
+          </Button>
+          <Button type="submit" variant="contained" disabled={submitting || !canSubmit}>
+            {isEdit ? 'Save' : 'Create'}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/admin/oidc/OidcProviderFormDialog.tsx
+++ b/qnop-ui/src/components/admin/oidc/OidcProviderFormDialog.tsx
@@ -19,13 +19,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useState, type FormEvent } from 'react';
+import { useMemo, useState, type FormEvent } from 'react';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -46,7 +47,14 @@ import {
   useUpdateOidcProvider,
 } from '../../../api/hooks/useOidcProviders';
 import { apiErrorMessage } from '../../../utils/apiError';
-import { PROVIDER_TYPES } from './oidcProviderTypes';
+import { ProviderCallbackInstructions } from './ProviderCallbackInstructions';
+import { PROVIDER_TYPES, supportsDiscovery } from './oidcProviderTypes';
+
+/** Provider types whose scopes qnop fixes; the operator cannot change them. */
+const LOCKED_SCOPES: Partial<Record<OidcProviderTypeDto, string>> = {
+  GITHUB: 'read:user user:email',
+  FACEBOOK: 'email public_profile',
+};
 
 interface OidcProviderFormDialogProps {
   open: boolean;
@@ -61,11 +69,22 @@ function optional(value: string): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+/** Whether a non-empty value parses as an absolute http(s) URL. */
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Create or edit an OIDC/OAuth2 identity provider. State is seeded once from
  * props via useState initializers; the parent passes a changing `key` so the
- * dialog remounts fresh on every open (no reset-via-effect). The client secret
- * is write-only: blank on edit keeps the stored secret.
+ * dialog remounts fresh on every open. The client secret is write-only: blank
+ * on edit keeps the stored secret. After a fresh create the dialog switches to
+ * a success step showing the callback URL to register at the IdP.
  */
 export function OidcProviderFormDialog({
   open,
@@ -77,7 +96,8 @@ export function OidcProviderFormDialog({
   const updateProvider = useUpdateOidcProvider();
   const discover = useDiscoverOidcEndpoints();
 
-  const editing = mode === 'edit' && provider;
+  const isEdit = mode === 'edit';
+  const editing = isEdit && provider;
   const [name, setName] = useState(editing ? provider.name : '');
   const [providerType, setProviderType] = useState<OidcProviderTypeDto>(
     editing ? provider.providerType : 'OIDC',
@@ -103,38 +123,95 @@ export function OidcProviderFormDialog({
   );
   const [enabled, setEnabled] = useState(editing ? provider.enabled : false);
   const [error, setError] = useState<string | null>(null);
-  const [discoverNote, setDiscoverNote] = useState<string | null>(null);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [acknowledgeClientId, setAcknowledgeClientId] = useState(false);
+  const [created, setCreated] = useState<OidcProviderDto | null>(null);
 
-  const isEdit = mode === 'edit';
+  const lockedScope = LOCKED_SCOPES[providerType];
+  const effectiveScope = lockedScope ?? scope;
+  const isOidc = providerType === 'OIDC';
+  const isGeneric = providerType === 'OAUTH2';
+  const showIssuer = supportsDiscovery(providerType);
+  const clientIdChanged = Boolean(editing && clientId.trim() !== provider.clientId);
   const submitting = createProvider.isPending || updateProvider.isPending;
-  const canSubmit =
-    name.trim().length > 0 &&
-    clientId.trim().length > 0 &&
-    (isEdit || clientSecret.trim().length > 0);
+
+  const errors = useMemo(() => {
+    const e: Partial<Record<string, string>> = {};
+    if (!name.trim()) e.name = 'A display name is required.';
+    if (!clientId.trim()) e.clientId = 'A client ID is required.';
+    if (!isEdit && !clientSecret.trim()) e.clientSecret = 'A client secret is required.';
+    if (showIssuer && isOidc && !issuerUri.trim()) {
+      e.issuerUri = 'An issuer URL is required for OIDC.';
+    }
+    if (issuerUri.trim() && !isHttpUrl(issuerUri.trim())) {
+      e.issuerUri = 'Enter a valid http(s) URL.';
+    }
+    if (isOidc && effectiveScope.trim() && !effectiveScope.trim().split(/\s+/).includes('openid')) {
+      e.scope = 'OIDC scopes must include "openid".';
+    }
+    const endpoints = [
+      ['authorizationUri', authorizationUri],
+      ['tokenUri', tokenUri],
+      ['userInfoUri', userInfoUri],
+      ['jwkSetUri', jwkSetUri],
+    ] as const;
+    for (const [field, value] of endpoints) {
+      if (isGeneric && field !== 'jwkSetUri' && !value.trim()) {
+        e[field] = 'Required for a generic OAuth2 provider.';
+      } else if (value.trim() && !isHttpUrl(value.trim())) {
+        e[field] = 'Enter a valid http(s) URL.';
+      }
+    }
+    return e;
+  }, [
+    name,
+    clientId,
+    clientSecret,
+    isEdit,
+    showIssuer,
+    isOidc,
+    isGeneric,
+    issuerUri,
+    effectiveScope,
+    authorizationUri,
+    tokenUri,
+    userInfoUri,
+    jwkSetUri,
+  ]);
+
+  const canSubmit = Object.keys(errors).length === 0 && (!clientIdChanged || acknowledgeClientId);
+
+  const fieldError = (field: string): string | undefined =>
+    submitAttempted ? errors[field] : undefined;
 
   const runDiscover = async () => {
-    setDiscoverNote(null);
-    const result = await discover.mutateAsync(issuerUri.trim());
-    if (!result.success) {
-      setDiscoverNote(result.error ?? 'Discovery failed for this issuer.');
-      return;
-    }
-    if (result.authorizationUri) setAuthorizationUri(result.authorizationUri);
-    if (result.tokenUri) setTokenUri(result.tokenUri);
-    if (result.userInfoUri) setUserInfoUri(result.userInfoUri);
-    if (result.jwkSetUri) setJwkSetUri(result.jwkSetUri);
-    setDiscoverNote('Endpoints filled in from the issuer.');
+    await discover.mutateAsync(issuerUri.trim()).then((result) => {
+      if (!result.success) return;
+      if (result.authorizationUri) setAuthorizationUri(result.authorizationUri);
+      if (result.tokenUri) setTokenUri(result.tokenUri);
+      if (result.userInfoUri) setUserInfoUri(result.userInfoUri);
+      if (result.jwkSetUri) setJwkSetUri(result.jwkSetUri);
+    });
+  };
+
+  // Editing the issuer invalidates a previous discovery result so the banner
+  // never shows endpoints for a different issuer.
+  const onIssuerChange = (value: string) => {
+    setIssuerUri(value);
+    if (discover.data || discover.error) discover.reset();
   };
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
+    setSubmitAttempted(true);
+    if (!canSubmit) return;
     setError(null);
     const common = {
       name: name.trim(),
       providerType,
       clientId: clientId.trim(),
       issuerUri: optional(issuerUri),
-      scope: optional(scope),
+      scope: optional(effectiveScope),
       authorizationUri: optional(authorizationUri),
       tokenUri: optional(tokenUri),
       userInfoUri: optional(userInfoUri),
@@ -149,10 +226,14 @@ export function OidcProviderFormDialog({
           id: provider.id,
           request: { ...common, enabled, clientSecret: optional(clientSecret) },
         });
+        onClose();
       } else {
-        await createProvider.mutateAsync({ ...common, clientSecret: clientSecret.trim() });
+        const result = await createProvider.mutateAsync({
+          ...common,
+          clientSecret: clientSecret.trim(),
+        });
+        setCreated(result);
       }
-      onClose();
     } catch (err) {
       setError(apiErrorMessage(err, 'Saving the provider failed. Please check the details.'));
     }
@@ -160,164 +241,309 @@ export function OidcProviderFormDialog({
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <Box component="form" onSubmit={onSubmit} noValidate>
-        <DialogTitle>{isEdit ? 'Edit provider' : 'Add provider'}</DialogTitle>
-        <DialogContent>
-          <Stack spacing={2.5} sx={{ mt: 1 }}>
-            <TextField
-              label="Display name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              fullWidth
-              required
-              helperText="Shown on the login button, e.g. “Google” or “Company SSO”."
-            />
-            <TextField
-              label="Provider type"
-              select
-              value={providerType}
-              onChange={(e) => setProviderType(e.target.value as OidcProviderTypeDto)}
-              fullWidth
-            >
-              {PROVIDER_TYPES.map((type) => (
-                <MenuItem key={type.value} value={type.value}>
-                  {type.label}
-                </MenuItem>
-              ))}
-            </TextField>
-            <TextField
-              label="Client ID"
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-              fullWidth
-              required
-              autoComplete="off"
-            />
-            <PasswordField
-              label={isEdit ? 'Client secret (leave blank to keep)' : 'Client secret'}
-              value={clientSecret}
-              onChange={setClientSecret}
-              autoComplete="new-password"
-              required={!isEdit}
-            />
-            <TextField
-              label="Issuer URL"
-              value={issuerUri}
-              onChange={(e) => setIssuerUri(e.target.value)}
-              fullWidth
-              placeholder="https://accounts.example.com"
-              helperText="For OIDC issuers, use Discover to fill the endpoints automatically."
-              slotProps={{
-                input: {
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <Button
-                        size="small"
-                        onClick={runDiscover}
-                        disabled={issuerUri.trim().length === 0 || discover.isPending}
-                      >
-                        {discover.isPending ? 'Discovering…' : 'Discover'}
-                      </Button>
-                    </InputAdornment>
-                  ),
-                },
-              }}
-            />
-            {discoverNote && (
-              <Alert severity={discover.data?.success ? 'success' : 'warning'}>
-                {discoverNote}
-              </Alert>
-            )}
-            <TextField
-              label="Scopes"
-              value={scope}
-              onChange={(e) => setScope(e.target.value)}
-              fullWidth
-              helperText="Space-separated, e.g. “openid email profile”."
-            />
-
-            <Accordion disableGutters elevation={0} sx={{ '&:before': { display: 'none' } }}>
-              <AccordionSummary expandIcon={<ChevronDown size={18} />} sx={{ px: 0 }}>
-                <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
-                  Endpoints &amp; attribute mapping (advanced)
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails sx={{ px: 0 }}>
-                <Stack spacing={2}>
-                  <Typography color="text.secondary" sx={{ fontSize: 13 }}>
-                    Optional. Required for non-discoverable OAuth2 providers; leave blank for
-                    GitHub/Google/Facebook (qnop knows their endpoints).
-                  </Typography>
-                  <TextField
-                    label="Authorization URL"
-                    value={authorizationUri}
-                    onChange={(e) => setAuthorizationUri(e.target.value)}
-                    fullWidth
-                  />
-                  <TextField
-                    label="Token URL"
-                    value={tokenUri}
-                    onChange={(e) => setTokenUri(e.target.value)}
-                    fullWidth
-                  />
-                  <TextField
-                    label="User info URL"
-                    value={userInfoUri}
-                    onChange={(e) => setUserInfoUri(e.target.value)}
-                    fullWidth
-                  />
-                  <TextField
-                    label="JWK set URL"
-                    value={jwkSetUri}
-                    onChange={(e) => setJwkSetUri(e.target.value)}
-                    fullWidth
-                  />
-                  <TextField
-                    label="Username attribute"
-                    value={userNameAttribute}
-                    onChange={(e) => setUserNameAttribute(e.target.value)}
-                    fullWidth
-                    placeholder="sub"
-                  />
-                  <TextField
-                    label="Email attribute"
-                    value={emailAttribute}
-                    onChange={(e) => setEmailAttribute(e.target.value)}
-                    fullWidth
-                    placeholder="email"
-                  />
-                  <TextField
-                    label="Display-name attribute"
-                    value={displayNameAttribute}
-                    onChange={(e) => setDisplayNameAttribute(e.target.value)}
-                    fullWidth
-                    placeholder="name"
-                  />
-                </Stack>
-              </AccordionDetails>
-            </Accordion>
-
-            {isEdit && (
-              <FormControlLabel
-                control={
-                  <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+      {created ? (
+        <CreateSuccessStep provider={created} onClose={onClose} />
+      ) : (
+        <Box component="form" onSubmit={onSubmit} noValidate>
+          <DialogTitle>{isEdit ? 'Edit provider' : 'Add provider'}</DialogTitle>
+          <DialogContent>
+            <Stack spacing={2.5} sx={{ mt: 1 }}>
+              <TextField
+                label="Display name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                fullWidth
+                required
+                error={Boolean(fieldError('name'))}
+                helperText={
+                  fieldError('name') ?? 'Shown on the login button, e.g. “Google” or “Company SSO”.'
                 }
-                label={enabled ? 'Enabled for login' : 'Disabled'}
               />
-            )}
+              <TextField
+                label="Provider type"
+                select
+                value={providerType}
+                onChange={(e) => setProviderType(e.target.value as OidcProviderTypeDto)}
+                fullWidth
+                disabled={isEdit}
+                helperText={
+                  isEdit ? 'The provider type cannot be changed after creation.' : undefined
+                }
+              >
+                {PROVIDER_TYPES.map((type) => (
+                  <MenuItem key={type.value} value={type.value}>
+                    {type.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                label="Client ID"
+                value={clientId}
+                onChange={(e) => setClientId(e.target.value)}
+                fullWidth
+                required
+                autoComplete="off"
+                error={Boolean(fieldError('clientId'))}
+                helperText={fieldError('clientId')}
+              />
+              {clientIdChanged && (
+                <Alert severity="warning">
+                  Changing the client ID points qnop at a different upstream app. Existing linked
+                  accounts may stop matching.
+                  <FormControlLabel
+                    sx={{ mt: 0.5, display: 'flex' }}
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={acknowledgeClientId}
+                        onChange={(e) => setAcknowledgeClientId(e.target.checked)}
+                      />
+                    }
+                    label="I understand, change the client ID."
+                  />
+                </Alert>
+              )}
+              <PasswordField
+                label={isEdit ? 'Client secret (leave blank to keep)' : 'Client secret'}
+                value={clientSecret}
+                onChange={setClientSecret}
+                autoComplete="new-password"
+                required={!isEdit}
+                error={Boolean(fieldError('clientSecret'))}
+                helperText={fieldError('clientSecret')}
+              />
+              {showIssuer && (
+                <TextField
+                  label="Issuer URL"
+                  value={issuerUri}
+                  onChange={(e) => onIssuerChange(e.target.value)}
+                  fullWidth
+                  required={isOidc}
+                  placeholder="https://accounts.example.com"
+                  error={Boolean(fieldError('issuerUri'))}
+                  helperText={
+                    fieldError('issuerUri') ??
+                    'Use Discover to fill the endpoints automatically from the issuer.'
+                  }
+                  slotProps={{
+                    input: {
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <Button
+                            size="small"
+                            onClick={runDiscover}
+                            disabled={!isHttpUrl(issuerUri.trim()) || discover.isPending}
+                          >
+                            {discover.isPending ? 'Discovering…' : 'Discover'}
+                          </Button>
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
+                />
+              )}
+              {discover.data && <DiscoveryBanner result={discover.data} />}
+              <TextField
+                label="Scopes"
+                value={effectiveScope}
+                onChange={(e) => setScope(e.target.value)}
+                fullWidth
+                disabled={Boolean(lockedScope)}
+                error={Boolean(fieldError('scope'))}
+                helperText={
+                  fieldError('scope') ??
+                  (lockedScope
+                    ? 'Scopes for this provider are managed by qnop and cannot be changed.'
+                    : 'Space-separated, e.g. “openid email profile”.')
+                }
+              />
 
-            {error && <Alert severity="error">{error}</Alert>}
-          </Stack>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2.5 }}>
-          <Button onClick={onClose} color="inherit">
-            Cancel
-          </Button>
-          <Button type="submit" variant="contained" disabled={submitting || !canSubmit}>
-            {isEdit ? 'Save' : 'Create'}
-          </Button>
-        </DialogActions>
-      </Box>
+              <Accordion
+                disableGutters
+                elevation={0}
+                defaultExpanded={isGeneric}
+                sx={{ '&:before': { display: 'none' } }}
+              >
+                <AccordionSummary expandIcon={<ChevronDown size={18} />} sx={{ px: 0 }}>
+                  <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+                    Endpoints &amp; attribute mapping{isGeneric ? ' (required)' : ' (advanced)'}
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails sx={{ px: 0 }}>
+                  <Stack spacing={2}>
+                    <Typography color="text.secondary" sx={{ fontSize: 13 }}>
+                      {isGeneric
+                        ? 'Required for a generic OAuth2 provider — qnop cannot discover these.'
+                        : 'Optional. Leave blank for GitHub/Google/Facebook (qnop knows their endpoints).'}
+                    </Typography>
+                    <TextField
+                      label="Authorization URL"
+                      value={authorizationUri}
+                      onChange={(e) => setAuthorizationUri(e.target.value)}
+                      fullWidth
+                      required={isGeneric}
+                      error={Boolean(fieldError('authorizationUri'))}
+                      helperText={fieldError('authorizationUri')}
+                    />
+                    <TextField
+                      label="Token URL"
+                      value={tokenUri}
+                      onChange={(e) => setTokenUri(e.target.value)}
+                      fullWidth
+                      required={isGeneric}
+                      error={Boolean(fieldError('tokenUri'))}
+                      helperText={fieldError('tokenUri')}
+                    />
+                    <TextField
+                      label="User info URL"
+                      value={userInfoUri}
+                      onChange={(e) => setUserInfoUri(e.target.value)}
+                      fullWidth
+                      required={isGeneric}
+                      error={Boolean(fieldError('userInfoUri'))}
+                      helperText={fieldError('userInfoUri')}
+                    />
+                    <TextField
+                      label="JWK set URL"
+                      value={jwkSetUri}
+                      onChange={(e) => setJwkSetUri(e.target.value)}
+                      fullWidth
+                      error={Boolean(fieldError('jwkSetUri'))}
+                      helperText={fieldError('jwkSetUri')}
+                    />
+                    <TextField
+                      label="Username attribute"
+                      value={userNameAttribute}
+                      onChange={(e) => setUserNameAttribute(e.target.value)}
+                      fullWidth
+                      placeholder="sub"
+                    />
+                    <TextField
+                      label="Email attribute"
+                      value={emailAttribute}
+                      onChange={(e) => setEmailAttribute(e.target.value)}
+                      fullWidth
+                      placeholder="email"
+                    />
+                    <TextField
+                      label="Display-name attribute"
+                      value={displayNameAttribute}
+                      onChange={(e) => setDisplayNameAttribute(e.target.value)}
+                      fullWidth
+                      placeholder="name"
+                    />
+                  </Stack>
+                </AccordionDetails>
+              </Accordion>
+
+              {isEdit && provider && (
+                <ProviderCallbackInstructions
+                  providerId={provider.id}
+                  providerType={providerType}
+                  variant="inline"
+                />
+              )}
+
+              {isEdit && (
+                <FormControlLabel
+                  control={
+                    <Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+                  }
+                  label={enabled ? 'Enabled for login' : 'Disabled'}
+                />
+              )}
+
+              {error && <Alert severity="error">{error}</Alert>}
+            </Stack>
+          </DialogContent>
+          <DialogActions sx={{ px: 3, pb: 2.5 }}>
+            <Button onClick={onClose} color="inherit">
+              Cancel
+            </Button>
+            <Button type="submit" variant="contained" disabled={submitting || !canSubmit}>
+              {isEdit ? 'Save' : 'Create'}
+            </Button>
+          </DialogActions>
+        </Box>
+      )}
     </Dialog>
+  );
+}
+
+interface DiscoveryBannerProps {
+  result: {
+    success: boolean;
+    error?: string;
+    authorizationUri?: string;
+    tokenUri?: string;
+    userInfoUri?: string;
+    jwkSetUri?: string;
+  };
+}
+
+/** Shows the outcome of a discovery probe — the four resolved endpoints, or the error. */
+function DiscoveryBanner({ result }: DiscoveryBannerProps) {
+  if (!result.success) {
+    return <Alert severity="warning">{result.error ?? 'Discovery failed for this issuer.'}</Alert>;
+  }
+  const rows: [string, string | undefined][] = [
+    ['Authorization', result.authorizationUri],
+    ['Token', result.tokenUri],
+    ['User info', result.userInfoUri],
+    ['JWK set', result.jwkSetUri],
+  ];
+  return (
+    <Alert severity="success" sx={{ '& .MuiAlert-message': { width: '100%' } }}>
+      <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
+        Endpoints discovered and filled in:
+      </Typography>
+      <Stack spacing={0.25}>
+        {rows.map(([label, value]) => (
+          <Typography
+            key={label}
+            variant="caption"
+            sx={{ display: 'block', wordBreak: 'break-all', color: 'text.secondary' }}
+          >
+            <strong>{label}:</strong> {value ?? '—'}
+          </Typography>
+        ))}
+      </Stack>
+    </Alert>
+  );
+}
+
+interface CreateSuccessStepProps {
+  provider: OidcProviderDto;
+  onClose: () => void;
+}
+
+/**
+ * Post-create hero: the provider is saved but disabled. The one thing left for
+ * the operator is registering the callback URL at the IdP, so that panel is the
+ * focus, followed by a reminder to enable the provider once the IdP side is set.
+ */
+function CreateSuccessStep({ provider, onClose }: CreateSuccessStepProps) {
+  return (
+    <>
+      <DialogTitle>Provider created</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            <strong>{provider.name}</strong> was created and is currently <strong>disabled</strong>.
+            Register the callback URL below at your provider, then enable it from the list.
+          </Typography>
+          <ProviderCallbackInstructions
+            providerId={provider.id}
+            providerType={provider.providerType}
+            variant="success"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onClose} variant="contained">
+          Done
+        </Button>
+      </DialogActions>
+    </>
   );
 }

--- a/qnop-ui/src/components/admin/oidc/OidcProviderFormDialog.tsx
+++ b/qnop-ui/src/components/admin/oidc/OidcProviderFormDialog.tsx
@@ -132,6 +132,10 @@ export function OidcProviderFormDialog({
   const isOidc = providerType === 'OIDC';
   const isGeneric = providerType === 'OAUTH2';
   const showIssuer = supportsDiscovery(providerType);
+  // Endpoints & attribute mapping are only shown for the generic types. For the
+  // well-known vendors (GitHub/Google/Facebook) qnop already knows them, so the
+  // whole section is hidden.
+  const showEndpoints = isOidc || isGeneric;
   const clientIdChanged = Boolean(editing && clientId.trim() !== provider.clientId);
   const submitting = createProvider.isPending || updateProvider.isPending;
 
@@ -149,17 +153,19 @@ export function OidcProviderFormDialog({
     if (isOidc && effectiveScope.trim() && !effectiveScope.trim().split(/\s+/).includes('openid')) {
       e.scope = 'OIDC scopes must include "openid".';
     }
-    const endpoints = [
-      ['authorizationUri', authorizationUri],
-      ['tokenUri', tokenUri],
-      ['userInfoUri', userInfoUri],
-      ['jwkSetUri', jwkSetUri],
-    ] as const;
-    for (const [field, value] of endpoints) {
-      if (isGeneric && field !== 'jwkSetUri' && !value.trim()) {
-        e[field] = 'Required for a generic OAuth2 provider.';
-      } else if (value.trim() && !isHttpUrl(value.trim())) {
-        e[field] = 'Enter a valid http(s) URL.';
+    if (showEndpoints) {
+      const endpoints = [
+        ['authorizationUri', authorizationUri],
+        ['tokenUri', tokenUri],
+        ['userInfoUri', userInfoUri],
+        ['jwkSetUri', jwkSetUri],
+      ] as const;
+      for (const [field, value] of endpoints) {
+        if (isGeneric && field !== 'jwkSetUri' && !value.trim()) {
+          e[field] = 'Required for a generic OAuth2 provider.';
+        } else if (value.trim() && !isHttpUrl(value.trim())) {
+          e[field] = 'Enter a valid http(s) URL.';
+        }
       }
     }
     return e;
@@ -169,6 +175,7 @@ export function OidcProviderFormDialog({
     clientSecret,
     isEdit,
     showIssuer,
+    showEndpoints,
     isOidc,
     isGeneric,
     issuerUri,
@@ -212,13 +219,19 @@ export function OidcProviderFormDialog({
       clientId: clientId.trim(),
       issuerUri: optional(issuerUri),
       scope: optional(effectiveScope),
-      authorizationUri: optional(authorizationUri),
-      tokenUri: optional(tokenUri),
-      userInfoUri: optional(userInfoUri),
-      jwkSetUri: optional(jwkSetUri),
-      userNameAttribute: optional(userNameAttribute),
-      emailAttribute: optional(emailAttribute),
-      displayNameAttribute: optional(displayNameAttribute),
+      // Endpoints & attribute mapping only apply to the generic types; for the
+      // well-known vendors qnop fills them in, so they are neither shown nor sent.
+      ...(showEndpoints
+        ? {
+            authorizationUri: optional(authorizationUri),
+            tokenUri: optional(tokenUri),
+            userInfoUri: optional(userInfoUri),
+            jwkSetUri: optional(jwkSetUri),
+            userNameAttribute: optional(userNameAttribute),
+            emailAttribute: optional(emailAttribute),
+            displayNameAttribute: optional(displayNameAttribute),
+          }
+        : {}),
     };
     try {
       if (isEdit && provider) {
@@ -358,83 +371,85 @@ export function OidcProviderFormDialog({
                 }
               />
 
-              <Accordion
-                disableGutters
-                elevation={0}
-                defaultExpanded={isGeneric}
-                sx={{ '&:before': { display: 'none' } }}
-              >
-                <AccordionSummary expandIcon={<ChevronDown size={18} />} sx={{ px: 0 }}>
-                  <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
-                    Endpoints &amp; attribute mapping{isGeneric ? ' (required)' : ' (advanced)'}
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails sx={{ px: 0 }}>
-                  <Stack spacing={2}>
-                    <Typography color="text.secondary" sx={{ fontSize: 13 }}>
-                      {isGeneric
-                        ? 'Required for a generic OAuth2 provider — qnop cannot discover these.'
-                        : 'Optional. Leave blank for GitHub/Google/Facebook (qnop knows their endpoints).'}
+              {showEndpoints && (
+                <Accordion
+                  disableGutters
+                  elevation={0}
+                  defaultExpanded={isGeneric}
+                  sx={{ '&:before': { display: 'none' } }}
+                >
+                  <AccordionSummary expandIcon={<ChevronDown size={18} />} sx={{ px: 0 }}>
+                    <Typography sx={{ fontSize: 14, fontWeight: 600 }}>
+                      Endpoints &amp; attribute mapping{isGeneric ? ' (required)' : ' (advanced)'}
                     </Typography>
-                    <TextField
-                      label="Authorization URL"
-                      value={authorizationUri}
-                      onChange={(e) => setAuthorizationUri(e.target.value)}
-                      fullWidth
-                      required={isGeneric}
-                      error={Boolean(fieldError('authorizationUri'))}
-                      helperText={fieldError('authorizationUri')}
-                    />
-                    <TextField
-                      label="Token URL"
-                      value={tokenUri}
-                      onChange={(e) => setTokenUri(e.target.value)}
-                      fullWidth
-                      required={isGeneric}
-                      error={Boolean(fieldError('tokenUri'))}
-                      helperText={fieldError('tokenUri')}
-                    />
-                    <TextField
-                      label="User info URL"
-                      value={userInfoUri}
-                      onChange={(e) => setUserInfoUri(e.target.value)}
-                      fullWidth
-                      required={isGeneric}
-                      error={Boolean(fieldError('userInfoUri'))}
-                      helperText={fieldError('userInfoUri')}
-                    />
-                    <TextField
-                      label="JWK set URL"
-                      value={jwkSetUri}
-                      onChange={(e) => setJwkSetUri(e.target.value)}
-                      fullWidth
-                      error={Boolean(fieldError('jwkSetUri'))}
-                      helperText={fieldError('jwkSetUri')}
-                    />
-                    <TextField
-                      label="Username attribute"
-                      value={userNameAttribute}
-                      onChange={(e) => setUserNameAttribute(e.target.value)}
-                      fullWidth
-                      placeholder="sub"
-                    />
-                    <TextField
-                      label="Email attribute"
-                      value={emailAttribute}
-                      onChange={(e) => setEmailAttribute(e.target.value)}
-                      fullWidth
-                      placeholder="email"
-                    />
-                    <TextField
-                      label="Display-name attribute"
-                      value={displayNameAttribute}
-                      onChange={(e) => setDisplayNameAttribute(e.target.value)}
-                      fullWidth
-                      placeholder="name"
-                    />
-                  </Stack>
-                </AccordionDetails>
-              </Accordion>
+                  </AccordionSummary>
+                  <AccordionDetails sx={{ px: 0 }}>
+                    <Stack spacing={2}>
+                      <Typography color="text.secondary" sx={{ fontSize: 13 }}>
+                        {isGeneric
+                          ? 'Required for a generic OAuth2 provider — qnop cannot discover these.'
+                          : 'Optional — usually filled in by Discover from the issuer; override only if needed.'}
+                      </Typography>
+                      <TextField
+                        label="Authorization URL"
+                        value={authorizationUri}
+                        onChange={(e) => setAuthorizationUri(e.target.value)}
+                        fullWidth
+                        required={isGeneric}
+                        error={Boolean(fieldError('authorizationUri'))}
+                        helperText={fieldError('authorizationUri')}
+                      />
+                      <TextField
+                        label="Token URL"
+                        value={tokenUri}
+                        onChange={(e) => setTokenUri(e.target.value)}
+                        fullWidth
+                        required={isGeneric}
+                        error={Boolean(fieldError('tokenUri'))}
+                        helperText={fieldError('tokenUri')}
+                      />
+                      <TextField
+                        label="User info URL"
+                        value={userInfoUri}
+                        onChange={(e) => setUserInfoUri(e.target.value)}
+                        fullWidth
+                        required={isGeneric}
+                        error={Boolean(fieldError('userInfoUri'))}
+                        helperText={fieldError('userInfoUri')}
+                      />
+                      <TextField
+                        label="JWK set URL"
+                        value={jwkSetUri}
+                        onChange={(e) => setJwkSetUri(e.target.value)}
+                        fullWidth
+                        error={Boolean(fieldError('jwkSetUri'))}
+                        helperText={fieldError('jwkSetUri')}
+                      />
+                      <TextField
+                        label="Username attribute"
+                        value={userNameAttribute}
+                        onChange={(e) => setUserNameAttribute(e.target.value)}
+                        fullWidth
+                        placeholder="sub"
+                      />
+                      <TextField
+                        label="Email attribute"
+                        value={emailAttribute}
+                        onChange={(e) => setEmailAttribute(e.target.value)}
+                        fullWidth
+                        placeholder="email"
+                      />
+                      <TextField
+                        label="Display-name attribute"
+                        value={displayNameAttribute}
+                        onChange={(e) => setDisplayNameAttribute(e.target.value)}
+                        fullWidth
+                        placeholder="name"
+                      />
+                    </Stack>
+                  </AccordionDetails>
+                </Accordion>
+              )}
 
               {isEdit && provider && (
                 <ProviderCallbackInstructions

--- a/qnop-ui/src/components/admin/oidc/OidcProvidersTable.tsx
+++ b/qnop-ui/src/components/admin/oidc/OidcProvidersTable.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type MouseEvent } from 'react';
+import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { MoreVertical, SquarePen, Trash2 } from 'lucide-react';
+import type { OidcProviderDto } from '../../../api/generated';
+import { formatDateTime } from '../../../utils/formatDate';
+import { ToneBadge } from '../ToneBadge';
+import { providerTypeLabel } from './oidcProviderTypes';
+
+interface OidcProvidersTableProps {
+  providers: OidcProviderDto[];
+  onEdit: (provider: OidcProviderDto) => void;
+  onToggleEnabled: (provider: OidcProviderDto) => void;
+  onDelete: (provider: OidcProviderDto) => void;
+}
+
+const COLUMNS = ['Provider', 'Type', 'Client ID', 'Status', 'Created', ''];
+
+export function OidcProvidersTable({
+  providers,
+  onEdit,
+  onToggleEnabled,
+  onDelete,
+}: OidcProvidersTableProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [active, setActive] = useState<OidcProviderDto | null>(null);
+
+  const openMenu = (event: MouseEvent<HTMLElement>, provider: OidcProviderDto) => {
+    setAnchorEl(event.currentTarget);
+    setActive(provider);
+  };
+  const closeMenu = () => setAnchorEl(null);
+
+  return (
+    <>
+      <Table size="medium" sx={{ '& td, & th': { borderColor: 'divider' } }}>
+        <TableHead>
+          <TableRow>
+            {COLUMNS.map((col, index) => (
+              <TableCell
+                key={col || 'actions'}
+                align={index === COLUMNS.length - 1 ? 'right' : 'left'}
+              >
+                {col}
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {providers.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={COLUMNS.length}>
+                <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+                  No identity providers configured yet.
+                </Typography>
+              </TableCell>
+            </TableRow>
+          )}
+          {providers.map((provider) => (
+            <TableRow key={provider.id} hover>
+              <TableCell>
+                <Typography sx={{ fontWeight: 600 }}>{provider.name}</Typography>
+              </TableCell>
+              <TableCell>
+                <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>
+                  {providerTypeLabel(provider.providerType)}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Typography
+                  sx={{ fontSize: 13, color: 'text.secondary', fontFamily: 'monospace' }}
+                  noWrap
+                >
+                  {provider.clientId}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                  <Tooltip title={provider.enabled ? 'Disable for login' : 'Enable for login'}>
+                    <Switch
+                      size="small"
+                      checked={provider.enabled}
+                      onChange={() => onToggleEnabled(provider)}
+                      slotProps={{ input: { 'aria-label': `Toggle ${provider.name}` } }}
+                    />
+                  </Tooltip>
+                  <ToneBadge
+                    tone={provider.enabled ? 'green' : 'neutral'}
+                    label={provider.enabled ? 'Enabled' : 'Disabled'}
+                  />
+                </Stack>
+              </TableCell>
+              <TableCell>
+                <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>
+                  {formatDateTime(provider.createdAt)}
+                </Typography>
+              </TableCell>
+              <TableCell align="right">
+                <IconButton
+                  size="small"
+                  aria-label={`Actions for ${provider.name}`}
+                  onClick={(e) => openMenu(e, provider)}
+                >
+                  <MoreVertical size={18} />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={closeMenu}>
+        <MenuItem
+          onClick={() => {
+            closeMenu();
+            if (active) onEdit(active);
+          }}
+        >
+          <ListItemIcon>
+            <SquarePen size={16} />
+          </ListItemIcon>
+          <ListItemText>Edit</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            closeMenu();
+            if (active) onDelete(active);
+          }}
+        >
+          <ListItemIcon>
+            <Trash2 size={16} />
+          </ListItemIcon>
+          <ListItemText>Delete</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/qnop-ui/src/components/admin/oidc/OidcProvidersTable.tsx
+++ b/qnop-ui/src/components/admin/oidc/OidcProvidersTable.tsx
@@ -20,6 +20,7 @@
  */
 
 import { useState, type MouseEvent } from 'react';
+import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -47,7 +48,7 @@ interface OidcProvidersTableProps {
   onDelete: (provider: OidcProviderDto) => void;
 }
 
-const COLUMNS = ['Provider', 'Type', 'Client ID', 'Status', 'Created', ''];
+const COLUMNS = ['Provider', 'Type', 'Issuer', 'Client ID', 'Status', 'Created', ''];
 
 export function OidcProvidersTable({
   providers,
@@ -95,8 +96,24 @@ export function OidcProvidersTable({
                 <Typography sx={{ fontWeight: 600 }}>{provider.name}</Typography>
               </TableCell>
               <TableCell>
-                <Typography sx={{ fontSize: 13, color: 'text.secondary' }}>
-                  {providerTypeLabel(provider.providerType)}
+                <Chip
+                  label={providerTypeLabel(provider.providerType)}
+                  size="small"
+                  variant="outlined"
+                />
+              </TableCell>
+              <TableCell>
+                <Typography
+                  sx={{
+                    fontSize: 13,
+                    color: 'text.secondary',
+                    fontFamily: 'monospace',
+                    maxWidth: 220,
+                  }}
+                  noWrap
+                  title={provider.issuerUri ?? undefined}
+                >
+                  {provider.issuerUri ?? '—'}
                 </Typography>
               </TableCell>
               <TableCell>

--- a/qnop-ui/src/components/admin/oidc/ProviderCallbackInstructions.test.tsx
+++ b/qnop-ui/src/components/admin/oidc/ProviderCallbackInstructions.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ProviderCallbackInstructions } from './ProviderCallbackInstructions';
+
+describe('ProviderCallbackInstructions', () => {
+  it('renders the Spring callback URL built from the provider id', () => {
+    render(<ProviderCallbackInstructions providerId="abc-123" providerType="GOOGLE" />);
+    expect(
+      screen.getByText(`${window.location.origin}/login/oauth2/code/abc-123`),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the provider-specific field label and a console link for known providers', () => {
+    render(<ProviderCallbackInstructions providerId="abc-123" providerType="GITHUB" />);
+    expect(screen.getByText('Authorization callback URL')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /github developer settings/i })).toHaveAttribute(
+      'href',
+      'https://github.com/settings/developers',
+    );
+  });
+
+  it('stays generic (no console link) for a plain OIDC provider', () => {
+    render(<ProviderCallbackInstructions providerId="abc-123" providerType="OIDC" />);
+    expect(screen.getByText('Valid Redirect URIs')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /open .* console|developer settings/i })).toBeNull();
+  });
+});

--- a/qnop-ui/src/components/admin/oidc/ProviderCallbackInstructions.tsx
+++ b/qnop-ui/src/components/admin/oidc/ProviderCallbackInstructions.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { Check, Copy, ExternalLink } from 'lucide-react';
+import type { OidcProviderTypeDto } from '../../../api/generated';
+
+interface ProviderHelp {
+  /** Where in the provider's admin UI the operator finds the redirect-URI setting. */
+  whereToFind: string;
+  /** What that field is labelled at the upstream provider. */
+  fieldLabel: string;
+  /** Optional direct link to the provider's console / developer settings. */
+  consoleUrl?: string;
+  /** Human-readable label for the console link. */
+  consoleLabel?: string;
+}
+
+/**
+ * Per-provider hints for *where* the callback URL needs to be pasted at the
+ * upstream IdP. For OIDC/OAUTH2 we stay generic — those types cover any
+ * conformant provider, so naming a specific console would mislead.
+ */
+const PROVIDER_HELP: Record<OidcProviderTypeDto, ProviderHelp> = {
+  GOOGLE: {
+    whereToFind: 'APIs & Services → Credentials → OAuth 2.0 Client IDs → your client',
+    fieldLabel: 'Authorized redirect URIs',
+    consoleUrl: 'https://console.cloud.google.com/apis/credentials',
+    consoleLabel: 'Open Google Cloud Console',
+  },
+  GITHUB: {
+    whereToFind: 'GitHub → Settings → Developer settings → OAuth Apps → your app',
+    fieldLabel: 'Authorization callback URL',
+    consoleUrl: 'https://github.com/settings/developers',
+    consoleLabel: 'Open GitHub developer settings',
+  },
+  FACEBOOK: {
+    whereToFind: 'Meta for Developers → your app → Facebook Login → Settings',
+    fieldLabel: 'Valid OAuth Redirect URIs',
+    consoleUrl: 'https://developers.facebook.com/apps',
+    consoleLabel: 'Open Meta for Developers',
+  },
+  OIDC: {
+    whereToFind: "Your IdP's client configuration (Keycloak, Authentik, Auth0, Dex, …)",
+    fieldLabel: 'Valid Redirect URIs',
+  },
+  OAUTH2: {
+    whereToFind: "Your provider's OAuth2 application settings",
+    fieldLabel: 'Redirect URI / Callback URL',
+  },
+};
+
+/**
+ * The OAuth2 callback URL qnop listens on for a provider — mirrors Spring's
+ * `{origin}/login/oauth2/code/{registrationId}` with the registration id being
+ * the provider's UUID. `window.location.origin` is what the browser hits when
+ * the upstream redirects back.
+ */
+function buildCallbackUrl(providerId: string): string {
+  return `${window.location.origin}/login/oauth2/code/${providerId}`;
+}
+
+interface ProviderCallbackInstructionsProps {
+  providerId: string;
+  providerType: OidcProviderTypeDto;
+  /** `success` = fresh-create hero step; `inline` = neutral edit-mode reference card. */
+  variant?: 'success' | 'inline';
+}
+
+/**
+ * "Register this URL with your IdP" panel: the callback URL in monospace with a
+ * one-click copy, plus the right setting to paste it into on the provider's
+ * side. This is the one external value an operator must act on after creating a
+ * provider, so it is composed as the hero of its container, not a footnote.
+ */
+export function ProviderCallbackInstructions({
+  providerId,
+  providerType,
+  variant = 'inline',
+}: ProviderCallbackInstructionsProps) {
+  const callbackUrl = useMemo(() => buildCallbackUrl(providerId), [providerId]);
+  const help = PROVIDER_HELP[providerType];
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(callbackUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard can fail in non-secure contexts; the URL stays selectable for manual copy.
+    }
+  };
+
+  const isSuccess = variant === 'success';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1.5,
+        p: 2.25,
+        borderRadius: 1.5,
+        border: 1,
+        borderColor: isSuccess ? 'success.light' : 'divider',
+        bgcolor: isSuccess ? 'rgba(46, 125, 50, 0.06)' : 'rgba(0, 0, 0, 0.02)',
+      }}
+    >
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'baseline' }}>
+        <Typography
+          variant="overline"
+          sx={{
+            color: isSuccess ? 'success.main' : 'text.secondary',
+            letterSpacing: 0.8,
+            fontWeight: 600,
+            lineHeight: 1,
+          }}
+        >
+          Callback URL
+        </Typography>
+        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+          register this at your provider
+        </Typography>
+      </Stack>
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'stretch' }}>
+        <Box
+          component="code"
+          tabIndex={0}
+          aria-label="OAuth2 callback URL"
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            px: 1.5,
+            py: 1.25,
+            borderRadius: 1,
+            border: 1,
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+            fontFamily: '"JetBrains Mono", "SF Mono", Menlo, ui-monospace, monospace',
+            fontSize: '0.85rem',
+            color: 'text.primary',
+            wordBreak: 'break-all',
+            userSelect: 'all',
+          }}
+        >
+          {callbackUrl}
+        </Box>
+        <Tooltip title={copied ? 'Copied' : 'Copy to clipboard'} placement="top" arrow>
+          <IconButton
+            onClick={handleCopy}
+            aria-label="Copy callback URL"
+            color={copied ? 'success' : 'default'}
+            sx={{
+              border: 1,
+              borderColor: copied ? 'success.light' : 'divider',
+              borderRadius: 1,
+              alignSelf: 'stretch',
+              px: 1.5,
+            }}
+          >
+            {copied ? <Check size={18} /> : <Copy size={18} />}
+          </IconButton>
+        </Tooltip>
+      </Stack>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={1.25}
+        sx={{
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          justifyContent: 'space-between',
+          mt: 0.25,
+        }}
+      >
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="body2" sx={{ lineHeight: 1.45 }}>
+            <Typography component="span" variant="body2" sx={{ color: 'text.secondary' }}>
+              Paste into:{' '}
+            </Typography>
+            <Typography component="span" variant="body2" sx={{ fontWeight: 600 }}>
+              {help.fieldLabel}
+            </Typography>
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: 'text.secondary', display: 'block', lineHeight: 1.4, mt: 0.25 }}
+          >
+            {help.whereToFind}
+          </Typography>
+        </Box>
+        {help.consoleUrl && (
+          <Button
+            component="a"
+            href={help.consoleUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="small"
+            variant="text"
+            endIcon={<ExternalLink size={14} />}
+            sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
+          >
+            {help.consoleLabel ?? 'Open provider console'}
+          </Button>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/admin/oidc/oidcProviderTypes.ts
+++ b/qnop-ui/src/components/admin/oidc/oidcProviderTypes.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { OidcProviderTypeDto } from '../../../api/generated';
+
+/** Human-readable labels for the provider-type enum, in form/select order. */
+export const PROVIDER_TYPES: { value: OidcProviderTypeDto; label: string }[] = [
+  { value: OidcProviderTypeDto.Oidc, label: 'Generic OIDC' },
+  { value: OidcProviderTypeDto.Google, label: 'Google' },
+  { value: OidcProviderTypeDto.Github, label: 'GitHub' },
+  { value: OidcProviderTypeDto.Facebook, label: 'Facebook' },
+  { value: OidcProviderTypeDto.Oauth2, label: 'Generic OAuth2' },
+];
+
+const LABELS: Record<string, string> = Object.fromEntries(
+  PROVIDER_TYPES.map((type) => [type.value, type.label]),
+);
+
+export function providerTypeLabel(type: OidcProviderTypeDto): string {
+  return LABELS[type] ?? type;
+}
+
+/** Whether the type resolves its endpoints from an issuer's discovery document. */
+export function supportsDiscovery(type: OidcProviderTypeDto): boolean {
+  return type === OidcProviderTypeDto.Oidc || type === OidcProviderTypeDto.Google;
+}

--- a/qnop-ui/src/components/admin/users/UserBadges.tsx
+++ b/qnop-ui/src/components/admin/users/UserBadges.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { UserRole } from '../../../api/generated';
+import type { UserRole, UserSource } from '../../../api/generated';
 import { ToneBadge, type BadgeTone } from '../ToneBadge';
 
 const ROLE_TONE: Record<UserRole, BadgeTone> = {
@@ -44,5 +44,24 @@ export function UserStatusBadge({ enabled }: { enabled: boolean }) {
     <ToneBadge tone="green" label="Active" />
   ) : (
     <ToneBadge tone="red" label="Disabled" />
+  );
+}
+
+/**
+ * Where the account comes from: a local (INTERNAL) login or an external OIDC
+ * provider. External accounts show the provider's name (e.g. "Keycloak") so the
+ * operator sees *which* IdP at a glance; local accounts read "Local".
+ */
+export function UserSourceBadge({
+  source,
+  providerName,
+}: {
+  source: UserSource;
+  providerName?: string;
+}) {
+  return source === 'EXTERNAL' ? (
+    <ToneBadge tone="blue" label={providerName?.trim() || 'External'} />
+  ) : (
+    <ToneBadge tone="neutral" label="Local" />
   );
 }

--- a/qnop-ui/src/components/admin/users/UsersTable.tsx
+++ b/qnop-ui/src/components/admin/users/UsersTable.tsx
@@ -41,7 +41,7 @@ import type { AdminUserSummary } from '../../../api/generated';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { formatDateTime, formatRelative } from '../../../utils/formatDate';
 import { ToneBadge } from '../ToneBadge';
-import { UserRoleBadge, UserStatusBadge } from './UserBadges';
+import { UserRoleBadge, UserSourceBadge, UserStatusBadge } from './UserBadges';
 
 interface UsersTableProps {
   users: AdminUserSummary[];
@@ -58,6 +58,7 @@ interface UsersTableProps {
 const COLUMNS: { key: string; label: string; sortable?: boolean }[] = [
   { key: 'displayName', label: 'User', sortable: true },
   { key: 'role', label: 'Role', sortable: true },
+  { key: 'source', label: 'Source' },
   { key: 'status', label: 'Status' },
   { key: 'createdAt', label: 'Created', sortable: true },
   { key: 'lastLoginAt', label: 'Last login', sortable: true },
@@ -133,14 +134,6 @@ export function UsersTable({
                       <Typography sx={{ fontWeight: 600, lineHeight: 1.3 }} noWrap>
                         {user.displayName}
                       </Typography>
-                      {user.source === 'EXTERNAL' && (
-                        <Typography
-                          component="span"
-                          sx={{ fontSize: 11, color: 'text.secondary', fontWeight: 500 }}
-                        >
-                          ({user.providerName ?? 'OIDC'})
-                        </Typography>
-                      )}
                       {user.passwordChangeRequired && (
                         <ToneBadge tone="amber" label="Password change" />
                       )}
@@ -153,6 +146,9 @@ export function UsersTable({
               </TableCell>
               <TableCell>
                 <UserRoleBadge role={user.role} />
+              </TableCell>
+              <TableCell>
+                <UserSourceBadge source={user.source} providerName={user.providerName} />
               </TableCell>
               <TableCell>
                 <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>

--- a/qnop-ui/src/components/auth/OidcButtons.test.tsx
+++ b/qnop-ui/src/components/auth/OidcButtons.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OidcButtons } from './OidcButtons';
+import { useConfig } from '../../api/hooks/useConfig';
+
+vi.mock('../../api/hooks/useConfig', () => ({ useConfig: vi.fn() }));
+
+function mockProviders(providers: unknown[]) {
+  vi.mocked(useConfig).mockReturnValue({
+    data: { auth: { oidcProviders: providers } },
+  } as never);
+}
+
+const GOOGLE = {
+  id: '1',
+  name: 'Google',
+  loginUrl: '/oauth2/authorization/1',
+  iconKind: 'google',
+  accountPickerLoginUrl: '/oauth2/authorization/1?prompt=select_account',
+};
+
+const GITHUB = {
+  id: '2',
+  name: 'GitHub',
+  loginUrl: '/oauth2/authorization/2',
+  iconKind: 'github',
+  accountSwitchHintUrl: 'https://github.com/logout',
+};
+
+describe('OidcButtons', () => {
+  it('renders nothing when no providers are enabled', () => {
+    mockProviders([]);
+    const { container } = render(<OidcButtons />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the primary button as an anchor pointing at the login URL', () => {
+    mockProviders([GOOGLE]);
+    render(<OidcButtons />);
+    const link = screen.getByRole('link', { name: /sign in with google/i });
+    expect(link).toHaveAttribute('href', '/oauth2/authorization/1');
+  });
+
+  it('renders a "Use a different account" link for a prompt-capable provider', () => {
+    mockProviders([GOOGLE]);
+    render(<OidcButtons />);
+    const switcher = screen.getByRole('link', { name: /different google account/i });
+    expect(switcher).toHaveAttribute('href', '/oauth2/authorization/1?prompt=select_account');
+  });
+
+  it('renders a sign-out hint with the host for a provider without a picker (GitHub)', () => {
+    mockProviders([GITHUB]);
+    render(<OidcButtons />);
+    expect(screen.getByText(/to switch accounts/i)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /different github account/i })).toBeNull();
+    expect(screen.getByRole('link', { name: 'github.com' })).toHaveAttribute(
+      'href',
+      'https://github.com/logout',
+    );
+  });
+
+  it('renders one button per enabled provider', () => {
+    mockProviders([GOOGLE, GITHUB]);
+    render(<OidcButtons />);
+    expect(screen.getByRole('link', { name: /sign in with google/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /sign in with github/i })).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/auth/OidcButtons.tsx
+++ b/qnop-ui/src/components/auth/OidcButtons.tsx
@@ -19,17 +19,22 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
-import { LogIn } from 'lucide-react';
+import Typography from '@mui/material/Typography';
+import type { OidcProviderLoginInfo } from '../../api/generated';
 import { useConfig } from '../../api/hooks/useConfig';
+import { ProviderIcon } from './ProviderIcon';
 
 /**
- * "Login with <provider>" buttons for each enabled OIDC provider (from
- * /config). OIDC is a full-page browser handshake, so the button navigates the
- * window to the provider's login URL rather than making an XHR. SAML is not
- * supported (backend is OIDC-only). Renders nothing when no provider is enabled.
+ * "Sign in with <provider>" buttons for each enabled OIDC provider (from
+ * /config). OIDC is a full-page browser handshake, so each button is a real
+ * anchor — Spring Security intercepts the navigation, and the operator keeps
+ * keyboard, middle-click, and open-in-new-tab semantics. Renders nothing when
+ * no provider is enabled. SAML is not supported (backend is OIDC-only).
  */
 export function OidcButtons() {
   const { data } = useConfig();
@@ -42,23 +47,96 @@ export function OidcButtons() {
   return (
     <>
       <Divider sx={{ my: 2.5, color: 'text.disabled', fontSize: 12 }}>or</Divider>
-      <Stack spacing={1.25}>
-        {providers.map((p) => (
-          <Button
-            key={p.id}
-            variant="outlined"
-            color="inherit"
-            fullWidth
-            startIcon={<LogIn size={16} />}
-            onClick={() => {
-              window.location.href = p.loginUrl;
-            }}
-            sx={{ borderColor: 'divider', color: 'text.primary', justifyContent: 'center' }}
-          >
-            Sign in with {p.name}
-          </Button>
+      <Stack spacing={1.5}>
+        {providers.map((provider) => (
+          <OidcProviderButton key={provider.id} provider={provider} />
         ))}
       </Stack>
     </>
   );
+}
+
+interface OidcProviderButtonProps {
+  provider: OidcProviderLoginInfo;
+}
+
+/**
+ * One provider button plus an optional "Use a different account" affordance
+ * underneath. The primary button is silent SSO (re-uses the upstream session);
+ * the affordance lets the operator switch accounts where the provider supports
+ * it.
+ */
+function OidcProviderButton({ provider }: OidcProviderButtonProps) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+      <Button
+        component="a"
+        href={provider.loginUrl}
+        variant="outlined"
+        color="inherit"
+        fullWidth
+        startIcon={<ProviderIcon kind={provider.iconKind} />}
+        sx={{ borderColor: 'divider', color: 'text.primary', justifyContent: 'center' }}
+      >
+        Sign in with {provider.name}
+      </Button>
+      <AccountSwitchAffordance provider={provider} />
+    </Box>
+  );
+}
+
+/**
+ * The small caption under a provider button. Renders a clickable "Use a
+ * different account" link when the provider honours a `prompt` (OIDC/Google/
+ * Facebook/OAuth2), a textual upstream sign-out hint when it does not (GitHub),
+ * or nothing when the backend omits both fields (defensive).
+ */
+function AccountSwitchAffordance({ provider }: OidcProviderButtonProps) {
+  if (provider.accountPickerLoginUrl) {
+    return (
+      <Link
+        component="a"
+        href={provider.accountPickerLoginUrl}
+        variant="caption"
+        underline="hover"
+        aria-label={`Sign in with a different ${provider.name} account`}
+        sx={{ color: 'text.secondary', fontWeight: 500, '&:hover': { color: 'text.secondary' } }}
+      >
+        Use a different account
+      </Link>
+    );
+  }
+  if (provider.accountSwitchHintUrl) {
+    const host = safeHostname(provider.accountSwitchHintUrl);
+    return (
+      <Typography
+        variant="caption"
+        sx={{ color: 'text.secondary', textAlign: 'center', lineHeight: 1.4 }}
+      >
+        To switch accounts, sign out at{' '}
+        <Link
+          component="a"
+          href={provider.accountSwitchHintUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          underline="hover"
+          color="inherit"
+          sx={{ fontFamily: 'monospace' }}
+        >
+          {host}
+        </Link>{' '}
+        first.
+      </Typography>
+    );
+  }
+  return null;
+}
+
+/** Hostname of an absolute URL for inline display; returns the input on parse failure. */
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
 }

--- a/qnop-ui/src/components/auth/PasswordField.tsx
+++ b/qnop-ui/src/components/auth/PasswordField.tsx
@@ -31,6 +31,8 @@ interface PasswordFieldProps {
   onChange: (value: string) => void;
   autoComplete?: string;
   required?: boolean;
+  error?: boolean;
+  helperText?: string;
 }
 
 /** A password input with a show/hide toggle, used across the auth screens. */
@@ -40,6 +42,8 @@ export function PasswordField({
   onChange,
   autoComplete,
   required,
+  error,
+  helperText,
 }: PasswordFieldProps) {
   const [show, setShow] = useState(false);
 
@@ -51,6 +55,8 @@ export function PasswordField({
       onChange={(e) => onChange(e.target.value)}
       autoComplete={autoComplete}
       required={required}
+      error={error}
+      helperText={helperText}
       fullWidth
       slotProps={{
         input: {

--- a/qnop-ui/src/components/auth/ProviderIcon.test.tsx
+++ b/qnop-ui/src/components/auth/ProviderIcon.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import type { OidcIconKind } from '../../api/generated';
+import { ProviderIcon } from './ProviderIcon';
+
+describe('ProviderIcon', () => {
+  it('renders an svg glyph for every icon kind', () => {
+    const kinds: OidcIconKind[] = ['github', 'google', 'facebook', 'oidc', 'oauth2'];
+    for (const kind of kinds) {
+      const { container } = render(<ProviderIcon kind={kind} />);
+      expect(container.querySelector('svg')).not.toBeNull();
+    }
+  });
+
+  it('uses the generic key glyph for oidc/oauth2 and a brand mark otherwise', () => {
+    const oidc = render(<ProviderIcon kind="oidc" />).container.querySelector('svg');
+    const github = render(<ProviderIcon kind="github" />).container.querySelector('svg');
+    // lucide tags its icons with a `lucide-*` class; the inline brand marks do not.
+    expect(oidc?.getAttribute('class') ?? '').toMatch(/lucide/);
+    expect(github?.getAttribute('class') ?? '').not.toMatch(/lucide/);
+  });
+});

--- a/qnop-ui/src/components/auth/ProviderIcon.tsx
+++ b/qnop-ui/src/components/auth/ProviderIcon.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { KeyRound } from 'lucide-react';
+import type { OidcIconKind } from '../../api/generated';
+
+interface ProviderIconProps {
+  kind: OidcIconKind;
+  size?: number;
+}
+
+/**
+ * Brand glyph for one OIDC/OAuth2 provider button on the login page. `github`,
+ * `google`, and `facebook` use the single-colour inline SVG marks each vendor's
+ * design policy permits in third-party UIs without a brand-approval process;
+ * they render in the surrounding text colour via `currentColor`. The generic
+ * `oidc`/`oauth2` fallback reuses lucide's `KeyRound` (already in the bundle).
+ */
+export function ProviderIcon({ kind, size = 18 }: ProviderIconProps) {
+  switch (kind) {
+    case 'github':
+      return <GithubMark size={size} />;
+    case 'google':
+      return <GoogleMark size={size} />;
+    case 'facebook':
+      return <FacebookMark size={size} />;
+    case 'oidc':
+    case 'oauth2':
+    default:
+      return <KeyRound size={size} aria-hidden />;
+  }
+}
+
+/** GitHub Octocat silhouette — single-colour, inherits text colour. */
+function GithubMark({ size }: { size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
+/** Google "G" mark — single-colour silhouette, inherits text colour. */
+function GoogleMark({ size }: { size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
+    </svg>
+  );
+}
+
+/** Facebook "f" mark — single-colour, inherits text colour. */
+function FacebookMark({ size }: { size: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+    </svg>
+  );
+}

--- a/qnop-ui/src/components/shell/UserFooter.tsx
+++ b/qnop-ui/src/components/shell/UserFooter.tsx
@@ -45,6 +45,7 @@ interface UserFooterProps {
 export function UserFooter({ collapsed }: UserFooterProps) {
   const displayName = useAuthStore((s) => s.displayName);
   const role = useAuthStore((s) => s.role);
+  const source = useAuthStore((s) => s.source);
   const logout = useAuthStore((s) => s.logout);
   const navigate = useNavigate();
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
@@ -89,17 +90,20 @@ export function UserFooter({ collapsed }: UserFooterProps) {
         anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
         transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       >
-        <MenuItem
-          onClick={() => {
-            setAnchor(null);
-            navigate('/change-password');
-          }}
-        >
-          <ListItemIcon>
-            <KeyRound size={16} />
-          </ListItemIcon>
-          Change password
-        </MenuItem>
+        {/* External (OIDC) accounts have no local password — only local users can change it. */}
+        {source !== 'EXTERNAL' && (
+          <MenuItem
+            onClick={() => {
+              setAnchor(null);
+              navigate('/change-password');
+            }}
+          >
+            <ListItemIcon>
+              <KeyRound size={16} />
+            </ListItemIcon>
+            Change password
+          </MenuItem>
+        )}
         <MenuItem onClick={onLogout}>
           <ListItemIcon>
             <LogOut size={16} />

--- a/qnop-ui/src/pages/admin/OidcProvidersPage.tsx
+++ b/qnop-ui/src/pages/admin/OidcProvidersPage.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import LinearProgress from '@mui/material/LinearProgress';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { Plus } from 'lucide-react';
+import type { OidcProviderDto } from '../../api/generated';
+import {
+  useDeleteOidcProvider,
+  useOidcProviders,
+  useUpdateOidcProvider,
+} from '../../api/hooks/useOidcProviders';
+import { ConfirmDialog } from '../../components/admin/ConfirmDialog';
+import { OidcProviderFormDialog } from '../../components/admin/oidc/OidcProviderFormDialog';
+import { OidcProvidersTable } from '../../components/admin/oidc/OidcProvidersTable';
+import { apiErrorMessage } from '../../utils/apiError';
+
+type DialogState =
+  | { open: false }
+  | { open: true; mode: 'create' }
+  | { open: true; mode: 'edit'; provider: OidcProviderDto };
+
+type Toast = { message: string; severity: 'success' | 'error' } | null;
+
+/** Admin OIDC/OAuth2 provider management: list, add, edit, enable and delete (#106). */
+export function OidcProvidersPage() {
+  const { data, isLoading, isFetching, isError } = useOidcProviders();
+  const updateProvider = useUpdateOidcProvider();
+  const deleteProvider = useDeleteOidcProvider();
+
+  const [dialog, setDialog] = useState<DialogState>({ open: false });
+  const [openSeq, setOpenSeq] = useState(0);
+  const [toDelete, setToDelete] = useState<OidcProviderDto | null>(null);
+  const [toast, setToast] = useState<Toast>(null);
+
+  const providers = data?.providers ?? [];
+
+  const openCreate = () => {
+    setDialog({ open: true, mode: 'create' });
+    setOpenSeq((n) => n + 1);
+  };
+  const openEdit = (provider: OidcProviderDto) => {
+    setDialog({ open: true, mode: 'edit', provider });
+    setOpenSeq((n) => n + 1);
+  };
+
+  const onToggleEnabled = async (provider: OidcProviderDto) => {
+    try {
+      await updateProvider.mutateAsync({
+        id: provider.id,
+        request: { enabled: !provider.enabled },
+      });
+      setToast({
+        message: `${provider.name} ${provider.enabled ? 'disabled' : 'enabled'}.`,
+        severity: 'success',
+      });
+    } catch (err) {
+      setToast({
+        message: apiErrorMessage(err, 'The change could not be saved.'),
+        severity: 'error',
+      });
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!toDelete) return;
+    try {
+      await deleteProvider.mutateAsync(toDelete.id);
+      setToast({ message: `${toDelete.name} deleted.`, severity: 'success' });
+    } catch (err) {
+      setToast({
+        message: apiErrorMessage(err, 'The provider could not be deleted.'),
+        severity: 'error',
+      });
+    } finally {
+      setToDelete(null);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        sx={{ justifyContent: 'space-between', alignItems: { sm: 'center' } }}
+      >
+        <Box>
+          <Typography variant="h1" sx={{ fontSize: 28 }}>
+            OIDC providers
+          </Typography>
+          <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+            Configure single sign-on identity providers. New providers start disabled.
+          </Typography>
+        </Box>
+        <Button variant="contained" startIcon={<Plus size={18} />} onClick={openCreate}>
+          Add provider
+        </Button>
+      </Stack>
+
+      <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+        <Box sx={{ height: 3 }}>{isFetching && <LinearProgress />}</Box>
+        {isError ? (
+          <Alert severity="error" sx={{ m: 2 }}>
+            The providers could not be loaded.
+          </Alert>
+        ) : (
+          <OidcProvidersTable
+            providers={providers}
+            onEdit={openEdit}
+            onToggleEnabled={onToggleEnabled}
+            onDelete={setToDelete}
+          />
+        )}
+        {isLoading && (
+          <Typography color="text.secondary" sx={{ p: 2, fontSize: 14 }}>
+            Loading…
+          </Typography>
+        )}
+      </Paper>
+
+      <OidcProviderFormDialog
+        key={openSeq}
+        open={dialog.open}
+        mode={dialog.open ? dialog.mode : 'create'}
+        provider={dialog.open && dialog.mode === 'edit' ? dialog.provider : undefined}
+        onClose={() => setDialog({ open: false })}
+      />
+
+      <ConfirmDialog
+        open={toDelete !== null}
+        title="Delete provider"
+        message={`Delete “${toDelete?.name}”? Users will no longer be able to sign in with it. This cannot be undone.`}
+        confirmLabel="Delete"
+        destructive
+        onConfirm={confirmDelete}
+        onClose={() => setToDelete(null)}
+      />
+
+      <Snackbar
+        open={toast !== null}
+        autoHideDuration={5000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert severity={toast.severity} onClose={() => setToast(null)} variant="filled">
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
@@ -43,6 +43,7 @@ import { passwordStrength } from '../../utils/passwordStrength';
 export function ChangePasswordPage() {
   const accessToken = useAuthStore((s) => s.accessToken);
   const forced = useAuthStore((s) => s.passwordChangeRequired);
+  const source = useAuthStore((s) => s.source);
   const clearAuth = useAuthStore((s) => s.clearAuth);
   const [current, setCurrent] = useState('');
   const [password, setPassword] = useState('');
@@ -54,6 +55,13 @@ export function ChangePasswordPage() {
   // Reachable only with a session token (full auth or a forced-change session).
   if (!accessToken && !done) {
     return <Navigate to="/login" replace />;
+  }
+
+  // External (OIDC) accounts have no local password to change; bounce a direct
+  // hit to the home page. A forced-change session keeps source null (its
+  // /users/me is 403-gated), so this never blocks the local first-login flow.
+  if (source === 'EXTERNAL' && !done) {
+    return <Navigate to="/" replace />;
   }
 
   const mismatch = confirm.length > 0 && confirm !== password;

--- a/qnop-ui/src/pages/auth/LoginPage.tsx
+++ b/qnop-ui/src/pages/auth/LoginPage.tsx
@@ -23,11 +23,12 @@ import { useState, type FormEvent } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 import InputAdornment from '@mui/material/InputAdornment';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
-import { AtSign } from 'lucide-react';
+import { ArrowRight, AtSign } from 'lucide-react';
 import { Link as RouterLink, useNavigate, useSearchParams } from 'react-router-dom';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { AuthModeSwitch } from '../../components/auth/AuthModeSwitch';
@@ -133,7 +134,16 @@ export function LoginPage() {
             </Box>
           </Box>
 
-          <Button type="submit" variant="contained" size="large" disabled={submitting} fullWidth>
+          <Button
+            type="submit"
+            variant="contained"
+            size="large"
+            disabled={submitting}
+            fullWidth
+            endIcon={
+              submitting ? <CircularProgress size={16} color="inherit" /> : <ArrowRight size={16} />
+            }
+          >
             Sign in
           </Button>
         </Stack>

--- a/qnop-ui/src/pages/auth/LoginPage.tsx
+++ b/qnop-ui/src/pages/auth/LoginPage.tsx
@@ -38,6 +38,17 @@ import { useAuthStore } from '../../stores/authStore';
 import { apiErrorMessage } from '../../utils/apiError';
 import { safeRedirectPath } from '../../utils/safeRedirectPath';
 
+/**
+ * OIDC redirect-failure codes set by the backend success handler (`/login?error=…`) mapped to
+ * user-facing copy. Unknown codes fall back to the generic message.
+ */
+const OIDC_LOGIN_ERRORS: Record<string, string> = {
+  account_disabled: 'Your account is disabled. Please contact an administrator.',
+  email_missing:
+    'The identity provider did not share an email address, which qnop requires for an account.',
+  oidc: 'Sign-in via the identity provider failed. Please try again or contact an administrator.',
+};
+
 /** Login screen: local credentials, OIDC providers, links to register / reset. */
 export function LoginPage() {
   const login = useAuthStore((s) => s.login);
@@ -46,7 +57,10 @@ export function LoginPage() {
   const { data: config } = useConfig();
   const [usernameOrEmail, setUsernameOrEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(() => {
+    const code = params.get('error');
+    return code ? (OIDC_LOGIN_ERRORS[code] ?? OIDC_LOGIN_ERRORS.oidc) : null;
+  });
   const [submitting, setSubmitting] = useState(false);
 
   const canRegister = !!config?.auth?.selfRegistrationEnabled;
@@ -75,6 +89,11 @@ export function LoginPage() {
       subtitle="Sign in to continue with your reviews."
       headerSlot={canRegister ? <AuthModeSwitch active="login" /> : undefined}
     >
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
       <Box component="form" onSubmit={onSubmit} noValidate>
         <Stack spacing={2}>
           <TextField
@@ -113,8 +132,6 @@ export function LoginPage() {
               </Link>
             </Box>
           </Box>
-
-          {error && <Alert severity="error">{error}</Alert>}
 
           <Button type="submit" variant="contained" size="large" disabled={submitting} fullWidth>
             Sign in

--- a/qnop-ui/src/pages/auth/RegisterPage.tsx
+++ b/qnop-ui/src/pages/auth/RegisterPage.tsx
@@ -24,13 +24,14 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
+import CircularProgress from '@mui/material/CircularProgress';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import InputAdornment from '@mui/material/InputAdornment';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { AtSign, Mail, User } from 'lucide-react';
+import { ArrowRight, AtSign, Mail, User } from 'lucide-react';
 import { Link as RouterLink, Navigate } from 'react-router-dom';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { AuthModeSwitch } from '../../components/auth/AuthModeSwitch';
@@ -158,6 +159,9 @@ export function RegisterPage() {
             size="large"
             disabled={submitting || !canSubmit}
             fullWidth
+            endIcon={
+              submitting ? <CircularProgress size={16} color="inherit" /> : <ArrowRight size={16} />
+            }
           >
             Create account
           </Button>

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -20,13 +20,14 @@
  */
 
 import { createBrowserRouter } from 'react-router-dom';
-import { FileText, KeyRound, Mail, Palette, ShieldCheck } from 'lucide-react';
+import { FileText, Mail, Palette, ShieldCheck } from 'lucide-react';
 import { AppShell } from '../components/shell/AppShell';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { ProtectedRoute } from '../components/auth/ProtectedRoute';
 import { RoleRoute } from '../components/auth/RoleRoute';
 import { ComingSoonPage } from '../pages/ComingSoonPage';
 import { HomePage } from '../pages/HomePage';
+import { OidcProvidersPage } from '../pages/admin/OidcProvidersPage';
 import { SettingsPage } from '../pages/admin/SettingsPage';
 import { UsersPage } from '../pages/admin/UsersPage';
 import { TeamsPage } from '../pages/admin/TeamsPage';
@@ -121,11 +122,7 @@ export const router = createBrowserRouter([
         path: 'admin/oidc-providers',
         element: (
           <AdminRoute>
-            <ComingSoonPage
-              title="OIDC providers"
-              description="Configure single sign-on identity providers — list, add, discover and enable."
-              icon={KeyRound}
-            />
+            <OidcProvidersPage />
           </AdminRoute>
         ),
       },


### PR DESCRIPTION
## Summary

Brings qnop's OIDC support to full parity with the plugwerk reference and hardens the account lifecycle, end-to-end against a local Keycloak. Started as the provider-management screen; grew to cover the whole "sign in with an IdP" flow plus the gaps surfaced while testing it live.

## Backend

- **Login-info contract** — `OidcProviderLoginInfo` gains `iconKind`, `accountPickerLoginUrl`, `accountSwitchHintUrl`; `OidcLoginInfoFactory` derives them per provider type.
- **Prompt forwarding** — `PromptAwareOAuth2AuthorizationRequestResolver` forwards an allow-listed `prompt` (GitHub carve-out, PKCE/state preserved). Generic OIDC/OAuth2 use `prompt=login` (Keycloak ignores `select_account`).
- **Discovery fix** — `ClientRegistrations.fromIssuerLocation(...).build()` needed a placeholder client id; surfaced as a misleading failure. Now works, and the real cause reaches the admin.
- **Account lifecycle** — OIDC login rejects disabled accounts (mirroring local login); disabling a user now revokes their access + refresh sessions immediately.
- **Dev** — `qnop.auth.oidc.allow-private-discovery-uris` flag (off by default) so a loopback Keycloak issuer can be discovered locally.

## Frontend

- **Login page** — per-provider brand icons (`ProviderIcon`), "Use a different account" affordance, anchor semantics; OIDC failures surfaced in a dismissible banner with specific messages.
- **Provider admin** — `ProviderCallbackInstructions` (copy + per-provider hints), provider-type lock on edit, client-side validation, scope locking, richer discovery banner, endpoints hidden for well-known vendors; issuer column + type chip in the table.
- **Users table** — external vs local accounts distinguished via a Source column.
- **Hardening** — "Change password" hidden/blocked for external accounts.
- **Polish** — login/register CTAs match the design prototype (arrow + loading state).

## Dev infra

- `docker compose --profile keycloak` — Keycloak 26 with an imported `qnop` realm (client `qnop-local`, test users alice/bob) for testing the login flow.

## Test plan

- [x] Backend unit/slice + ArchUnit green locally
- [x] Frontend lint + typecheck + 92 unit tests + build green
- [x] OIDC flow verified live against the bundled Keycloak (discovery, login, auto-provisioning, account switch, disabled-account rejection, error banner)
- [ ] CI: backend integration tests (Testcontainers) — could not run locally (no Docker)

Closes #106

🤖 Co-Author: Claude (Opus 4.x) via Claude Code
