### PR TITLE
feat: profile-picture upload (admin + self-service) (#117)

### DIFF
--- a/docs/adr/0031-profile-avatar-storage.md
+++ b/docs/adr/0031-profile-avatar-storage.md
@@ -1,0 +1,98 @@
+# ADR-0031: Profile-avatar storage location
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+Issue #117 adds per-user **profile pictures** (avatars): a user uploads/replaces/
+removes their own, and an admin can do the same for any user. The initials
+avatar (`UserAvatar`) remains the fallback when none is set.
+
+Two existing ADRs bracket the choice of where the bytes live:
+
+- **ADR-0005** sends **binary review documents** to S3-compatible object storage
+  through a `StorageProvider` SPI (AWS SDK v2, `endpointOverride` + path-style),
+  with an upload-then-commit pattern and an orphan reaper. That seam is
+  **mandated but entirely unbuilt** — no SDK dependency is wired, no client bean,
+  no `qnop.s3.*` configuration, no bucket provisioning, no reaper. MinIO runs in
+  local `docker-compose` but the application never talks to it.
+- **ADR-0024** keeps **branding assets** (a handful of small, config-like logo
+  blobs) in PostgreSQL `bytea` in `application_asset`, deliberately *out* of
+  object storage to keep backups atomic and avoid the orphan-reaper lifecycle. It
+  explicitly scopes itself to "small, bounded, config-like" assets and warns that
+  "large/numerous binary assets must **not** follow this pattern."
+
+Avatars sit between the two: **small and bounded** like branding, but **one per
+user and user-generated** ("numerous") rather than a fixed set of config slots.
+Neither ADR covers them, so #117 forces a conscious decision.
+
+## Decision
+
+**Profile-avatar bytes live in PostgreSQL `bytea`, in a dedicated `user_avatar`
+table (one row per user), reached through a small `AvatarStorage` port.**
+
+- `user_avatar` has `user_id` as primary key and a foreign key to `qnop_user`
+  with **`ON DELETE CASCADE`** — deleting a user atomically deletes their avatar,
+  so there is **no orphan-reaper concern** (the very lifecycle problem ADR-0024
+  cites against object storage). The row also carries `content_type`, `content`
+  (`bytea`), `sha256` (HTTP ETag / cache-buster), `size_bytes`, `width`/`height`,
+  and `updated_at`/`updated_by` audit columns. Postgres-only `CHECK` domains and
+  the FK live in Liquibase (migration `0009`), not JPA annotations (ADR-0020).
+- All access goes through an **`AvatarStorage`** interface in `qnop-core`
+  (`io.qnop.service.avatar`) with a single `PostgresAvatarStorage` implementation.
+  The rest of the backend (validation, endpoints, DTOs) and the entire frontend
+  depend only on the port, so the storage backend is swappable without touching
+  them.
+- A hard **1 MiB** size cap and a **PNG/JPEG/WebP** allow-list (content sniffed
+  from magic bytes, **SVG excluded** as an avatar XSS surface), reusing the
+  branding validation toolkit (`ImageDimensions`, magic-byte sniffing).
+
+Rationale:
+
+- **Bounded and per-user, not unbounded.** One small, replaceable image per user
+  (current-only, no history) with a hard 1 MiB cap is closer to branding than to
+  versioned review documents. At realistic user counts this is tens of MB of
+  `bytea`, which Postgres handles comfortably.
+- **Lifecycle simplicity.** The `ON DELETE CASCADE` FK removes the avatar with
+  the user — none of ADR-0005's upload-then-commit/reaper machinery is needed.
+- **Backup atomicity & no new infrastructure.** Avatars are captured by a DB
+  backup; shipping #117 needs no S3 wiring, bucket provisioning, or MinIO
+  integration in CI. It reuses the proven, tested branding upload pipeline.
+- **Right-sized scope.** Building the full ADR-0005 `StorageProvider` SPI for a
+  ~50 KB avatar is premature; that seam is better lit up by its actual driver —
+  the PDF/document vertical slice — which needs streaming, range requests, and
+  large payloads.
+
+## Consequences
+
+- A DB backup captures avatars; no separate object-storage backup is needed.
+- The `AvatarStorage` port is the single seam to re-home avatars in object
+  storage later (a second adapter) once ADR-0005's `StorageProvider` SPI is built
+  for review documents — without changing endpoints, DTOs, or the frontend.
+- `updated_by` is a plain audit column (no FK): an admin who set another user's
+  avatar can still be deleted; the breadcrumb is best-effort.
+- The read path `GET /api/v1/users/{id}/avatar` is **public** (`permitAll`), like
+  branding — an `<img>` element cannot attach a bearer token. Avatars are
+  low-sensitivity display pictures; the URL carries a `?v=<token>` cache-buster
+  and serves `byte[]` with an ETag/304. This does not extend ADR-0005's stance on
+  document access, which stays authenticated.
+- Server-side downscaling is not introduced now: the client crops to a canonical
+  square before upload, and the backend bounds dimensions and caps size. True
+  server-side thumbnailing (and WebP decode, which `ImageIO` lacks) is deferred.
+
+## Alternatives considered
+
+- **Build the ADR-0005 `StorageProvider` SPI + S3 now, avatars as first
+  consumer.** Architecturally the long-term home for per-user binaries and it
+  would de-risk the document slice, but it is a large unbuilt scope (SPI +
+  Community default, bucket provisioning, upload-then-commit + reaper, presigned
+  URLs, MinIO in CI) for a tiny avatar. Deferred; the `AvatarStorage` port keeps
+  the migration path open.
+- **A `bytea` column on `qnop_user`.** Rejected: it would load avatar bytes on
+  every user query that hydrates the entity; a dedicated 1:1 table keeps the hot
+  user row lean.
+- **Reuse `application_asset` (branding's table).** Rejected: its schema is
+  slot-keyed and config-scoped; per-user avatars want a `user_id`-keyed table
+  with a cascading FK.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0028](0028-branding-upload-and-svg-sanitization.md) | Branding upload pipeline & SVG sanitization | Accepted |
 | [0029](0029-distributed-scheduler-locks.md) | Distributed scheduler locks for @Scheduled jobs (ShedLock) | Accepted |
 | [0030](0030-concurrency-control-strategy.md) | Concurrency control for entity writes (optimistic locking + atomic updates) | Accepted |
+| [0031](0031-profile-avatar-storage.md) | Profile-avatar storage in Postgres bytea behind an AvatarStorage port | Accepted |
 
 ## Template
 

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2055,6 +2055,12 @@ components:
           $ref: '#/components/schemas/UserRole'
         source:
           $ref: '#/components/schemas/UserSource'
+        avatarUrl:
+          type: string
+          nullable: true
+          description: |
+            URL of the user's profile picture (with a cache-busting `?v=` token),
+            or null when none is set — the UI then renders the initials avatar.
       required:
         - id
         - displayName
@@ -2096,6 +2102,12 @@ components:
         createdAt:
           type: string
           format: date-time
+        avatarUrl:
+          type: string
+          nullable: true
+          description: |
+            URL of the user's profile picture (with a cache-busting `?v=` token),
+            or null when none is set — the UI then renders the initials avatar.
       required:
         - id
         - displayName

--- a/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
@@ -38,9 +38,11 @@ import io.qnop.service.AdminUserService.AdminUserView;
 import io.qnop.service.AdminUserService.GeneratedPasswordOutcome;
 import io.qnop.service.AdminUserService.PasswordResetOutcome;
 import io.qnop.service.UserNotFoundException;
+import io.qnop.service.avatar.AvatarService;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,9 +61,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminUserController implements AdminUsersApi {
 
   private final AdminUserService adminUsers;
+  private final AvatarService avatars;
 
-  public AdminUserController(AdminUserService adminUsers) {
+  public AdminUserController(AdminUserService adminUsers, AvatarService avatars) {
     this.adminUsers = adminUsers;
+    this.avatars = avatars;
   }
 
   @Override
@@ -69,9 +73,15 @@ public class AdminUserController implements AdminUsersApi {
       String q, UserRole role, Boolean enabled, String sort, Integer page, Integer size) {
     AdminUserPage result =
         adminUsers.list(q, role == null ? null : role.name(), enabled, sort, page, size);
+    // One batched lookup for the whole page so building avatar URLs never streams image bytes.
+    Map<UUID, Instant> avatarTimestamps =
+        avatars.updatedAt(result.items().stream().map(AdminUserView::id).toList());
     return ResponseEntity.ok(
         new AdminUserListResponse()
-            .items(result.items().stream().map(AdminUserController::toSummary).toList())
+            .items(
+                result.items().stream()
+                    .map(v -> toSummary(v, avatarTimestamps.get(v.id())))
+                    .toList())
             .total(result.total())
             .page(result.page())
             .size(result.size()));
@@ -86,12 +96,14 @@ public class AdminUserController implements AdminUsersApi {
             request.getEmail(),
             request.getRole().name(),
             request.getInitialPassword());
-    return ResponseEntity.status(HttpStatus.CREATED).body(toDetail(created));
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(toDetail(created, avatarUpdatedAt(created)));
   }
 
   @Override
   public ResponseEntity<AdminUserDetail> getUser(UUID userId) {
-    return ResponseEntity.ok(toDetail(adminUsers.get(userId)));
+    AdminUserView view = adminUsers.get(userId);
+    return ResponseEntity.ok(toDetail(view, avatarUpdatedAt(view)));
   }
 
   @Override
@@ -103,7 +115,7 @@ public class AdminUserController implements AdminUsersApi {
             request.getRole() == null ? null : request.getRole().name(),
             request.getEnabled(),
             CurrentUser.requireUserId());
-    return ResponseEntity.ok(toDetail(updated));
+    return ResponseEntity.ok(toDetail(updated, avatarUpdatedAt(updated)));
   }
 
   @Override
@@ -147,7 +159,11 @@ public class AdminUserController implements AdminUsersApi {
                 .timestamp(OffsetDateTime.now(ZoneOffset.UTC)));
   }
 
-  private static AdminUserSummary toSummary(AdminUserView v) {
+  private Instant avatarUpdatedAt(AdminUserView v) {
+    return avatars.updatedAt(v.id()).orElse(null);
+  }
+
+  private static AdminUserSummary toSummary(AdminUserView v, Instant avatarUpdatedAt) {
     return new AdminUserSummary()
         .id(v.id())
         .displayName(v.displayName())
@@ -159,10 +175,11 @@ public class AdminUserController implements AdminUsersApi {
         .passwordChangeRequired(v.passwordChangeRequired())
         .providerName(v.providerName())
         .lastLoginAt(toOffset(v.lastLoginAt()))
-        .createdAt(toOffset(v.createdAt()));
+        .createdAt(toOffset(v.createdAt()))
+        .avatarUrl(AvatarUrls.forUser(v.id(), avatarUpdatedAt));
   }
 
-  private static AdminUserDetail toDetail(AdminUserView v) {
+  private static AdminUserDetail toDetail(AdminUserView v, Instant avatarUpdatedAt) {
     return new AdminUserDetail()
         .id(v.id())
         .displayName(v.displayName())
@@ -174,7 +191,8 @@ public class AdminUserController implements AdminUsersApi {
         .passwordChangeRequired(v.passwordChangeRequired())
         .providerName(v.providerName())
         .lastLoginAt(toOffset(v.lastLoginAt()))
-        .createdAt(toOffset(v.createdAt()));
+        .createdAt(toOffset(v.createdAt()))
+        .avatarUrl(AvatarUrls.forUser(v.id(), avatarUpdatedAt));
   }
 
   private static OffsetDateTime toOffset(Instant instant) {

--- a/qnop-app/src/main/java/io/qnop/web/AvatarController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AvatarController.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.service.avatar.AvatarService;
+import io.qnop.service.avatar.AvatarStorage.AvatarContent;
+import io.qnop.service.avatar.AvatarValidationException;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Profile-avatar endpoints (issue #117). The self surface ({@code /users/me/avatar}) is gated to
+ * the JWT subject; the admin surface ({@code /admin/users/{userId}/avatar}) is admin-only (enforced
+ * centrally in the security chain); the read path ({@code GET /users/{userId}/avatar}) is public so
+ * an {@code <img>} element can load it without a bearer token (ADR-0031).
+ *
+ * <p>Like {@code BrandingController}, these are deliberately hand-written rather than generated
+ * from the OpenAPI JSON contract: they carry multipart uploads and binary responses with ETag/304
+ * caching, which sit outside the published JSON surface (ADR-0028). The {@code @RestController}
+ * mappings are mounted under {@code /api/v1} by {@link ApiPathConfig}.
+ */
+@RestController
+public class AvatarController {
+
+  private final AvatarService avatars;
+
+  public AvatarController(AvatarService avatars) {
+    this.avatars = avatars;
+  }
+
+  @PostMapping(value = "/users/me/avatar", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<AvatarUploadResponse> uploadMine(@RequestParam("file") MultipartFile file)
+      throws IOException {
+    UUID me = CurrentUser.requireUserId();
+    Instant updatedAt = avatars.store(me, file.getBytes(), me);
+    return ResponseEntity.ok(new AvatarUploadResponse(AvatarUrls.forUser(me, updatedAt)));
+  }
+
+  @DeleteMapping("/users/me/avatar")
+  public ResponseEntity<Void> deleteMine() {
+    avatars.remove(CurrentUser.requireUserId());
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping(
+      value = "/admin/users/{userId}/avatar",
+      consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<AvatarUploadResponse> uploadForUser(
+      @PathVariable UUID userId, @RequestParam("file") MultipartFile file) throws IOException {
+    Instant updatedAt = avatars.store(userId, file.getBytes(), CurrentUser.requireUserId());
+    return ResponseEntity.ok(new AvatarUploadResponse(AvatarUrls.forUser(userId, updatedAt)));
+  }
+
+  @DeleteMapping("/admin/users/{userId}/avatar")
+  public ResponseEntity<Void> deleteForUser(@PathVariable UUID userId) {
+    avatars.remove(userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/users/{userId}/avatar")
+  public ResponseEntity<byte[]> serve(
+      @PathVariable UUID userId,
+      @RequestHeader(value = "If-None-Match", required = false) String ifNoneMatch) {
+    AvatarContent avatar =
+        avatars.get(userId).orElseThrow(() -> AvatarValidationException.notFound("no avatar"));
+    String etag = "\"" + avatar.sha256() + "\"";
+    if (etag.equals(ifNoneMatch)) {
+      return ResponseEntity.status(304).eTag(etag).cacheControl(CacheControl.noCache()).build();
+    }
+    return ResponseEntity.ok()
+        .eTag(etag)
+        .cacheControl(CacheControl.noCache())
+        .contentType(MediaType.parseMediaType(avatar.contentType()))
+        .body(avatar.content());
+  }
+
+  @ExceptionHandler(AvatarValidationException.class)
+  public ResponseEntity<ErrorResponse> onAvatarError(AvatarValidationException ex) {
+    return ResponseEntity.status(ex.getStatus())
+        .body(
+            new ErrorResponse()
+                .code(ex.getCode())
+                .message(ex.getMessage())
+                .timestamp(OffsetDateTime.now()));
+  }
+
+  /** The new avatar URL after an upload, so the SPA can update the avatar without a refetch. */
+  public record AvatarUploadResponse(String avatarUrl) {}
+}

--- a/qnop-app/src/main/java/io/qnop/web/AvatarUrls.java
+++ b/qnop-app/src/main/java/io/qnop/web/AvatarUrls.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Builds the public avatar URL exposed on user DTOs (issue #117). The {@code ?v=} cache-buster is
+ * the avatar's {@code updated_at} epoch, so the browser refetches whenever the picture changes
+ * while still caching it (the read path also serves an ETag). Returns {@code null} when the user
+ * has no avatar, so the SPA renders the initials fallback.
+ */
+final class AvatarUrls {
+
+  private AvatarUrls() {}
+
+  static String forUser(UUID userId, Instant updatedAt) {
+    if (updatedAt == null) {
+      return null;
+    }
+    return ApiPathConfig.API_V1_PREFIX
+        + "/users/"
+        + userId
+        + "/avatar?v="
+        + updatedAt.toEpochMilli();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
@@ -26,6 +26,8 @@ import io.qnop.api.v1.model.UserRole;
 import io.qnop.api.v1.model.UserSource;
 import io.qnop.service.UserService;
 import io.qnop.service.UserService.UserProfileView;
+import io.qnop.service.avatar.AvatarService;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,20 +41,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class CurrentUserController implements UsersApi {
 
   private final UserService users;
+  private final AvatarService avatars;
 
-  public CurrentUserController(UserService users) {
+  public CurrentUserController(UserService users, AvatarService avatars) {
     this.users = users;
+    this.avatars = avatars;
   }
 
   @Override
   public ResponseEntity<CurrentUserResponse> getCurrentUser() {
-    UserProfileView profile = users.getProfile(CurrentUser.requireUserId());
+    UUID userId = CurrentUser.requireUserId();
+    UserProfileView profile = users.getProfile(userId);
     return ResponseEntity.ok(
         new CurrentUserResponse()
             .id(profile.id())
             .displayName(profile.displayName())
             .email(profile.email())
             .role(UserRole.fromValue(profile.role()))
-            .source(UserSource.fromValue(profile.source())));
+            .source(UserSource.fromValue(profile.source()))
+            .avatarUrl(AvatarUrls.forUser(userId, avatars.updatedAt(userId).orElse(null))));
   }
 }

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -135,6 +135,11 @@ public class SecurityConfiguration {
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/branding/**")
                     .permitAll()
+                    // Avatars are served to <img> elements, which cannot carry a bearer token;
+                    // the read path is public (low-sensitivity display pictures, ADR-0031). Upload
+                    // and delete stay authenticated/admin via the matchers below.
+                    .requestMatchers(HttpMethod.GET, "/api/v1/users/*/avatar")
+                    .permitAll()
                     // The SPA needs the public server config before authentication
                     // (enabled OIDC providers, self-registration, edition). OpenAPI
                     // declares GET /config as security: [] — honour that here.

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
     open-in-view: false
   liquibase:
     change-log: classpath:/db/changelog/db.changelog-master.yaml
+  servlet:
+    multipart:
+      # Headroom over the 1 MiB avatar cap (AvatarLimits) so the service-level
+      # size check returns a clean 413 before the container rejects the request.
+      max-file-size: 2MB
+      max-request-size: 4MB
 
 management:
   endpoints:

--- a/qnop-app/src/test/java/io/qnop/web/AvatarControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AvatarControllerIT.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.avatar.AvatarLimits;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Verifies the profile-avatar endpoints (issue #117) through the real security chain: a user
+ * uploads their own picture and an admin uploads for any user; the read path is public and serves
+ * an ETag/304; validation rejects bad types/sizes; removal restores the absent (404) state; and the
+ * admin user DTO exposes the avatar URL. Requires Docker (Testcontainers).
+ */
+@Transactional
+class AvatarControllerIT extends AbstractIntegrationTest {
+
+  @Autowired WebApplicationContext context;
+  @Autowired UserRepository users;
+
+  private MockMvc mockMvc;
+  private UUID userId;
+  private UUID adminId;
+  private byte[] png;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+    String tag = "avatar-" + UUID.randomUUID();
+    userId = users.saveAndFlush(User.internal("Member", tag + "@example.com", tag, "hash")).getId();
+    String adminTag = "avatar-admin-" + UUID.randomUUID();
+    adminId =
+        users
+            .saveAndFlush(User.internal("Admin", adminTag + "@example.com", adminTag, "hash"))
+            .getId();
+    BufferedImage image = new BufferedImage(48, 48, BufferedImage.TYPE_INT_ARGB);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ImageIO.write(image, "png", out);
+    png = out.toByteArray();
+  }
+
+  private JwtRequestPostProcessor self() {
+    return jwt()
+        .jwt(j -> j.subject(userId.toString()))
+        .authorities(new SimpleGrantedAuthority("ROLE_MEMBER"));
+  }
+
+  private JwtRequestPostProcessor admin() {
+    return jwt()
+        .jwt(j -> j.subject(adminId.toString()))
+        .authorities(new SimpleGrantedAuthority("ROLE_ADMIN"));
+  }
+
+  private MockMultipartFile file(String name, String contentType, byte[] bytes) {
+    return new MockMultipartFile("file", name, contentType, bytes);
+  }
+
+  @Test
+  void selfUploadThenPubliclyServedWithEtagAnd304() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/users/me/avatar").file(file("a.png", "image/png", png)).with(self()))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.avatarUrl").value(org.hamcrest.Matchers.containsString(userId.toString())));
+
+    MvcResult served =
+        mockMvc
+            .perform(get("/api/v1/users/" + userId + "/avatar"))
+            .andExpect(status().isOk())
+            .andExpect(header().exists("ETag"))
+            .andReturn();
+
+    String etag = served.getResponse().getHeader("ETag");
+    mockMvc
+        .perform(get("/api/v1/users/" + userId + "/avatar").header("If-None-Match", etag))
+        .andExpect(status().isNotModified());
+  }
+
+  @Test
+  void adminUploadsForAnotherUser() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/admin/users/" + userId + "/avatar")
+                .file(file("a.png", "image/png", png))
+                .with(admin()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(get("/api/v1/users/" + userId + "/avatar")).andExpect(status().isOk());
+  }
+
+  @Test
+  void publicGetMissingAvatarReturns404() throws Exception {
+    mockMvc.perform(get("/api/v1/users/" + userId + "/avatar")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void selfUploadRejectsUnsupportedType() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/users/me/avatar")
+                .file(file("note.txt", "text/plain", new byte[] {1, 2, 3, 4, 5, 6, 7, 8}))
+                .with(self()))
+        .andExpect(status().isUnsupportedMediaType());
+  }
+
+  @Test
+  void selfUploadRejectsOversizedPayload() throws Exception {
+    byte[] tooBig = new byte[(int) AvatarLimits.MAX_SIZE_BYTES + 1];
+    mockMvc
+        .perform(
+            multipart("/api/v1/users/me/avatar")
+                .file(file("big.png", "image/png", tooBig))
+                .with(self()))
+        .andExpect(status().isPayloadTooLarge());
+  }
+
+  @Test
+  void memberCannotUploadViaAdminPath() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/admin/users/" + userId + "/avatar")
+                .file(file("a.png", "image/png", png))
+                .with(self()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void anonymousUploadIsUnauthorized() throws Exception {
+    mockMvc
+        .perform(multipart("/api/v1/users/me/avatar").file(file("a.png", "image/png", png)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void selfRemoveRestoresAbsentState() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/users/me/avatar").file(file("a.png", "image/png", png)).with(self()))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(delete("/api/v1/users/me/avatar").with(self()))
+        .andExpect(status().isNoContent());
+
+    mockMvc.perform(get("/api/v1/users/" + userId + "/avatar")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void adminUserDetailExposesAvatarUrl() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/admin/users/" + userId + "/avatar")
+                .file(file("a.png", "image/png", png))
+                .with(admin()))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(get("/api/v1/admin/users/" + userId).with(admin()))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.avatarUrl").value(org.hamcrest.Matchers.containsString("/avatar?v=")));
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/UserAvatar.java
+++ b/qnop-core/src/main/java/io/qnop/entity/UserAvatar.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+
+/**
+ * One user's profile picture (issue #117), one row per user keyed by {@code user_id}. Re-uploading
+ * replaces the row (current-only, no history); removing the picture deletes it.
+ *
+ * <p>The bytes live in Postgres ({@code bytea}) rather than object storage so a database backup is
+ * a complete restore, and the {@code user_id → qnop_user} foreign key cascades on delete — removing
+ * a user removes their avatar, so there is no orphan-reaper concern (ADR-0031). The {@code
+ * content_type} domain, the cascading FK, and the primary key live in Liquibase (migration {@code
+ * 0009}), not JPA annotations (ADR-0020); JPA runs {@code ddl-auto=none}. {@code updatedBy} is a
+ * best-effort audit breadcrumb (no FK): the admin who set another user's avatar may still be
+ * deleted.
+ */
+@Entity
+@Table(name = "user_avatar")
+public class UserAvatar {
+
+  @Id
+  @Column(name = "user_id", nullable = false, updatable = false)
+  private UUID userId;
+
+  @Column(name = "content_type", nullable = false, length = 64)
+  private String contentType;
+
+  @Column(name = "content", nullable = false)
+  private byte[] content;
+
+  /** Hex-encoded SHA-256 of {@link #content}; used as the HTTP ETag on the read path. */
+  @Column(name = "sha256", nullable = false, length = 64)
+  private String sha256;
+
+  @Column(name = "size_bytes", nullable = false)
+  private long sizeBytes;
+
+  /** Intrinsic pixel width/height when decodable (raster), else {@code null}. */
+  @Column(name = "width")
+  private Integer width;
+
+  @Column(name = "height")
+  private Integer height;
+
+  @CreationTimestamp
+  @Column(name = "updated_at", nullable = false, updatable = false)
+  private Instant updatedAt;
+
+  /** The user (self or admin) who last set the picture, if known. Nullable; no FK. */
+  @Column(name = "updated_by")
+  private UUID updatedBy;
+
+  protected UserAvatar() {
+    // for JPA
+  }
+
+  /** Creates an avatar row for the given user. {@code updatedBy} may be {@code null}. */
+  public static UserAvatar create(
+      UUID userId,
+      String contentType,
+      byte[] content,
+      String sha256,
+      long sizeBytes,
+      Integer width,
+      Integer height,
+      UUID updatedBy) {
+    UserAvatar avatar = new UserAvatar();
+    avatar.userId = userId;
+    avatar.contentType = contentType;
+    avatar.content = content == null ? null : content.clone();
+    avatar.sha256 = sha256;
+    avatar.sizeBytes = sizeBytes;
+    avatar.width = width;
+    avatar.height = height;
+    avatar.updatedBy = updatedBy;
+    return avatar;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  /**
+   * Returns a defensive copy so the stored bytes (and their {@code sha256}/{@code size}) stay
+   * intact.
+   */
+  public byte[] getContent() {
+    return content == null ? null : content.clone();
+  }
+
+  public String getSha256() {
+    return sha256;
+  }
+
+  public long getSizeBytes() {
+    return sizeBytes;
+  }
+
+  public Integer getWidth() {
+    return width;
+  }
+
+  public Integer getHeight() {
+    return height;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public UUID getUpdatedBy() {
+    return updatedBy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UserAvatar other)) {
+      return false;
+    }
+    return userId != null && userId.equals(other.userId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(userId);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/UserAvatarRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserAvatarRepository.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.UserAvatar;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Data access for {@link UserAvatar} (issue #117). {@code findById} loads the full bytes for the
+ * serving path; the {@code updatedAt} projections deliberately avoid selecting the {@code bytea}
+ * {@code content}, so building avatar URLs for the admin user list never streams image bytes.
+ */
+public interface UserAvatarRepository extends JpaRepository<UserAvatar, UUID> {
+
+  /** When the user's avatar was last set, without loading the image bytes. */
+  @Query("select a.updatedAt from UserAvatar a where a.userId = :userId")
+  Optional<Instant> findUpdatedAtByUserId(@Param("userId") UUID userId);
+
+  /** Batch variant for the admin user list: one row per user that has an avatar. */
+  @Query(
+      "select a.userId as userId, a.updatedAt as updatedAt from UserAvatar a where a.userId in :userIds")
+  List<AvatarUpdatedAtView> findUpdatedAtByUserIdIn(@Param("userIds") Collection<UUID> userIds);
+
+  /**
+   * Idempotent bulk delete (replaces the entity-load delete so a missing row is a no-op). Flushes
+   * pending changes first and clears the persistence context afterwards, so a subsequent {@code
+   * findById} in the same session reads the database rather than a stale cached row (matters when a
+   * remove/replace and a read share one transaction).
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("delete from UserAvatar a where a.userId = :userId")
+  int deleteByUserId(@Param("userId") UUID userId);
+
+  /** Projection exposing only the user id and avatar timestamp (no bytes). */
+  interface AvatarUpdatedAtView {
+    UUID getUserId();
+
+    Instant getUpdatedAt();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/avatar/AvatarLimits.java
+++ b/qnop-core/src/main/java/io/qnop/service/avatar/AvatarLimits.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.avatar;
+
+import java.util.Set;
+
+/**
+ * Bounds for profile-avatar uploads (issue #117). Avatars are small, one-per-user images (ADR-0031)
+ * with a tight cap. The allowed content types match the {@code user_avatar} {@code CHECK} domain
+ * (migration 0009). SVG is deliberately excluded — an SVG avatar is an XSS surface even sanitized,
+ * and the client always uploads a rasterized square crop.
+ */
+public final class AvatarLimits {
+
+  private AvatarLimits() {}
+
+  public static final String PNG = "image/png";
+  public static final String JPEG = "image/jpeg";
+  public static final String WEBP = "image/webp";
+
+  /** Content types accepted on upload, derived from the bytes (not the client-declared header). */
+  public static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(PNG, JPEG, WEBP);
+
+  /** Maximum stored size in bytes (1 MiB) — an avatar is a small square, not a document. */
+  public static final long MAX_SIZE_BYTES = 1024L * 1024L;
+
+  /**
+   * Maximum raster width/height in pixels; the client crops to a canonical square well under this.
+   */
+  public static final int MAX_DIMENSION_PX = 1024;
+}

--- a/qnop-core/src/main/java/io/qnop/service/avatar/AvatarService.java
+++ b/qnop-core/src/main/java/io/qnop/service/avatar/AvatarService.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.avatar;
+
+import io.qnop.repository.UserRepository;
+import io.qnop.service.avatar.AvatarStorage.AvatarContent;
+import io.qnop.service.avatar.AvatarStorage.NewAvatar;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import org.springframework.stereotype.Service;
+
+/**
+ * Validates and stores user profile avatars, and reads them back for serving (issue #117). The
+ * upload pipeline mirrors branding (ADR-0028): sniff the real content type from the bytes (never
+ * trust the client-declared header) → enforce the size cap → bound the pixel dimensions → SHA-256 →
+ * delegate the persist to {@link AvatarStorage}.
+ *
+ * <p>The CPU-bound validation (content-type sniffing, {@code ImageIO} decode) runs <em>outside</em>
+ * any transaction; only the storage write is transactional. SVG is rejected — only the rasterized
+ * crop the client produces (PNG/JPEG/WebP) is accepted.
+ */
+@Service
+public class AvatarService {
+
+  private final AvatarStorage storage;
+  private final UserRepository users;
+
+  public AvatarService(AvatarStorage storage, UserRepository users) {
+    this.storage = storage;
+    this.users = users;
+  }
+
+  /**
+   * Validates the uploaded bytes and replaces {@code userId}'s avatar.
+   *
+   * @param actor the user performing the upload (self or an admin), recorded as {@code updated_by}
+   * @return when the new avatar was stored (its {@code updated_at}), for building the avatar URL
+   * @throws AvatarValidationException if the user is unknown, the type unsupported, the payload too
+   *     large, or the image unreadable/oversized
+   */
+  public Instant store(UUID userId, byte[] bytes, UUID actor) {
+    if (!users.existsById(userId)) {
+      throw AvatarValidationException.userNotFound("no such user: " + userId);
+    }
+    if (bytes == null || bytes.length == 0) {
+      throw AvatarValidationException.invalidImage("empty upload");
+    }
+    if (bytes.length > AvatarLimits.MAX_SIZE_BYTES) {
+      throw AvatarValidationException.tooLarge(
+          "avatar exceeds " + AvatarLimits.MAX_SIZE_BYTES + " bytes");
+    }
+
+    String contentType = sniffContentType(bytes);
+    int[] dimensions = enforceDimensions(contentType, bytes);
+
+    storage.put(
+        new NewAvatar(
+            userId,
+            contentType,
+            bytes,
+            sha256Hex(bytes),
+            bytes.length,
+            dimensions == null ? null : dimensions[0],
+            dimensions == null ? null : dimensions[1],
+            actor));
+    return storage.findUpdatedAt(userId).orElseThrow();
+  }
+
+  /** The user's avatar bytes for serving, or empty when none is set. */
+  public Optional<AvatarContent> get(UUID userId) {
+    return storage.find(userId);
+  }
+
+  /** Removes the user's avatar (idempotent). */
+  public void remove(UUID userId) {
+    storage.remove(userId);
+  }
+
+  /** When the user's avatar was last set, or empty when none is set. */
+  public Optional<Instant> updatedAt(UUID userId) {
+    return storage.findUpdatedAt(userId);
+  }
+
+  /** Batch {@link #updatedAt(UUID)} for the admin user list. */
+  public Map<UUID, Instant> updatedAt(Collection<UUID> userIds) {
+    return storage.findUpdatedAt(userIds);
+  }
+
+  /**
+   * Bounds the raster dimensions and returns {@code [width, height]}, or {@code null} when the
+   * format carries no readable raster dimensions (WebP without an ImageIO plugin) — the size cap
+   * still applies.
+   */
+  private int[] enforceDimensions(String contentType, byte[] bytes) {
+    Optional<int[]> dimensions = rasterDimensions(bytes);
+    if ((AvatarLimits.PNG.equals(contentType) || AvatarLimits.JPEG.equals(contentType))
+        && dimensions.isEmpty()) {
+      throw AvatarValidationException.invalidImage("unreadable " + contentType);
+    }
+    dimensions.ifPresent(
+        d -> {
+          if (d[0] > AvatarLimits.MAX_DIMENSION_PX || d[1] > AvatarLimits.MAX_DIMENSION_PX) {
+            throw AvatarValidationException.invalidImage(
+                "dimensions exceed " + AvatarLimits.MAX_DIMENSION_PX + "px");
+          }
+        });
+    return dimensions.orElse(null);
+  }
+
+  private static Optional<int[]> rasterDimensions(byte[] bytes) {
+    try {
+      BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+      return image == null
+          ? Optional.empty()
+          : Optional.of(new int[] {image.getWidth(), image.getHeight()});
+    } catch (IOException e) {
+      return Optional.empty();
+    }
+  }
+
+  /** Derives the content type from the magic bytes; the client-declared header is not trusted. */
+  private static String sniffContentType(byte[] b) {
+    if (isPng(b)) {
+      return AvatarLimits.PNG;
+    }
+    if (isJpeg(b)) {
+      return AvatarLimits.JPEG;
+    }
+    if (isWebp(b)) {
+      return AvatarLimits.WEBP;
+    }
+    throw AvatarValidationException.unsupportedType("only PNG, JPEG and WebP are accepted");
+  }
+
+  private static boolean isPng(byte[] b) {
+    byte[] sig = {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    if (b.length < sig.length) {
+      return false;
+    }
+    for (int i = 0; i < sig.length; i++) {
+      if (b[i] != sig[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isJpeg(byte[] b) {
+    return b.length >= 3 && (b[0] & 0xFF) == 0xFF && (b[1] & 0xFF) == 0xD8 && (b[2] & 0xFF) == 0xFF;
+  }
+
+  private static boolean isWebp(byte[] b) {
+    return b.length >= 12
+        && b[0] == 'R'
+        && b[1] == 'I'
+        && b[2] == 'F'
+        && b[3] == 'F'
+        && b[8] == 'W'
+        && b[9] == 'E'
+        && b[10] == 'B'
+        && b[11] == 'P';
+  }
+
+  private static String sha256Hex(byte[] content) {
+    try {
+      return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/avatar/AvatarStorage.java
+++ b/qnop-core/src/main/java/io/qnop/service/avatar/AvatarStorage.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.avatar;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Storage port for profile avatars (issue #117, ADR-0031). The default implementation keeps the
+ * bytes in Postgres {@code bytea}; this seam lets a later S3 adapter re-home them once the ADR-0005
+ * {@code StorageProvider} SPI is built, without touching the service, endpoints, or frontend.
+ */
+public interface AvatarStorage {
+
+  /** The user's full avatar bytes for serving, or empty when none is set. */
+  Optional<AvatarContent> find(UUID userId);
+
+  /** When the user's avatar was last set (without loading the bytes), or empty when none is set. */
+  Optional<Instant> findUpdatedAt(UUID userId);
+
+  /** Batch {@link #findUpdatedAt(UUID)}: an entry only for users that have an avatar. */
+  Map<UUID, Instant> findUpdatedAt(Collection<UUID> userIds);
+
+  /** Replaces the user's avatar with the given validated content (current-only, no history). */
+  void put(NewAvatar avatar);
+
+  /** Removes the user's avatar (idempotent). */
+  void remove(UUID userId);
+
+  /** An avatar's bytes and serving metadata, for the read path. */
+  record AvatarContent(String contentType, byte[] content, String sha256) {}
+
+  /** Validated avatar content to persist. */
+  record NewAvatar(
+      UUID userId,
+      String contentType,
+      byte[] content,
+      String sha256,
+      long sizeBytes,
+      Integer width,
+      Integer height,
+      UUID updatedBy) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/avatar/AvatarValidationException.java
+++ b/qnop-core/src/main/java/io/qnop/service/avatar/AvatarValidationException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.avatar;
+
+/**
+ * Raised when an avatar upload (or read) is rejected (issue #117). Carries the HTTP status and a
+ * stable machine-readable code so the web layer can map it directly without a switch.
+ */
+public class AvatarValidationException extends RuntimeException {
+
+  private final int status;
+  private final String code;
+
+  public AvatarValidationException(int status, String code, String message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public static AvatarValidationException unsupportedType(String detail) {
+    return new AvatarValidationException(415, "UNSUPPORTED_MEDIA_TYPE", detail);
+  }
+
+  public static AvatarValidationException tooLarge(String detail) {
+    return new AvatarValidationException(413, "PAYLOAD_TOO_LARGE", detail);
+  }
+
+  public static AvatarValidationException invalidImage(String detail) {
+    return new AvatarValidationException(400, "INVALID_IMAGE", detail);
+  }
+
+  public static AvatarValidationException userNotFound(String detail) {
+    return new AvatarValidationException(404, "USER_NOT_FOUND", detail);
+  }
+
+  public static AvatarValidationException notFound(String detail) {
+    return new AvatarValidationException(404, "NOT_FOUND", detail);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/avatar/PostgresAvatarStorage.java
+++ b/qnop-core/src/main/java/io/qnop/service/avatar/PostgresAvatarStorage.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.avatar;
+
+import io.qnop.entity.UserAvatar;
+import io.qnop.repository.UserAvatarRepository;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Postgres-{@code bytea} implementation of {@link AvatarStorage} (ADR-0031). A replace is a bulk
+ * delete-then-insert keyed by {@code user_id}, so each upload yields a fresh {@code updated_at}
+ * (the row's creation timestamp) and the {@code (user_id)} primary key is never transiently
+ * duplicated.
+ */
+@Component
+public class PostgresAvatarStorage implements AvatarStorage {
+
+  private final UserAvatarRepository repository;
+
+  public PostgresAvatarStorage(UserAvatarRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<AvatarContent> find(UUID userId) {
+    return repository
+        .findById(userId)
+        .map(a -> new AvatarContent(a.getContentType(), a.getContent(), a.getSha256()));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<Instant> findUpdatedAt(UUID userId) {
+    return repository.findUpdatedAtByUserId(userId);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Map<UUID, Instant> findUpdatedAt(Collection<UUID> userIds) {
+    if (userIds.isEmpty()) {
+      return Map.of();
+    }
+    return repository.findUpdatedAtByUserIdIn(userIds).stream()
+        .collect(
+            Collectors.toMap(
+                UserAvatarRepository.AvatarUpdatedAtView::getUserId,
+                UserAvatarRepository.AvatarUpdatedAtView::getUpdatedAt));
+  }
+
+  @Override
+  @Transactional
+  public void put(NewAvatar avatar) {
+    // Bulk-delete the current row first (immediate DML) so the re-insert never collides with the
+    // (user_id) primary key, then insert the fresh row with a new creation timestamp.
+    repository.deleteByUserId(avatar.userId());
+    repository.saveAndFlush(
+        UserAvatar.create(
+            avatar.userId(),
+            avatar.contentType(),
+            avatar.content(),
+            avatar.sha256(),
+            avatar.sizeBytes(),
+            avatar.width(),
+            avatar.height(),
+            avatar.updatedBy()));
+  }
+
+  @Override
+  @Transactional
+  public void remove(UUID userId) {
+    repository.deleteByUserId(userId);
+  }
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -35,3 +35,6 @@ databaseChangeLog:
   - include:
       file: migrations/0008-team-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0009-user-avatar-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0009-user-avatar-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0009-user-avatar-schema.yaml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Profile-avatar schema (issue #117): user_avatar, one row per user. See ADR-0031
+# for why avatar bytes live in Postgres bytea behind an AvatarStorage port rather
+# than object storage. Postgres-only CHECK constraints and the cascading FK live
+# here in Liquibase, NOT in JPA annotations (ADR-0020). JPA runs ddl-auto=none, so
+# the entity column mapping must match exactly.
+databaseChangeLog:
+  - changeSet:
+      id: 0009-user-avatar
+      author: qnop
+      comment: Per-user profile avatar; one row per user, current-asset (not history).
+      changes:
+        - createTable:
+            tableName: user_avatar
+            columns:
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: content_type
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: content
+                  type: BYTEA
+                  constraints: { nullable: false }
+              - column:
+                  name: sha256
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: size_bytes
+                  type: BIGINT
+                  constraints: { nullable: false }
+              - column: { name: width, type: INT }
+              - column: { name: height, type: INT }
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              # Best-effort audit breadcrumb (who set the picture); no FK, so the
+              # admin who set another user's avatar can still be deleted.
+              - column: { name: updated_by, type: UUID }
+        # Deleting a user removes their avatar atomically — no orphan-reaper concern
+        # (ADR-0031). Contrast application_asset.uploaded_by, which does not cascade.
+        - addForeignKeyConstraint:
+            baseTableName: user_avatar
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            constraintName: fk_user_avatar_user
+            onDelete: CASCADE
+        - sql:
+            comment: Postgres-only CHECK constraint on the content_type domain.
+            splitStatements: true
+            sql: |
+              ALTER TABLE user_avatar ADD CONSTRAINT ck_user_avatar_content_type
+                CHECK (content_type IN ('image/png', 'image/jpeg', 'image/webp'));

--- a/qnop-core/src/test/java/io/qnop/service/avatar/AvatarServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/avatar/AvatarServiceTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.avatar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.repository.UserRepository;
+import io.qnop.service.avatar.AvatarStorage.NewAvatar;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AvatarServiceTest {
+
+  private AvatarStorage storage;
+  private UserRepository users;
+  private AvatarService service;
+
+  private final UUID userId = UUID.randomUUID();
+  private final UUID actor = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    storage = mock(AvatarStorage.class);
+    users = mock(UserRepository.class);
+    service = new AvatarService(storage, users);
+    when(users.existsById(userId)).thenReturn(true);
+    when(storage.findUpdatedAt(userId))
+        .thenReturn(Optional.of(Instant.parse("2026-06-26T00:00:00Z")));
+  }
+
+  @Test
+  void storeRejectsUnknownUser() {
+    when(users.existsById(userId)).thenReturn(false);
+    assertThatThrownBy(() -> service.store(userId, png(64, 64), actor))
+        .isInstanceOf(AvatarValidationException.class)
+        .satisfies(e -> assertThat(((AvatarValidationException) e).getStatus()).isEqualTo(404));
+    verify(storage, never()).put(any());
+  }
+
+  @Test
+  void storeRejectsEmptyUpload() {
+    assertThatThrownBy(() -> service.store(userId, new byte[0], actor))
+        .isInstanceOf(AvatarValidationException.class);
+    verify(storage, never()).put(any());
+  }
+
+  @Test
+  void storeRejectsOversizedPayload() {
+    byte[] tooBig = new byte[(int) AvatarLimits.MAX_SIZE_BYTES + 1];
+    assertThatThrownBy(() -> service.store(userId, tooBig, actor))
+        .isInstanceOf(AvatarValidationException.class)
+        .satisfies(e -> assertThat(((AvatarValidationException) e).getStatus()).isEqualTo(413));
+    verify(storage, never()).put(any());
+  }
+
+  @Test
+  void storeRejectsUnsupportedType() {
+    assertThatThrownBy(() -> service.store(userId, new byte[] {1, 2, 3, 4, 5, 6, 7, 8}, actor))
+        .isInstanceOf(AvatarValidationException.class)
+        .satisfies(e -> assertThat(((AvatarValidationException) e).getStatus()).isEqualTo(415));
+    verify(storage, never()).put(any());
+  }
+
+  @Test
+  void storeRejectsUnreadablePng() {
+    // Valid PNG signature but no decodable image data → ImageIO returns null.
+    byte[] brokenPng = {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01};
+    assertThatThrownBy(() -> service.store(userId, brokenPng, actor))
+        .isInstanceOf(AvatarValidationException.class)
+        .satisfies(e -> assertThat(((AvatarValidationException) e).getStatus()).isEqualTo(400));
+    verify(storage, never()).put(any());
+  }
+
+  @Test
+  void storeRejectsOversizedDimensions() throws IOException {
+    int tooWide = AvatarLimits.MAX_DIMENSION_PX + 1;
+    assertThatThrownBy(() -> service.store(userId, png(tooWide, 16), actor))
+        .isInstanceOf(AvatarValidationException.class)
+        .satisfies(e -> assertThat(((AvatarValidationException) e).getStatus()).isEqualTo(400));
+    verify(storage, never()).put(any());
+  }
+
+  @Test
+  void storeAcceptsPngAndPersistsSniffedTypeWithDimensions() throws IOException {
+    Instant updatedAt = service.store(userId, png(48, 48), actor);
+
+    ArgumentCaptor<NewAvatar> captor = ArgumentCaptor.forClass(NewAvatar.class);
+    verify(storage).put(captor.capture());
+    NewAvatar stored = captor.getValue();
+    assertThat(stored.userId()).isEqualTo(userId);
+    assertThat(stored.contentType()).isEqualTo(AvatarLimits.PNG);
+    assertThat(stored.width()).isEqualTo(48);
+    assertThat(stored.height()).isEqualTo(48);
+    assertThat(stored.sha256()).hasSize(64);
+    assertThat(stored.updatedBy()).isEqualTo(actor);
+    assertThat(updatedAt).isEqualTo(Instant.parse("2026-06-26T00:00:00Z"));
+  }
+
+  @Test
+  void storeAcceptsJpeg() throws IOException {
+    service.store(userId, jpeg(32, 32), actor);
+    ArgumentCaptor<NewAvatar> captor = ArgumentCaptor.forClass(NewAvatar.class);
+    verify(storage).put(captor.capture());
+    assertThat(captor.getValue().contentType()).isEqualTo(AvatarLimits.JPEG);
+  }
+
+  @Test
+  void storeAcceptsWebpWithoutReadableDimensions() {
+    // A RIFF/WEBP header is enough to sniff; ImageIO has no WebP plugin, so dimensions stay null
+    // and only the size cap applies.
+    byte[] webp = {'R', 'I', 'F', 'F', 0, 0, 0, 0, 'W', 'E', 'B', 'P', 'V', 'P', '8', ' '};
+    service.store(userId, webp, actor);
+    ArgumentCaptor<NewAvatar> captor = ArgumentCaptor.forClass(NewAvatar.class);
+    verify(storage).put(captor.capture());
+    assertThat(captor.getValue().contentType()).isEqualTo(AvatarLimits.WEBP);
+    assertThat(captor.getValue().width()).isNull();
+  }
+
+  @Test
+  void getRemoveAndUpdatedAtDelegateToStorage() {
+    service.remove(userId);
+    verify(storage).remove(userId);
+    service.get(userId);
+    verify(storage).find(userId);
+    service.updatedAt(userId);
+    // findUpdatedAt(userId) is also stubbed in setUp; verify the single-id delegation happened.
+    verify(storage).findUpdatedAt(userId);
+  }
+
+  private static byte[] png(int w, int h) throws IOException {
+    return raster(w, h, BufferedImage.TYPE_INT_ARGB, "png");
+  }
+
+  private static byte[] jpeg(int w, int h) throws IOException {
+    return raster(w, h, BufferedImage.TYPE_INT_RGB, "jpg");
+  }
+
+  private static byte[] raster(int w, int h, int type, String format) throws IOException {
+    BufferedImage image = new BufferedImage(w, h, type);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ImageIO.write(image, format, out);
+    return out.toByteArray();
+  }
+}

--- a/qnop-ui/package.json
+++ b/qnop-ui/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "1.21.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
+    "react-easy-crop": "^6.0.2",
     "react-router-dom": "7.18.0",
     "zustand": "5.0.14"
   },

--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      react-easy-crop:
+        specifier: ^6.0.2
+        version: 6.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-router-dom:
         specifier: 7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1688,6 +1691,9 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1809,6 +1815,12 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-easy-crop@6.0.2:
+    resolution: {integrity: sha512-nY/YiNEuRjc851+/PsOR6Q7XoshmnXMl+oEOsxp3Ah0PrhECi5388jjRnHwsTFx3W0o2zPwvq85oljzUqZNpEw==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3868,6 +3880,8 @@ snapshots:
 
   node-releases@2.0.47: {}
 
+  normalize-wheel@1.0.1: {}
+
   object-assign@4.1.1: {}
 
   obug@2.1.3: {}
@@ -3993,6 +4007,12 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-easy-crop@6.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   react-is@16.13.1: {}
 

--- a/qnop-ui/src/api/hooks/useAvatar.ts
+++ b/qnop-ui/src/api/hooks/useAvatar.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { axiosInstance } from '../config';
+import { adminUserKeys } from './useAdminUsers';
+import { useAuthStore } from '../../stores/authStore';
+
+/**
+ * Hooks for profile-avatar upload/remove (issue #117). The avatar endpoints are hand-written on the
+ * backend (multipart in, outside the OpenAPI JSON contract), so they are called through the shared
+ * {@link axiosInstance} with a {@code FormData} body rather than a generated client method.
+ */
+interface AvatarUploadResponse {
+  avatarUrl: string | null;
+}
+
+async function uploadAvatar(path: string, file: Blob): Promise<AvatarUploadResponse> {
+  const form = new FormData();
+  // The filename is cosmetic; the backend sniffs the real type from the bytes.
+  form.append('file', file, 'avatar');
+  const response = await axiosInstance.post<AvatarUploadResponse>(path, form);
+  return response.data;
+}
+
+/** Uploads the current user's own avatar and reflects the new URL in the shell immediately. */
+export function useUploadMyAvatar() {
+  const setAvatarUrl = useAuthStore((s) => s.setAvatarUrl);
+  return useMutation({
+    mutationFn: (file: Blob) => uploadAvatar('/users/me/avatar', file),
+    onSuccess: (data) => setAvatarUrl(data.avatarUrl ?? null),
+  });
+}
+
+/** Removes the current user's own avatar. */
+export function useRemoveMyAvatar() {
+  const setAvatarUrl = useAuthStore((s) => s.setAvatarUrl);
+  return useMutation({
+    mutationFn: async () => {
+      await axiosInstance.delete('/users/me/avatar');
+    },
+    onSuccess: () => setAvatarUrl(null),
+  });
+}
+
+/** Admin: uploads/replaces a given user's avatar; refreshes the admin user list. */
+export function useUploadUserAvatar() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ userId, file }: { userId: string; file: Blob }) =>
+      uploadAvatar(`/admin/users/${userId}/avatar`, file),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: adminUserKeys.all }),
+  });
+}
+
+/** Admin: removes a given user's avatar; refreshes the admin user list. */
+export function useRemoveUserAvatar() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (userId: string) => {
+      await axiosInstance.delete(`/admin/users/${userId}/avatar`);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: adminUserKeys.all }),
+  });
+}

--- a/qnop-ui/src/components/admin/users/UserFormDialog.tsx
+++ b/qnop-ui/src/components/admin/users/UserFormDialog.tsx
@@ -38,8 +38,10 @@ import type { AdminUserSummary, UserRole } from '../../../api/generated';
 import { PasswordField } from '../../auth/PasswordField';
 import { PasswordStrengthMeter } from '../../auth/PasswordStrengthMeter';
 import { useCreateUser, useUpdateUser } from '../../../api/hooks/useAdminUsers';
+import { useRemoveUserAvatar, useUploadUserAvatar } from '../../../api/hooks/useAvatar';
 import { apiErrorCode, apiErrorMessage } from '../../../utils/apiError';
 import { passwordStrength } from '../../../utils/passwordStrength';
+import { AvatarUploader } from '../../profile/AvatarUploader';
 
 interface UserFormDialogProps {
   open: boolean;
@@ -71,9 +73,14 @@ const CONFLICT_MESSAGES: Record<string, string> = {
 export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProps) {
   const createUser = useCreateUser();
   const updateUser = useUpdateUser();
+  const uploadAvatar = useUploadUserAvatar();
+  const removeAvatar = useRemoveUserAvatar();
 
   const editing = mode === 'edit' && user;
   const [displayName, setDisplayName] = useState(editing ? user.displayName : '');
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(
+    editing ? (user.avatarUrl ?? null) : null,
+  );
   const [username, setUsername] = useState(editing ? (user.username ?? '') : '');
   const [email, setEmail] = useState(editing ? user.email : '');
   const [role, setRole] = useState<UserRole>(editing ? user.role : 'MEMBER');
@@ -83,6 +90,29 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
   const [error, setError] = useState<string | null>(null);
 
   const submitting = createUser.isPending || updateUser.isPending;
+  const avatarBusy = uploadAvatar.isPending || removeAvatar.isPending;
+
+  const onAvatarSelect = async (blob: Blob) => {
+    if (!user) return;
+    setError(null);
+    try {
+      const result = await uploadAvatar.mutateAsync({ userId: user.id, file: blob });
+      setAvatarUrl(result.avatarUrl ?? null);
+    } catch (err) {
+      setError(apiErrorMessage(err, 'The picture could not be uploaded.'));
+    }
+  };
+
+  const onAvatarRemove = async () => {
+    if (!user) return;
+    setError(null);
+    try {
+      await removeAvatar.mutateAsync(user.id);
+      setAvatarUrl(null);
+    } catch (err) {
+      setError(apiErrorMessage(err, 'The picture could not be removed.'));
+    }
+  };
   const passwordOk = method === 'invite' || passwordStrength(password).acceptable;
   const canSubmit =
     mode === 'edit'
@@ -125,6 +155,16 @@ export function UserFormDialog({ open, mode, user, onClose }: UserFormDialogProp
         <DialogTitle>{isEdit ? 'Edit user' : 'Add user'}</DialogTitle>
         <DialogContent>
           <Stack spacing={2.5} sx={{ mt: 1 }}>
+            {isEdit && user && (
+              <AvatarUploader
+                name={displayName || user.displayName}
+                imageUrl={avatarUrl}
+                busy={avatarBusy}
+                onSelect={onAvatarSelect}
+                onRemove={onAvatarRemove}
+              />
+            )}
+
             <TextField
               label="Full name"
               value={displayName}

--- a/qnop-ui/src/components/admin/users/UsersTable.tsx
+++ b/qnop-ui/src/components/admin/users/UsersTable.tsx
@@ -126,7 +126,7 @@ export function UsersTable({
             <TableRow key={user.id} hover>
               <TableCell>
                 <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
-                  <UserAvatar name={user.displayName} size={36} />
+                  <UserAvatar name={user.displayName} size={36} imageUrl={user.avatarUrl} />
                   <Box sx={{ minWidth: 0 }}>
                     <Stack
                       direction="row"

--- a/qnop-ui/src/components/profile/AvatarCropDialog.tsx
+++ b/qnop-ui/src/components/profile/AvatarCropDialog.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useCallback, useState } from 'react';
+import Cropper, { type Area } from 'react-easy-crop';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Slider from '@mui/material/Slider';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { ZoomIn } from 'lucide-react';
+import { getCroppedAvatarBlob } from '../../utils/cropImage';
+
+interface AvatarCropDialogProps {
+  open: boolean;
+  imageSrc: string;
+  busy?: boolean;
+  onCancel: () => void;
+  onCropped: (blob: Blob) => void;
+}
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 3;
+
+/**
+ * Square avatar cropper (issue #117): pan + zoom over the picked image with a round mask, then
+ * export the selection as a canonical square via {@link getCroppedAvatarBlob}.
+ */
+export function AvatarCropDialog({
+  open,
+  imageSrc,
+  busy,
+  onCancel,
+  onCropped,
+}: AvatarCropDialogProps) {
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [area, setArea] = useState<Area | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  const onCropComplete = useCallback((_: Area, areaPixels: Area) => setArea(areaPixels), []);
+
+  const apply = async () => {
+    if (!area) return;
+    setExporting(true);
+    try {
+      onCropped(await getCroppedAvatarBlob(imageSrc, area));
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const disabled = busy || exporting;
+
+  return (
+    <Dialog open={open} onClose={disabled ? undefined : onCancel} maxWidth="xs" fullWidth>
+      <DialogTitle>Adjust your picture</DialogTitle>
+      <DialogContent>
+        <Box
+          sx={{
+            position: 'relative',
+            width: '100%',
+            height: 300,
+            bgcolor: 'common.black',
+            borderRadius: 2,
+            overflow: 'hidden',
+          }}
+        >
+          <Cropper
+            image={imageSrc}
+            crop={crop}
+            zoom={zoom}
+            aspect={1}
+            cropShape="round"
+            showGrid={false}
+            onCropChange={setCrop}
+            onZoomChange={setZoom}
+            onCropComplete={onCropComplete}
+          />
+        </Box>
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', mt: 2 }}>
+          <ZoomIn size={18} />
+          <Slider
+            min={MIN_ZOOM}
+            max={MAX_ZOOM}
+            step={0.01}
+            value={zoom}
+            onChange={(_, value) => setZoom(value as number)}
+            aria-label="Zoom"
+            disabled={disabled}
+          />
+        </Stack>
+        <Typography sx={{ fontSize: 12, color: 'text.secondary', mt: 0.5 }}>
+          Drag to reposition, use the slider to zoom.
+        </Typography>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onCancel} color="inherit" disabled={disabled}>
+          Cancel
+        </Button>
+        <Button onClick={apply} variant="contained" disabled={disabled || !area}>
+          Use photo
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/profile/AvatarUploader.test.tsx
+++ b/qnop-ui/src/components/profile/AvatarUploader.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { AvatarUploader } from './AvatarUploader';
+
+function renderUploader(props: Partial<React.ComponentProps<typeof AvatarUploader>> = {}) {
+  const merged = {
+    name: 'Ada Lovelace',
+    imageUrl: null,
+    onSelect: vi.fn(),
+    onRemove: vi.fn(),
+    ...props,
+  };
+  return {
+    ...render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <AvatarUploader {...merged} />
+      </ThemeProvider>,
+    ),
+    onSelect: merged.onSelect,
+  };
+}
+
+function fileInput(container: HTMLElement): HTMLInputElement {
+  return container.querySelector('input[type="file"]') as HTMLInputElement;
+}
+
+describe('AvatarUploader', () => {
+  it('rejects a non-image file without selecting it', () => {
+    const { container, onSelect } = renderUploader();
+    const file = new File(['x'], 'note.txt', { type: 'text/plain' });
+    fireEvent.change(fileInput(container), { target: { files: [file] } });
+    expect(screen.getByText(/PNG, JPEG or WebP image/)).toBeTruthy();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('rejects an image larger than the cap', () => {
+    const { container, onSelect } = renderUploader();
+    const big = new File([new Uint8Array(1024 * 1024 + 1)], 'big.png', { type: 'image/png' });
+    fireEvent.change(fileInput(container), { target: { files: [big] } });
+    expect(screen.getByText(/larger than 1 MB/)).toBeTruthy();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('shows the remove action only when an avatar is set', () => {
+    const { queryByText } = renderUploader({ imageUrl: null });
+    expect(queryByText('Remove photo')).toBeNull();
+
+    renderUploader({ imageUrl: '/api/v1/users/1/avatar?v=1' });
+    expect(screen.getByText('Remove photo')).toBeTruthy();
+  });
+});

--- a/qnop-ui/src/components/profile/AvatarUploader.tsx
+++ b/qnop-ui/src/components/profile/AvatarUploader.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState, type DragEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { ImagePlus, Trash2 } from 'lucide-react';
+import { UserAvatar } from '../shell/UserAvatar';
+import { ConfirmDialog } from '../admin/ConfirmDialog';
+import { AvatarCropDialog } from './AvatarCropDialog';
+
+/** Accepted types and size cap — mirror the server (AvatarLimits) for fast, local feedback. */
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+const MAX_BYTES = 1024 * 1024;
+
+interface AvatarUploaderProps {
+  /** Name for the initials fallback in the preview. */
+  name: string;
+  /** Current avatar URL, or null. */
+  imageUrl: string | null;
+  /** Whether an upload/remove is in flight. */
+  busy?: boolean;
+  /** Called with the cropped, ready-to-upload square image. */
+  onSelect: (blob: Blob) => void;
+  /** Called to remove the current picture. */
+  onRemove: () => void;
+}
+
+/**
+ * Reusable avatar upload control (issue #117): a live circular preview plus a drag-and-drop / browse
+ * dropzone that validates type and size, opens the square cropper, and emits the cropped blob.
+ * Presentational — the parent owns the upload/remove mutations, so the same control serves the
+ * self-service profile screen and the admin user dialog.
+ */
+export function AvatarUploader({ name, imageUrl, busy, onSelect, onRemove }: AvatarUploaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [cropSrc, setCropSrc] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState(false);
+
+  const accept = (file: File) => {
+    setError(null);
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      setError('Please choose a PNG, JPEG or WebP image.');
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      setError('That image is larger than 1 MB.');
+      return;
+    }
+    setCropSrc(URL.createObjectURL(file));
+  };
+
+  const onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) accept(file);
+    event.target.value = ''; // allow re-picking the same file
+  };
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragOver(false);
+    if (busy) return;
+    const file = event.dataTransfer.files?.[0];
+    if (file) accept(file);
+  };
+
+  const closeCrop = () => {
+    if (cropSrc) URL.revokeObjectURL(cropSrc);
+    setCropSrc(null);
+  };
+
+  const onCropped = (blob: Blob) => {
+    onSelect(blob);
+    closeCrop();
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={3}
+        sx={{ alignItems: { sm: 'center' } }}
+      >
+        <Box
+          sx={{ position: 'relative', flexShrink: 0, alignSelf: { xs: 'flex-start', sm: 'auto' } }}
+        >
+          <UserAvatar name={name} size={96} imageUrl={imageUrl} />
+          {busy && (
+            <Box
+              sx={{
+                position: 'absolute',
+                inset: 0,
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                bgcolor: 'rgba(0,0,0,0.45)',
+              }}
+            >
+              <CircularProgress size={28} sx={{ color: '#fff' }} />
+            </Box>
+          )}
+        </Box>
+
+        <Box sx={{ flex: 1, minWidth: 0, width: '100%' }}>
+          <Box
+            role="button"
+            tabIndex={0}
+            aria-label="Upload a profile picture"
+            onClick={() => !busy && inputRef.current?.click()}
+            onKeyDown={(e) => {
+              if ((e.key === 'Enter' || e.key === ' ') && !busy) {
+                e.preventDefault();
+                inputRef.current?.click();
+              }
+            }}
+            onDragOver={(e) => {
+              e.preventDefault();
+              if (!busy) setDragOver(true);
+            }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={onDrop}
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 0.75,
+              textAlign: 'center',
+              px: 2,
+              py: 2.5,
+              cursor: busy ? 'default' : 'pointer',
+              borderRadius: 2.5,
+              border: '1.5px dashed',
+              borderColor: dragOver ? 'primary.main' : 'divider',
+              bgcolor: dragOver ? 'action.hover' : 'transparent',
+              color: dragOver ? 'primary.main' : 'text.secondary',
+              transition: 'border-color 150ms ease, background-color 150ms ease, color 150ms ease',
+              outline: 'none',
+              '&:hover': busy ? {} : { borderColor: 'primary.main', color: 'primary.main' },
+              '&:focus-visible': { borderColor: 'primary.main', color: 'primary.main' },
+            }}
+          >
+            <ImagePlus size={22} />
+            <Typography sx={{ fontSize: 14 }}>
+              Drag an image here or{' '}
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                browse
+              </Box>
+            </Typography>
+            <Typography sx={{ fontSize: 12, color: 'text.disabled' }}>
+              PNG, JPEG or WebP · up to 1 MB
+            </Typography>
+          </Box>
+
+          {imageUrl && (
+            <Button
+              size="small"
+              color="error"
+              startIcon={<Trash2 size={15} />}
+              onClick={() => setConfirmRemove(true)}
+              disabled={busy}
+              sx={{ mt: 1, textTransform: 'none' }}
+            >
+              Remove photo
+            </Button>
+          )}
+        </Box>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPTED_TYPES.join(',')}
+        hidden
+        onChange={onInputChange}
+      />
+
+      {cropSrc && (
+        <AvatarCropDialog
+          open
+          imageSrc={cropSrc}
+          busy={busy}
+          onCancel={closeCrop}
+          onCropped={onCropped}
+        />
+      )}
+
+      <ConfirmDialog
+        open={confirmRemove}
+        title="Remove profile picture"
+        message="This removes the profile picture and falls back to the initials avatar. A new one can be uploaded anytime."
+        confirmLabel="Remove"
+        destructive
+        onConfirm={() => {
+          setConfirmRemove(false);
+          onRemove();
+        }}
+        onClose={() => setConfirmRemove(false)}
+      />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/shell/UserAvatar.test.tsx
+++ b/qnop-ui/src/components/shell/UserAvatar.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { UserAvatar } from './UserAvatar';
+
+function renderAvatar(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={buildTheme('light')}>{ui}</ThemeProvider>);
+}
+
+describe('UserAvatar', () => {
+  it('shows initials when no image URL is set', () => {
+    const { container } = renderAvatar(<UserAvatar name="Ada Lovelace" />);
+    expect(screen.getByText('AL')).toBeTruthy();
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders the uploaded image when a URL is provided', () => {
+    const { container } = renderAvatar(
+      <UserAvatar name="Ada Lovelace" imageUrl="/api/v1/users/1/avatar?v=7" />,
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('/api/v1/users/1/avatar?v=7');
+  });
+
+  it('falls back to initials when the image fails to load', () => {
+    const { container } = renderAvatar(<UserAvatar name="Ada Lovelace" imageUrl="/broken" />);
+    fireEvent.error(container.querySelector('img') as HTMLImageElement);
+    expect(screen.getByText('AL')).toBeTruthy();
+    expect(container.querySelector('img')).toBeNull();
+  });
+});

--- a/qnop-ui/src/components/shell/UserAvatar.tsx
+++ b/qnop-ui/src/components/shell/UserAvatar.tsx
@@ -19,12 +19,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useState } from 'react';
 import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 
 interface UserAvatarProps {
   name: string | null;
   size?: number;
+  /** Uploaded profile picture; falls back to the initials avatar when absent or it fails to load. */
+  imageUrl?: string | null;
 }
 
 function initials(name: string): string {
@@ -34,12 +37,27 @@ function initials(name: string): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-/** Initials avatar with a deterministic colour from the brand avatar palette. */
-export function UserAvatar({ name, size = 28 }: UserAvatarProps) {
+/**
+ * Avatar: renders the uploaded profile picture when present, otherwise an initials
+ * avatar with a deterministic colour from the brand palette (issue #117). A broken
+ * or expired image URL falls back to the initials too.
+ */
+export function UserAvatar({ name, size = 28, imageUrl }: UserAvatarProps) {
   const theme = useTheme();
   const safe = name ?? '?';
   const palette = theme.qnop.avatarPalette;
   const idx = (safe.charCodeAt(0) + safe.charCodeAt(safe.length - 1)) % palette.length;
+
+  // Track load failure so a broken/expired image falls back to initials. Reset it during render
+  // when the URL changes (e.g. the cache-busting ?v= after an upload) — the React-recommended
+  // "adjust state during render" pattern, avoiding a setState-in-effect cascade.
+  const [failed, setFailed] = useState(false);
+  const [lastUrl, setLastUrl] = useState(imageUrl);
+  if (imageUrl !== lastUrl) {
+    setLastUrl(imageUrl);
+    setFailed(false);
+  }
+  const showImage = Boolean(imageUrl) && !failed;
 
   return (
     <Box
@@ -49,6 +67,7 @@ export function UserAvatar({ name, size = 28 }: UserAvatarProps) {
         height: size,
         borderRadius: '50%',
         flexShrink: 0,
+        overflow: 'hidden',
         bgcolor: palette[idx],
         color: '#fff',
         display: 'flex',
@@ -59,7 +78,17 @@ export function UserAvatar({ name, size = 28 }: UserAvatarProps) {
         lineHeight: 1,
       }}
     >
-      {initials(safe)}
+      {showImage ? (
+        <Box
+          component="img"
+          src={imageUrl ?? undefined}
+          alt=""
+          onError={() => setFailed(true)}
+          sx={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+        />
+      ) : (
+        initials(safe)
+      )}
     </Box>
   );
 }

--- a/qnop-ui/src/components/shell/UserFooter.tsx
+++ b/qnop-ui/src/components/shell/UserFooter.tsx
@@ -26,7 +26,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
-import { KeyRound, LogOut } from 'lucide-react';
+import { KeyRound, LogOut, UserRound } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/authStore';
 import { UserAvatar } from './UserAvatar';
@@ -41,11 +41,12 @@ interface UserFooterProps {
   collapsed: boolean;
 }
 
-/** Sidebar footer: the signed-in user with a menu (profile placeholder, logout). */
+/** Sidebar footer: the signed-in user with a menu (profile, change password, logout). */
 export function UserFooter({ collapsed }: UserFooterProps) {
   const displayName = useAuthStore((s) => s.displayName);
   const role = useAuthStore((s) => s.role);
   const source = useAuthStore((s) => s.source);
+  const avatarUrl = useAuthStore((s) => s.avatarUrl);
   const logout = useAuthStore((s) => s.logout);
   const navigate = useNavigate();
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
@@ -70,7 +71,7 @@ export function UserFooter({ collapsed }: UserFooterProps) {
           '&:hover': { bgcolor: 'action.hover' },
         }}
       >
-        <UserAvatar name={displayName} size={28} />
+        <UserAvatar name={displayName} size={28} imageUrl={avatarUrl} />
         {!collapsed && (
           <Box sx={{ minWidth: 0, textAlign: 'left', flex: 1 }}>
             <Typography noWrap sx={{ fontSize: 13, fontWeight: 500, lineHeight: 1.2 }}>
@@ -90,6 +91,17 @@ export function UserFooter({ collapsed }: UserFooterProps) {
         anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
         transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       >
+        <MenuItem
+          onClick={() => {
+            setAnchor(null);
+            navigate('/profile');
+          }}
+        >
+          <ListItemIcon>
+            <UserRound size={16} />
+          </ListItemIcon>
+          Profile
+        </MenuItem>
         {/* External (OIDC) accounts have no local password — only local users can change it. */}
         {source !== 'EXTERNAL' && (
           <MenuItem

--- a/qnop-ui/src/pages/ProfilePage.tsx
+++ b/qnop-ui/src/pages/ProfilePage.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useAuthStore } from '../stores/authStore';
+import { useUploadMyAvatar, useRemoveMyAvatar } from '../api/hooks/useAvatar';
+import { UserAvatar } from '../components/shell/UserAvatar';
+import { UserRoleBadge, UserSourceBadge } from '../components/admin/users/UserBadges';
+import { AvatarUploader } from '../components/profile/AvatarUploader';
+
+type Toast = { message: string; severity: 'success' | 'error' } | null;
+
+/**
+ * Self-service profile screen (issue #117): an identity header plus the profile-picture control.
+ * The picture is independent of the account source, so OIDC users can set one too. Built to grow —
+ * display-name/email editing can slot in alongside the avatar section later.
+ */
+export function ProfilePage() {
+  const displayName = useAuthStore((s) => s.displayName);
+  const email = useAuthStore((s) => s.email);
+  const role = useAuthStore((s) => s.role);
+  const source = useAuthStore((s) => s.source);
+  const avatarUrl = useAuthStore((s) => s.avatarUrl);
+
+  const upload = useUploadMyAvatar();
+  const remove = useRemoveMyAvatar();
+  const [toast, setToast] = useState<Toast>(null);
+  const busy = upload.isPending || remove.isPending;
+
+  const onSelect = async (blob: Blob) => {
+    try {
+      await upload.mutateAsync(blob);
+      setToast({ message: 'Profile picture updated.', severity: 'success' });
+    } catch {
+      setToast({
+        message: 'The picture could not be uploaded. Please try again.',
+        severity: 'error',
+      });
+    }
+  };
+
+  const onRemove = async () => {
+    try {
+      await remove.mutateAsync();
+      setToast({ message: 'Profile picture removed.', severity: 'success' });
+    } catch {
+      setToast({
+        message: 'The picture could not be removed. Please try again.',
+        severity: 'error',
+      });
+    }
+  };
+
+  return (
+    <Stack spacing={3} sx={{ maxWidth: 720 }}>
+      <Box>
+        <Typography variant="h1" sx={{ fontSize: 28 }}>
+          Profile
+        </Typography>
+        <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+          Manage your account and how you appear across qnop.
+        </Typography>
+      </Box>
+
+      <Paper variant="outlined" sx={{ p: { xs: 2.5, sm: 3 } }}>
+        <Stack direction="row" spacing={2.5} sx={{ alignItems: 'center' }}>
+          <UserAvatar name={displayName} size={72} imageUrl={avatarUrl} />
+          <Box sx={{ minWidth: 0 }}>
+            <Typography sx={{ fontSize: 22, fontWeight: 600, lineHeight: 1.2 }} noWrap>
+              {displayName ?? 'Unknown'}
+            </Typography>
+            <Typography color="text.secondary" noWrap>
+              {email}
+            </Typography>
+            <Stack direction="row" spacing={1} sx={{ mt: 1, flexWrap: 'wrap' }}>
+              {role && <UserRoleBadge role={role} />}
+              {source && <UserSourceBadge source={source} />}
+            </Stack>
+          </Box>
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 2.5, sm: 3 } }}>
+        <Typography sx={{ fontSize: 16, fontWeight: 600 }}>Profile picture</Typography>
+        <Typography color="text.secondary" sx={{ fontSize: 14, mt: 0.5, mb: 2.5 }}>
+          Upload a photo so teammates recognise you. It is shown across the app; remove it to fall
+          back to your initials.
+        </Typography>
+        <Divider sx={{ mb: 2.5 }} />
+        <AvatarUploader
+          name={displayName ?? '?'}
+          imageUrl={avatarUrl}
+          busy={busy}
+          onSelect={onSelect}
+          onRemove={onRemove}
+        />
+      </Paper>
+
+      <Snackbar
+        open={toast !== null}
+        autoHideDuration={5000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert severity={toast.severity} onClose={() => setToast(null)} variant="filled">
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -27,6 +27,7 @@ import { ProtectedRoute } from '../components/auth/ProtectedRoute';
 import { RoleRoute } from '../components/auth/RoleRoute';
 import { ComingSoonPage } from '../pages/ComingSoonPage';
 import { HomePage } from '../pages/HomePage';
+import { ProfilePage } from '../pages/ProfilePage';
 import { MailTemplatesPage } from '../pages/admin/MailTemplatesPage';
 import { OidcProvidersPage } from '../pages/admin/OidcProvidersPage';
 import { SettingsPage } from '../pages/admin/SettingsPage';
@@ -65,6 +66,7 @@ export const router = createBrowserRouter([
     ),
     children: [
       { index: true, element: <HomePage /> },
+      { path: 'profile', element: <ProfilePage /> },
       {
         path: 'reviews',
         element: (

--- a/qnop-ui/src/stores/authStore.ts
+++ b/qnop-ui/src/stores/authStore.ts
@@ -33,6 +33,8 @@ interface AuthState {
   email: string | null;
   role: UserRole | null;
   source: UserSource | null;
+  /** URL of the current user's profile picture, or null for the initials avatar. */
+  avatarUrl: string | null;
   isAuthenticated: boolean;
   /** True while the initial refresh-on-load is in flight; gates the first render. */
   isHydrating: boolean;
@@ -44,6 +46,8 @@ interface AuthState {
   passwordChangeRequired: boolean;
 
   setAccessToken: (token: string | null) => void;
+  /** Updates just the avatar URL after a self-service upload/remove, so the shell reflects it. */
+  setAvatarUrl: (url: string | null) => void;
   login: (usernameOrEmail: string, password: string) => Promise<void>;
   fetchMe: () => Promise<void>;
   hydrate: () => Promise<void>;
@@ -57,6 +61,7 @@ const EMPTY_PROFILE = {
   email: null,
   role: null,
   source: null,
+  avatarUrl: null,
 } as const;
 
 export const useAuthStore = create<AuthState>((set, get) => ({
@@ -67,6 +72,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   passwordChangeRequired: false,
 
   setAccessToken: (token) => set({ accessToken: token }),
+
+  setAvatarUrl: (url) => set({ avatarUrl: url }),
 
   login: async (usernameOrEmail, password) => {
     const response = await fetch(`${API_BASE}/auth/login`, {
@@ -97,6 +104,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         email: me.email,
         role: me.role,
         source: me.source,
+        avatarUrl: me.avatarUrl ?? null,
         isAuthenticated: true,
         passwordChangeRequired: false,
       });

--- a/qnop-ui/src/utils/cropImage.ts
+++ b/qnop-ui/src/utils/cropImage.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Client-side avatar cropping (issue #117). The cropper hands us a pixel rectangle; we draw it onto
+ * a fixed square canvas and export a bounded image. Producing a canonical square here means the
+ * upload is already small and square, so the server only validates (it never resizes), and the
+ * "avoid serving oversized originals" requirement is satisfied at the source.
+ */
+export const AVATAR_OUTPUT_SIZE = 512;
+
+export interface PixelArea {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', () => reject(new Error('The image could not be read.')));
+    image.src = src;
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (webp) => {
+        if (webp) {
+          resolve(webp);
+          return;
+        }
+        // Older browsers may not encode WebP from a canvas; fall back to PNG.
+        canvas.toBlob(
+          (png) => (png ? resolve(png) : reject(new Error('The image could not be processed.'))),
+          'image/png',
+        );
+      },
+      'image/webp',
+      0.9,
+    );
+  });
+}
+
+/** Crops {@link area} out of the source image and returns a square {@link AVATAR_OUTPUT_SIZE} blob. */
+export async function getCroppedAvatarBlob(imageSrc: string, area: PixelArea): Promise<Blob> {
+  const image = await loadImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  canvas.width = AVATAR_OUTPUT_SIZE;
+  canvas.height = AVATAR_OUTPUT_SIZE;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Image editing is not supported in this browser.');
+  }
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(
+    image,
+    area.x,
+    area.y,
+    area.width,
+    area.height,
+    0,
+    0,
+    AVATAR_OUTPUT_SIZE,
+    AVATAR_OUTPUT_SIZE,
+  );
+  return canvasToBlob(canvas);
+}


### PR DESCRIPTION
Closes #117.

Per-user profile pictures: a user uploads/replaces/removes their own, and an admin can do the same for any user. The initials avatar remains the fallback.

## Backend
- **Storage (ADR-0031, new):** avatar bytes in Postgres `bytea`, dedicated `user_avatar` table (one row per user, `FK … ON DELETE CASCADE` — no orphan reaper), behind a small `AvatarStorage` port (single `PostgresAvatarStorage` adapter) so a later S3 adapter can re-home them without touching the rest. Reuses the branding upload pipeline; **SVG excluded** (XSS), **1 MiB** cap, **PNG/JPEG/WebP** sniffed from magic bytes.
- **Endpoints (hand-written, branding/ADR-0028 pattern):** self `POST`/`DELETE /users/me/avatar`, admin `POST`/`DELETE /admin/users/{id}/avatar`, public `GET /users/{id}/avatar` (`byte[]` + ETag/304) so an `<img>` loads without a bearer token. `CurrentUserResponse` / `AdminUserSummary` / `AdminUserDetail` carry a cache-busting `avatarUrl` (null → initials); the admin list batches the timestamp lookup so it never streams bytes.

## Frontend
- `UserAvatar` renders the uploaded image with an initials fallback (also on load error); wired at the shell footer and admin user table, with `avatarUrl` carried in `authStore`.
- **Self-service:** a new in-shell **/profile** screen (from the user menu) with a designed `AvatarUploader` — drag-and-drop/browse, client-side type+size validation, an interactive square **cropper** (`react-easy-crop`) exporting a canonical 512px WebP (PNG fallback), live preview, and remove-with-confirm.
- **Admin:** the same uploader embedded in the user edit dialog; the list refreshes so row thumbnails update.

## Test plan
- [x] Backend unit (`AvatarServiceTest`) + Testcontainers IT (`AvatarControllerIT`: self/admin upload, public ETag/304, 404 fallback, 415/413 validation, 401/403 authz, remove, DTO `avatarUrl`).
- [x] Frontend: `UserAvatar` (image/initials/load-error) + `AvatarUploader` (type+size rejection, remove visibility); `pnpm lint` / `test` (109 passed) / `build` green.
- [x] `./gradlew spotlessApply` + ArchUnit + compile green locally (Docker off here → backend IT verified via CI).
- [ ] Manual: self upload→crop→save→shell avatar updates; admin upload for another user→row thumbnail updates; remove→initials fallback.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code