### PR TITLE
test: integration tests for settings, OIDC providers and mail templates (#163)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/web/SeededAdminSettingsIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededAdminSettingsIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Admin application settings (issue #163). {@code application_setting} is migration-seeded and not
+ * truncated by {@code clean.sql}, so the one mutating test restores {@code
+ * general.application_name} to its default in {@link AfterEach} to keep the JVM-shared database
+ * clean for other IT classes.
+ */
+class SeededAdminSettingsIT extends SeededIntegrationTest {
+
+  private static final String SETTINGS = "/api/v1/admin/settings";
+  private static final String APP_NAME = "general.application_name";
+
+  private MockHttpServletRequestBuilder asAdmin(MockHttpServletRequestBuilder builder) {
+    return builder.header("Authorization", "Bearer " + token(ADMIN_ID));
+  }
+
+  @AfterEach
+  void restoreApplicationName() throws Exception {
+    mockMvc.perform(
+        asAdmin(patch(SETTINGS))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"values\":{\"" + APP_NAME + "\":\"qnop\"}}"));
+  }
+
+  @Test
+  void listsAllSettingsAndMasksSensitiveOnes() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(SETTINGS)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.settings").isArray())
+        .andExpect(jsonPath("$.settings[?(@.key=='" + APP_NAME + "')]").exists())
+        .andExpect(
+            jsonPath("$.settings[?(@.key=='smtp.password')].sensitive").value(hasItem(true)));
+  }
+
+  @Test
+  void updatesASetting() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(SETTINGS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"" + APP_NAME + "\":\"My QNOP\"}}"))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.settings[?(@.key=='" + APP_NAME + "')].value").value(hasItem("My QNOP")));
+  }
+
+  @Test
+  void rejectsAnUnknownKey() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(SETTINGS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"does.not.exist\":\"x\"}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.fieldErrors").isArray());
+  }
+
+  @Test
+  void rejectsAValueOfTheWrongType() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(SETTINGS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"smtp.port\":\"not-a-number\"}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  void keepsASensitiveSecretWhenTheMaskSentinelIsSent() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(SETTINGS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"smtp.password\":\"***\"}}"))
+        .andExpect(status().isOk());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/SeededMailTemplateIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededMailTemplateIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Mail templates (issues #140/#141): read, placeholder validation, preview rendering, and the
+ * SMTP-less test-send. The happy-path override (PUT) and reset (DELETE) mutate the migration-seeded
+ * {@code mail_template} table, which {@code clean.sql} does not restore, so they are exercised at
+ * the service layer instead; here we cover only the rejected (no-commit) PUT and read/preview
+ * paths.
+ */
+class SeededMailTemplateIT extends SeededIntegrationTest {
+
+  private static final String TEMPLATES = "/api/v1/admin/email/templates";
+  private static final String RESET_KEY = "auth.password_reset";
+
+  private MockHttpServletRequestBuilder asAdmin(MockHttpServletRequestBuilder builder) {
+    return builder.header("Authorization", "Bearer " + token(ADMIN_ID));
+  }
+
+  @Test
+  void listsTemplatesWithTheirPlaceholders() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(TEMPLATES)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.templates").isArray())
+        .andExpect(jsonPath("$.templates[?(@.key=='" + RESET_KEY + "')]").exists());
+  }
+
+  @Test
+  void getsASingleTemplate() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(TEMPLATES + "/" + RESET_KEY)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.key").value(RESET_KEY))
+        .andExpect(jsonPath("$.subject").isNotEmpty())
+        .andExpect(jsonPath("$.placeholders").value(hasItem("actionUrl")));
+  }
+
+  @Test
+  void getsAnUnknownTemplateAs404() throws Exception {
+    mockMvc.perform(asAdmin(get(TEMPLATES + "/does.not.exist"))).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void previewsATemplateWithSampleVariables() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(TEMPLATES + "/" + RESET_KEY + "/preview"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"variables\":{}}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.subject").isNotEmpty())
+        .andExpect(jsonPath("$.bodyPlain").isNotEmpty())
+        .andExpect(jsonPath("$.sampleVars").exists());
+  }
+
+  @Test
+  void rejectsAPreviewDraftWithAnUnknownPlaceholder() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(TEMPLATES + "/" + RESET_KEY + "/preview"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"subject\":\"Hi {{bogus}}\",\"bodyPlain\":\"Body {{bogus}}\","
+                        + "\"variables\":{}}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsAnUpdateWithAnUnknownPlaceholder() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(put(TEMPLATES + "/" + RESET_KEY))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"locale\":\"en\",\"subject\":\"Reset {{bogus}}\","
+                        + "\"bodyPlain\":\"Click {{actionUrl}}\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void sendingATestEmailIsSkippedWhenSmtpIsNotConfigured() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post("/api/v1/admin/email/test"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"recipient\":\"test@qnop.test\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SKIPPED"));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/SeededOidcProviderIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededOidcProviderIT.java
@@ -68,11 +68,11 @@ class SeededOidcProviderIT extends SeededIntegrationTest {
             asAdmin(post(PROVIDERS))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
-                    "{\"name\":\"New IdP\",\"providerType\":\"OIDC\","
+                    "{\"name\":\"New IdP\",\"providerType\":\"GITHUB\","
                         + "\"clientId\":\"new-client\",\"clientSecret\":\"new-secret\"}"))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.name").value("New IdP"))
-        .andExpect(jsonPath("$.providerType").value("OIDC"))
+        .andExpect(jsonPath("$.providerType").value("GITHUB"))
         .andExpect(jsonPath("$.hasClientSecret").value(true))
         .andExpect(jsonPath("$.clientSecret").doesNotExist());
   }

--- a/qnop-app/src/test/java/io/qnop/web/SeededOidcProviderIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededOidcProviderIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * OIDC provider CRUD against the seeded providers (issue #163). Create/update deliberately omit the
+ * optional URIs so the SSRF policy and the network-bound discovery endpoint are not exercised here.
+ * The client secret is write-only: responses expose only {@code hasClientSecret}.
+ */
+class SeededOidcProviderIT extends SeededIntegrationTest {
+
+  private static final String PROVIDERS = "/api/v1/admin/oidc-providers";
+
+  private MockHttpServletRequestBuilder asAdmin(MockHttpServletRequestBuilder builder) {
+    return builder.header("Authorization", "Bearer " + token(ADMIN_ID));
+  }
+
+  @Test
+  void listsSeededProvidersWithSecretFlags() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(PROVIDERS)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.providers").isArray())
+        // The enabled provider carries a secret, the disabled one does not.
+        .andExpect(
+            jsonPath("$.providers[?(@.name=='Seeded Google')].hasClientSecret")
+                .value(hasItem(true)))
+        .andExpect(
+            jsonPath("$.providers[?(@.name=='Seeded OIDC (disabled)')].hasClientSecret")
+                .value(hasItem(false)));
+  }
+
+  @Test
+  void createsAProviderWithoutEchoingTheSecret() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(PROVIDERS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"name\":\"New IdP\",\"providerType\":\"OIDC\","
+                        + "\"clientId\":\"new-client\",\"clientSecret\":\"new-secret\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.name").value("New IdP"))
+        .andExpect(jsonPath("$.providerType").value("OIDC"))
+        .andExpect(jsonPath("$.hasClientSecret").value(true))
+        .andExpect(jsonPath("$.clientSecret").doesNotExist());
+  }
+
+  @Test
+  void rejectsADuplicateName() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(PROVIDERS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"name\":\"Seeded Google\",\"providerType\":\"OIDC\","
+                        + "\"clientId\":\"dup\",\"clientSecret\":\"dup-secret\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectsABlankNameWithAValidationError() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(post(PROVIDERS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"name\":\"\",\"providerType\":\"OIDC\","
+                        + "\"clientId\":\"x\",\"clientSecret\":\"y\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  void getsAProviderById() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(PROVIDERS + "/" + OIDC_ENABLED_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("Seeded Google"))
+        .andExpect(jsonPath("$.hasClientSecret").value(true));
+  }
+
+  @Test
+  void getsAnUnknownProviderAs404() throws Exception {
+    mockMvc
+        .perform(asAdmin(get(PROVIDERS + "/d0000000-0000-0000-0000-0000000000ff")))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void disablesAProviderAndKeepsTheSecretWhenOmitted() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(PROVIDERS + "/" + OIDC_ENABLED_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"enabled\":false}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.enabled").value(false))
+        .andExpect(jsonPath("$.hasClientSecret").value(true));
+  }
+
+  @Test
+  void updatingAnUnknownProviderIs404() throws Exception {
+    mockMvc
+        .perform(
+            asAdmin(patch(PROVIDERS + "/d0000000-0000-0000-0000-0000000000ff"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"enabled\":false}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deletesAProvider() throws Exception {
+    mockMvc
+        .perform(asAdmin(delete(PROVIDERS + "/" + OIDC_DISABLED_ID)))
+        .andExpect(status().isNoContent());
+    mockMvc
+        .perform(asAdmin(get(PROVIDERS + "/" + OIDC_DISABLED_ID)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deletingAnUnknownProviderIs404() throws Exception {
+    mockMvc
+        .perform(asAdmin(delete(PROVIDERS + "/d0000000-0000-0000-0000-0000000000ff")))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/SeededUserSettingsUpdateIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededUserSettingsUpdateIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/** Updating the current user's settings (issue #163). */
+class SeededUserSettingsUpdateIT extends SeededIntegrationTest {
+
+  private static final String SETTINGS = "/api/v1/users/me/settings";
+
+  private MockHttpServletRequestBuilder asMember(MockHttpServletRequestBuilder builder) {
+    return builder.header("Authorization", "Bearer " + token(MEMBER_ID));
+  }
+
+  @Test
+  void updatesAUserSetting() throws Exception {
+    mockMvc
+        .perform(
+            asMember(patch(SETTINGS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"theme\":\"dark\"}}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.settings").isArray());
+  }
+
+  @Test
+  void rejectsAnUnknownKey() throws Exception {
+    mockMvc
+        .perform(
+            asMember(patch(SETTINGS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"does.not.exist\":\"x\"}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_SETTING"));
+  }
+
+  @Test
+  void rejectsAnInvalidEnumValue() throws Exception {
+    mockMvc
+        .perform(
+            asMember(patch(SETTINGS))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"theme\":\"purple\"}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_SETTING"));
+  }
+
+  @Test
+  void rejectsAnonymousAccess() throws Exception {
+    mockMvc
+        .perform(
+            patch(SETTINGS)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"theme\":\"dark\"}}"))
+        .andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
## Summary

Wave 4 of the comprehensive integration-test suite (#163): the **admin configuration** surface — application settings, user settings update, OIDC provider CRUD, and mail templates — against the seeded dataset.

New IT classes:

- **`SeededAdminSettingsIT`** — list (with sensitive masking), update, unknown key (`400 VALIDATION_ERROR` + `fieldErrors`), wrong-type value, and the `***` mask-sentinel keeping a stored secret. Restores `general.application_name` in `@AfterEach` (the table is migration-seeded and not truncated by `clean.sql`).
- **`SeededUserSettingsUpdateIT`** — valid update (`theme`), unknown key (`400 INVALID_SETTING`), invalid enum value, anonymous (`401`).
- **`SeededOidcProviderIT`** — list with `hasClientSecret` flags, create (secret never echoed), duplicate name, validation, get, get-unknown (`404`), disable + keep-secret-on-omit, update-unknown (`404`), delete + delete-unknown. Optional URIs / the network discovery endpoint are intentionally avoided.
- **`SeededMailTemplateIT`** — list/get/get-unknown, preview with sample vars, **placeholder validation** on preview drafts and on PUT (#141), and the SMTP-less test-send (`SKIPPED`).

### Deferred

Happy-path mail-template override (PUT) and reset (DELETE) mutate the migration-seeded `mail_template` table that `clean.sql` does not restore, so they belong in service-layer tests; here only the rejected (no-commit) PUT and read/preview paths are covered.

## Test plan

- [x] `spotlessApply` + `compileTestJava` green locally
- [ ] CI Backend job (Testcontainers) green

Part of #163.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code