### PR TITLE
chore: Mailpit SMTP sink in docker-compose for local mail testing (#160)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,12 @@ QNOP_KEYCLOAK_ADMIN_PASSWORD=admin
 # LOCAL DEV ONLY — never set this in production.
 QNOP_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS=true
 
+# --- Mailpit (local SMTP sink for testing outgoing mail, issue #146) ---
+# Only used by the `mail` compose profile:  docker compose --profile mail up -d
+# SMTP intake on :1025, web inbox at http://localhost:8025. LOCAL DEV ONLY.
+QNOP_MAILPIT_SMTP_PORT=1025
+QNOP_MAILPIT_UI_PORT=8025
+
 # --- Running the server ---
 # docker-compose loads this file automatically. For `./gradlew :qnop-app:bootRun`
 # export these into your shell first:  set -a; source .env; set +a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,32 @@ services:
       retries: 30
       start_period: 30s
 
+  # Mailpit — a local SMTP sink for testing outgoing mail (#146). It accepts every
+  # message on :1025 instead of delivering it and serves a web inbox on :8025
+  # (messages are in-memory and cleared on restart — fine for a test sink).
+  # NOT started by default; enable via the `mail` profile:
+  #   docker compose --profile mail up -d
+  #
+  # Point the qnop SMTP settings (Administration → Email / SMTP) at it:
+  #   Host: localhost   Port: 1025   Encryption: None   (no username/password)
+  #   From: noreply@qnop.local   Enable outgoing mail: ON
+  # Then use "Send test" there and read the message at http://localhost:8025.
+  # Bound to loopback only — this dev sink must never be reachable off-host.
+  mailpit:
+    image: axllent/mailpit:latest@sha256:37a38e48e9338cd7e89dfeb487f37b02ebfcd9cb23111bed2d345e79d37d6dd6
+    profiles: ['mail']
+    environment:
+      # Allow unauthenticated/plaintext SMTP from the local app — dev only.
+      MP_SMTP_AUTH_ALLOW_INSECURE: 'true'
+    ports:
+      - '127.0.0.1:${QNOP_MAILPIT_SMTP_PORT:-1025}:1025' # SMTP intake
+      - '127.0.0.1:${QNOP_MAILPIT_UI_PORT:-8025}:8025' # web inbox
+    healthcheck:
+      test: ['CMD', '/mailpit', 'readyz']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   qnop_pgdata:
   qnop_miniodata:


### PR DESCRIPTION
Closes #160.

Adds **Mailpit** to the local dev stack so the send-test-email affordance (#142/#146) and the transactional mail flows (password reset, account verification) can be exercised end-to-end without a real provider.

## Changes
- **`docker-compose.yml`** — `mailpit` service behind a dedicated **`mail` profile** (off by default, mirroring `keycloak`): SMTP intake on `:1025`, web inbox on `:8025`, both **loopback-bound**, image **digest pinned**, healthcheck via `/mailpit readyz`. Messages are in-memory (a test sink, cleared on restart).
- **`.env.example`** — documents `QNOP_MAILPIT_SMTP_PORT` / `QNOP_MAILPIT_UI_PORT`.
- No application or contract changes.

## Usage
```bash
docker compose --profile mail up -d        # starts Postgres + MinIO + Mailpit
```
Then in **Administration → Email / SMTP**: Host `localhost`, Port `1025`, Encryption `None`, Enable outgoing mail ON → Save → **Send test**. Read it at **http://localhost:8025**.

## Test plan
- [x] `docker compose --profile mail config` validates.
- [x] `docker compose --profile mail up -d mailpit` → container **healthy**; inbox returns HTTP 200 on :8025; SMTP port 1025 open.
- [x] Default `docker compose up -d` unchanged (Mailpit not started without the profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code