### PR TITLE
feat(ui): mail template editor screen (#106)

### DIFF
--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -21,6 +21,7 @@
 
 import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import {
+  AdminEmailApi,
   AdminOidcProvidersApi,
   AdminSettingsApi,
   AdminTeamsApi,
@@ -90,3 +91,4 @@ export const adminUsersApi = new AdminUsersApi(undefined, undefined, axiosInstan
 export const adminTeamsApi = new AdminTeamsApi(undefined, undefined, axiosInstance);
 export const adminSettingsApi = new AdminSettingsApi(undefined, undefined, axiosInstance);
 export const adminOidcProvidersApi = new AdminOidcProvidersApi(undefined, undefined, axiosInstance);
+export const adminEmailApi = new AdminEmailApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useMailTemplates.test.tsx
+++ b/qnop-ui/src/api/hooks/useMailTemplates.test.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { MailTemplateListResponse } from '../generated';
+import {
+  mailTemplateKeys,
+  useMailTemplates,
+  usePreviewMailTemplate,
+  useResetMailTemplate,
+  useSendTestEmail,
+  useUpdateMailTemplate,
+} from './useMailTemplates';
+import { adminEmailApi } from '../config';
+
+const EMPTY: MailTemplateListResponse = { templates: [] };
+
+vi.mock('../config', () => ({
+  adminEmailApi: {
+    listMailTemplates: vi.fn(),
+    updateMailTemplate: vi.fn(),
+    resetMailTemplate: vi.fn(),
+    previewMailTemplate: vi.fn(),
+    sendTestEmail: vi.fn(),
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('mailTemplateKeys', () => {
+  it('namespaces the templates query', () => {
+    expect(mailTemplateKeys.all).toEqual(['admin', 'mail-templates']);
+  });
+});
+
+describe('useMailTemplates', () => {
+  it('fetches and returns the template list', async () => {
+    vi.mocked(adminEmailApi.listMailTemplates).mockResolvedValue({ data: EMPTY } as Awaited<
+      ReturnType<typeof adminEmailApi.listMailTemplates>
+    >);
+
+    const { result } = renderHook(() => useMailTemplates(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(adminEmailApi.listMailTemplates).toHaveBeenCalled();
+    expect(result.current.data?.templates).toEqual([]);
+  });
+});
+
+describe('useUpdateMailTemplate', () => {
+  it('forwards the key and request', async () => {
+    vi.mocked(adminEmailApi.updateMailTemplate).mockResolvedValue({ data: {} } as Awaited<
+      ReturnType<typeof adminEmailApi.updateMailTemplate>
+    >);
+
+    const { result } = renderHook(() => useUpdateMailTemplate(), { wrapper });
+    await result.current.mutateAsync({
+      key: 'auth.password_reset',
+      request: { locale: 'en', subject: 'Hi', bodyPlain: 'Body' },
+    });
+
+    expect(adminEmailApi.updateMailTemplate).toHaveBeenCalledWith({
+      key: 'auth.password_reset',
+      updateMailTemplateRequest: { locale: 'en', subject: 'Hi', bodyPlain: 'Body' },
+    });
+  });
+});
+
+describe('useResetMailTemplate', () => {
+  it('resets by key', async () => {
+    vi.mocked(adminEmailApi.resetMailTemplate).mockResolvedValue({ data: undefined } as Awaited<
+      ReturnType<typeof adminEmailApi.resetMailTemplate>
+    >);
+
+    const { result } = renderHook(() => useResetMailTemplate(), { wrapper });
+    await result.current.mutateAsync('auth.password_reset');
+
+    expect(adminEmailApi.resetMailTemplate).toHaveBeenCalledWith({ key: 'auth.password_reset' });
+  });
+});
+
+describe('usePreviewMailTemplate', () => {
+  it('wraps the key and locale', async () => {
+    vi.mocked(adminEmailApi.previewMailTemplate).mockResolvedValue({
+      data: { subject: 'S', bodyPlain: 'B' },
+    } as Awaited<ReturnType<typeof adminEmailApi.previewMailTemplate>>);
+
+    const { result } = renderHook(() => usePreviewMailTemplate(), { wrapper });
+    const out = await result.current.mutateAsync({ key: 'k', locale: 'de' });
+
+    expect(adminEmailApi.previewMailTemplate).toHaveBeenCalledWith({
+      key: 'k',
+      previewMailTemplateRequest: { locale: 'de' },
+    });
+    expect(out.subject).toBe('S');
+  });
+});
+
+describe('useSendTestEmail', () => {
+  it('wraps the recipient and returns the outcome', async () => {
+    vi.mocked(adminEmailApi.sendTestEmail).mockResolvedValue({
+      data: { status: 'SENT', detail: 'ok' },
+    } as Awaited<ReturnType<typeof adminEmailApi.sendTestEmail>>);
+
+    const { result } = renderHook(() => useSendTestEmail(), { wrapper });
+    const out = await result.current.mutateAsync('a@example.com');
+
+    expect(adminEmailApi.sendTestEmail).toHaveBeenCalledWith({
+      sendTestEmailRequest: { recipient: 'a@example.com' },
+    });
+    expect(out.status).toBe('SENT');
+  });
+});

--- a/qnop-ui/src/api/hooks/useMailTemplates.ts
+++ b/qnop-ui/src/api/hooks/useMailTemplates.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  MailTemplateListResponse,
+  MailTemplatePreviewResponse,
+  SendTestEmailResponse,
+  UpdateMailTemplateRequest,
+} from '../generated';
+import { adminEmailApi } from '../config';
+
+export const mailTemplateKeys = {
+  all: ['admin', 'mail-templates'] as const,
+};
+
+/** All mail templates with their current (override or built-in) content. */
+export function useMailTemplates() {
+  return useQuery<MailTemplateListResponse>({
+    queryKey: mailTemplateKeys.all,
+    queryFn: async () => {
+      const response = await adminEmailApi.listMailTemplates();
+      return response.data;
+    },
+  });
+}
+
+/** Creates or updates a per-locale template override, then refreshes the list. */
+export function useUpdateMailTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { key: string; request: UpdateMailTemplateRequest }) => {
+      const response = await adminEmailApi.updateMailTemplate({
+        key: vars.key,
+        updateMailTemplateRequest: vars.request,
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: mailTemplateKeys.all }),
+  });
+}
+
+/** Removes a template override, reverting to the built-in default, then refreshes. */
+export function useResetMailTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (key: string) => {
+      await adminEmailApi.resetMailTemplate({ key });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: mailTemplateKeys.all }),
+  });
+}
+
+/** Renders a template (with sample data) without sending it. */
+export function usePreviewMailTemplate() {
+  return useMutation({
+    mutationFn: async (vars: {
+      key: string;
+      locale?: string;
+    }): Promise<MailTemplatePreviewResponse> => {
+      const response = await adminEmailApi.previewMailTemplate({
+        key: vars.key,
+        previewMailTemplateRequest: { locale: vars.locale },
+      });
+      return response.data;
+    },
+  });
+}
+
+/**
+ * Sends a test email with the current SMTP settings. The endpoint never fails
+ * the request — the outcome (SENT/SKIPPED/FAILED) is in the response body.
+ */
+export function useSendTestEmail() {
+  return useMutation({
+    mutationFn: async (recipient: string): Promise<SendTestEmailResponse> => {
+      const response = await adminEmailApi.sendTestEmail({ sendTestEmailRequest: { recipient } });
+      return response.data;
+    },
+  });
+}

--- a/qnop-ui/src/components/admin/mail/MailTemplateEditor.tsx
+++ b/qnop-ui/src/components/admin/mail/MailTemplateEditor.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type FormEvent } from 'react';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { Eye, RotateCcw } from 'lucide-react';
+import type { MailTemplateResponse } from '../../../api/generated';
+import { ConfirmDialog } from '../ConfirmDialog';
+import { ToneBadge } from '../ToneBadge';
+import {
+  usePreviewMailTemplate,
+  useResetMailTemplate,
+  useUpdateMailTemplate,
+} from '../../../api/hooks/useMailTemplates';
+import { apiErrorMessage } from '../../../utils/apiError';
+import { MailTemplatePreviewDialog } from './MailTemplatePreviewDialog';
+
+interface MailTemplateEditorProps {
+  template: MailTemplateResponse;
+  onNotify: (message: string, severity: 'success' | 'error') => void;
+}
+
+/**
+ * Editor for a single mail template. State is seeded from props via useState
+ * initializers; the parent passes a changing `key` so switching templates
+ * remounts the editor fresh. A DATABASE override can be reset to the built-in
+ * default; DEFAULT templates can be overridden by saving.
+ */
+export function MailTemplateEditor({ template, onNotify }: MailTemplateEditorProps) {
+  const updateTemplate = useUpdateMailTemplate();
+  const resetTemplate = useResetMailTemplate();
+  const preview = usePreviewMailTemplate();
+
+  const [subject, setSubject] = useState(template.subject);
+  const [bodyPlain, setBodyPlain] = useState(template.bodyPlain);
+  const [bodyHtml, setBodyHtml] = useState(template.bodyHtml ?? '');
+  const [confirmReset, setConfirmReset] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const isOverride = template.source === 'DATABASE';
+  const dirty =
+    subject !== template.subject ||
+    bodyPlain !== template.bodyPlain ||
+    bodyHtml !== (template.bodyHtml ?? '');
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      await updateTemplate.mutateAsync({
+        key: template.key,
+        request: {
+          locale: template.locale,
+          subject,
+          bodyPlain,
+          bodyHtml: bodyHtml.trim().length > 0 ? bodyHtml : undefined,
+        },
+      });
+      onNotify('Template saved.', 'success');
+    } catch (err) {
+      onNotify(apiErrorMessage(err, 'The template could not be saved.'), 'error');
+    }
+  };
+
+  const onReset = async () => {
+    setConfirmReset(false);
+    try {
+      await resetTemplate.mutateAsync(template.key);
+      onNotify('Template reset to the built-in default.', 'success');
+    } catch (err) {
+      onNotify(apiErrorMessage(err, 'The template could not be reset.'), 'error');
+    }
+  };
+
+  const openPreview = async () => {
+    setPreviewOpen(true);
+    try {
+      await preview.mutateAsync({ key: template.key, locale: template.locale });
+    } catch (err) {
+      onNotify(apiErrorMessage(err, 'The preview could not be rendered.'), 'error');
+      setPreviewOpen(false);
+    }
+  };
+
+  return (
+    <Stack component="form" onSubmit={onSubmit} spacing={2.5}>
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+        <Typography sx={{ fontWeight: 600, fontFamily: 'monospace' }}>{template.key}</Typography>
+        <ToneBadge
+          tone={isOverride ? 'blue' : 'neutral'}
+          label={isOverride ? 'Custom' : 'Default'}
+        />
+        <Typography color="text.secondary" sx={{ fontSize: 13 }}>
+          {template.locale}
+        </Typography>
+      </Stack>
+
+      <TextField
+        label="Subject"
+        value={subject}
+        onChange={(e) => setSubject(e.target.value)}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Plain-text body"
+        value={bodyPlain}
+        onChange={(e) => setBodyPlain(e.target.value)}
+        fullWidth
+        required
+        multiline
+        minRows={6}
+        slotProps={{ htmlInput: { style: { fontFamily: 'monospace', fontSize: 13 } } }}
+        helperText="Mustache syntax, e.g. {{name}}."
+      />
+      <TextField
+        label="HTML body (optional)"
+        value={bodyHtml}
+        onChange={(e) => setBodyHtml(e.target.value)}
+        fullWidth
+        multiline
+        minRows={6}
+        slotProps={{ htmlInput: { style: { fontFamily: 'monospace', fontSize: 13 } } }}
+        helperText="Leave blank for a plain-text-only email."
+      />
+
+      <Stack direction="row" spacing={1.5} sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
+        <Button type="submit" variant="contained" disabled={!dirty || updateTemplate.isPending}>
+          {updateTemplate.isPending ? 'Saving…' : 'Save'}
+        </Button>
+        <Button startIcon={<Eye size={16} />} onClick={openPreview} disabled={preview.isPending}>
+          Preview
+        </Button>
+        {isOverride && (
+          <Button
+            startIcon={<RotateCcw size={16} />}
+            color="inherit"
+            onClick={() => setConfirmReset(true)}
+            disabled={resetTemplate.isPending}
+          >
+            Reset to default
+          </Button>
+        )}
+      </Stack>
+
+      <ConfirmDialog
+        open={confirmReset}
+        title="Reset template"
+        message={`Discard the custom “${template.key}” template and revert to the built-in default?`}
+        confirmLabel="Reset"
+        destructive
+        onConfirm={onReset}
+        onClose={() => setConfirmReset(false)}
+      />
+      <MailTemplatePreviewDialog
+        open={previewOpen}
+        loading={preview.isPending}
+        preview={preview.data ?? null}
+        onClose={() => setPreviewOpen(false)}
+      />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/admin/mail/MailTemplatePreviewDialog.tsx
+++ b/qnop-ui/src/components/admin/mail/MailTemplatePreviewDialog.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { MailTemplatePreviewResponse } from '../../../api/generated';
+
+interface MailTemplatePreviewDialogProps {
+  open: boolean;
+  loading: boolean;
+  preview: MailTemplatePreviewResponse | null;
+  onClose: () => void;
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Typography sx={{ fontSize: 12, fontWeight: 600, color: 'text.secondary', mb: 0.5 }}>
+        {label}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
+
+/**
+ * Shows a rendered template (subject + plain-text, and the HTML body in a
+ * sandboxed iframe so untrusted markup cannot run scripts or navigate). The
+ * server renders with representative sample data.
+ */
+export function MailTemplatePreviewDialog({
+  open,
+  loading,
+  preview,
+  onClose,
+}: MailTemplatePreviewDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>Preview (sample data)</DialogTitle>
+      <DialogContent dividers>
+        {loading && (
+          <Typography color="text.secondary" sx={{ fontSize: 14 }}>
+            Rendering…
+          </Typography>
+        )}
+        {!loading && preview && (
+          <Stack spacing={2.5}>
+            <Field label="SUBJECT">
+              <Typography sx={{ fontWeight: 600 }}>{preview.subject}</Typography>
+            </Field>
+            <Field label="PLAIN TEXT">
+              <Box
+                component="pre"
+                sx={{
+                  m: 0,
+                  p: 1.5,
+                  bgcolor: 'action.hover',
+                  borderRadius: 1,
+                  fontSize: 13,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  fontFamily: 'monospace',
+                }}
+              >
+                {preview.bodyPlain}
+              </Box>
+            </Field>
+            {preview.bodyHtml && (
+              <Field label="HTML">
+                <Box
+                  component="iframe"
+                  title="HTML preview"
+                  srcDoc={preview.bodyHtml}
+                  sandbox=""
+                  sx={{
+                    width: '100%',
+                    height: 360,
+                    border: 1,
+                    borderColor: 'divider',
+                    borderRadius: 1,
+                    bgcolor: 'background.paper',
+                  }}
+                />
+              </Field>
+            )}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onClose} variant="contained">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/admin/mail/SendTestEmailDialog.tsx
+++ b/qnop-ui/src/components/admin/mail/SendTestEmailDialog.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type FormEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import type { SendTestEmailResponse } from '../../../api/generated';
+import { useSendTestEmail } from '../../../api/hooks/useMailTemplates';
+import { apiErrorMessage } from '../../../utils/apiError';
+
+interface SendTestEmailDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SEVERITY: Record<SendTestEmailResponse['status'], 'success' | 'warning' | 'error'> = {
+  SENT: 'success',
+  SKIPPED: 'warning',
+  FAILED: 'error',
+};
+
+/** Sends a test email with the current SMTP settings and reports the outcome. */
+export function SendTestEmailDialog({ open, onClose }: SendTestEmailDialogProps) {
+  const sendTest = useSendTestEmail();
+  const [recipient, setRecipient] = useState('');
+  const [result, setResult] = useState<SendTestEmailResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setResult(null);
+    try {
+      setResult(await sendTest.mutateAsync(recipient.trim()));
+    } catch (err) {
+      setError(apiErrorMessage(err, 'The test email could not be sent.'));
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <Box component="form" onSubmit={onSubmit} noValidate>
+        <DialogTitle>Send test email</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Recipient"
+              type="email"
+              value={recipient}
+              onChange={(e) => setRecipient(e.target.value)}
+              fullWidth
+              required
+              autoComplete="off"
+              helperText="Uses the configured SMTP settings."
+            />
+            {result && <Alert severity={SEVERITY[result.status]}>{result.detail}</Alert>}
+            {error && <Alert severity="error">{error}</Alert>}
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2.5 }}>
+          <Button onClick={onClose} color="inherit">
+            Close
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={sendTest.isPending || recipient.trim().length === 0}
+          >
+            {sendTest.isPending ? 'Sending…' : 'Send'}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/pages/admin/MailTemplatesPage.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplatesPage.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import LinearProgress from '@mui/material/LinearProgress';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { MailCheck } from 'lucide-react';
+import { useMailTemplates } from '../../api/hooks/useMailTemplates';
+import { MailTemplateEditor } from '../../components/admin/mail/MailTemplateEditor';
+import { SendTestEmailDialog } from '../../components/admin/mail/SendTestEmailDialog';
+import { ToneBadge } from '../../components/admin/ToneBadge';
+
+type Toast = { message: string; severity: 'success' | 'error' } | null;
+
+/** Admin mail-template editor: edit, preview, reset, and send a test email (#106). */
+export function MailTemplatesPage() {
+  const { data, isLoading, isFetching, isError } = useMailTemplates();
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [testOpen, setTestOpen] = useState(false);
+  const [toast, setToast] = useState<Toast>(null);
+
+  const templates = data?.templates ?? [];
+  const selected = templates.find((t) => t.key === selectedKey) ?? templates[0];
+
+  const notify = (message: string, severity: 'success' | 'error') =>
+    setToast({ message, severity });
+
+  return (
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        sx={{ justifyContent: 'space-between', alignItems: { sm: 'center' } }}
+      >
+        <Box>
+          <Typography variant="h1" sx={{ fontSize: 28 }}>
+            Mail templates
+          </Typography>
+          <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+            Edit, preview and reset transactional emails. Customised templates override the
+            defaults.
+          </Typography>
+        </Box>
+        <Button
+          variant="outlined"
+          startIcon={<MailCheck size={18} />}
+          onClick={() => setTestOpen(true)}
+        >
+          Send test email
+        </Button>
+      </Stack>
+
+      {isError ? (
+        <Alert severity="error">The mail templates could not be loaded.</Alert>
+      ) : (
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ alignItems: 'stretch' }}>
+          <Paper variant="outlined" sx={{ width: { md: 280 }, flexShrink: 0, overflow: 'hidden' }}>
+            <Box sx={{ height: 3 }}>{isFetching && <LinearProgress />}</Box>
+            <List disablePadding>
+              {templates.map((template) => (
+                <ListItemButton
+                  key={template.key}
+                  selected={selected?.key === template.key}
+                  onClick={() => setSelectedKey(template.key)}
+                >
+                  <ListItemText
+                    primary={template.key}
+                    secondary={template.locale}
+                    slotProps={{
+                      primary: { sx: { fontSize: 14, fontFamily: 'monospace' } },
+                      secondary: { sx: { fontSize: 12 } },
+                    }}
+                  />
+                  {template.source === 'DATABASE' && <ToneBadge tone="blue" label="Custom" />}
+                </ListItemButton>
+              ))}
+              {!isLoading && templates.length === 0 && (
+                <Typography color="text.secondary" sx={{ p: 2, fontSize: 14 }}>
+                  No templates.
+                </Typography>
+              )}
+            </List>
+          </Paper>
+
+          <Paper variant="outlined" sx={{ flex: 1, p: { xs: 2, sm: 3 } }}>
+            {selected ? (
+              <MailTemplateEditor key={selected.key} template={selected} onNotify={notify} />
+            ) : (
+              <Typography color="text.secondary" sx={{ fontSize: 14 }}>
+                {isLoading ? 'Loading…' : 'Select a template to edit.'}
+              </Typography>
+            )}
+          </Paper>
+        </Stack>
+      )}
+
+      <SendTestEmailDialog open={testOpen} onClose={() => setTestOpen(false)} />
+
+      <Snackbar
+        open={toast !== null}
+        autoHideDuration={5000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert severity={toast.severity} onClose={() => setToast(null)} variant="filled">
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -20,13 +20,14 @@
  */
 
 import { createBrowserRouter } from 'react-router-dom';
-import { FileText, Mail, Palette, ShieldCheck } from 'lucide-react';
+import { FileText, Palette, ShieldCheck } from 'lucide-react';
 import { AppShell } from '../components/shell/AppShell';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { ProtectedRoute } from '../components/auth/ProtectedRoute';
 import { RoleRoute } from '../components/auth/RoleRoute';
 import { ComingSoonPage } from '../pages/ComingSoonPage';
 import { HomePage } from '../pages/HomePage';
+import { MailTemplatesPage } from '../pages/admin/MailTemplatesPage';
 import { OidcProvidersPage } from '../pages/admin/OidcProvidersPage';
 import { SettingsPage } from '../pages/admin/SettingsPage';
 import { UsersPage } from '../pages/admin/UsersPage';
@@ -130,11 +131,7 @@ export const router = createBrowserRouter([
         path: 'admin/mail-templates',
         element: (
           <AdminRoute>
-            <ComingSoonPage
-              title="Mail templates"
-              description="Edit, preview and test the transactional email templates."
-              icon={Mail}
-            />
+            <MailTemplatesPage />
           </AdminRoute>
         ),
       },


### PR DESCRIPTION
## Summary

Third of four PRs for the admin settings surface (#106): the **Mail templates** Administration screen over the generated `AdminEmailApi` (list, update, reset, preview, test-send). Replaces the placeholder at `/admin/mail-templates`.

- **`useMailTemplates` hooks** — list, update, reset, preview, send-test.
- **`MailTemplatesPage`** — master-detail: a template list (with a Custom/Default badge) beside the editor, plus a **Send test email** action.
- **`MailTemplateEditor`** — edit subject, plain-text and optional HTML body; **save** an override, **reset** a customised template to the built-in default (confirmed), and **preview**. State seeded via `useState` initializers, remounted per selected template (no reset-via-effect).
- **`MailTemplatePreviewDialog`** — renders subject + plain text, and the HTML body in a **sandboxed iframe** (no scripts/navigation) using the server's sample data.
- **`SendTestEmailDialog`** — sends via the current SMTP settings and reports SENT / SKIPPED / FAILED.

> Note: preview renders the *stored* template (override or default) with sample data — the backend preview endpoint takes a key + locale, not unsaved editor content, so save before previewing edits.

## Test plan

- [x] `pnpm test` — 103 unit tests pass (incl. 6 new mail-template hook tests)
- [x] `pnpm lint`, `pnpm format:check` clean
- [x] `tsc -b` + `vite build` succeed
- [ ] Manual: ADMIN edits a template, saves, previews, resets; sends a test email and sees the SMTP outcome

Part of #106. Part of #97.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code