### PR TITLE
fix: validate login response before storing the access token

### DIFF
--- a/qnop-ui/src/stores/authStore.ts
+++ b/qnop-ui/src/stores/authStore.ts
@@ -85,7 +85,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (!response.ok) {
       throw new Error(response.status === 429 ? 'RATE_LIMITED' : 'INVALID_CREDENTIALS');
     }
-    const body = (await response.json()) as { accessToken: string };
+    const body = (await response.json()) as { accessToken?: string };
+    if (typeof body.accessToken !== 'string') {
+      // A 200 without a usable token (format change, WAF/proxy page) must not leave the store
+      // in a half-authenticated state with an undefined token — fail loudly instead.
+      throw new Error('Unexpected login response');
+    }
     set({ accessToken: body.accessToken });
     await get().fetchMe();
   },


### PR DESCRIPTION
## Summary

`authStore.login` cast the response body as `{ accessToken: string }` (required) and stored `body.accessToken` directly. Without `strictNullChecks`, a 200 response missing the token — a format change, a WAF/proxy page, a misbehaving reverse proxy — stores `undefined`, leaving the store in a half-authenticated state (the subsequent `fetchMe` then 401s, but only after the store is broken).

Mirrors the existing `refresh.ts` guard: type the body as `{ accessToken?: string }` and reject a non-string token with an explicit error **before** `set()`.

## Test plan

- [x] `pnpm lint` clean.
- [x] Store tests pass (`vitest run src/stores`, 10/10).
- [ ] Full `tsc -b` / build runs in CI (needs the generated API client, which requires the openapi-generator — not runnable in this sandbox; the only local tsc errors are the pre-existing missing `api/generated` module, unrelated to this one-line guard).

Closes #176

🤖 Co-Author: Claude (Opus 4.x) via Claude Code