### PR TITLE
feat(ui): complete send-test-email affordance in Email/SMTP settings (#146)

### DIFF
--- a/qnop-ui/src/pages/admin/EmailServerPage.test.tsx
+++ b/qnop-ui/src/pages/admin/EmailServerPage.test.tsx
@@ -26,6 +26,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AdminSetting } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
+import { useAuthStore } from '../../stores/authStore';
 import { EmailServerPage } from './EmailServerPage';
 
 const { updateMutate, testMutate } = vi.hoisted(() => ({
@@ -95,6 +96,7 @@ vi.mock('../../api/hooks/useMailTemplates', () => ({
 beforeEach(() => {
   updateMutate.mockReset().mockResolvedValue({ settings: SETTINGS });
   testMutate.mockReset().mockResolvedValue({ status: 'SENT', detail: 'Sent.' });
+  useAuthStore.setState({ email: 'admin@example.com' });
 });
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -177,5 +179,42 @@ describe('EmailServerPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Send test' }));
 
     await waitFor(() => expect(testMutate).toHaveBeenCalledWith('qa@example.com'));
+  });
+
+  it('defaults the recipient to the signed-in admin email', () => {
+    renderPage();
+
+    expect((screen.getByLabelText('Recipient') as HTMLInputElement).value).toBe(
+      'admin@example.com',
+    );
+  });
+
+  it('surfaces a skipped send as an info status alert', async () => {
+    testMutate.mockResolvedValue({ status: 'SKIPPED', detail: 'SMTP is not configured.' });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send test' }));
+
+    const alert = await screen.findByRole('status');
+    expect(alert.textContent).toContain('SMTP is not configured.');
+    expect(alert.className).toContain('MuiAlert-colorInfo');
+  });
+
+  it('surfaces a failed send as an error alert', async () => {
+    testMutate.mockResolvedValue({ status: 'FAILED', detail: 'Connection refused.' });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send test' }));
+
+    const alert = await screen.findByText('Connection refused.');
+    expect(alert.closest('.MuiAlert-colorError')).toBeTruthy();
+  });
+
+  it('disables the test-send when no recipient is set', () => {
+    useAuthStore.setState({ email: null });
+    renderPage();
+
+    expect((screen.getByLabelText('Recipient') as HTMLInputElement).value).toBe('');
+    expect(screen.getByRole('button', { name: 'Send test' })).toBeDisabled();
   });
 });

--- a/qnop-ui/src/pages/admin/EmailServerPage.tsx
+++ b/qnop-ui/src/pages/admin/EmailServerPage.tsx
@@ -35,6 +35,7 @@ import { AtSign, SendHorizonal, Server, Zap } from 'lucide-react';
 import type { AdminSetting, SendTestEmailResponse } from '../../api/generated';
 import { useSettings, useUpdateSettings } from '../../api/hooks/useSettings';
 import { useSendTestEmail } from '../../api/hooks/useMailTemplates';
+import { useAuthStore } from '../../stores/authStore';
 import { PasswordField } from '../../components/auth/PasswordField';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { SectionCard } from '../../components/admin/layout/SectionCard';
@@ -52,9 +53,9 @@ import {
 import { apiErrorMessage, apiFieldErrors } from '../../utils/apiError';
 import { isEmail, isPort } from '../../utils/validation';
 
-const TEST_SEVERITY: Record<SendTestEmailResponse['status'], 'success' | 'warning' | 'error'> = {
+const TEST_SEVERITY: Record<SendTestEmailResponse['status'], 'success' | 'info' | 'error'> = {
   SENT: 'success',
-  SKIPPED: 'warning',
+  SKIPPED: 'info',
   FAILED: 'error',
 };
 
@@ -98,7 +99,9 @@ export function EmailServerPage() {
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [serverErrors, setServerErrors] = useState<Record<string, string>>({});
   const { toast, notify, clear } = useToast();
-  const [testRecipient, setTestRecipient] = useState('');
+  // Default the test recipient to the signed-in admin (issue #146); still editable.
+  const adminEmail = useAuthStore((s) => s.email);
+  const [testRecipient, setTestRecipient] = useState(adminEmail ?? '');
   const [testResult, setTestResult] = useState<SendTestEmailResponse | null>(null);
   const [testError, setTestError] = useState<string | null>(null);
 
@@ -375,7 +378,7 @@ export function EmailServerPage() {
                 </Typography>
               )}
               {testResult && (
-                <Alert severity={TEST_SEVERITY[testResult.status]} sx={{ mt: 1.5 }}>
+                <Alert severity={TEST_SEVERITY[testResult.status]} role="status" sx={{ mt: 1.5 }}>
                   {testResult.detail}
                 </Alert>
               )}


### PR DESCRIPTION
Closes #146.

> The issue text predates #142 — it points at `ApplicationSettingsForm`/`SettingsPage`, but the SMTP settings now live on the dedicated **`EmailServerPage`** (`/admin/email`), where #142 already shipped the inline test-send (recipient field, button, status-mapped result, "save first" guard). This PR closes the **remaining** acceptance criteria.

## Changes (`EmailServerPage.tsx`)
- **Default recipient** — prefilled with the signed-in admin's email from the auth store; still editable.
- **`role="status"`** on the result `Alert` so screen readers announce the outcome.
- **SKIPPED → `info`** severity (it's a "not configured" notice, not a warning); SENT stays success, FAILED stays error.

## Decision
- The test-send is **not** gated on `smtp.enabled` (your call): a disabled/unconfigured server simply returns `SKIPPED` ("SMTP is not configured"), surfaced inline.

## Test plan
- [x] `qnop-ui`: `tsc`, ESLint, Prettier, `vitest` — **154 passed**, incl. new cases: default recipient, `SKIPPED → info(status)`, `FAILED → error`, empty-recipient guard (existing SENT + unsaved-changes cases kept). Production build green.
- Backend untouched (no Java/contract changes); CI runs the full gate.

Manual: open `/admin/email` → recipient is prefilled; send → result announced inline; with SMTP off → SKIPPED info; bad config → FAILED error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code