### PR TITLE
feat(ui): render uploaded branding across the app, live on upload (#154)

### DIFF
--- a/qnop-ui/src/api/hooks/useConfig.ts
+++ b/qnop-ui/src/api/hooks/useConfig.ts
@@ -27,10 +27,15 @@ export const configKeys = {
   all: ['config'] as const,
 };
 
+/** Short staleness window so branding changes propagate across sessions (issue #154). */
+const CONFIG_STALE_MS = 5 * 60_000;
+
 /**
  * Public server configuration (edition, branding, OIDC providers, self-
- * registration flag, upload limits, supported formats). Fetched once and cached
- * for the session; it rarely changes within a session.
+ * registration flag, upload limits, supported formats). Cached with a short
+ * staleness window and refetched on window focus, so an updated branding asset
+ * (issue #154) propagates to other sessions without a manual reload; the admin
+ * upload also invalidates this query for same-session immediacy.
  */
 export function useConfig() {
   return useQuery<ServerConfigResponse>({
@@ -39,6 +44,7 @@ export function useConfig() {
       const response = await serverConfigApi.getServerConfig();
       return response.data;
     },
-    staleTime: Infinity,
+    staleTime: CONFIG_STALE_MS,
+    refetchOnWindowFocus: true,
   });
 }

--- a/qnop-ui/src/components/auth/AuthLayout.tsx
+++ b/qnop-ui/src/components/auth/AuthLayout.tsx
@@ -24,6 +24,8 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { Fingerprint, Server, ShieldCheck } from 'lucide-react';
+import { useConfig } from '../../api/hooks/useConfig';
+import { BrandLogo } from '../branding/BrandLogo';
 import { tokens } from '../../theme/tokens';
 
 const TRUST = [
@@ -46,6 +48,8 @@ interface AuthLayoutProps {
  * the design prototype's "Sovereign document review" treatment.
  */
 export function AuthLayout({ title, subtitle, headerSlot, children }: AuthLayoutProps) {
+  // The auth hero is always dark, so use the dark-surface (light) logo variant (issue #154).
+  const logoUrl = useConfig().data?.branding?.logoDark.url;
   return (
     <Box
       sx={{
@@ -93,41 +97,48 @@ export function AuthLayout({ title, subtitle, headerSlot, children }: AuthLayout
           }}
         />
 
-        <Box
-          sx={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', gap: 1.25 }}
-        >
-          <Box
-            sx={{
-              width: 38,
-              height: 38,
-              borderRadius: 1.5,
-              bgcolor: 'rgba(255,255,255,0.12)',
-              border: '1px solid rgba(255,255,255,0.18)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <ShieldCheck size={22} />
-          </Box>
-          <Box>
-            <Typography
-              sx={{ fontWeight: 700, fontSize: 17, letterSpacing: '-0.02em', lineHeight: 1 }}
-            >
-              qnop
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: 10.5,
-                letterSpacing: '0.1em',
-                textTransform: 'uppercase',
-                color: '#9BCEFA',
-                mt: 0.4,
-              }}
-            >
-              Quality Notes · Sovereign
-            </Typography>
-          </Box>
+        <Box sx={{ position: 'relative', zIndex: 1 }}>
+          <BrandLogo
+            url={logoUrl}
+            alt="qnop"
+            sx={{ height: 38, maxWidth: 220 }}
+            fallback={
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+                <Box
+                  sx={{
+                    width: 38,
+                    height: 38,
+                    borderRadius: 1.5,
+                    bgcolor: 'rgba(255,255,255,0.12)',
+                    border: '1px solid rgba(255,255,255,0.18)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <ShieldCheck size={22} />
+                </Box>
+                <Box>
+                  <Typography
+                    sx={{ fontWeight: 700, fontSize: 17, letterSpacing: '-0.02em', lineHeight: 1 }}
+                  >
+                    qnop
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: 10.5,
+                      letterSpacing: '0.1em',
+                      textTransform: 'uppercase',
+                      color: '#9BCEFA',
+                      mt: 0.4,
+                    }}
+                  >
+                    Quality Notes · Sovereign
+                  </Typography>
+                </Box>
+              </Box>
+            }
+          />
         </Box>
 
         <Box sx={{ position: 'relative', zIndex: 1, mt: 'auto', maxWidth: 460 }}>

--- a/qnop-ui/src/components/branding/BrandLogo.test.tsx
+++ b/qnop-ui/src/components/branding/BrandLogo.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BrandLogo } from './BrandLogo';
+
+const fallback = <span>FALLBACK</span>;
+
+describe('BrandLogo', () => {
+  it('renders the image when a URL is given', () => {
+    render(<BrandLogo url="/logo.svg?v=abc" alt="qnop" fallback={fallback} />);
+
+    expect(screen.getByAltText('qnop').getAttribute('src')).toBe('/logo.svg?v=abc');
+    expect(screen.queryByText('FALLBACK')).toBeNull();
+  });
+
+  it('renders the fallback when there is no URL', () => {
+    render(<BrandLogo url={null} alt="qnop" fallback={fallback} />);
+
+    expect(screen.getByText('FALLBACK')).toBeTruthy();
+    expect(screen.queryByAltText('qnop')).toBeNull();
+  });
+
+  it('falls back when the image fails to load', () => {
+    render(<BrandLogo url="/broken.svg?v=1" alt="qnop" fallback={fallback} />);
+
+    fireEvent.error(screen.getByAltText('qnop'));
+
+    expect(screen.getByText('FALLBACK')).toBeTruthy();
+    expect(screen.queryByAltText('qnop')).toBeNull();
+  });
+
+  it('retries the image after a failure once the URL changes', () => {
+    const { rerender } = render(<BrandLogo url="/broken.svg?v=1" alt="qnop" fallback={fallback} />);
+    fireEvent.error(screen.getByAltText('qnop'));
+    expect(screen.getByText('FALLBACK')).toBeTruthy();
+
+    rerender(<BrandLogo url="/fixed.svg?v=2" alt="qnop" fallback={fallback} />);
+
+    expect(screen.getByAltText('qnop').getAttribute('src')).toBe('/fixed.svg?v=2');
+    expect(screen.queryByText('FALLBACK')).toBeNull();
+  });
+});

--- a/qnop-ui/src/components/branding/BrandLogo.tsx
+++ b/qnop-ui/src/components/branding/BrandLogo.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState, type ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+interface BrandLogoProps {
+  /** Effective asset URL from `config.branding` (carries the cache-busting `?v=` token). */
+  url: string | null | undefined;
+  /** Accessible name for the logo image. */
+  alt: string;
+  /** Rendered when there is no URL or the image fails to load. */
+  fallback: ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Renders a branding asset from `config.branding` with a robust fallback (issue #154): a missing
+ * URL or a broken/expired image shows `fallback` instead, mirroring {@link UserAvatar}'s
+ * image-with-fallback. The `?v=` cache-busting token in the URL means a fresh upload reloads the
+ * image; changing the URL resets a prior load failure (the React "adjust state during render"
+ * pattern, avoiding a setState-in-effect cascade).
+ */
+export function BrandLogo({ url, alt, fallback, sx }: BrandLogoProps) {
+  const [failed, setFailed] = useState(false);
+  const [lastUrl, setLastUrl] = useState(url);
+  if (url !== lastUrl) {
+    setLastUrl(url);
+    setFailed(false);
+  }
+
+  if (!url || failed) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <Box
+      component="img"
+      src={url}
+      alt={alt}
+      onError={() => setFailed(true)}
+      sx={{ display: 'block', objectFit: 'contain', ...sx }}
+    />
+  );
+}

--- a/qnop-ui/src/components/branding/FaviconManager.tsx
+++ b/qnop-ui/src/components/branding/FaviconManager.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useConfig } from '../../api/hooks/useConfig';
+import { useFavicon } from '../../hooks/useFavicon';
+
+/**
+ * Drives the document favicon from `config.branding.logomark` (issue #154). Renders nothing; lives
+ * near the app root so the favicon tracks the effective logomark (custom or factory default) and
+ * updates with its cache-busting `?v=` token. Falls back to the static favicon until config loads.
+ */
+export function FaviconManager() {
+  const { data } = useConfig();
+  useFavicon(data?.branding?.logomark?.url);
+  return null;
+}

--- a/qnop-ui/src/components/shell/SidebarContent.tsx
+++ b/qnop-ui/src/components/shell/SidebarContent.tsx
@@ -27,9 +27,12 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import { useTheme, type SxProps, type Theme } from '@mui/material/styles';
 import { ShieldCheck } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
+import { useConfig } from '../../api/hooks/useConfig';
 import { useAuthStore } from '../../stores/authStore';
+import { BrandLogo } from '../branding/BrandLogo';
 import { visibleNavGroups } from './navConfig';
 import { UserFooter } from './UserFooter';
 
@@ -47,10 +50,29 @@ interface SidebarContentProps {
 export function SidebarContent({ collapsed, onNavigate }: SidebarContentProps) {
   const role = useAuthStore((s) => s.role);
   const groups = visibleNavGroups(role);
+  const theme = useTheme();
+  const branding = useConfig().data?.branding;
+  const logomarkUrl = branding?.logomark.url;
+  // Pick the logo variant for the sidebar surface: dark theme → light logo, and vice versa.
+  const fullLogoUrl =
+    theme.palette.mode === 'dark' ? branding?.logoDark.url : branding?.logoLight.url;
+
+  // The brand-mark box, shared by the collapsed rail and the expanded fallback.
+  const markBoxSx: SxProps<Theme> = {
+    width: 30,
+    height: 30,
+    borderRadius: 1.75,
+    bgcolor: 'primary.main',
+    color: 'primary.contrastText',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  };
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-      {/* Brand */}
+      {/* Brand — driven by config.branding (issue #154), falling back to the wordmark */}
       <Box
         sx={{
           display: 'flex',
@@ -63,41 +85,47 @@ export function SidebarContent({ collapsed, onNavigate }: SidebarContentProps) {
           borderColor: 'divider',
         }}
       >
-        <Box
-          sx={{
-            width: 30,
-            height: 30,
-            borderRadius: 1.75,
-            bgcolor: 'primary.main',
-            color: 'primary.contrastText',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            flexShrink: 0,
-          }}
-        >
-          <ShieldCheck size={18} />
-        </Box>
-        {!collapsed && (
-          <Box sx={{ minWidth: 0 }}>
-            <Typography
-              sx={{ fontWeight: 700, fontSize: 15, letterSpacing: '-0.015em', lineHeight: 1 }}
-            >
-              qnop
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: 10.5,
-                letterSpacing: '0.08em',
-                textTransform: 'uppercase',
-                color: 'text.disabled',
-                mt: 0.4,
-                fontWeight: 500,
-              }}
-            >
-              Quality Notes · Sovereign
-            </Typography>
+        {collapsed ? (
+          <Box sx={markBoxSx}>
+            <BrandLogo
+              url={logomarkUrl}
+              alt="qnop"
+              fallback={<ShieldCheck size={18} />}
+              sx={{ width: 20, height: 20 }}
+            />
           </Box>
+        ) : (
+          <BrandLogo
+            url={fullLogoUrl}
+            alt="qnop"
+            sx={{ height: 30, maxWidth: 180 }}
+            fallback={
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
+                <Box sx={markBoxSx}>
+                  <ShieldCheck size={18} />
+                </Box>
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography
+                    sx={{ fontWeight: 700, fontSize: 15, letterSpacing: '-0.015em', lineHeight: 1 }}
+                  >
+                    qnop
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: 10.5,
+                      letterSpacing: '0.08em',
+                      textTransform: 'uppercase',
+                      color: 'text.disabled',
+                      mt: 0.4,
+                      fontWeight: 500,
+                    }}
+                  >
+                    Quality Notes · Sovereign
+                  </Typography>
+                </Box>
+              </Box>
+            }
+          />
         )}
       </Box>
 

--- a/qnop-ui/src/hooks/useFavicon.test.ts
+++ b/qnop-ui/src/hooks/useFavicon.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFavicon } from './useFavicon';
+
+function iconHref(): string | null {
+  return document.querySelector<HTMLLinkElement>('link[rel="icon"]')?.getAttribute('href') ?? null;
+}
+
+beforeEach(() => {
+  document.querySelectorAll('link[rel="icon"]').forEach((el) => el.remove());
+  const link = document.createElement('link');
+  link.setAttribute('rel', 'icon');
+  link.setAttribute('type', 'image/svg+xml');
+  link.setAttribute('href', '/favicon.svg');
+  document.head.appendChild(link);
+});
+
+describe('useFavicon', () => {
+  it('points the icon link at the given URL', () => {
+    renderHook(() => useFavicon('/brand/logomark.svg?v=abc'));
+
+    expect(iconHref()).toBe('/brand/logomark.svg?v=abc');
+  });
+
+  it('keeps the static favicon when the URL is absent', () => {
+    renderHook(() => useFavicon(null));
+
+    expect(iconHref()).toBe('/favicon.svg');
+  });
+
+  it('restores the previous icon on unmount', () => {
+    const { unmount } = renderHook(() => useFavicon('/brand/logomark.svg?v=abc'));
+    expect(iconHref()).toBe('/brand/logomark.svg?v=abc');
+
+    unmount();
+
+    expect(iconHref()).toBe('/favicon.svg');
+  });
+});

--- a/qnop-ui/src/hooks/useFavicon.ts
+++ b/qnop-ui/src/hooks/useFavicon.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect } from 'react';
+
+/**
+ * Points the document's `<link rel="icon">` at `url` (the branding logomark) at runtime,
+ * restoring the previous icon when the URL changes or the caller unmounts (issue #154). A null/empty
+ * URL is a no-op, so the static favicon from index.html remains. SPA-only.
+ */
+export function useFavicon(url: string | null | undefined) {
+  useEffect(() => {
+    if (!url) {
+      return;
+    }
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    if (!link) {
+      return;
+    }
+    const previous = link.getAttribute('href');
+    link.setAttribute('href', url);
+    return () => {
+      if (previous === null) {
+        link.removeAttribute('href');
+      } else {
+        link.setAttribute('href', previous);
+      }
+    };
+  }, [url]);
+}

--- a/qnop-ui/src/main.tsx
+++ b/qnop-ui/src/main.tsx
@@ -35,6 +35,7 @@ import '@fontsource/jetbrains-mono/500.css';
 import './index.css';
 import { queryClient } from './api/queryClient';
 import { AuthHydrationBoundary } from './components/auth/AuthHydrationBoundary';
+import { FaviconManager } from './components/branding/FaviconManager';
 import { router } from './router';
 import { buildTheme } from './theme/theme';
 import { useUiStore } from './stores/uiStore';
@@ -47,6 +48,7 @@ function Root() {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
+        <FaviconManager />
         <AuthHydrationBoundary>
           <RouterProvider router={router} />
         </AuthHydrationBoundary>


### PR DESCRIPTION
Closes #154.

The branding upload (#106) and the `/config` branding exposure already existed, but the live surfaces still hardcoded a `ShieldCheck` placeholder — an uploaded logo only showed in the admin preview. This drives the surfaces from `config.branding`.

## Changes
- **`BrandLogo`** — renders a branding asset (custom or factory default) with a robust fallback: a missing URL or a broken/expired image shows the caller's `fallback` node (mirrors `UserAvatar`). The contract's cache-busting `?v=` URL reloads the image after an upload; a URL change clears a prior load failure (adjust-state-during-render).
- **Sidebar** (`SidebarContent`): collapsed → `logomark`; expanded → the full logo (`logoLight`/`logoDark` by theme mode); both fall back to the `ShieldCheck` box + "qnop" wordmark.
- **Auth shell** (`AuthLayout`): the full logo on the dark hero (`logoDark`), same fallback.
- **Favicon**: `useFavicon` + a `FaviconManager` near the app root point `<link rel="icon">` at the `logomark`, restoring the static default otherwise.
- **`useConfig`**: short `staleTime` + `refetchOnWindowFocus` so other sessions pick up a new asset without a manual reload (the active-propagation option); the admin upload already invalidates the query for same-session immediacy.

## "Immediately on upload"
- **Same session**: free — the admin upload/remove invalidates `config`, so every surface re-renders with the new `?v=` URL.
- **Other sessions**: now refetch on window focus / after the staleness window (active propagation, per decision).

## Test plan
- [x] `qnop-ui`: `tsc`, ESLint, Prettier, `vitest` — **161 passed** (new: `BrandLogo` image/fallback/error/URL-reset; `useFavicon` set/absent/restore). Production build green.
- Backend untouched (no contract change — reuses `ServerConfigBrandingSlot`); CI runs the full gate.

Manual: upload a logo in Administration → Branding → it appears in the sidebar, login screen and favicon immediately; broken/absent asset falls back to the ShieldCheck + "qnop" mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code