### PR TITLE
fix: forced first-login password change — min-length + clear forced-change flag (#128, #130)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1768,7 +1768,8 @@ components:
         newPassword:
           type: string
           format: password
-          minLength: 12
+          minLength: 8
+          maxLength: 200
           description: The replacement password. Must meet the minimum-length policy.
       required:
         - currentPassword

--- a/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
@@ -31,6 +31,7 @@ import io.qnop.bootstrap.AbstractIntegrationTest;
 import io.qnop.entity.User;
 import io.qnop.entity.UserRole;
 import io.qnop.repository.UserRepository;
+import io.qnop.service.JwtTokenService;
 import io.qnop.web.security.RefreshTokenCookieFactory;
 import jakarta.servlet.http.Cookie;
 import java.util.regex.Matcher;
@@ -63,6 +64,7 @@ class AuthControllerIT extends AbstractIntegrationTest {
   @Autowired MockMvc mockMvc;
   @Autowired UserRepository userRepository;
   @Autowired PasswordEncoder passwordEncoder;
+  @Autowired JwtTokenService jwtTokenService;
 
   @Test
   void loginIssuesAccessTokenAndRefreshCookie() throws Exception {
@@ -167,6 +169,45 @@ class AuthControllerIT extends AbstractIntegrationTest {
         .andExpect(status().isUnauthorized());
 
     assertThat(user.getId()).isNotNull();
+  }
+
+  @Test
+  void changePasswordAcceptsTheEightCharacterPolicyMinimum() throws Exception {
+    // Regression: the change-password minimum must stay at 8 — matching the other
+    // password fields and the UI strength meter. A 12-char minimum here rejected
+    // passwords the UI had accepted, surfacing as a misleading 400 on first login.
+    // Mint the token directly so the shared, IP-scoped login rate-limit bucket
+    // (drained by the other tests) cannot make this assertion flaky.
+    String accessToken = jwtTokenService.issueAccessToken(createUser("judy").getId());
+
+    String body =
+        "{\"currentPassword\":\"%s\",\"newPassword\":\"%s\"}".formatted(PASSWORD, "pass8wrd");
+    mockMvc
+        .perform(
+            post("/api/v1/auth/change-password")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void changePasswordRejectsTooShortPasswordWithValidationEnvelope() throws Exception {
+    // A password below the minimum trips bean validation, which the global handler
+    // maps to a 400 carrying code VALIDATION_ERROR (the UI keys its message off this).
+    // Mint the token directly to avoid the shared login rate-limit bucket.
+    String accessToken = jwtTokenService.issueAccessToken(createUser("mallory").getId());
+
+    String body =
+        "{\"currentPassword\":\"%s\",\"newPassword\":\"%s\"}".formatted(PASSWORD, "short7x");
+    mockMvc
+        .perform(
+            post("/api/v1/auth/change-password")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
@@ -172,6 +172,31 @@ class AuthControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
+  void changePasswordClearsTheForcedChangeRequirement() throws Exception {
+    // Regression: a user created with "must change password on first login" was sent
+    // back to the change-password screen after every login because the change never
+    // cleared password_change_required. A successful change must clear the flag.
+    User user = createUser("nina");
+    user.setPasswordChangeRequired(true);
+    userRepository.saveAndFlush(user);
+    String accessToken = jwtTokenService.issueAccessToken(user.getId());
+
+    String body =
+        "{\"currentPassword\":\"%s\",\"newPassword\":\"%s\"}"
+            .formatted(PASSWORD, "a-brand-new-strong-password");
+    mockMvc
+        .perform(
+            post("/api/v1/auth/change-password")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isNoContent());
+
+    assertThat(userRepository.findById(user.getId()).orElseThrow().isPasswordChangeRequired())
+        .isFalse();
+  }
+
+  @Test
   void changePasswordAcceptsTheEightCharacterPolicyMinimum() throws Exception {
     // Regression: the change-password minimum must stay at 8 — matching the other
     // password fields and the UI strength meter. A 12-char minimum here rejected

--- a/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
@@ -85,10 +85,14 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   int bumpPasswordInvalidatedBefore(@Param("id") UUID id, @Param("at") Instant at);
 
   /**
-   * Atomically replaces the password hash and increments {@code version} (issue #61), so a password
-   * change cannot be lost to, or clobber, a concurrent edit.
+   * Atomically replaces the password hash, clears {@code password_change_required}, and increments
+   * {@code version} (issue #61). A self-service password change always satisfies any forced-change
+   * requirement, and the version bump means the change cannot be lost to, or clobber, a concurrent
+   * edit.
    */
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE User u SET u.passwordHash = :hash, u.version = u.version + 1 WHERE u.id = :id")
+  @Query(
+      "UPDATE User u SET u.passwordHash = :hash, u.passwordChangeRequired = false,"
+          + " u.version = u.version + 1 WHERE u.id = :id")
   int updatePasswordHash(@Param("id") UUID id, @Param("hash") String hash);
 }

--- a/qnop-core/src/main/java/io/qnop/service/AuthService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AuthService.java
@@ -78,8 +78,9 @@ public class AuthService {
   }
 
   /**
-   * Re-verifies the current password, stores the new hash, and invalidates every existing session
-   * (access tokens via {@code passwordInvalidatedBefore}; refresh families revoked).
+   * Re-verifies the current password, stores the new hash, clears any forced-change requirement
+   * ({@code password_change_required}), and invalidates every existing session (access tokens via
+   * {@code passwordInvalidatedBefore}; refresh families revoked).
    */
   @Transactional
   public ChangePasswordOutcome changePassword(

--- a/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
@@ -69,7 +69,12 @@ export function ChangePasswordPage() {
       clearAuth();
       setDone(true);
     } catch (err) {
-      setError(apiErrorMessage(err, 'The current password is wrong or the request failed.'));
+      setError(
+        apiErrorMessage(
+          err,
+          'The current password is wrong, or the new password does not meet the requirements.',
+        ),
+      );
     } finally {
       setSubmitting(false);
     }

--- a/qnop-ui/src/utils/apiError.test.ts
+++ b/qnop-ui/src/utils/apiError.test.ts
@@ -36,8 +36,13 @@ describe('apiErrorMessage', () => {
     expect(apiErrorMessage(axiosWithStatus(429), 'fallback')).toMatch(/attempts/i);
   });
 
-  it('maps a 400 to an invalid/expired message', () => {
+  it('maps a 400 without a validation code to an invalid/expired message', () => {
     expect(apiErrorMessage(axiosWithStatus(400), 'fallback')).toMatch(/invalid|expired/i);
+  });
+
+  it('maps a 400 VALIDATION_ERROR to the caller fallback, not the link-expired text', () => {
+    const error = axiosWithBody(400, { code: 'VALIDATION_ERROR' });
+    expect(apiErrorMessage(error, 'fallback')).toBe('fallback');
   });
 
   it('maps the RATE_LIMITED sentinel error to the rate-limit message', () => {

--- a/qnop-ui/src/utils/apiError.ts
+++ b/qnop-ui/src/utils/apiError.ts
@@ -24,15 +24,21 @@ import { isAxiosError } from 'axios';
 const RATE_LIMITED = 'Too many attempts. Please try again later.';
 
 /**
- * Maps an API/network error to a concise, user-facing German message. Rate
- * limits (429) and bad requests (400) get specific text; everything else falls
- * back to the caller's default. Never surfaces server internals.
+ * Maps an API/network error to a concise, user-facing message. Rate limits (429)
+ * get specific text. A 400 is split by its error code: a body-validation failure
+ * (`VALIDATION_ERROR`, e.g. the password policy) surfaces the caller's
+ * context-specific fallback, while any other 400 — a consumed or expired
+ * token/link in the reset flow — gets the link-expired text. Everything else
+ * falls back to the caller's default. Never surfaces server internals.
  */
 export function apiErrorMessage(error: unknown, fallback: string): string {
   if (isAxiosError(error)) {
     const status = error.response?.status;
     if (status === 429) return RATE_LIMITED;
-    if (status === 400) return 'The request is invalid or the link has expired.';
+    if (status === 400) {
+      if (apiErrorCode(error) === 'VALIDATION_ERROR') return fallback;
+      return 'The request is invalid or the link has expired.';
+    }
   }
   if (error instanceof Error && error.message === 'RATE_LIMITED') {
     return RATE_LIMITED;


### PR DESCRIPTION
## Summary

Two bugs broke the **forced first-login password change** end-to-end. This PR fixes both — same flow, overlapping files.

### Bug 1 — misleading 400, valid password rejected (#128)
The UI accepted a new password from **8** characters, but `ChangePasswordRequest.newPassword` required `minLength: 12`. An 8–11 char password passed the client check, failed server-side validation, and came back as a **400** (`code: VALIDATION_ERROR`, no logged exception). The frontend blanket-mapped *any* 400 to the reset-link text. `change-password` was the only password field requiring 12.

### Bug 2 — forced-change login loop (#130)
After a successful change, the next login sent the user **back** to the change-password screen forever: `AuthService.changePassword` never cleared `password_change_required`, so `PasswordChangeRequiredFilter` kept returning `403 PASSWORD_CHANGE_REQUIRED`. The self-service reset path already cleared the flag; the change-password path did not.

## Changes

- **openapi:** `ChangePasswordRequest.newPassword` `minLength 12 → 8` (+ `maxLength 200`), consistent with the other password fields. Regenerated DTO: `@Size(min=8,max=200)`.
- **`apiError.ts`:** show the link-expired text only for a 400 *without* a `VALIDATION_ERROR` code; otherwise surface the caller's context fallback. The reset flow keeps its "link expired" semantics.
- **`ChangePasswordPage.tsx`:** fallback text covers a wrong current password *or* a policy violation.
- **`UserRepository.updatePasswordHash`:** also clears `password_change_required` in the same atomic, version-bumping update; `AuthService.changePassword` javadoc updated.

## Test plan

- [x] Backend build green; DTO regenerated as `@Size(min=8,max=200)`
- [x] Frontend: unit tests + lint + prettier + typecheck green
- [x] Backend ITs compile + Spotless clean
- [x] CI: backend integration tests — incl. regression tests for the forced-change flag and the 8-char minimum
- [ ] Manual: create a user with *must change password on first login*; log in; set an 8–11 char password → succeeds; sign in again with the new password → reaches the app (no loop)

Closes #128
Closes #130

🤖 Co-Author: Claude (Opus 4.x) via Claude Code
