### PR TITLE
fix(mail): align seeded templates with flow variables; brand HTML via EmailLayoutBuilder (#140)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/mail/MailTemplateSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/mail/MailTemplateSchemaIT.java
@@ -48,11 +48,13 @@ class MailTemplateSchemaIT extends AbstractIntegrationTest {
         .hasValueSatisfying(
             t -> {
               assertThat(t.getSubject()).contains("{{siteName}}");
-              assertThat(t.getBodyPlain()).contains("{{username}}", "{{verificationLink}}");
-              assertThat(t.getBodyHtml()).isNotBlank();
+              // Unified vocabulary that the send flows actually supply (issue #140).
+              assertThat(t.getBodyPlain()).contains("{{recipientName}}", "{{actionUrl}}");
+              // Seeds carry plain text only; the branded HTML is built by EmailLayoutBuilder.
+              assertThat(t.getBodyHtml()).isNull();
             });
     assertThat(templates.findByTemplateKeyAndLocale("auth.password_reset", "en"))
-        .hasValueSatisfying(t -> assertThat(t.getBodyPlain()).contains("{{resetLink}}"));
+        .hasValueSatisfying(t -> assertThat(t.getBodyPlain()).contains("{{actionUrl}}"));
     assertThat(templates.findByTemplateKeyAndLocale("auth.admin_password_reset", "en")).isPresent();
   }
 

--- a/qnop-app/src/test/java/io/qnop/mail/SeededMailTemplateRenderIT.java
+++ b/qnop-app/src/test/java/io/qnop/mail/SeededMailTemplateRenderIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.MailTemplate;
+import io.qnop.repository.MailTemplateRepository;
+import io.qnop.service.mail.MailTemplateKey;
+import io.qnop.service.mail.MailTemplateService;
+import io.qnop.service.mail.RenderedMail;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Regression for issue #140: every seeded {@code mail_template} row must render against exactly the
+ * variable set its live send flow supplies — no missing-variable {@code MustacheException}. The
+ * seeds and the flow vocabulary drifted apart historically ({@code username}/{@code resetLink} vs
+ * {@code recipientName}/{@code actionUrl}), so strict Mustache rendering threw and every seeded
+ * template silently became {@code SendResult.Failed}. Runs against the real migrated schema
+ * (Testcontainers); requires Docker.
+ */
+class SeededMailTemplateRenderIT extends AbstractIntegrationTest {
+
+  /** Exactly the variables the registration / password-reset / admin-reset flows supply (#140). */
+  private static final Map<String, Object> FLOW_VARS =
+      Map.of(
+          "siteName", "qnop",
+          "recipientName", "Jane Doe",
+          "actionUrl", "https://qnop.example/action?token=abc123",
+          "expiresAtHuman", "in 30 minutes");
+
+  @Autowired MailTemplateRepository templates;
+  @Autowired MailTemplateService templateService;
+
+  @Test
+  void everySeededRowRendersAgainstItsFlowVariableSet() {
+    var rows = templates.findAll();
+    assertThat(rows).as("seeded mail_template rows").isNotEmpty();
+
+    for (MailTemplate row : rows) {
+      MailTemplateKey key =
+          MailTemplateKey.fromKey(row.getTemplateKey())
+              .orElseThrow(
+                  () -> new AssertionError("seeded unknown template key: " + row.getTemplateKey()));
+
+      assertThatCode(() -> templateService.render(key, FLOW_VARS, row.getLocale()))
+          .as("rendering seeded row %s/%s", row.getTemplateKey(), row.getLocale())
+          .doesNotThrowAnyException();
+
+      RenderedMail mail = templateService.render(key, FLOW_VARS, row.getLocale());
+      assertThat(mail.subject()).isNotBlank();
+      assertThat(mail.bodyPlain()).contains("Jane Doe").contains("in 30 minutes");
+      // The branded HTML chrome is built by EmailLayoutBuilder for every template.
+      assertThat(mail.bodyHtml()).isNotNull().contains("<!DOCTYPE html>").contains("qnop");
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
@@ -29,6 +29,7 @@ import io.qnop.repository.UserRepository;
 import io.qnop.security.PasswordGenerator;
 import io.qnop.service.auth.PasswordResetFlowService;
 import io.qnop.service.auth.PasswordResetFlowService.SetupLinkOutcome;
+import io.qnop.service.mail.MailTemplateKey;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
@@ -137,7 +138,7 @@ public class AdminUserService {
     User saved = users.save(user);
 
     if (invite) {
-      passwordResetFlow.sendSetupLink(saved);
+      passwordResetFlow.sendSetupLink(saved, MailTemplateKey.PASSWORD_RESET);
     }
     return toView(saved, null);
   }
@@ -220,7 +221,8 @@ public class AdminUserService {
           "NO_LOCAL_PASSWORD",
           "This account signs in via an identity provider; it has no password.");
     }
-    SetupLinkOutcome outcome = passwordResetFlow.sendSetupLink(user);
+    SetupLinkOutcome outcome =
+        passwordResetFlow.sendSetupLink(user, MailTemplateKey.ADMIN_PASSWORD_RESET);
     // Revoke active sessions now (the modifying writes clear the persistence context, so do this
     // after the link has been issued from the still-managed entity).
     users.bumpPasswordInvalidatedBefore(id, Instant.now());

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
@@ -27,6 +27,7 @@ import io.qnop.service.UserService;
 import io.qnop.service.mail.MailService;
 import io.qnop.service.mail.MailService.SendResult;
 import io.qnop.service.mail.MailTemplateKey;
+import io.qnop.service.mail.RelativeTimePhrase;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -66,7 +67,10 @@ public class PasswordResetFlowService {
     if (!settings.getBoolean(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED)) {
       return;
     }
-    userService.findInternalByEmail(email).filter(User::isEnabled).ifPresent(this::sendResetEmail);
+    userService
+        .findInternalByEmail(email)
+        .filter(User::isEnabled)
+        .ifPresent(user -> sendResetEmail(user, MailTemplateKey.PASSWORD_RESET));
   }
 
   /** Consumes a reset token and applies the new password. Throws on an invalid token. */
@@ -82,24 +86,30 @@ public class PasswordResetFlowService {
    * out-of-band fallback). Unlike {@link #requestReset}, this is not gated by the self-service
    * feature flag or anti-enumeration — the admin already knows the account exists and is acting on
    * it deliberately (e.g. (re)sending an invitation or unblocking a locked-out user).
+   *
+   * @param template the template to send — {@code PASSWORD_RESET} for an invitation/re-send, {@code
+   *     ADMIN_PASSWORD_RESET} for an admin-initiated reset (issue #140).
    */
   @Transactional
-  public SetupLinkOutcome sendSetupLink(User user) {
-    return sendResetEmail(user);
+  public SetupLinkOutcome sendSetupLink(User user, MailTemplateKey template) {
+    return sendResetEmail(user, template);
   }
 
-  private SetupLinkOutcome sendResetEmail(User user) {
-    String rawToken = resetTokens.issue(user).rawToken();
+  private SetupLinkOutcome sendResetEmail(User user, MailTemplateKey template) {
+    var issued = resetTokens.issue(user);
     String actionUrl =
-        baseUrl() + "/reset-password?token=" + URLEncoder.encode(rawToken, StandardCharsets.UTF_8);
+        baseUrl()
+            + "/reset-password?token="
+            + URLEncoder.encode(issued.rawToken(), StandardCharsets.UTF_8);
     SendResult result =
         mailService.sendMailFromTemplate(
-            MailTemplateKey.PASSWORD_RESET,
+            template,
             user.getEmail(),
             Map.of(
                 "siteName", siteName(),
                 "recipientName", user.getDisplayName(),
-                "actionUrl", actionUrl),
+                "actionUrl", actionUrl,
+                "expiresAtHuman", RelativeTimePhrase.until(issued.expiresAt())),
             null);
     return new SetupLinkOutcome(result instanceof SendResult.Sent, actionUrl);
   }

--- a/qnop-core/src/main/java/io/qnop/service/auth/RegistrationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/RegistrationService.java
@@ -27,8 +27,10 @@ import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.UserService;
 import io.qnop.service.mail.MailService;
 import io.qnop.service.mail.MailTemplateKey;
+import io.qnop.service.mail.RelativeTimePhrase;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,8 +70,8 @@ public class RegistrationService {
     }
     User user =
         userService.createSelfRegistered(username, email, password, displayName, defaultRole());
-    String rawToken = verificationTokens.issue(user).rawToken();
-    sendVerificationEmail(user, rawToken);
+    var issued = verificationTokens.issue(user);
+    sendVerificationEmail(user, issued.rawToken(), issued.expiresAt());
   }
 
   /**
@@ -95,7 +97,7 @@ public class RegistrationService {
     userService.enable(user.getId());
   }
 
-  private void sendVerificationEmail(User user, String rawToken) {
+  private void sendVerificationEmail(User user, String rawToken, Instant expiresAt) {
     String actionUrl =
         baseUrl() + "/verify-email?token=" + URLEncoder.encode(rawToken, StandardCharsets.UTF_8);
     mailService.sendMailFromTemplate(
@@ -104,7 +106,8 @@ public class RegistrationService {
         Map.of(
             "siteName", siteName(),
             "recipientName", user.getDisplayName(),
-            "actionUrl", actionUrl),
+            "actionUrl", actionUrl,
+            "expiresAtHuman", RelativeTimePhrase.until(expiresAt)),
         null);
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/mail/EmailLayoutBuilder.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/EmailLayoutBuilder.java
@@ -23,53 +23,90 @@ package io.qnop.service.mail;
 import org.springframework.stereotype.Component;
 
 /**
- * Wraps a rendered HTML content fragment in a responsive, email-client-safe HTML document (issue
- * #19): a centered, max-width table layout with inline styles (the only CSS most mail clients
- * honor) and an optional call-to-action button. Template authors and the mail-sending flows (#20)
- * supply the inner content; this builder owns the shared chrome so every qnop email looks
- * consistent.
+ * Builds the shared, branded HTML chrome around a rendered content fragment (issue #19/#140), so
+ * every transactional qnop email looks consistent. The design is a light "editorial document"
+ * aesthetic — warm paper background, ink-dark type, a single confident indigo accent, the {@code
+ * qnop·} wordmark, a prominent call-to-action and a monospace fallback link.
  *
- * <p>The caller is responsible for HTML-escaping any user-supplied values in {@code contentHtml}
- * (the Mustache HTML compiler in {@link MailTemplateService} escapes variables by default).
+ * <p>Email-client-safe by construction: a centered max-width table layout with inline styles only
+ * (the only CSS most clients honor), declared {@code light} color-scheme so clients do not
+ * auto-invert it badly, and a hidden preheader for the inbox preview line.
+ *
+ * <p>The {@code contentHtml} fragment is expected to be already rendered and HTML-escaped (the
+ * Mustache HTML compiler in {@link MailTemplateService} escapes variables by default). The {@code
+ * brandName}, {@code ctaUrl}, {@code ctaText}, {@code preheader} and {@code footerLine} values are
+ * escaped here.
  */
 @Component
 public class EmailLayoutBuilder {
 
+  private static final String ACCENT = "#2b43d0";
+  private static final String INK = "#18191f";
+  private static final String INK_SOFT = "#3c3f49";
+  private static final String MUTED = "#9a9ea8";
+  private static final String PAPER = "#eceae3";
+  private static final String HAIRLINE = "#ece9e1";
+  private static final String BODY_FONT =
+      "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif";
+  private static final String MONO_FONT =
+      "'SFMono-Regular',ui-monospace,Menlo,Consolas,'Liberation Mono',monospace";
+
   /**
-   * Builds the full HTML document.
+   * Wraps a content fragment in the full branded HTML document.
    *
+   * @param brandName the product/site name shown as the wordmark (defaults to {@code qnop})
+   * @param preheader the hidden inbox-preview line
    * @param contentHtml the inner content fragment (already rendered + escaped)
-   * @param ctaUrl optional call-to-action URL; when null no button is rendered
-   * @param ctaText label for the call-to-action button (used only when {@code ctaUrl} is set)
-   * @param footerLine a short footer line (e.g. the product name / a do-not-reply notice)
+   * @param ctaUrl optional call-to-action URL; when blank no button or fallback link is rendered
+   * @param ctaText label for the call-to-action button
+   * @param footerLine a short footer line (e.g. a do-not-reply notice)
    */
-  public String wrap(String contentHtml, String ctaUrl, String ctaText, String footerLine) {
-    String button = ctaUrl == null || ctaUrl.isBlank() ? "" : ctaButton(ctaUrl, ctaText);
+  public String wrap(
+      String brandName,
+      String preheader,
+      String contentHtml,
+      String ctaUrl,
+      String ctaText,
+      String footerLine) {
+    String brand = brandName == null || brandName.isBlank() ? "qnop" : brandName;
+    String cta = ctaUrl == null || ctaUrl.isBlank() ? "" : ctaBlock(ctaUrl, ctaText);
     return """
         <!DOCTYPE html>
         <html lang="en">
           <head>
             <meta charset="utf-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <meta name="color-scheme" content="light only" />
+            <meta name="supported-color-schemes" content="light" />
           </head>
-          <body style="margin:0;padding:0;background:#f4f5f7;">
-            <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" style="background:#f4f5f7;">
+          <body style="margin:0;padding:0;background:%s;-webkit-font-smoothing:antialiased;">
+            <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:%s;font-size:1px;line-height:1px;">%s</div>
+            <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" border="0" style="background:%s;">
               <tr>
-                <td align="center" style="padding:32px 16px;">
-                  <table role="presentation" width="100%%" cellpadding="0" cellspacing="0"
-                         style="max-width:560px;background:#ffffff;border-radius:12px;overflow:hidden;
-                                font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
+                <td align="center" style="padding:40px 16px;">
+                  <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" border="0"
+                         style="max-width:560px;width:100%%;background:#ffffff;border:1px solid #e6e3db;
+                                border-radius:16px;overflow:hidden;font-family:%s;">
+                    <tr><td style="height:4px;background:%s;font-size:0;line-height:0;">&nbsp;</td></tr>
                     <tr>
-                      <td style="padding:32px;color:#1a1a1a;font-size:15px;line-height:1.6;">
+                      <td style="padding:30px 36px 0;">
+                        <span style="font-size:19px;font-weight:700;letter-spacing:-0.02em;color:%s;">%s<span style="color:%s;">.</span></span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="padding:20px 36px 8px;color:%s;font-size:15px;line-height:1.65;">
                         %s
                         %s
                       </td>
                     </tr>
                     <tr>
-                      <td style="padding:16px 32px 32px;color:#8a8f98;font-size:12px;line-height:1.5;">
-                        %s
+                      <td style="padding:8px 36px 32px;">
+                        <div style="border-top:1px solid %s;padding-top:18px;color:%s;font-size:12px;line-height:1.6;">%s</div>
                       </td>
                     </tr>
+                  </table>
+                  <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%%;">
+                    <tr><td style="padding:16px 36px 0;text-align:center;color:#b3b6bd;font-size:11px;letter-spacing:0.04em;">%s · Qualified Notes on Papers</td></tr>
                   </table>
                 </td>
               </tr>
@@ -77,20 +114,54 @@ public class EmailLayoutBuilder {
           </body>
         </html>
         """
-        .formatted(contentHtml, button, footerLine);
+        .formatted(
+            PAPER,
+            PAPER,
+            escape(preheader),
+            PAPER,
+            BODY_FONT,
+            ACCENT,
+            INK,
+            escape(brand),
+            ACCENT,
+            INK_SOFT,
+            contentHtml,
+            cta,
+            HAIRLINE,
+            MUTED,
+            escape(footerLine),
+            escape(brand));
   }
 
-  private String ctaButton(String ctaUrl, String ctaText) {
+  private String ctaBlock(String ctaUrl, String ctaText) {
+    String label = ctaText == null || ctaText.isBlank() ? "Open" : ctaText;
+    String url = escape(ctaUrl);
     return """
-        <table role="presentation" cellpadding="0" cellspacing="0" style="margin:24px 0;">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:26px 0 6px;">
           <tr>
-            <td align="center" style="border-radius:8px;background:#2d6cdf;">
-              <a href="%s" style="display:inline-block;padding:12px 24px;color:#ffffff;
-                 text-decoration:none;font-weight:600;font-size:15px;">%s</a>
+            <td style="border-radius:10px;background:%s;box-shadow:0 1px 2px rgba(20,28,90,0.25);">
+              <a href="%s" style="display:inline-block;padding:13px 28px;color:#ffffff;text-decoration:none;font-weight:600;font-size:15px;letter-spacing:0.01em;">%s</a>
             </td>
           </tr>
         </table>
+        <p style="margin:16px 0 0;color:%s;font-size:12px;line-height:1.6;">Button not working? Paste this link into your browser:</p>
+        <p style="margin:6px 0 0;">
+          <a href="%s" style="color:%s;font-size:12px;word-break:break-all;font-family:%s;text-decoration:none;">%s</a>
+        </p>
         """
-        .formatted(ctaUrl, ctaText == null ? "Open" : ctaText);
+        .formatted(ACCENT, url, escape(label), MUTED, url, ACCENT, MONO_FONT, url);
+  }
+
+  /** Minimal HTML-attribute/text escaping for the non-fragment values placed into the chrome. */
+  private static String escape(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&#39;");
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -32,9 +32,11 @@ import java.util.Optional;
  * the enum is the authoritative <em>registry</em> of which templates exist, the entity is one
  * stored per-locale override.
  *
- * <p>Bodies are logic-less Mustache; variables (e.g. {@code {{siteName}}}, {@code {{actionUrl}}})
- * are supplied at render time. HTML defaults are intentionally absent here — the seeded rows carry
- * the rich responsive HTML; when neither exists the message is sent plain-text only.
+ * <p>Bodies are logic-less Mustache; variables ({@code {{siteName}}}, {@code {{recipientName}}},
+ * {@code {{actionUrl}}}, {@code {{expiresAtHuman}}}) are supplied at render time and must match the
+ * variables the live send flows pass (issue #140). Each key carries a plain-text body and an inner
+ * HTML content fragment; {@link EmailLayoutBuilder} wraps the fragment in the shared branded chrome
+ * unless a stored row overrides the HTML.
  */
 public enum MailTemplateKey {
   REGISTRATION_VERIFICATION(
@@ -43,43 +45,81 @@ public enum MailTemplateKey {
       """
       Hi {{recipientName}},
 
-      Please confirm your email address to activate your {{siteName}} account:
+      Confirm your email address to activate your {{siteName}} account:
 
       {{actionUrl}}
 
-      If you did not create this account, you can safely ignore this message.
-      """),
+      This link expires {{expiresAtHuman}}. If you did not create this account, you can safely ignore this message.
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Confirm your email</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;">Confirm this address to activate your <strong style="color:#18191f;">{{siteName}}</strong> account.</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">This link expires {{expiresAtHuman}}. If you didn't create this account, you can ignore this email.</p>
+      """,
+      "Verify email address",
+      "Confirm your email to activate your {{siteName}} account."),
   PASSWORD_RESET(
       "auth.password_reset",
       "Reset your {{siteName}} password",
       """
       Hi {{recipientName}},
 
-      We received a request to reset your {{siteName}} password. Use the link below to choose a new one:
+      We received a request to reset your {{siteName}} password. Choose a new one here:
 
       {{actionUrl}}
 
-      If you did not request this, you can safely ignore this message; your password stays unchanged.
-      """),
+      This link expires {{expiresAtHuman}}. If you did not request this, you can safely ignore this message; your password stays unchanged.
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Reset your password</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;">We received a request to reset your <strong style="color:#18191f;">{{siteName}}</strong> password. Choose a new one below.</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">This link expires {{expiresAtHuman}}. If you didn't request this, ignore this email — your password stays unchanged.</p>
+      """,
+      "Choose a new password",
+      "Reset your {{siteName}} password."),
   ADMIN_PASSWORD_RESET(
       "auth.admin_password_reset",
       "Your {{siteName}} password was reset by an administrator",
       """
       Hi {{recipientName}},
 
-      An administrator has reset your {{siteName}} password. Use the link below to set a new one:
+      An administrator reset your {{siteName}} password. Set a new one to sign back in:
 
       {{actionUrl}}
-      """);
+
+      This link expires {{expiresAtHuman}}.
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Set a new password</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;">An administrator reset your <strong style="color:#18191f;">{{siteName}}</strong> password. Set a new one to sign back in.</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">This link expires {{expiresAtHuman}}.</p>
+      """,
+      "Set a new password",
+      "An administrator reset your {{siteName}} password.");
 
   private final String key;
   private final String defaultSubject;
   private final String defaultBodyPlain;
+  private final String defaultBodyHtmlContent;
+  private final String ctaLabel;
+  private final String preheader;
 
-  MailTemplateKey(String key, String defaultSubject, String defaultBodyPlain) {
+  MailTemplateKey(
+      String key,
+      String defaultSubject,
+      String defaultBodyPlain,
+      String defaultBodyHtmlContent,
+      String ctaLabel,
+      String preheader) {
     this.key = key;
     this.defaultSubject = defaultSubject;
     this.defaultBodyPlain = defaultBodyPlain;
+    this.defaultBodyHtmlContent = defaultBodyHtmlContent;
+    this.ctaLabel = ctaLabel;
+    this.preheader = preheader;
   }
 
   /** The stable storage key (matches the {@code template_key} column). */
@@ -93,6 +133,25 @@ public enum MailTemplateKey {
 
   public String defaultBodyPlain() {
     return defaultBodyPlain;
+  }
+
+  /**
+   * The inner HTML content fragment (heading + body), wrapped in the shared branded chrome by
+   * {@link EmailLayoutBuilder} when no stored HTML override exists. Logic-less Mustache,
+   * HTML-escaped.
+   */
+  public String defaultBodyHtmlContent() {
+    return defaultBodyHtmlContent;
+  }
+
+  /** The call-to-action button label for this template. */
+  public String ctaLabel() {
+    return ctaLabel;
+  }
+
+  /** The hidden inbox-preview line (Mustache). */
+  public String preheader() {
+    return preheader;
   }
 
   /** Resolves a storage key back to its catalog entry, if known. */

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateService.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateService.java
@@ -50,30 +50,55 @@ public class MailTemplateService {
 
   private final MailTemplateRepository repository;
   private final ApplicationSettingsService settings;
+  private final EmailLayoutBuilder layoutBuilder;
   private final Mustache.Compiler plainCompiler = Mustache.compiler().escapeHTML(false);
   private final Mustache.Compiler htmlCompiler = Mustache.compiler().escapeHTML(true);
 
   public MailTemplateService(
-      MailTemplateRepository repository, ApplicationSettingsService settings) {
+      MailTemplateRepository repository,
+      ApplicationSettingsService settings,
+      EmailLayoutBuilder layoutBuilder) {
     this.repository = repository;
     this.settings = settings;
+    this.layoutBuilder = layoutBuilder;
   }
 
   /**
    * Renders the template for {@code locale} (with fallback) using {@code vars}. Throws {@link
    * com.samskivert.mustache.MustacheException} if a referenced variable is missing.
+   *
+   * <p>When a stored row carries an HTML override it is used verbatim; otherwise the catalog
+   * default's content fragment is rendered and wrapped in the shared branded chrome ({@link
+   * EmailLayoutBuilder}), so every email — default or reset-to-default — looks consistent.
    */
   public RenderedMail render(MailTemplateKey key, Map<String, Object> vars, String locale) {
     Optional<MailTemplate> row = resolve(key, locale);
     String subject = row.map(MailTemplate::getSubject).orElseGet(key::defaultSubject);
     String plain = row.map(MailTemplate::getBodyPlain).orElseGet(key::defaultBodyPlain);
-    String html = row.map(MailTemplate::getBodyHtml).orElse(null);
+    String storedHtml = row.map(MailTemplate::getBodyHtml).filter(h -> !h.isBlank()).orElse(null);
 
     String renderedSubject = plainCompiler.compile(subject).execute(vars);
     String renderedPlain = plainCompiler.compile(plain).execute(vars);
     String renderedHtml =
-        html != null && !html.isBlank() ? htmlCompiler.compile(html).execute(vars) : null;
+        storedHtml != null
+            ? htmlCompiler.compile(storedHtml).execute(vars)
+            : buildBrandedHtml(key, vars);
     return new RenderedMail(renderedSubject, renderedPlain, renderedHtml);
+  }
+
+  /** Renders the catalog default content fragment and wraps it in the branded chrome. */
+  private String buildBrandedHtml(MailTemplateKey key, Map<String, Object> vars) {
+    String content = htmlCompiler.compile(key.defaultBodyHtmlContent()).execute(vars);
+    String preheader = plainCompiler.compile(key.preheader()).execute(vars);
+    Object brand = vars.get("siteName");
+    Object actionUrl = vars.get("actionUrl");
+    return layoutBuilder.wrap(
+        brand == null ? null : brand.toString(),
+        preheader,
+        content,
+        actionUrl == null ? null : actionUrl.toString(),
+        key.ctaLabel(),
+        "This is an automated message — please don't reply.");
   }
 
   /** Renders {@code key} with the provided variables, or representative sample data if none. */
@@ -170,7 +195,8 @@ public class MailTemplateService {
     return Map.of(
         "siteName", "qnop",
         "recipientName", "Jane Doe",
-        "actionUrl", "https://qnop.example/action?token=SAMPLE");
+        "actionUrl", "https://qnop.example/action?token=SAMPLE",
+        "expiresAtHuman", "in 30 minutes");
   }
 
   private MailTemplateView toView(MailTemplate row, MailTemplateView.Source source) {

--- a/qnop-core/src/main/java/io/qnop/service/mail/RelativeTimePhrase.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/RelativeTimePhrase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Renders a coarse, human-friendly "expires in …" phrase for mail bodies (issue #140), so the
+ * {@code expiresAtHuman} template variable reads naturally ("in 30 minutes", "in 24 hours", "in 7
+ * days") regardless of the exact token TTL. Rounded to the nearest sensible unit; never negative.
+ */
+public final class RelativeTimePhrase {
+
+  private RelativeTimePhrase() {}
+
+  /** A phrase like {@code "in 30 minutes"} for the time from now until {@code expiresAt}. */
+  public static String until(Instant expiresAt) {
+    return until(Instant.now(), expiresAt);
+  }
+
+  static String until(Instant now, Instant expiresAt) {
+    long minutes = Math.max(1, Math.round(Duration.between(now, expiresAt).toSeconds() / 60.0));
+    if (minutes < 60) {
+      return "in " + plural(minutes, "minute");
+    }
+    long hours = Math.round(minutes / 60.0);
+    if (hours < 48) {
+      return "in " + plural(hours, "hour");
+    }
+    long days = Math.round(hours / 24.0);
+    return "in " + plural(days, "day");
+  }
+
+  private static String plural(long count, String unit) {
+    return count + " " + unit + (count == 1 ? "" : "s");
+  }
+}

--- a/qnop-core/src/main/resources/db/changelog/migrations/0003-mail-template-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0003-mail-template-schema.yaml
@@ -7,8 +7,11 @@
 # body_plain is always required (accessibility / spam-filter friendliness),
 # body_html is the optional alternative the mail layer sends as
 # multipart/alternative. Seeds ship usable English defaults out of the box;
-# Mustache placeholders ({{username}}, {{verificationLink}}/{{resetLink}},
-# {{expiresAtHuman}}, {{siteName}}) are rendered by MailTemplateService (#19).
+# Mustache placeholders ({{recipientName}}, {{actionUrl}}, {{expiresAtHuman}},
+# {{siteName}}) are rendered by MailTemplateService (#19) and must match exactly
+# the variables the send flows supply (issue #140). The seeds carry plain text
+# only; the branded HTML is built by EmailLayoutBuilder from the catalog content
+# fragment, so there is a single source of email chrome (issue #140).
 databaseChangeLog:
   - changeSet:
       id: 0003-create-mail-template
@@ -73,30 +76,13 @@ databaseChangeLog:
               - column:
                   name: body_plain
                   value: |
-                    Hi {{username}},
+                    Hi {{recipientName}},
 
-                    Please verify your email address to finish setting up your
-                    {{siteName}} account. This link expires {{expiresAtHuman}}.
+                    Confirm your email address to activate your {{siteName}} account:
 
-                    {{verificationLink}}
+                    {{actionUrl}}
 
-                    If you did not create an account, you can safely ignore this message.
-              - column:
-                  name: body_html
-                  value: |
-                    <!DOCTYPE html>
-                    <html>
-                      <body>
-                        <p>Hi {{username}},</p>
-                        <p>Please verify your email address to finish setting up your
-                          {{siteName}} account. This link expires {{expiresAtHuman}}.</p>
-                        <p><a href="{{verificationLink}}">Verify my email</a></p>
-                        <p>If the button does not work, paste this URL into your browser:<br>
-                          <a href="{{verificationLink}}">{{verificationLink}}</a></p>
-                        <p style="color:#666;font-size:0.9em;">If you did not create an account,
-                          you can safely ignore this message.</p>
-                      </body>
-                    </html>
+                    This link expires {{expiresAtHuman}}. If you did not create this account, you can safely ignore this message.
       rollback:
         - delete:
             tableName: mail_template
@@ -117,34 +103,13 @@ databaseChangeLog:
               - column:
                   name: body_plain
                   value: |
-                    Hi {{username}},
+                    Hi {{recipientName}},
 
-                    We received a request to reset the password on your {{siteName}}
-                    account. Click the link below to choose a new one — it is valid
-                    {{expiresAtHuman}}.
+                    We received a request to reset your {{siteName}} password. Choose a new one here:
 
-                    {{resetLink}}
+                    {{actionUrl}}
 
-                    If you did not request a password reset, you can safely ignore this
-                    message — your existing password remains active.
-              - column:
-                  name: body_html
-                  value: |
-                    <!DOCTYPE html>
-                    <html>
-                      <body>
-                        <p>Hi {{username}},</p>
-                        <p>We received a request to reset the password on your {{siteName}}
-                          account. Click the button below to choose a new one — it is valid
-                          {{expiresAtHuman}}.</p>
-                        <p><a href="{{resetLink}}">Reset my password</a></p>
-                        <p>If the button does not work, paste this URL into your browser:<br>
-                          <a href="{{resetLink}}">{{resetLink}}</a></p>
-                        <p style="color:#666;font-size:0.9em;">If you did not request a password
-                          reset, you can safely ignore this message — your existing password
-                          remains active.</p>
-                      </body>
-                    </html>
+                    This link expires {{expiresAtHuman}}. If you did not request this, you can safely ignore this message; your password stays unchanged.
       rollback:
         - delete:
             tableName: mail_template
@@ -161,36 +126,17 @@ databaseChangeLog:
               - column: { name: id, valueComputed: gen_random_uuid() }
               - column: { name: template_key, value: auth.admin_password_reset }
               - column: { name: locale, value: en }
-              - column: { name: subject, value: "An administrator reset your {{siteName}} password" }
+              - column: { name: subject, value: "Your {{siteName}} password was reset by an administrator" }
               - column:
                   name: body_plain
                   value: |
-                    Hi {{username}},
+                    Hi {{recipientName}},
 
-                    An administrator has initiated a password reset on your {{siteName}}
-                    account. Click the link below to choose a new password — it is valid
-                    {{expiresAtHuman}}.
+                    An administrator reset your {{siteName}} password. Set a new one to sign back in:
 
-                    {{resetLink}}
+                    {{actionUrl}}
 
-                    If you have questions about this change, contact your administrator.
-              - column:
-                  name: body_html
-                  value: |
-                    <!DOCTYPE html>
-                    <html>
-                      <body>
-                        <p>Hi {{username}},</p>
-                        <p>An administrator has initiated a password reset on your {{siteName}}
-                          account. Click the button below to choose a new password — it is valid
-                          {{expiresAtHuman}}.</p>
-                        <p><a href="{{resetLink}}">Choose new password</a></p>
-                        <p>If the button does not work, paste this URL into your browser:<br>
-                          <a href="{{resetLink}}">{{resetLink}}</a></p>
-                        <p style="color:#666;font-size:0.9em;">If you have questions about this
-                          change, contact your administrator.</p>
-                      </body>
-                    </html>
+                    This link expires {{expiresAtHuman}}.
       rollback:
         - delete:
             tableName: mail_template

--- a/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
@@ -39,6 +39,7 @@ import io.qnop.service.AdminUserService.GeneratedPasswordOutcome;
 import io.qnop.service.AdminUserService.PasswordResetOutcome;
 import io.qnop.service.auth.PasswordResetFlowService;
 import io.qnop.service.auth.PasswordResetFlowService.SetupLinkOutcome;
+import io.qnop.service.mail.MailTemplateKey;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -86,7 +87,7 @@ class AdminUserServiceTest {
     verify(users).save(saved.capture());
     assertThat(saved.getValue().isPasswordChangeRequired()).isTrue();
     assertThat(saved.getValue().getPasswordHash()).isEqualTo("hashed");
-    verify(passwordResetFlow, never()).sendSetupLink(any());
+    verify(passwordResetFlow, never()).sendSetupLink(any(), any());
   }
 
   @Test
@@ -100,7 +101,7 @@ class AdminUserServiceTest {
     verify(users).save(saved.capture());
     assertThat(saved.getValue().getPasswordHash()).isEqualTo("hashed");
     assertThat(saved.getValue().isEnabled()).isTrue();
-    verify(passwordResetFlow).sendSetupLink(saved.getValue());
+    verify(passwordResetFlow).sendSetupLink(saved.getValue(), MailTemplateKey.PASSWORD_RESET);
   }
 
   @Test
@@ -301,14 +302,14 @@ class AdminUserServiceTest {
     UUID internalId = UUID.randomUUID();
     User internal = User.internal("Int", "int@example.com", "int", "h");
     when(users.findById(internalId)).thenReturn(Optional.of(internal));
-    when(passwordResetFlow.sendSetupLink(internal))
+    when(passwordResetFlow.sendSetupLink(internal, MailTemplateKey.ADMIN_PASSWORD_RESET))
         .thenReturn(new SetupLinkOutcome(true, "https://app/reset?token=x"));
 
     PasswordResetOutcome outcome = service.sendPasswordReset(internalId);
 
     assertThat(outcome.emailSent()).isTrue();
     assertThat(outcome.resetUrl()).isNull(); // hidden when the email went out
-    verify(passwordResetFlow).sendSetupLink(internal);
+    verify(passwordResetFlow).sendSetupLink(internal, MailTemplateKey.ADMIN_PASSWORD_RESET);
     verify(refreshTokens).revokeAllForUser(internalId);
     verify(users).bumpPasswordInvalidatedBefore(eq(internalId), any());
   }
@@ -319,7 +320,7 @@ class AdminUserServiceTest {
     UUID id = UUID.randomUUID();
     User internal = User.internal("Int", "int@example.com", "int", "h");
     when(users.findById(id)).thenReturn(Optional.of(internal));
-    when(passwordResetFlow.sendSetupLink(internal))
+    when(passwordResetFlow.sendSetupLink(internal, MailTemplateKey.ADMIN_PASSWORD_RESET))
         .thenReturn(new SetupLinkOutcome(false, "https://app/reset?token=y"));
 
     PasswordResetOutcome outcome = service.sendPasswordReset(id);

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
@@ -45,11 +45,19 @@ class MailTemplateServiceTest {
   @Mock private MailTemplateRepository repository;
   @Mock private ApplicationSettingsService settings;
 
+  /** Exactly the variable set the live send flows supply (issue #140). */
+  private static final Map<String, Object> FLOW_VARS =
+      Map.of(
+          "siteName", "qnop",
+          "recipientName", "Jane",
+          "actionUrl", "https://qnop.example/reset?token=abc",
+          "expiresAtHuman", "in 30 minutes");
+
   private MailTemplateService service;
 
   @BeforeEach
   void setUp() {
-    service = new MailTemplateService(repository, settings);
+    service = new MailTemplateService(repository, settings, new EmailLayoutBuilder());
     lenient()
         .when(settings.getString(ApplicationSettingKey.GENERAL_DEFAULT_LANGUAGE))
         .thenReturn("en");
@@ -76,19 +84,34 @@ class MailTemplateServiceTest {
   }
 
   @Test
-  @DisplayName("falls back to the catalog defaults when no row exists for any locale")
+  @DisplayName("falls back to the catalog defaults and builds branded HTML when no row exists")
   void fallsBackToCatalogDefaults() {
     when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
 
-    RenderedMail mail =
-        service.render(
-            MailTemplateKey.PASSWORD_RESET,
-            Map.of("siteName", "qnop", "recipientName", "Jane", "actionUrl", "https://x"),
-            "de");
+    RenderedMail mail = service.render(MailTemplateKey.PASSWORD_RESET, FLOW_VARS, "de");
 
     assertThat(mail.subject()).isEqualTo("Reset your qnop password");
-    assertThat(mail.bodyPlain()).contains("Jane");
-    assertThat(mail.bodyHtml()).isNull();
+    assertThat(mail.bodyPlain()).contains("Jane").contains("in 30 minutes");
+    // The catalog default has no stored HTML — the branded chrome is built from the fragment.
+    assertThat(mail.bodyHtml())
+        .isNotNull()
+        .contains("<!DOCTYPE html>")
+        .contains("Reset your password")
+        .contains("Choose a new password") // the CTA label
+        .contains("https://qnop.example/reset?token=abc"); // the action URL in the CTA
+  }
+
+  @Test
+  @DisplayName("every catalog template renders against exactly the variables its flow supplies")
+  void everyTemplateRendersAgainstFlowVars() {
+    when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
+
+    for (MailTemplateKey key : MailTemplateKey.values()) {
+      RenderedMail mail = service.render(key, FLOW_VARS, "en");
+      assertThat(mail.subject()).as("subject of %s", key).isNotBlank();
+      assertThat(mail.bodyPlain()).as("plain of %s", key).isNotBlank();
+      assertThat(mail.bodyHtml()).as("html of %s", key).isNotNull().contains("qnop");
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

The seeded `mail_template` rows used a different placeholder vocabulary (`{{username}}`, `{{verificationLink}}`/`{{resetLink}}`, `{{expiresAtHuman}}`) than the live send flows supply (`{siteName, recipientName, actionUrl}`). With strict Mustache rendering, a seeded row threw on the missing variables, so **every seeded template silently became `SendResult.Failed`** (masked in dev because SMTP is unconfigured → `Skipped`).

### What changed
- **Unified vocabulary** → `{siteName, recipientName, actionUrl, expiresAtHuman}`. Registration and password-reset flows now also pass `expiresAtHuman`, derived from the issued token's expiry (`RelativeTimePhrase` → "in 24 hours" / "in 30 minutes"). Seeds in `0003` rewritten to match.
- **Wired `auth.admin_password_reset`** (defined + seeded but never sent): `PasswordResetFlowService.sendSetupLink` now takes the template key; `AdminUserService.sendPasswordReset` sends `ADMIN_PASSWORD_RESET`, while invitations stay on `PASSWORD_RESET`.
- **Wired in `EmailLayoutBuilder`** (was dead code). Rebuilt into a **premium, branded, email-client-safe HTML chrome** (table layout + inline styles, `qnop·` wordmark, accent stripe, prominent CTA, monospace fallback link, quiet footer). It is now the single source of the HTML body: `MailTemplateService` renders the catalog content fragment and wraps it, so default- and reset-to-default templates are branded too. Seeds carry plain text only — no duplicated HTML to drift.

### Design

Authored with the frontend-design skill — light "editorial document" aesthetic (warm paper, ink type, one confident indigo accent). Same chrome for verification, reset and admin-reset. Rendered preview (password-reset, sample data) attached in the chat.

## Acceptance criteria
- [x] Each seeded template renders against the exact variable map its flow supplies (no `SendResult.Failed` from missing vars on a fresh DB) — `SeededMailTemplateRenderIT` (Testcontainers) + `MailTemplateServiceTest.everyTemplateRendersAgainstFlowVars`.
- [x] Admin-initiated reset sends `auth.admin_password_reset`.
- [x] `EmailLayoutBuilder` is wired in (not deleted).
- [x] Regression test renders every seeded `(key, locale)` row against its flow's variable set.

## Test plan
- [x] `./gradlew build -x test` + ArchUnit + Spotless green; unit tests pass (mail, admin, registration, reset).
- [ ] CI: `SeededMailTemplateRenderIT` against Testcontainers PostgreSQL (Docker unavailable locally).

> Note on migration: rewrites the `0003` seed bodies as the issue directs. Pre-release / disposable dev DBs; CI runs fresh Testcontainers DBs.

Closes #140. Part of #139.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code