### PR TITLE
test: integration tests for admin users and teams (#163)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/web/SeededAdminUserCrudIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededAdminUserCrudIT.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+/**
+ * Admin user create/update/delete and the self-protection guards (issue #163). {@code LAST_ADMIN}
+ * is deliberately not asserted here: the acting principal is itself an enabled admin, so the
+ * self-guards ({@code SELF_LOCKOUT}/{@code SELF_DELETE}) always preempt it via the API — the
+ * last-admin path is covered at the service layer.
+ */
+class SeededAdminUserCrudIT extends SeededIntegrationTest {
+
+  private static final String USERS = "/api/v1/admin/users";
+
+  private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder asAdmin(
+      org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder builder) {
+    return builder.header("Authorization", "Bearer " + token(ADMIN_ID));
+  }
+
+  @Test
+  void createsAUserWithAnInitialPassword() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(USERS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"displayName\":\"New User\",\"username\":\"newuser\","
+                        + "\"email\":\"newuser@qnop.test\",\"role\":\"MEMBER\","
+                        + "\"initialPassword\":\"Init-Pass-1234!\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.username").value("newuser"))
+        .andExpect(jsonPath("$.email").value("newuser@qnop.test"))
+        .andExpect(jsonPath("$.role").value("MEMBER"))
+        .andExpect(jsonPath("$.source").value("INTERNAL"))
+        .andExpect(jsonPath("$.enabled").value(true));
+
+    // The freshly created account can authenticate with its initial password.
+    org.junit.jupiter.api.Assertions.assertEquals(
+        200, login("newuser", "Init-Pass-1234!").getResponse().getStatus());
+  }
+
+  @Test
+  void createsAnInvitedUserWithoutAPassword() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(USERS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"displayName\":\"Invited\",\"username\":\"invited\","
+                        + "\"email\":\"invited@qnop.test\",\"role\":\"AUDITOR\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.role").value("AUDITOR"))
+        .andExpect(jsonPath("$.enabled").value(true));
+  }
+
+  @Test
+  void rejectsADuplicateEmail() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(USERS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"displayName\":\"Clash\",\"username\":\"clash\","
+                        + "\"email\":\"admin@qnop.test\",\"role\":\"MEMBER\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("EMAIL_TAKEN"));
+  }
+
+  @Test
+  void rejectsADuplicateUsername() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(USERS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"displayName\":\"Clash\",\"username\":\"admin\","
+                        + "\"email\":\"clash@qnop.test\",\"role\":\"MEMBER\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("USERNAME_TAKEN"));
+  }
+
+  @Test
+  void rejectsATooShortUsernameWithAValidationError() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(USERS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"displayName\":\"Short\",\"username\":\"ab\","
+                        + "\"email\":\"short@qnop.test\",\"role\":\"MEMBER\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  void updatesDisplayNameAndRole() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(USERS + "/" + MEMBER2_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"displayName\":\"Renamed Member\",\"role\":\"AUDITOR\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("Renamed Member"))
+        .andExpect(jsonPath("$.role").value("AUDITOR"));
+  }
+
+  @Test
+  void rejectsChangingOwnRole() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(USERS + "/" + ADMIN_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"role\":\"MEMBER\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("SELF_LOCKOUT"));
+  }
+
+  @Test
+  void rejectsDisablingOwnAccount() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(USERS + "/" + ADMIN_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"enabled\":false}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("SELF_LOCKOUT"));
+  }
+
+  @Test
+  void updatingAnUnknownUserIsNotFound() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(USERS + "/a0000000-0000-0000-0000-0000000000ff"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"displayName\":\"Ghost\"}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deletesAUser() throws Exception {
+    mockMvc.perform(asAdmin(delete(USERS + "/" + MEMBER2_ID))).andExpect(status().isNoContent());
+    mockMvc.perform(asAdmin(get(USERS + "/" + MEMBER2_ID))).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void rejectsDeletingOwnAccount() throws Exception {
+    mockMvc
+        .perform(asAdmin(delete(USERS + "/" + ADMIN_ID)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("SELF_DELETE"));
+  }
+
+  @Test
+  void deletingAnUnknownUserIsNotFound() throws Exception {
+    mockMvc
+        .perform(asAdmin(delete(USERS + "/a0000000-0000-0000-0000-0000000000ff")))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/SeededAdminUserPasswordIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededAdminUserPasswordIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/** Admin-initiated password reset + generate-password (issue #163). */
+class SeededAdminUserPasswordIT extends SeededIntegrationTest {
+
+  private static final String USERS = "/api/v1/admin/users";
+
+  private String bearer() {
+    return "Bearer " + token(ADMIN_ID);
+  }
+
+  @Test
+  void sendsAPasswordResetForAnInternalUser() throws Exception {
+    mockMvc
+        .perform(
+            post(USERS + "/" + MEMBER_ID + "/password-reset").header("Authorization", bearer()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.emailSent").isBoolean());
+  }
+
+  @Test
+  void rejectsAPasswordResetForAnExternalUser() throws Exception {
+    mockMvc
+        .perform(
+            post(USERS + "/" + EXTERNAL_ID + "/password-reset").header("Authorization", bearer()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("NO_LOCAL_PASSWORD"));
+  }
+
+  @Test
+  void passwordResetForAnUnknownUserIsNotFound() throws Exception {
+    mockMvc
+        .perform(
+            post(USERS + "/a0000000-0000-0000-0000-0000000000ff/password-reset")
+                .header("Authorization", bearer()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void generatesAPasswordForAnInternalUser() throws Exception {
+    mockMvc
+        .perform(post(USERS + "/" + MEMBER_ID + "/password").header("Authorization", bearer()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.password").isNotEmpty());
+  }
+
+  @Test
+  void rejectsGeneratingAPasswordForAnExternalUser() throws Exception {
+    mockMvc
+        .perform(post(USERS + "/" + EXTERNAL_ID + "/password").header("Authorization", bearer()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("NO_LOCAL_PASSWORD"));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/SeededTeamIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededTeamIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/** Team CRUD against the seeded teams (issue #163). */
+class SeededTeamIT extends SeededIntegrationTest {
+
+  private static final String TEAMS = "/api/v1/admin/teams";
+
+  private MockHttpServletRequestBuilder asAdmin(MockHttpServletRequestBuilder builder) {
+    return builder.header("Authorization", "Bearer " + token(ADMIN_ID));
+  }
+
+  @Test
+  void listsTheSeededTeamsWithMemberCounts() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(TEAMS)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(greaterThanOrEqualTo(2)))
+        .andExpect(jsonPath("$.items").isArray());
+  }
+
+  @Test
+  void createsATeam() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(TEAMS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Gamma\",\"description\":\"A third team\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.name").value("Gamma"))
+        .andExpect(jsonPath("$.enabled").value(true))
+        .andExpect(jsonPath("$.memberCount").value(0));
+  }
+
+  @Test
+  void rejectsADuplicateTeamName() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(TEAMS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Alpha\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("NAME_TAKEN"));
+  }
+
+  @Test
+  void rejectsAnEmptyNameWithAValidationError() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(TEAMS)).contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  void getsATeamWithItsMembers() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(TEAMS + "/" + TEAM_ALPHA_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("Alpha"))
+        .andExpect(jsonPath("$.members").isArray())
+        .andExpect(jsonPath("$.members.length()").value(3));
+  }
+
+  @Test
+  void getsAnUnknownTeamAs404() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(TEAMS + "/b0000000-0000-0000-0000-0000000000ff")))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("TEAM_NOT_FOUND"));
+  }
+
+  @Test
+  void updatesATeamDescription() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(TEAMS + "/" + TEAM_ALPHA_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"description\":\"Updated description\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.description").value("Updated description"));
+  }
+
+  @Test
+  void rejectsRenamingToAnExistingName() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(TEAMS + "/" + TEAM_ALPHA_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Beta\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("NAME_TAKEN"));
+  }
+
+  @Test
+  void deletesATeam() throws Exception {
+    mockMvc.perform(asAdmin(delete(TEAMS + "/" + TEAM_BETA_ID))).andExpect(status().isNoContent());
+    mockMvc.perform(asAdmin(get(TEAMS + "/" + TEAM_BETA_ID))).andExpect(status().isNotFound());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/SeededTeamMembershipIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededTeamMembershipIT.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Team membership: add / set-role / remove against the seeded teams (issue #163). Seeded Alpha
+ * holds admin (LEAD), member, auditor; Beta holds member (LEAD), member2.
+ */
+class SeededTeamMembershipIT extends SeededIntegrationTest {
+
+  private static final String TEAMS = "/api/v1/admin/teams";
+  private static final String UNKNOWN_ID = "00000000-0000-0000-0000-0000000000ff";
+
+  private MockHttpServletRequestBuilder asAdmin(MockHttpServletRequestBuilder builder) {
+    return builder.header("Authorization", "Bearer " + token(ADMIN_ID));
+  }
+
+  private String members(Object teamId) {
+    return TEAMS + "/" + teamId + "/members";
+  }
+
+  @Test
+  void addsANewMember() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(members(TEAM_ALPHA_ID)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER2_ID + "\",\"teamRole\":\"MEMBER\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.userId").value(MEMBER2_ID.toString()))
+        .andExpect(jsonPath("$.teamRole").value("MEMBER"));
+  }
+
+  @Test
+  void rejectsAddingAnExistingMember() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(members(TEAM_ALPHA_ID)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER_ID + "\",\"teamRole\":\"MEMBER\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("ALREADY_MEMBER"));
+  }
+
+  @Test
+  void addingToAnUnknownTeamIsNotFound() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(members(UNKNOWN_ID)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER_ID + "\",\"teamRole\":\"MEMBER\"}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void addingAnUnknownUserIsNotFound() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(members(TEAM_ALPHA_ID)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + UNKNOWN_ID + "\",\"teamRole\":\"MEMBER\"}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+  }
+
+  @Test
+  void promotesAMemberToLead() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(members(TEAM_ALPHA_ID) + "/" + MEMBER_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamRole\":\"LEAD\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.teamRole").value("LEAD"));
+  }
+
+  @Test
+  void settingTheRoleOfANonMemberIsNotFound() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(members(TEAM_ALPHA_ID) + "/" + MEMBER2_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamRole\":\"LEAD\"}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void removesAMember() throws Exception {
+    mockMvc
+        .perform(asAdmin(delete(members(TEAM_ALPHA_ID) + "/" + AUDITOR_ID)))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(asAdmin(get(TEAMS + "/" + TEAM_ALPHA_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.members.length()").value(2));
+  }
+
+  @Test
+  void removingANonMemberIsNotFound() throws Exception {
+    mockMvc
+        .perform(asAdmin(delete(members(TEAM_ALPHA_ID) + "/" + MEMBER2_ID)))
+        .andExpect(status().isNotFound());
+  }
+}


### PR DESCRIPTION
## Summary

Wave 3 of the comprehensive integration-test suite (#163): the **admin users** and **teams** verticals, driven against the seeded dataset (Testcontainers + MockMvc, bearer auth — admin endpoints are CSRF-exempt).

New IT classes:

- **`SeededAdminUserCrudIT`** — create (with/without initial password; the created account can log in), duplicate email/username (`409`), short-username validation, update displayName+role, **self-lockout** on role-change and disable, update unknown (`404`), delete + verify gone, **self-delete** guard, delete unknown.
- **`SeededAdminUserPasswordIT`** — admin send-reset and generate-password for an internal user, `NO_LOCAL_PASSWORD` for the external account, not-found.
- **`SeededTeamIT`** — list with member counts, create, duplicate name (`NAME_TAKEN`), empty-name validation, get-with-members, update description, rename conflict, delete + verify gone.
- **`SeededTeamMembershipIT`** — add member, already-member (`409`), unknown team/user (`404`), promote to LEAD, set-role of a non-member (`404`), remove member (member count drops), remove non-member.

### Note on `LAST_ADMIN`

Not asserted via the API: the acting principal is always an enabled admin, so `SELF_LOCKOUT`/`SELF_DELETE` always preempt the last-admin path. That guard is better exercised at the service layer (future wave / unit test).

## Test plan

- [x] `spotlessApply` + `compileTestJava` green locally
- [ ] CI Backend job (Testcontainers) green

Part of #163.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code