### PR TITLE
feat: reset / regenerate a user's password from the UI (#116)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -876,6 +876,47 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /admin/users/{userId}/password:
+    post:
+      tags:
+        - AdminUsers
+      summary: Generate a new password for a user (admin)
+      description: |
+        Sets a freshly generated strong password on the user, marks it for change
+        on first login, and revokes the user's active sessions immediately. The
+        generated password is returned **once** for the admin to hand over — it is
+        never stored in clear text and cannot be retrieved again. External (OIDC)
+        accounts have no local password and are rejected with 409. An admin may
+        target their own account; doing so ends their sessions (the response still
+        carries the new password to sign back in with).
+      operationId: generateUserPassword
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserIdParam'
+      responses:
+        '200':
+          description: The password was generated and set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminGeneratedPasswordResponse'
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The account has no local password (external/OIDC)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /admin/teams:
     get:
       tags:
@@ -2083,6 +2124,17 @@ components:
             sent so the operator can deliver it out of band.
       required:
         - emailSent
+    AdminGeneratedPasswordResponse:
+      type: object
+      description: |
+        A freshly generated password, returned exactly once. It is never stored in
+        clear text and cannot be retrieved again — the admin must hand it over now.
+      properties:
+        password:
+          type: string
+          description: The generated plaintext password, shown a single time.
+      required:
+        - password
     AdminUserListResponse:
       type: object
       description: A page of users for the admin list.

--- a/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
@@ -21,6 +21,7 @@
 package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.AdminUsersApi;
+import io.qnop.api.v1.model.AdminGeneratedPasswordResponse;
 import io.qnop.api.v1.model.AdminPasswordResetResponse;
 import io.qnop.api.v1.model.AdminUserCreateRequest;
 import io.qnop.api.v1.model.AdminUserDetail;
@@ -34,6 +35,7 @@ import io.qnop.service.AdminUserConflictException;
 import io.qnop.service.AdminUserService;
 import io.qnop.service.AdminUserService.AdminUserPage;
 import io.qnop.service.AdminUserService.AdminUserView;
+import io.qnop.service.AdminUserService.GeneratedPasswordOutcome;
 import io.qnop.service.AdminUserService.PasswordResetOutcome;
 import io.qnop.service.UserNotFoundException;
 import java.time.Instant;
@@ -117,6 +119,12 @@ public class AdminUserController implements AdminUsersApi {
         new AdminPasswordResetResponse()
             .emailSent(outcome.emailSent())
             .resetUrl(outcome.resetUrl()));
+  }
+
+  @Override
+  public ResponseEntity<AdminGeneratedPasswordResponse> generateUserPassword(UUID userId) {
+    GeneratedPasswordOutcome outcome = adminUsers.generatePassword(userId);
+    return ResponseEntity.ok(new AdminGeneratedPasswordResponse().password(outcome.password()));
   }
 
   @ExceptionHandler(UserNotFoundException.class)

--- a/qnop-app/src/test/java/io/qnop/web/AdminUserControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AdminUserControllerIT.java
@@ -229,6 +229,38 @@ class AdminUserControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
+  void adminGeneratesPasswordForUser() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User target = createUser("member", UserRole.MEMBER);
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/users/{id}/password", target.getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.password").isNotEmpty());
+
+    // The account must change the generated password on first login.
+    assertThat(userRepository.findById(target.getId()).orElseThrow().isPasswordChangeRequired())
+        .isTrue();
+  }
+
+  @Test
+  void generatePasswordRejectsExternalAccount() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User external = userRepository.saveAndFlush(User.external("Ext", "ext@example.com"));
+    String token = adminToken();
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/users/{id}/password", external.getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("NO_LOCAL_PASSWORD"));
+  }
+
+  @Test
   void sendsPasswordReset() throws Exception {
     createUser("root", UserRole.ADMIN);
     User target = createUser("member", UserRole.MEMBER);

--- a/qnop-core/src/main/java/io/qnop/security/PasswordGenerator.java
+++ b/qnop-core/src/main/java/io/qnop/security/PasswordGenerator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import java.security.SecureRandom;
+
+/**
+ * Generates strong, human-transcribable passwords for the admin reset / self-service "generate"
+ * affordances (issue #116). A fresh password is 16 characters from a 56-symbol readable alphabet
+ * (the ambiguous glyphs {@code 0/O} and {@code 1/l/I} are removed so it can be read aloud or copied
+ * from a one-time dialog) — about 93 bits of entropy, well above the 8-character minimum a user may
+ * choose. {@link SecureRandom#nextInt(int)} is bias-free, so every glyph is equally likely.
+ */
+public final class PasswordGenerator {
+
+  /** Readable alphabet — A–Z a–z 2–9 minus the ambiguous {@code 0 O 1 l I}. */
+  static final String ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789";
+
+  /** Length of a generated password; deliberately above the {@code minLength: 8} policy. */
+  static final int LENGTH = 16;
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private PasswordGenerator() {}
+
+  /** A fresh 16-character password drawn uniformly from the readable alphabet. */
+  public static String generate() {
+    StringBuilder password = new StringBuilder(LENGTH);
+    for (int i = 0; i < LENGTH; i++) {
+      password.append(ALPHABET.charAt(RANDOM.nextInt(ALPHABET.length())));
+    }
+    return password.toString();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
@@ -26,6 +26,7 @@ import io.qnop.entity.UserSource;
 import io.qnop.repository.OidcIdentityRepository;
 import io.qnop.repository.UserProviderName;
 import io.qnop.repository.UserRepository;
+import io.qnop.security.PasswordGenerator;
 import io.qnop.service.auth.PasswordResetFlowService;
 import io.qnop.service.auth.PasswordResetFlowService.SetupLinkOutcome;
 import java.time.Instant;
@@ -226,6 +227,41 @@ public class AdminUserService {
     refreshTokens.revokeAllForUser(id);
     return new PasswordResetOutcome(
         outcome.emailSent(), outcome.emailSent() ? null : outcome.resetUrl());
+  }
+
+  /**
+   * Generates a strong password for an internal account, sets it (requiring a change on first
+   * login), and revokes the user's active sessions immediately — the new password is the only way
+   * back in. Returns the plaintext exactly once; it is never stored in clear text. External (OIDC)
+   * accounts have no local password and are rejected (409). An admin may target their own account,
+   * which signs them out (they sign back in with the new password).
+   */
+  @Transactional
+  public GeneratedPasswordOutcome generatePassword(UUID id) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    if (user.getSource() != UserSource.INTERNAL) {
+      throw new AdminUserConflictException(
+          "NO_LOCAL_PASSWORD",
+          "This account signs in via an identity provider; it has no password.");
+    }
+    String password = PasswordGenerator.generate();
+    user.setPasswordHash(passwordEncoder.encode(password));
+    user.setPasswordChangeRequired(true);
+    // flush() persists the hash + flag before bumpPasswordInvalidatedBefore clears the context.
+    users.flush();
+    users.bumpPasswordInvalidatedBefore(id, Instant.now());
+    refreshTokens.revokeAllForUser(id);
+    return new GeneratedPasswordOutcome(password);
+  }
+
+  /**
+   * A freshly generated password, surfaced once; {@code toString} is masked to keep it out of logs.
+   */
+  public record GeneratedPasswordOutcome(String password) {
+    @Override
+    public String toString() {
+      return "GeneratedPasswordOutcome[password=***]";
+    }
   }
 
   /** The provider name for a user, or null for internal accounts (avoids a null-key map lookup). */

--- a/qnop-core/src/test/java/io/qnop/security/PasswordGeneratorTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/PasswordGeneratorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Pins the generated-password contract (issue #116): length, readable charset, and uniqueness. */
+class PasswordGeneratorTest {
+
+  @Test
+  @DisplayName("generates a 16-character password drawn only from the readable alphabet")
+  void lengthAndCharset() {
+    String password = PasswordGenerator.generate();
+
+    assertThat(password).hasSize(16);
+    assertThat(password.chars()).allMatch(c -> PasswordGenerator.ALPHABET.indexOf(c) >= 0);
+  }
+
+  @Test
+  @DisplayName("never emits the ambiguous glyphs 0 O 1 l I")
+  void excludesAmbiguousGlyphs() {
+    String many =
+        IntStream.range(0, 200)
+            .mapToObj(i -> PasswordGenerator.generate())
+            .reduce("", String::concat);
+
+    assertThat(many).doesNotContainAnyWhitespaces();
+    assertThat(many.chars()).noneMatch(c -> "0O1lI".indexOf(c) >= 0);
+  }
+
+  @Test
+  @DisplayName("clears the 8-character policy minimum with margin")
+  void exceedsPolicyMinimum() {
+    assertThat(PasswordGenerator.generate().length()).isGreaterThanOrEqualTo(8);
+  }
+
+  @Test
+  @DisplayName("is effectively unique across many calls (no fixed/degenerate output)")
+  void uniqueAcrossCalls() {
+    Set<String> seen = new HashSet<>();
+    for (int i = 0; i < 500; i++) {
+      seen.add(PasswordGenerator.generate());
+    }
+
+    assertThat(seen).hasSize(500);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
@@ -35,6 +35,7 @@ import io.qnop.repository.OidcIdentityRepository;
 import io.qnop.repository.UserRepository;
 import io.qnop.service.AdminUserService.AdminUserPage;
 import io.qnop.service.AdminUserService.AdminUserView;
+import io.qnop.service.AdminUserService.GeneratedPasswordOutcome;
 import io.qnop.service.AdminUserService.PasswordResetOutcome;
 import io.qnop.service.auth.PasswordResetFlowService;
 import io.qnop.service.auth.PasswordResetFlowService.SetupLinkOutcome;
@@ -198,6 +199,45 @@ class AdminUserServiceTest {
 
     verify(refreshTokens, never()).revokeAllForUser(any());
     verify(users, never()).bumpPasswordInvalidatedBefore(any(), any());
+  }
+
+  @Test
+  @DisplayName("generate sets a strong password, requires change, and revokes sessions")
+  void generatePasswordForInternalUser() {
+    UUID id = UUID.randomUUID();
+    User member = User.internal("Member", "m@example.com", "m", "old-hash");
+    member.setRole(UserRole.MEMBER);
+    when(users.findById(id)).thenReturn(Optional.of(member));
+
+    GeneratedPasswordOutcome outcome = service.generatePassword(id);
+
+    assertThat(outcome.password()).hasSize(16);
+    assertThat(member.isPasswordChangeRequired()).isTrue();
+    verify(passwordEncoder).encode(outcome.password());
+    verify(users).bumpPasswordInvalidatedBefore(eq(id), any());
+    verify(refreshTokens).revokeAllForUser(id);
+  }
+
+  @Test
+  @DisplayName("generate rejects an external (OIDC) account without touching sessions")
+  void generatePasswordRejectsExternal() {
+    UUID id = UUID.randomUUID();
+    User external = User.external("Ext", "ext@example.com");
+    when(users.findById(id)).thenReturn(Optional.of(external));
+
+    assertThatThrownBy(() -> service.generatePassword(id))
+        .isInstanceOf(AdminUserConflictException.class)
+        .extracting("code")
+        .isEqualTo("NO_LOCAL_PASSWORD");
+    verify(refreshTokens, never()).revokeAllForUser(any());
+  }
+
+  @Test
+  @DisplayName("the generated-password outcome never leaks the plaintext via toString")
+  void generatedPasswordOutcomeTostringMasked() {
+    assertThat(new GeneratedPasswordOutcome("s3cret-value").toString())
+        .doesNotContain("s3cret-value")
+        .contains("***");
   }
 
   @Test

--- a/qnop-ui/src/api/hooks/useAdminUsers.ts
+++ b/qnop-ui/src/api/hooks/useAdminUsers.ts
@@ -21,6 +21,7 @@
 
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
+  AdminGeneratedPasswordResponse,
   AdminPasswordResetResponse,
   AdminUserCreateRequest,
   AdminUserListResponse,
@@ -116,5 +117,22 @@ export function useSendUserPasswordReset() {
       const response = await adminUsersApi.sendUserPasswordReset({ userId: id });
       return response.data;
     },
+  });
+}
+
+/**
+ * Admin password generation: assigns a fresh random password, flags it for a
+ * forced change on next login, and revokes the user's sessions. The plaintext
+ * {@code password} is returned exactly once — it can never be retrieved again.
+ * Invalidates the list so the "password change" badge reflects the new state.
+ */
+export function useGenerateUserPassword() {
+  const queryClient = useQueryClient();
+  return useMutation<AdminGeneratedPasswordResponse, unknown, string>({
+    mutationFn: async (id: string) => {
+      const response = await adminUsersApi.generateUserPassword({ userId: id });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: adminUserKeys.all }),
   });
 }

--- a/qnop-ui/src/components/admin/users/GeneratedPasswordDialog.tsx
+++ b/qnop-ui/src/components/admin/users/GeneratedPasswordDialog.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import { Check, Copy } from 'lucide-react';
+
+interface GeneratedPasswordDialogProps {
+  open: boolean;
+  displayName: string;
+  password: string;
+  onClose: () => void;
+}
+
+/**
+ * Reveals an admin-generated temporary password (issue #116). The password is
+ * shown exactly once and cannot be retrieved later, so the dialog makes that
+ * explicit and offers copy-to-clipboard. Sessions are already revoked and the
+ * user must change the password on their next sign-in.
+ */
+export function GeneratedPasswordDialog({
+  open,
+  displayName,
+  password,
+  onClose,
+}: GeneratedPasswordDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(password);
+      setCopied(true);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — the field stays selectable.
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Temporary password for {displayName}</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>
+          Share this one-time password with the user over a secure channel. They must change it on
+          their next sign-in, and their existing sessions have already been revoked.
+        </DialogContentText>
+        <TextField
+          value={password}
+          fullWidth
+          size="small"
+          sx={{ '& input': { fontFamily: 'monospace', fontSize: 16, letterSpacing: '0.04em' } }}
+          slotProps={{
+            input: {
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip title={copied ? 'Copied' : 'Copy'}>
+                    <IconButton aria-label="Copy password" size="small" edge="end" onClick={copy}>
+                      {copied ? <Check size={16} /> : <Copy size={16} />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+        <Alert severity="warning" sx={{ mt: 2 }}>
+          This password is shown only once and cannot be retrieved later. If you lose it, generate a
+          new one.
+        </Alert>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onClose} variant="contained">
+          Done
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/admin/users/UsersTable.tsx
+++ b/qnop-ui/src/components/admin/users/UsersTable.tsx
@@ -36,7 +36,7 @@ import TableRow from '@mui/material/TableRow';
 import TableSortLabel from '@mui/material/TableSortLabel';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { KeyRound, MoreVertical, SquarePen, Trash2 } from 'lucide-react';
+import { KeyRound, KeySquare, MoreVertical, SquarePen, Trash2 } from 'lucide-react';
 import type { AdminUserSummary } from '../../../api/generated';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { formatDateTime, formatRelative } from '../../../utils/formatDate';
@@ -51,6 +51,7 @@ interface UsersTableProps {
   onSort: (field: string) => void;
   onEdit: (user: AdminUserSummary) => void;
   onResetPassword: (user: AdminUserSummary) => void;
+  onGeneratePassword: (user: AdminUserSummary) => void;
   onToggleEnabled: (user: AdminUserSummary) => void;
   onDelete: (user: AdminUserSummary) => void;
 }
@@ -72,6 +73,7 @@ export function UsersTable({
   onSort,
   onEdit,
   onResetPassword,
+  onGeneratePassword,
   onToggleEnabled,
   onDelete,
 }: UsersTableProps) {
@@ -214,7 +216,19 @@ export function UsersTable({
           <ListItemIcon>
             <KeyRound size={16} />
           </ListItemIcon>
-          <ListItemText>Reset password</ListItemText>
+          <ListItemText>Email reset link</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={active?.source === 'EXTERNAL'}
+          onClick={() => {
+            closeMenu();
+            if (active) onGeneratePassword(active);
+          }}
+        >
+          <ListItemIcon>
+            <KeySquare size={16} />
+          </ListItemIcon>
+          <ListItemText>Generate password</ListItemText>
         </MenuItem>
         <MenuItem
           disabled={active ? isSelf(active) : false}

--- a/qnop-ui/src/pages/admin/UsersPage.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.tsx
@@ -38,12 +38,14 @@ import type { AdminUserSummary, UserRole } from '../../api/generated';
 import {
   useAdminUsers,
   useDeleteUser,
+  useGenerateUserPassword,
   useSendUserPasswordReset,
   useUpdateUser,
 } from '../../api/hooks/useAdminUsers';
 import { UserFormDialog } from '../../components/admin/users/UserFormDialog';
 import { UsersTable } from '../../components/admin/users/UsersTable';
 import { ResetLinkDialog } from '../../components/admin/users/ResetLinkDialog';
+import { GeneratedPasswordDialog } from '../../components/admin/users/GeneratedPasswordDialog';
 import { ConfirmDialog } from '../../components/admin/ConfirmDialog';
 import { useAuthStore } from '../../stores/authStore';
 import { apiErrorCode, apiErrorMessage } from '../../utils/apiError';
@@ -72,6 +74,7 @@ export function UsersPage() {
   const updateUser = useUpdateUser();
   const deleteUser = useDeleteUser();
   const sendReset = useSendUserPasswordReset();
+  const generatePassword = useGenerateUserPassword();
 
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -84,6 +87,10 @@ export function UsersPage() {
   const [openSeq, setOpenSeq] = useState(0);
   const [deleteTarget, setDeleteTarget] = useState<AdminUserSummary | null>(null);
   const [resetLink, setResetLink] = useState<{ displayName: string; url: string } | null>(null);
+  const [generatedPassword, setGeneratedPassword] = useState<{
+    displayName: string;
+    password: string;
+  } | null>(null);
   const [toast, setToast] = useState<Toast>(null);
 
   const openCreate = () => {
@@ -153,6 +160,18 @@ export function UsersPage() {
     } catch (err) {
       setToast({
         message: conflictOr(err, 'The reset could not be triggered.'),
+        severity: 'error',
+      });
+    }
+  };
+
+  const onGeneratePassword = async (user: AdminUserSummary) => {
+    try {
+      const outcome = await generatePassword.mutateAsync(user.id);
+      setGeneratedPassword({ displayName: user.displayName, password: outcome.password });
+    } catch (err) {
+      setToast({
+        message: conflictOr(err, 'A password could not be generated.'),
         severity: 'error',
       });
     }
@@ -267,6 +286,7 @@ export function UsersPage() {
               onSort={onSort}
               onEdit={openEdit}
               onResetPassword={onResetPassword}
+              onGeneratePassword={onGeneratePassword}
               onToggleEnabled={onToggleEnabled}
               onDelete={setDeleteTarget}
             />
@@ -316,6 +336,13 @@ export function UsersPage() {
         displayName={resetLink?.displayName ?? ''}
         url={resetLink?.url ?? ''}
         onClose={() => setResetLink(null)}
+      />
+
+      <GeneratedPasswordDialog
+        open={generatedPassword !== null}
+        displayName={generatedPassword?.displayName ?? ''}
+        password={generatedPassword?.password ?? ''}
+        onClose={() => setGeneratedPassword(null)}
       />
 
       <Snackbar

--- a/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
@@ -23,17 +23,20 @@ import { useState, type FormEvent } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { Link as RouterLink, Navigate } from 'react-router-dom';
+import { Check, Copy, Sparkles } from 'lucide-react';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { PasswordField } from '../../components/auth/PasswordField';
 import { PasswordStrengthMeter } from '../../components/auth/PasswordStrengthMeter';
 import { changePassword } from '../../api/auth';
 import { useAuthStore } from '../../stores/authStore';
 import { apiErrorMessage } from '../../utils/apiError';
-import { passwordStrength } from '../../utils/passwordStrength';
+import { generateStrongPassword, passwordStrength } from '../../utils/passwordStrength';
 
 /**
  * Change-password screen — used both for a forced first-login change and for a
@@ -51,6 +54,8 @@ export function ChangePasswordPage() {
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
+  const [generated, setGenerated] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   // Reachable only with a session token (full auth or a forced-change session).
   if (!accessToken && !done) {
@@ -67,6 +72,24 @@ export function ChangePasswordPage() {
   const mismatch = confirm.length > 0 && confirm !== password;
   const canSubmit =
     current.length > 0 && passwordStrength(password).acceptable && password === confirm;
+
+  const onGenerate = () => {
+    const value = generateStrongPassword();
+    setPassword(value);
+    setConfirm(value);
+    setGenerated(value);
+    setCopied(false);
+  };
+
+  const copyGenerated = async () => {
+    if (!generated) return;
+    try {
+      await navigator.clipboard.writeText(generated);
+      setCopied(true);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — the value stays visible to copy by hand.
+    }
+  };
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -116,16 +139,65 @@ export function ChangePasswordPage() {
               <PasswordField
                 label="New password"
                 value={password}
-                onChange={setPassword}
+                onChange={(value) => {
+                  setPassword(value);
+                  setGenerated(null);
+                }}
                 autoComplete="new-password"
                 required
               />
               <PasswordStrengthMeter password={password} />
+              <Button
+                type="button"
+                size="small"
+                startIcon={<Sparkles size={15} />}
+                onClick={onGenerate}
+                sx={{ mt: 0.5, textTransform: 'none' }}
+              >
+                Generate strong password
+              </Button>
+              {generated && (
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{
+                    mt: 1,
+                    p: 1,
+                    pl: 1.5,
+                    borderRadius: 1,
+                    bgcolor: 'action.hover',
+                    alignItems: 'center',
+                  }}
+                >
+                  <Typography
+                    sx={{ fontFamily: 'monospace', fontSize: 14, flex: 1, wordBreak: 'break-all' }}
+                  >
+                    {generated}
+                  </Typography>
+                  <Tooltip title={copied ? 'Copied' : 'Copy'}>
+                    <IconButton
+                      size="small"
+                      aria-label="Copy generated password"
+                      onClick={copyGenerated}
+                    >
+                      {copied ? <Check size={15} /> : <Copy size={15} />}
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+              )}
+              {generated && (
+                <Typography sx={{ fontSize: 12, color: 'text.secondary', mt: 0.5 }}>
+                  Save this somewhere safe — it now fills the new-password fields.
+                </Typography>
+              )}
             </Box>
             <PasswordField
               label="Confirm new password"
               value={confirm}
-              onChange={setConfirm}
+              onChange={(value) => {
+                setConfirm(value);
+                setGenerated(null);
+              }}
               autoComplete="new-password"
               required
             />

--- a/qnop-ui/src/utils/passwordStrength.test.ts
+++ b/qnop-ui/src/utils/passwordStrength.test.ts
@@ -20,7 +20,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { passwordStrength } from './passwordStrength';
+import {
+  GENERATED_PASSWORD_LENGTH,
+  generateStrongPassword,
+  passwordStrength,
+} from './passwordStrength';
 
 describe('passwordStrength', () => {
   it('scores an empty password as 0 and not acceptable', () => {
@@ -43,5 +47,36 @@ describe('passwordStrength', () => {
     expect(r.score).toBe(4);
     expect(r.label).toBe('Strong');
     expect(r.acceptable).toBe(true);
+  });
+});
+
+describe('generateStrongPassword', () => {
+  it('uses the default length and honours a custom length', () => {
+    expect(generateStrongPassword()).toHaveLength(GENERATED_PASSWORD_LENGTH);
+    expect(generateStrongPassword(32)).toHaveLength(32);
+  });
+
+  it('always produces a password the strength meter rates as strong', () => {
+    for (let i = 0; i < 200; i++) {
+      const r = passwordStrength(generateStrongPassword());
+      expect(r.acceptable).toBe(true);
+      expect(r.score).toBe(4);
+    }
+  });
+
+  it('contains every required character class and no ambiguous glyphs', () => {
+    for (let i = 0; i < 200; i++) {
+      const pw = generateStrongPassword();
+      expect(pw).toMatch(/[a-z]/);
+      expect(pw).toMatch(/[A-Z]/);
+      expect(pw).toMatch(/[0-9]/);
+      expect(pw).toMatch(/[^A-Za-z0-9]/);
+      expect(pw).not.toMatch(/[0O1lI]/);
+    }
+  });
+
+  it('returns a different password on each call', () => {
+    const seen = new Set(Array.from({ length: 500 }, () => generateStrongPassword()));
+    expect(seen.size).toBe(500);
   });
 });

--- a/qnop-ui/src/utils/passwordStrength.ts
+++ b/qnop-ui/src/utils/passwordStrength.ts
@@ -43,3 +43,49 @@ export function passwordStrength(password: string): PasswordStrength {
   const score = (password.length === 0 ? 0 : raw) as PasswordStrength['score'];
   return { score, label: LABELS[score], acceptable: password.length >= 8 };
 }
+
+// Readable character classes for self-service generation — ambiguous glyphs
+// (0/O, 1/l/I) are dropped so a copied password is hard to mistype.
+const LOWER = 'abcdefghijkmnpqrstuvwxyz';
+const UPPER = 'ABCDEFGHJKLMNPQRSTUVWXYZ';
+const DIGITS = '23456789';
+const SYMBOLS = '!@#$%^&*-_=+';
+const ALL = LOWER + UPPER + DIGITS + SYMBOLS;
+
+/** Default length for a generated password — comfortably above the 8-char policy. */
+export const GENERATED_PASSWORD_LENGTH = 20;
+
+/**
+ * Returns an unbiased index in {@code [0, maxExclusive)} using the Web Crypto API
+ * with rejection sampling (no {@code Math.random}, no modulo bias).
+ */
+function randomIndex(maxExclusive: number): number {
+  const limit = Math.floor(0x1_0000_0000 / maxExclusive) * maxExclusive;
+  const buffer = new Uint32Array(1);
+  let value: number;
+  do {
+    crypto.getRandomValues(buffer);
+    value = buffer[0];
+  } while (value >= limit);
+  return value % maxExclusive;
+}
+
+const pick = (chars: string): string => chars[randomIndex(chars.length)];
+
+/**
+ * Generates a strong random password for the self-service change screen (#116).
+ * Guarantees at least one lowercase, uppercase, digit and symbol — so it always
+ * clears the policy and reads as "Strong" — then fills and shuffles the rest with
+ * cryptographically secure randomness.
+ */
+export function generateStrongPassword(length: number = GENERATED_PASSWORD_LENGTH): string {
+  const required = [pick(LOWER), pick(UPPER), pick(DIGITS), pick(SYMBOLS)];
+  const rest = Array.from({ length: Math.max(0, length - required.length) }, () => pick(ALL));
+  const chars = [...required, ...rest];
+  // Fisher–Yates shuffle so the guaranteed characters are not always up front.
+  for (let i = chars.length - 1; i > 0; i--) {
+    const j = randomIndex(i + 1);
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+  return chars.join('');
+}


### PR DESCRIPTION
Closes #116.

Adds two ways to (re)issue a local password, both backed by a new generator and the existing session-revocation path.

## Backend
- **`PasswordGenerator`** — `SecureRandom`, 16 chars from a 56-char readable alphabet (no `0/O/1/l/I`), ~93 bits entropy.
- **`POST /api/v1/admin/users/{userId}/password`** (`generateUserPassword` → `AdminGeneratedPasswordResponse { password }`): sets a fresh hash, flags `passwordChangeRequired`, then `bumpPasswordInvalidatedBefore` + `revokeAllForUser` (kills access tokens and refresh sessions). External (OIDC) accounts are rejected with `409 NO_LOCAL_PASSWORD`. The plaintext is returned once and never logged (masked `toString`).

## Frontend — admin
- New **`GeneratedPasswordDialog`**: monospace password, copy-to-clipboard, shown-once / not-retrievable warning.
- **`UsersTable`** row action **"Generate password"** (disabled for external accounts); the existing reset action is relabelled **"Email reset link"** to disambiguate the two.
- `useGenerateUserPassword` hook invalidates the list so the *password change* badge reflects the new state.

## Frontend — self-service
- **`ChangePasswordPage`** gains a **"Generate strong password"** affordance that fills both fields and reveals the value once (copy-to-clipboard).
- `generateStrongPassword()` uses the **Web Crypto API** (no `Math.random`, unbiased rejection sampling) and guarantees every character class, so it always clears the 8-char policy and reads as "Strong".

## Test plan
- [x] Backend unit tests: `PasswordGeneratorTest` (length, charset, no ambiguous glyphs, uniqueness), `AdminUserServiceTest` (internal generate, external rejected, masked `toString`).
- [x] Backend IT: `AdminUserControllerIT` (200 + non-empty password + `passwordChangeRequired`; external → 409). Runs in CI (Testcontainers).
- [x] Frontend: `passwordStrength.test.ts` extended (length, always-Strong over 200 runs, all classes / no ambiguous glyphs, uniqueness over 500 runs).
- [x] `pnpm lint`, `pnpm test` (97 passed), `pnpm build` green.
- [ ] Manual: admin generates → reveal dialog → user forced to change on next login; sessions revoked. Self-service generate → fills + reveals → submit logs out.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code