### PR TITLE
feat(api): mail-template metadata (placeholders, friendly name, defaults) + validate placeholders (#141)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1937,11 +1937,14 @@ components:
         - DEFAULT
     MailTemplateResponse:
       type: object
-      description: The effective content of one mail template.
+      description: The effective content of one mail template, plus editor metadata.
       properties:
         key:
           type: string
           description: Stable template storage key (e.g. `auth.password_reset`).
+        friendlyName:
+          type: string
+          description: Human-readable label for the template (e.g. `Password reset`).
         locale:
           type: string
         subject:
@@ -1953,6 +1956,22 @@ components:
           description: Optional HTML alternative; absent when the template is plain-text only.
         source:
           $ref: '#/components/schemas/MailTemplateSource'
+        placeholders:
+          type: array
+          items:
+            type: string
+          description: >-
+            The sorted, closed set of `{{placeholder}}` names this template
+            accepts. The editor offers these as chips and rejects any other.
+        defaultSubject:
+          type: string
+          description: The built-in catalog subject (for compare/reset in the editor).
+        defaultBodyPlain:
+          type: string
+          description: The built-in catalog plain-text body.
+        defaultBodyHtml:
+          type: string
+          description: The built-in catalog HTML body (branded chrome); absent if none.
         updatedAt:
           type: string
           format: date-time
@@ -1962,10 +1981,14 @@ components:
           description: Id of the admin who last saved the override; absent for built-in defaults.
       required:
         - key
+        - friendlyName
         - locale
         - subject
         - bodyPlain
         - source
+        - placeholders
+        - defaultSubject
+        - defaultBodyPlain
     MailTemplateListResponse:
       type: object
       properties:
@@ -2013,9 +2036,18 @@ components:
           type: string
         bodyHtml:
           type: string
+        sampleVars:
+          type: object
+          additionalProperties:
+            type: string
+          description: >-
+            The effective variables used for this render — per-key demo values
+            overlaid with any caller-supplied overrides — so the editor can
+            prefill its sample-variable inputs.
       required:
         - subject
         - bodyPlain
+        - sampleVars
     UserSettingItem:
       type: object
       description: One user setting with its current value.

--- a/qnop-app/src/main/java/io/qnop/web/AdminEmailController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminEmailController.java
@@ -34,6 +34,8 @@ import io.qnop.service.mail.MailService;
 import io.qnop.service.mail.MailService.SendResult;
 import io.qnop.service.mail.MailTemplateKey;
 import io.qnop.service.mail.MailTemplateService;
+import io.qnop.service.mail.MailTemplateService.MailPreview;
+import io.qnop.service.mail.MailTemplateValidationException;
 import io.qnop.service.mail.MailTemplateView;
 import io.qnop.service.mail.RenderedMail;
 import java.time.ZoneOffset;
@@ -96,15 +98,20 @@ public class AdminEmailController implements AdminEmailApi {
   @Override
   public ResponseEntity<MailTemplateResponse> updateMailTemplate(
       String key, UpdateMailTemplateRequest request) {
-    MailTemplateView saved =
-        templates.update(
-            resolveKey(key),
-            request.getLocale(),
-            request.getSubject(),
-            request.getBodyPlain(),
-            request.getBodyHtml(),
-            currentActor());
-    return ResponseEntity.ok(toResponse(saved));
+    MailTemplateKey templateKey = resolveKey(key);
+    try {
+      MailTemplateView saved =
+          templates.update(
+              templateKey,
+              request.getLocale(),
+              request.getSubject(),
+              request.getBodyPlain(),
+              request.getBodyHtml(),
+              currentActor());
+      return ResponseEntity.ok(toResponse(saved));
+    } catch (MailTemplateValidationException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
   }
 
   @Override
@@ -117,19 +124,22 @@ public class AdminEmailController implements AdminEmailApi {
   public ResponseEntity<MailTemplatePreviewResponse> previewMailTemplate(
       String key, PreviewMailTemplateRequest request) {
     MailTemplateKey templateKey = resolveKey(key);
-    RenderedMail rendered;
+    MailPreview preview;
     try {
-      rendered =
-          templates.preview(templateKey, request.getLocale(), toVars(request.getVariables()));
+      preview = templates.preview(templateKey, request.getLocale(), toVars(request.getVariables()));
+    } catch (MailTemplateValidationException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
     } catch (RuntimeException e) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Template render failed: " + e.getMessage());
     }
+    RenderedMail rendered = preview.rendered();
     return ResponseEntity.ok(
         new MailTemplatePreviewResponse()
             .subject(rendered.subject())
             .bodyPlain(rendered.bodyPlain())
-            .bodyHtml(rendered.bodyHtml()));
+            .bodyHtml(rendered.bodyHtml())
+            .sampleVars(preview.sampleVars()));
   }
 
   private MailTemplateKey resolveKey(String key) {
@@ -163,11 +173,16 @@ public class AdminEmailController implements AdminEmailApi {
   private MailTemplateResponse toResponse(MailTemplateView view) {
     return new MailTemplateResponse()
         .key(view.key())
+        .friendlyName(view.friendlyName())
         .locale(view.locale())
         .subject(view.subject())
         .bodyPlain(view.bodyPlain())
         .bodyHtml(view.bodyHtml())
         .source(MailTemplateSource.valueOf(view.source().name()))
+        .placeholders(view.placeholders())
+        .defaultSubject(view.defaultSubject())
+        .defaultBodyPlain(view.defaultBodyPlain())
+        .defaultBodyHtml(view.defaultBodyHtml())
         .updatedAt(view.updatedAt() == null ? null : view.updatedAt().atOffset(ZoneOffset.UTC))
         .updatedBy(view.updatedBy());
   }

--- a/qnop-app/src/test/java/io/qnop/web/AdminEmailControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/AdminEmailControllerTest.java
@@ -40,11 +40,11 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.autoconfigure.AutoConfigureMockMvc;
 
 /**
  * Web-slice test for {@link AdminEmailController} (issue #141): the mail-template metadata fields

--- a/qnop-app/src/test/java/io/qnop/web/AdminEmailControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/AdminEmailControllerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import io.qnop.service.mail.MailTemplateService;
+import io.qnop.service.mail.MailTemplateService.MailPreview;
+import io.qnop.service.mail.MailTemplateValidationException;
+import io.qnop.service.mail.MailTemplateView;
+import io.qnop.service.mail.RenderedMail;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.autoconfigure.AutoConfigureMockMvc;
+
+/**
+ * Web-slice test for {@link AdminEmailController} (issue #141): the mail-template metadata fields
+ * on the response and the placeholder-validation 400 arms. Security filters are disabled — the
+ * security chain is exercised elsewhere; here we test the handler + DTO mapping. No DB.
+ */
+@WebMvcTest
+@AutoConfigureMockMvc(addFilters = false)
+@ContextConfiguration(classes = {AdminEmailController.class, ApiPathConfig.class})
+class AdminEmailControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private MailService mailService;
+  @MockitoBean private MailTemplateService templates;
+
+  private static MailTemplateView view() {
+    return new MailTemplateView(
+        "auth.password_reset",
+        "Password reset",
+        "en",
+        "Reset {{siteName}}",
+        "Hi {{recipientName}}",
+        null,
+        MailTemplateView.Source.DEFAULT,
+        List.of("actionUrl", "expiresAtHuman", "recipientName", "siteName"),
+        "Reset your {{siteName}} password",
+        "Hi {{recipientName}}, {{actionUrl}}",
+        "<!DOCTYPE html>…{{actionUrl}}…",
+        null,
+        null);
+  }
+
+  @Test
+  void getTemplateExposesEditorMetadata() throws Exception {
+    when(templates.getEffective(MailTemplateKey.PASSWORD_RESET)).thenReturn(view());
+
+    mockMvc
+        .perform(get("/api/v1/admin/email/templates/auth.password_reset"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.friendlyName").value("Password reset"))
+        .andExpect(jsonPath("$.placeholders[0]").value("actionUrl"))
+        .andExpect(jsonPath("$.placeholders.length()").value(4))
+        .andExpect(jsonPath("$.defaultSubject").value("Reset your {{siteName}} password"))
+        .andExpect(jsonPath("$.defaultBodyPlain").value("Hi {{recipientName}}, {{actionUrl}}"))
+        .andExpect(jsonPath("$.defaultBodyHtml").exists());
+  }
+
+  @Test
+  void previewReturnsEffectiveSampleVars() throws Exception {
+    MailPreview preview =
+        new MailPreview(
+            new RenderedMail("Reset qnop", "Hi Jane Doe", "<p>Hi</p>"),
+            Map.of("siteName", "qnop", "recipientName", "Jane Doe"));
+    when(templates.preview(eq(MailTemplateKey.PASSWORD_RESET), any(), any())).thenReturn(preview);
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/email/templates/auth.password_reset/preview")
+                .contentType("application/json")
+                .content("{}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.subject").value("Reset qnop"))
+        .andExpect(jsonPath("$.sampleVars.recipientName").value("Jane Doe"));
+  }
+
+  @Test
+  void updateWithUnknownPlaceholderReturns400() throws Exception {
+    when(templates.update(any(), any(), any(), any(), any(), any()))
+        .thenThrow(
+            new MailTemplateValidationException(
+                List.of("unknownThing"), List.of("siteName", "actionUrl")));
+
+    mockMvc
+        .perform(
+            put("/api/v1/admin/email/templates/auth.password_reset")
+                .contentType("application/json")
+                .content(
+                    "{\"locale\":\"en\",\"subject\":\"s\",\"bodyPlain\":\"{{unknownThing}}\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void unknownTemplateKeyReturns404() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/admin/email/templates/does.not.exist"))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailPlaceholderValidator.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailPlaceholderValidator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Extracts and validates the {@code {{placeholder}}} variable references in a mail template body
+ * (issue #141), so the editor can reject unknown variables before they fail at render time.
+ *
+ * <p>Only ordinary escaped variable tags ({@code {{ name }}}) are treated as references. Comments
+ * ({@code {{! … }}}), partials ({@code {{> … }}}), section/inverted markers ({@code {{# }}}, {@code
+ * {{/ }}}, {@code {{^ }}}), set-delimiter tags ({@code {{= … }}}) and the unescaped forms ({@code
+ * {{{ … }}}}, {@code {{& … }}}) are skipped — they are template structure, not variables to bind.
+ */
+public final class MailPlaceholderValidator {
+
+  private MailPlaceholderValidator() {}
+
+  /** A triple-stache (skipped), or an ordinary double-stache whose inner text is captured. */
+  private static final Pattern TAG =
+      Pattern.compile("\\{\\{\\{\\s*[^{}]*?\\s*\\}\\}\\}|\\{\\{\\s*([^{}]*?)\\s*\\}\\}");
+
+  /** Leading characters that mark a tag as structure rather than a bound variable. */
+  private static final String NON_VARIABLE_PREFIXES = "!>#/^&=";
+
+  /** The sorted set of variable placeholders referenced in {@code content}. */
+  public static SortedSet<String> referencedPlaceholders(String content) {
+    SortedSet<String> refs = new TreeSet<>();
+    if (content == null || content.isEmpty()) {
+      return refs;
+    }
+    Matcher matcher = TAG.matcher(content);
+    while (matcher.find()) {
+      String inner = matcher.group(1);
+      if (inner == null) {
+        continue; // a {{{triple}}} — skipped
+      }
+      inner = inner.trim();
+      if (inner.isEmpty() || NON_VARIABLE_PREFIXES.indexOf(inner.charAt(0)) >= 0) {
+        continue;
+      }
+      refs.add(inner);
+    }
+    return refs;
+  }
+
+  /**
+   * The placeholders referenced across the given content pieces that are not in {@code allowed},
+   * sorted. Empty when every reference is recognised.
+   */
+  public static SortedSet<String> unknownPlaceholders(Set<String> allowed, String... contents) {
+    SortedSet<String> unknown = new TreeSet<>();
+    for (String content : contents) {
+      for (String ref : referencedPlaceholders(content)) {
+        if (!allowed.contains(ref)) {
+          unknown.add(ref);
+        }
+      }
+    }
+    return unknown;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -20,6 +20,10 @@
  */
 package io.qnop.service.mail;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -41,6 +45,7 @@ import java.util.Optional;
 public enum MailTemplateKey {
   REGISTRATION_VERIFICATION(
       "auth.registration_verification",
+      "Account verification",
       "Verify your {{siteName}} account",
       """
       Hi {{recipientName}},
@@ -58,9 +63,14 @@ public enum MailTemplateKey {
       <p style="margin:0;color:#9a9ea8;font-size:13px;">This link expires {{expiresAtHuman}}. If you didn't create this account, you can ignore this email.</p>
       """,
       "Verify email address",
-      "Confirm your email to activate your {{siteName}} account."),
+      "Confirm your email to activate your {{siteName}} account.",
+      "siteName",
+      "recipientName",
+      "actionUrl",
+      "expiresAtHuman"),
   PASSWORD_RESET(
       "auth.password_reset",
+      "Password reset",
       "Reset your {{siteName}} password",
       """
       Hi {{recipientName}},
@@ -78,9 +88,14 @@ public enum MailTemplateKey {
       <p style="margin:0;color:#9a9ea8;font-size:13px;">This link expires {{expiresAtHuman}}. If you didn't request this, ignore this email — your password stays unchanged.</p>
       """,
       "Choose a new password",
-      "Reset your {{siteName}} password."),
+      "Reset your {{siteName}} password.",
+      "siteName",
+      "recipientName",
+      "actionUrl",
+      "expiresAtHuman"),
   ADMIN_PASSWORD_RESET(
       "auth.admin_password_reset",
+      "Admin password reset",
       "Your {{siteName}} password was reset by an administrator",
       """
       Hi {{recipientName}},
@@ -98,33 +113,73 @@ public enum MailTemplateKey {
       <p style="margin:0;color:#9a9ea8;font-size:13px;">This link expires {{expiresAtHuman}}.</p>
       """,
       "Set a new password",
-      "An administrator reset your {{siteName}} password.");
+      "An administrator reset your {{siteName}} password.",
+      "siteName",
+      "recipientName",
+      "actionUrl",
+      "expiresAtHuman");
+
+  /**
+   * Representative demo value per known placeholder, used to prefill the preview's sample-variable
+   * editor (issue #141). Every placeholder a template declares must have an entry here.
+   */
+  private static final Map<String, String> DEMO_VALUES =
+      Map.of(
+          "siteName", "qnop",
+          "recipientName", "Jane Doe",
+          "actionUrl", "https://qnop.example/action?token=SAMPLE",
+          "expiresAtHuman", "in 30 minutes");
 
   private final String key;
+  private final String friendlyName;
   private final String defaultSubject;
   private final String defaultBodyPlain;
   private final String defaultBodyHtmlContent;
   private final String ctaLabel;
   private final String preheader;
+  private final List<String> placeholders;
 
   MailTemplateKey(
       String key,
+      String friendlyName,
       String defaultSubject,
       String defaultBodyPlain,
       String defaultBodyHtmlContent,
       String ctaLabel,
-      String preheader) {
+      String preheader,
+      String... placeholders) {
     this.key = key;
+    this.friendlyName = friendlyName;
     this.defaultSubject = defaultSubject;
     this.defaultBodyPlain = defaultBodyPlain;
     this.defaultBodyHtmlContent = defaultBodyHtmlContent;
     this.ctaLabel = ctaLabel;
     this.preheader = preheader;
+    this.placeholders = Arrays.stream(placeholders).sorted().toList();
   }
 
   /** The stable storage key (matches the {@code template_key} column). */
   public String key() {
     return key;
+  }
+
+  /** A human-readable label for the template (e.g. {@code Password reset}). */
+  public String friendlyName() {
+    return friendlyName;
+  }
+
+  /** The sorted, closed set of placeholder names this template accepts. */
+  public List<String> placeholders() {
+    return placeholders;
+  }
+
+  /** A placeholder → representative demo value map for this template's placeholders. */
+  public Map<String, String> sampleVars() {
+    Map<String, String> vars = new LinkedHashMap<>();
+    for (String placeholder : placeholders) {
+      vars.put(placeholder, DEMO_VALUES.getOrDefault(placeholder, ""));
+    }
+    return vars;
   }
 
   public String defaultSubject() {

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateService.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateService.java
@@ -25,9 +25,13 @@ import io.qnop.entity.MailTemplate;
 import io.qnop.repository.MailTemplateRepository;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +51,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MailTemplateService {
 
   private static final String FALLBACK_LOCALE = "en";
+  private static final String AUTOMATED_FOOTER =
+      "This is an automated message — please don't reply.";
 
   private final MailTemplateRepository repository;
   private final ApplicationSettingsService settings;
@@ -98,13 +104,50 @@ public class MailTemplateService {
         content,
         actionUrl == null ? null : actionUrl.toString(),
         key.ctaLabel(),
-        "This is an automated message — please don't reply.");
+        AUTOMATED_FOOTER);
   }
 
-  /** Renders {@code key} with the provided variables, or representative sample data if none. */
-  public RenderedMail preview(MailTemplateKey key, String locale, Map<String, Object> vars) {
-    return render(key, vars == null || vars.isEmpty() ? sampleVars() : vars, locale);
+  /** The catalog default HTML body as a template (placeholders intact), for compare/reset. */
+  private String defaultBodyHtml(MailTemplateKey key) {
+    return layoutBuilder.wrap(
+        "{{siteName}}",
+        key.preheader(),
+        key.defaultBodyHtmlContent(),
+        "{{actionUrl}}",
+        key.ctaLabel(),
+        AUTOMATED_FOOTER);
   }
+
+  /**
+   * Renders {@code key} for the editor preview (issue #141). Per-key demo values are overlaid with
+   * any caller-supplied overrides (overrides for unknown placeholders are ignored); the effective
+   * variable set is returned so the editor can prefill its sample-variable inputs. Rejects an
+   * effective template that references a placeholder outside the key's closed set.
+   */
+  public MailPreview preview(MailTemplateKey key, String locale, Map<String, Object> overrides) {
+    Map<String, String> sampleVars = effectiveSampleVars(key, overrides);
+    validateEffectivePlaceholders(key, locale);
+    RenderedMail rendered = render(key, new HashMap<>(sampleVars), locale);
+    return new MailPreview(rendered, sampleVars);
+  }
+
+  /** The per-key demo values overlaid with caller overrides scoped to the key's placeholder set. */
+  private Map<String, String> effectiveSampleVars(
+      MailTemplateKey key, Map<String, Object> overrides) {
+    Map<String, String> vars = key.sampleVars();
+    if (overrides != null) {
+      for (String placeholder : key.placeholders()) {
+        Object override = overrides.get(placeholder);
+        if (override != null) {
+          vars.put(placeholder, override.toString());
+        }
+      }
+    }
+    return vars;
+  }
+
+  /** A preview render plus the effective variables it was rendered with. */
+  public record MailPreview(RenderedMail rendered, Map<String, String> sampleVars) {}
 
   /** The effective view per known template at the configured default locale. */
   public List<MailTemplateView> listAll() {
@@ -117,11 +160,21 @@ public class MailTemplateService {
   /** The effective view for one template at {@code locale} (exact row, else catalog default). */
   public MailTemplateView getEffective(MailTemplateKey key, String locale) {
     return findRow(key, locale)
-        .map(row -> toView(row, MailTemplateView.Source.DATABASE))
+        .map(
+            row ->
+                buildView(
+                    key,
+                    row.getLocale(),
+                    row.getSubject(),
+                    row.getBodyPlain(),
+                    row.getBodyHtml(),
+                    MailTemplateView.Source.DATABASE,
+                    row.getUpdatedAt(),
+                    row.getUpdatedBy()))
         .orElseGet(
             () ->
-                new MailTemplateView(
-                    key.key(),
+                buildView(
+                    key,
                     locale,
                     key.defaultSubject(),
                     key.defaultBodyPlain(),
@@ -140,6 +193,7 @@ public class MailTemplateService {
       String bodyPlain,
       String bodyHtml,
       UUID actor) {
+    validatePlaceholders(key, subject, bodyPlain, bodyHtml);
     MailTemplate row =
         findRow(key, locale)
             .orElseGet(() -> new MailTemplate(key.key(), locale, subject, bodyPlain));
@@ -147,7 +201,16 @@ public class MailTemplateService {
     row.setBodyPlain(bodyPlain);
     row.setBodyHtml(bodyHtml);
     row.setUpdatedBy(actor == null ? null : actor.toString());
-    return toView(repository.save(row), MailTemplateView.Source.DATABASE);
+    MailTemplate saved = repository.save(row);
+    return buildView(
+        key,
+        saved.getLocale(),
+        saved.getSubject(),
+        saved.getBodyPlain(),
+        saved.getBodyHtml(),
+        MailTemplateView.Source.DATABASE,
+        saved.getUpdatedAt(),
+        saved.getUpdatedBy());
   }
 
   /**
@@ -191,23 +254,59 @@ public class MailTemplateService {
     return configured == null || configured.isBlank() ? FALLBACK_LOCALE : configured;
   }
 
-  private Map<String, Object> sampleVars() {
-    return Map.of(
-        "siteName", "qnop",
-        "recipientName", "Jane Doe",
-        "actionUrl", "https://qnop.example/action?token=SAMPLE",
-        "expiresAtHuman", "in 30 minutes");
+  /**
+   * Assembles a view, attaching the key's editor metadata (friendly name, placeholders, defaults).
+   */
+  private MailTemplateView buildView(
+      MailTemplateKey key,
+      String locale,
+      String subject,
+      String bodyPlain,
+      String bodyHtml,
+      MailTemplateView.Source source,
+      Instant updatedAt,
+      String updatedBy) {
+    return new MailTemplateView(
+        key.key(),
+        key.friendlyName(),
+        locale,
+        subject,
+        bodyPlain,
+        bodyHtml,
+        source,
+        key.placeholders(),
+        key.defaultSubject(),
+        key.defaultBodyPlain(),
+        defaultBodyHtml(key),
+        updatedAt,
+        updatedBy);
   }
 
-  private MailTemplateView toView(MailTemplate row, MailTemplateView.Source source) {
-    return new MailTemplateView(
-        row.getTemplateKey(),
-        row.getLocale(),
-        row.getSubject(),
-        row.getBodyPlain(),
-        row.getBodyHtml(),
-        source,
-        row.getUpdatedAt(),
-        row.getUpdatedBy());
+  /** Rejects a submitted body that references a placeholder outside the key's closed set. */
+  private void validatePlaceholders(
+      MailTemplateKey key, String subject, String bodyPlain, String bodyHtml) {
+    SortedSet<String> unknown =
+        MailPlaceholderValidator.unknownPlaceholders(
+            Set.copyOf(key.placeholders()), subject, bodyPlain, bodyHtml);
+    if (!unknown.isEmpty()) {
+      throw new MailTemplateValidationException(unknown, key.placeholders());
+    }
+  }
+
+  /** Validates the effective (stored or default) template content before a preview render. */
+  private void validateEffectivePlaceholders(MailTemplateKey key, String locale) {
+    Optional<MailTemplate> row = resolve(key, locale);
+    String subject = row.map(MailTemplate::getSubject).orElseGet(key::defaultSubject);
+    String plain = row.map(MailTemplate::getBodyPlain).orElseGet(key::defaultBodyPlain);
+    String htmlSource =
+        row.map(MailTemplate::getBodyHtml)
+            .filter(h -> !h.isBlank())
+            .orElseGet(key::defaultBodyHtmlContent);
+    SortedSet<String> unknown =
+        MailPlaceholderValidator.unknownPlaceholders(
+            Set.copyOf(key.placeholders()), subject, plain, htmlSource);
+    if (!unknown.isEmpty()) {
+      throw new MailTemplateValidationException(unknown, key.placeholders());
+    }
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateValidationException.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateValidationException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import java.util.Collection;
+
+/**
+ * Raised when a mail-template body references a {@code {{placeholder}}} outside the template's
+ * closed set (issue #141). The web layer maps it to {@code 400 Bad Request}.
+ */
+public class MailTemplateValidationException extends RuntimeException {
+
+  public MailTemplateValidationException(Collection<String> unknown, Collection<String> allowed) {
+    super(
+        "Unknown placeholder(s): "
+            + format(unknown)
+            + ". This template accepts only: "
+            + format(allowed)
+            + ".");
+  }
+
+  private static String format(Collection<String> names) {
+    return names.stream().map(name -> "{{" + name + "}}").reduce((a, b) -> a + ", " + b).orElse("");
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateView.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateView.java
@@ -21,19 +21,29 @@
 package io.qnop.service.mail;
 
 import java.time.Instant;
+import java.util.List;
 
 /**
  * A web-safe view of one template's effective content for the admin API: either a stored per-locale
  * row ({@code source = DATABASE}) or the built-in catalog fallback ({@code source = DEFAULT}). No
  * JPA entity leaks to the web layer (ADR-0004).
+ *
+ * <p>Carries the editor metadata (issue #141): a {@code friendlyName}, the closed {@code
+ * placeholders} set the template accepts, and the built-in {@code default*} content for
+ * compare/reset in the UI.
  */
 public record MailTemplateView(
     String key,
+    String friendlyName,
     String locale,
     String subject,
     String bodyPlain,
     String bodyHtml,
     Source source,
+    List<String> placeholders,
+    String defaultSubject,
+    String defaultBodyPlain,
+    String defaultBodyHtml,
     Instant updatedAt,
     String updatedBy) {
 

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailPlaceholderValidatorTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailPlaceholderValidatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MailPlaceholderValidatorTest {
+
+  @Test
+  @DisplayName("collects ordinary variable references, sorted and de-duplicated")
+  void collectsVariables() {
+    assertThat(
+            MailPlaceholderValidator.referencedPlaceholders(
+                "Hi {{ recipientName }}, open {{actionUrl}} ({{recipientName}})"))
+        .containsExactly("actionUrl", "recipientName");
+  }
+
+  @Test
+  @DisplayName("skips comments, partials, section markers, triple-stache and unescaped tags")
+  void skipsNonVariableTags() {
+    String body =
+        "{{! a plain comment }}"
+            + "{{> partial}}"
+            + "{{#section}}{{/section}}{{^inv}}"
+            + "{{{tripleVar}}}"
+            + "{{& unescapedVar}}"
+            + "{{realVar}}";
+
+    assertThat(MailPlaceholderValidator.referencedPlaceholders(body)).containsExactly("realVar");
+  }
+
+  @Test
+  @DisplayName("unknownPlaceholders reports only references outside the allowed set")
+  void reportsUnknown() {
+    Set<String> allowed = Set.of("siteName", "actionUrl");
+
+    assertThat(
+            MailPlaceholderValidator.unknownPlaceholders(
+                allowed, "{{siteName}} subject", "Body {{actionUrl}} and {{rogue}}", null))
+        .containsExactly("rogue");
+
+    assertThat(
+            MailPlaceholderValidator.unknownPlaceholders(
+                allowed, "{{siteName}}", "{{actionUrl}}", "<p>{{siteName}}</p>"))
+        .isEmpty();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
@@ -139,14 +139,87 @@ class MailTemplateServiceTest {
   }
 
   @Test
-  @DisplayName("preview uses representative sample data when no variables are supplied")
+  @DisplayName("preview uses per-key demo data and returns the effective sampleVars")
   void previewUsesSampleVars() {
     when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
 
-    RenderedMail mail = service.preview(MailTemplateKey.REGISTRATION_VERIFICATION, "en", Map.of());
+    MailTemplateService.MailPreview preview =
+        service.preview(MailTemplateKey.REGISTRATION_VERIFICATION, "en", Map.of());
 
-    assertThat(mail.subject()).isEqualTo("Verify your qnop account");
-    assertThat(mail.bodyPlain()).contains("Jane Doe");
+    assertThat(preview.rendered().subject()).isEqualTo("Verify your qnop account");
+    assertThat(preview.rendered().bodyPlain()).contains("Jane Doe");
+    assertThat(preview.sampleVars())
+        .containsEntry("recipientName", "Jane Doe")
+        .containsEntry("expiresAtHuman", "in 30 minutes")
+        .containsOnlyKeys("siteName", "recipientName", "actionUrl", "expiresAtHuman");
+  }
+
+  @Test
+  @DisplayName("preview overlays caller overrides and ignores unknown override keys")
+  void previewOverlaysOverrides() {
+    when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
+
+    MailTemplateService.MailPreview preview =
+        service.preview(
+            MailTemplateKey.PASSWORD_RESET,
+            "en",
+            Map.of("recipientName", "Alice", "bogus", "ignored"));
+
+    assertThat(preview.rendered().bodyPlain()).contains("Alice");
+    assertThat(preview.sampleVars())
+        .containsEntry("recipientName", "Alice")
+        .doesNotContainKey("bogus");
+  }
+
+  @Test
+  @DisplayName("getEffective carries friendlyName, sorted placeholders and the catalog defaults")
+  void getEffectivePopulatesEditorMetadata() {
+    when(repository.findByTemplateKeyAndLocale(any(), any())).thenReturn(Optional.empty());
+
+    MailTemplateView view = service.getEffective(MailTemplateKey.PASSWORD_RESET, "en");
+
+    assertThat(view.friendlyName()).isEqualTo("Password reset");
+    assertThat(view.placeholders())
+        .containsExactly("actionUrl", "expiresAtHuman", "recipientName", "siteName");
+    assertThat(view.defaultSubject()).isEqualTo("Reset your {{siteName}} password");
+    assertThat(view.defaultBodyPlain()).contains("{{recipientName}}", "{{actionUrl}}");
+    assertThat(view.defaultBodyHtml()).contains("<!DOCTYPE html>", "{{actionUrl}}");
+  }
+
+  @Test
+  @DisplayName("updating a body with an unknown placeholder is rejected")
+  void updateRejectsUnknownPlaceholder() {
+    assertThatThrownBy(
+            () ->
+                service.update(
+                    MailTemplateKey.PASSWORD_RESET,
+                    "en",
+                    "Hi {{recipientName}}",
+                    "Reset via {{actionUrl}} for {{unknownThing}}",
+                    null,
+                    null))
+        .isInstanceOf(MailTemplateValidationException.class)
+        .hasMessageContaining("{{unknownThing}}");
+  }
+
+  @Test
+  @DisplayName("updating a body that uses only known placeholders is accepted")
+  void updateAcceptsKnownPlaceholders() {
+    MailTemplate row = new MailTemplate("auth.password_reset", "en", "s", "p");
+    when(repository.findByTemplateKeyAndLocale("auth.password_reset", "en"))
+        .thenReturn(Optional.of(row));
+    when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    MailTemplateView saved =
+        service.update(
+            MailTemplateKey.PASSWORD_RESET,
+            "en",
+            "Reset for {{recipientName}}",
+            "Open {{actionUrl}} — expires {{expiresAtHuman}}",
+            "<p>{{siteName}}</p>",
+            null);
+
+    assertThat(saved.source()).isEqualTo(MailTemplateView.Source.DATABASE);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Extends the published mail-template contract and `MailTemplateService` / `AdminEmailController` so the reference editor (#144) and live preview (#145) have the metadata they need. Builds on #140 — same placeholder vocabulary `{siteName, recipientName, actionUrl, expiresAtHuman}`.

### What changed
- **`MailTemplateResponse`** gains `friendlyName`, the sorted closed **`placeholders`** set, and **`defaultSubject` / `defaultBodyPlain` / `defaultBodyHtml`** (the built-in catalog values, for compare/reset). `GET`/`list` populate them. The default HTML is the branded `EmailLayoutBuilder` chrome with placeholders intact.
- **`MailTemplateKey`** is the single source of truth: each key declares its `friendlyName`, its closed placeholder set, and (via a shared demo map) a representative value per placeholder.
- **Preview** overlays the per-key demo values with caller `variables` (unknown keys ignored) and **returns the effective `sampleVars`** — so the editor prefills its sample-variable inputs without a "(0)" first paint. (`MailTemplatePreviewResponse.sampleVars` added.)
- **Placeholder validation** (`MailPlaceholderValidator`): `PUT /admin/email/templates/{key}` and `POST …/preview` reject any `{{ref}}` outside the key's set with a clear **400**, skipping comments `{{! }}`, partials `{{> }}`, section/inverted markers `{{# }}`/`{{/ }}`/`{{^ }}`, and the unescaped `{{{triple}}}` / `{{&}}` forms.

## Acceptance criteria
- [x] `MailTemplateResponse` includes `friendlyName`, `placeholders`, `default*`; `GET`/`list` populate them.
- [x] Preview returns the effective `sampleVars`; missing placeholders fall back to per-key demo values.
- [x] Updating/previewing a body with an unknown placeholder → 400 with a clear message; valid bodies pass.
- [x] Unit (`MailTemplateServiceTest`, `MailPlaceholderValidatorTest`) + `@WebMvcTest` (`AdminEmailControllerTest`) coverage.
- [x] Vocabulary agreed once with #140.

## Test plan
- [x] `./gradlew build -x test` + ArchUnit + Spotless green; `AdminEmailControllerTest` + mail unit tests pass.

Closes #141. Part of #139.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code