### PR TITLE
ci: smoke-test deployment via docker-compose against testdata (#207)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the build context small and deterministic: no VCS metadata, no build
+# outputs, no Gradle/IDE caches, and no frontend (the image is the backend jar).
+.git
+.gradle
+**/build
+**/node_modules
+qnop-ui
+.github
+.idea
+.vscode
+*.iml
+.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,25 @@ jobs:
       - run: pnpm test:run
       - run: pnpm build
 
+  smoke:
+    name: Smoke (docker-compose deploy + testdata)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      # Build the backend image and bring up PostgreSQL + the server, then run
+      # the smoke script: wait for /actuator/health, seed testdata/db/seed.sql
+      # into the running database, and exercise the base API over HTTP (#207).
+      - name: Build and start the test-deployment stack
+        run: docker compose -f docker-compose.smoke.yml up -d --build
+      - name: Run smoke tests
+        run: bash scripts/smoke-test.sh
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.smoke.yml logs --no-color
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.smoke.yml down -v
+
   license-headers:
     name: License headers (SPDX)
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Multi-stage image for the qnop Community server (qnop-app, ADR-0020).
+#
+# Stage 1 builds the Spring Boot executable jar with the Gradle wrapper; stage 2
+# runs it on a slim JRE as a non-root user. The datasource host comes from
+# QNOP_DB_HOST (see application.yml) and the server fails fast unless the
+# QNOP_AUTH_* secrets are supplied (ADR-0022). Tests / ArchUnit / Spotless are
+# intentionally not run here — the dedicated CI jobs own those gates; this image
+# only packages the runnable artifact (used by the smoke-test stack, issue #207).
+
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+
+# The whole multi-module project is needed to configure the build (settings.gradle
+# includes every module). The frontend, build outputs and VCS metadata are kept
+# out of the context via .dockerignore.
+COPY . .
+
+# Build only the boot jar (not the plain library jar) and stage it at a stable
+# path for the runtime stage.
+RUN ./gradlew --no-daemon -x test :qnop-app:bootJar \
+    && cp "$(ls qnop-app/build/libs/*.jar | grep -v -- '-plain')" /workspace/app.jar
+
+FROM eclipse-temurin:21-jre AS runtime
+WORKDIR /app
+
+# Run unprivileged.
+RUN groupadd --system qnop && useradd --system --gid qnop --home /app qnop
+
+COPY --from=build /workspace/app.jar /app/app.jar
+USER qnop
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Test-deployment stack for the CI smoke tests (issue #207): a standalone
+# PostgreSQL plus the qnop server built from the repo Dockerfile. This is NOT a
+# production or local-dev stack — the QNOP_AUTH_* values below are throwaway test
+# secrets that intentionally match the encryption key/salt used to produce
+# testdata/db/seed.sql, so the seeded rows (e.g. the OIDC client secret) stay
+# decryptable. MinIO is omitted: object storage is not consumed yet.
+#
+# Usage:  docker compose -f docker-compose.smoke.yml up -d --build
+#         bash scripts/smoke-test.sh
+#         docker compose -f docker-compose.smoke.yml down -v
+
+services:
+  postgres:
+    image: postgres:18@sha256:1a5b3e745bbd82d6deb146505e504da3c2f248cac15e431951b148fbe4f8613a
+    environment:
+      POSTGRES_USER: qnop
+      POSTGRES_PASSWORD: qnop
+      POSTGRES_DB: qnop
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U qnop -d qnop']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      QNOP_DB_HOST: postgres
+      QNOP_DB_PORT: '5432'
+      QNOP_DB_NAME: qnop
+      QNOP_DB_USERNAME: qnop
+      QNOP_DB_PASSWORD: qnop
+      # Test-only secrets — must match testdata/db/seed.sql's encryption inputs.
+      QNOP_AUTH_JWT_SECRET: integration-test-jwt-secret-0123456789
+      QNOP_AUTH_ENCRYPTION_KEY: integration-test-encryption-key-0123456789
+      QNOP_AUTH_ENCRYPTION_SALT: 0123456789abcdef0123456789abcdef
+      QNOP_CORS_ALLOWED_ORIGINS: http://localhost:5173
+    ports:
+      - '8080:8080'

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 
 BASE_URL="${SMOKE_BASE_URL:-http://localhost:8080}"
 COMPOSE_FILE="${SMOKE_COMPOSE_FILE:-docker-compose.smoke.yml}"
+CLEAN_FILE="testdata/db/clean.sql"
 SEED_FILE="testdata/db/seed.sql"
 SEED_USER="admin"
 SEED_PASS="Test-Pass-1234!"
@@ -38,8 +39,13 @@ for i in $(seq 1 "$HEALTH_RETRIES"); do
   sleep "$HEALTH_DELAY"
 done
 
-# 2) Seed the running database with the shared fixtures (schema is migrated by now).
-log "seeding ${SEED_FILE}"
+# 2) Seed the running database with the shared fixtures (schema is migrated by
+#    now). Clean first: on first boot the app bootstraps an initial 'admin' user,
+#    which would collide with the seeded admin — so wipe the app tables, then load
+#    the deterministic dataset (same clean+seed contract as the IT suite, #163).
+log "cleaning + seeding ${SEED_FILE}"
+docker compose -f "$COMPOSE_FILE" exec -T postgres \
+  psql -v ON_ERROR_STOP=1 -U qnop -d qnop <"$CLEAN_FILE" >/dev/null
 docker compose -f "$COMPOSE_FILE" exec -T postgres \
   psql -v ON_ERROR_STOP=1 -U qnop -d qnop <"$SEED_FILE" >/dev/null
 log "seeded"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Smoke test (issue #207): waits for the deployed qnop server to become healthy,
+# seeds the shared fixtures from testdata/, and exercises the base functionality
+# over real HTTP. Fails fast (non-zero exit) on the first deviation.
+#
+# Run from the repo root, with the stack already up:
+#   docker compose -f docker-compose.smoke.yml up -d --build
+#   bash scripts/smoke-test.sh
+set -euo pipefail
+
+BASE_URL="${SMOKE_BASE_URL:-http://localhost:8080}"
+COMPOSE_FILE="${SMOKE_COMPOSE_FILE:-docker-compose.smoke.yml}"
+SEED_FILE="testdata/db/seed.sql"
+SEED_USER="admin"
+SEED_PASS="Test-Pass-1234!"
+HEALTH_RETRIES=60
+HEALTH_DELAY=5
+
+log() { echo "[smoke] $*"; }
+fail() {
+  echo "[smoke] FAIL: $*" >&2
+  exit 1
+}
+
+# 1) Readiness — covers the container boot, DB connectivity and Liquibase.
+log "waiting for ${BASE_URL}/actuator/health ..."
+for i in $(seq 1 "$HEALTH_RETRIES"); do
+  status="$(curl -sf "${BASE_URL}/actuator/health" 2>/dev/null | jq -r '.status' 2>/dev/null || true)"
+  if [ "$status" = "UP" ]; then
+    log "health UP after $((i * HEALTH_DELAY - HEALTH_DELAY))s"
+    break
+  fi
+  if [ "$i" -eq "$HEALTH_RETRIES" ]; then
+    fail "server did not become healthy within $((HEALTH_RETRIES * HEALTH_DELAY))s"
+  fi
+  sleep "$HEALTH_DELAY"
+done
+
+# 2) Seed the running database with the shared fixtures (schema is migrated by now).
+log "seeding ${SEED_FILE}"
+docker compose -f "$COMPOSE_FILE" exec -T postgres \
+  psql -v ON_ERROR_STOP=1 -U qnop -d qnop <"$SEED_FILE" >/dev/null
+log "seeded"
+
+# 3) Public bootstrap config endpoint.
+code="$(curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/api/v1/config")"
+[ "$code" = "200" ] || fail "GET /api/v1/config -> HTTP $code (expected 200)"
+log "GET /api/v1/config -> 200"
+
+# 4) Login as the seeded admin (covers seeded data + bcrypt + JWT issuance).
+token="$(
+  curl -sf -X POST "${BASE_URL}/api/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"usernameOrEmail\":\"${SEED_USER}\",\"password\":\"${SEED_PASS}\"}" |
+    jq -r '.accessToken'
+)"
+[ -n "$token" ] && [ "$token" != "null" ] || fail "login did not return an access token"
+log "POST /api/v1/auth/login -> access token issued"
+
+# 5) Authenticated admin query of the seeded users.
+total="$(
+  curl -sf "${BASE_URL}/api/v1/admin/users" -H "Authorization: Bearer ${token}" |
+    jq -r '.total'
+)"
+[ "$total" -ge 8 ] 2>/dev/null || fail "GET /api/v1/admin/users total=${total} (expected >= 8 seeded users)"
+log "GET /api/v1/admin/users -> total=${total}"
+
+# 6) Current-user principal resolves from the JWT.
+role="$(
+  curl -sf "${BASE_URL}/api/v1/users/me" -H "Authorization: Bearer ${token}" |
+    jq -r '.role'
+)"
+[ "$role" = "ADMIN" ] || fail "GET /api/v1/users/me role=${role} (expected ADMIN)"
+log "GET /api/v1/users/me -> role=${role}"
+
+log "ALL SMOKE CHECKS PASSED"


### PR DESCRIPTION
## Summary

Closes #207. Adds a **smoke-test stage** to CI that performs a real test-deployment with `docker-compose` and exercises the base functionality end-to-end over HTTP, seeded with the shared `testdata/` fixtures. This catches packaging/boot/migration/wiring regressions that the in-process Testcontainers suite (#163) cannot.

### What's added

- **`Dockerfile`** — multi-stage: builds the `:qnop-app` boot jar with the Gradle wrapper, runs it on a non-root `eclipse-temurin:21-jre`. Datasource host from `QNOP_DB_HOST`; `/actuator/health` already exposed; fails fast without `QNOP_AUTH_*` (ADR-0022).
- **`docker-compose.smoke.yml`** — standalone PostgreSQL + the app, wired with throwaway test secrets that match `testdata/db/seed.sql`'s encryption key/salt so the seed stays self-consistent. MinIO omitted (object storage not yet consumed).
- **`scripts/smoke-test.sh`** — waits for `/actuator/health` → `UP`, seeds `testdata/db/seed.sql` into the running DB, then asserts:
  1. `GET /api/v1/config` → 200 (public bootstrap config)
  2. `POST /api/v1/auth/login` as `admin` / `Test-Pass-1234!` → access token (seeded data + bcrypt + JWT)
  3. `GET /api/v1/admin/users` → ≥ 8 seeded users (auth + real DB query)
  4. `GET /api/v1/users/me` → role `ADMIN` (JWT principal)
- **`ci.yml`** — a `smoke` job that builds the image, brings the stack up, runs the script, dumps container logs on failure, and tears down with `down -v`.
- **`.dockerignore`** — keeps the build context lean (no VCS/build outputs/frontend).

### Out of scope

Frontend deployment/serving, image publishing, and endpoints needing object storage or SMTP.

## Test plan

- [x] `scripts/smoke-test.sh` passes `bash -n`; `:qnop-app:bootJar` builds a single executable jar locally (Dockerfile build command verified).
- [ ] CI `smoke` job green (builds the image, deploys, seeds, and passes all checks — runs only in CI; Docker is unavailable locally).

🤖 Co-Author: Claude (Opus 4.x) via Claude Code