### PR TITLE
fix: emit uniform ErrorResponse envelope from PasswordChangeRequiredFilter

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/security/PasswordChangeRequiredFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/PasswordChangeRequiredFilter.java
@@ -21,6 +21,7 @@
 package io.qnop.web.security;
 
 import io.qnop.service.UserService;
+import io.qnop.web.ApiErrorWriter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,7 +29,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -61,13 +61,11 @@ public class PasswordChangeRequiredFilter extends OncePerRequestFilter {
     if (authentication instanceof JwtAuthenticationToken jwt
         && !request.getRequestURI().startsWith(AUTH_PREFIX)
         && requiresPasswordChange(jwt.getName())) {
-      response.setStatus(HttpStatus.FORBIDDEN.value());
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      response
-          .getWriter()
-          .write(
-              "{\"error\":\"PASSWORD_CHANGE_REQUIRED\",\"message\":\"You must change your password"
-                  + " before accessing this resource.\"}");
+      ApiErrorWriter.write(
+          response,
+          HttpStatus.FORBIDDEN,
+          "PASSWORD_CHANGE_REQUIRED",
+          "You must change your password before accessing this resource.");
       return;
     }
     filterChain.doFilter(request, response);

--- a/qnop-app/src/test/java/io/qnop/web/security/PasswordChangeRequiredFilterTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/PasswordChangeRequiredFilterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.service.UserService;
+import jakarta.servlet.FilterChain;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Unit tests for {@link PasswordChangeRequiredFilter}. Verifies the gate blocks protected paths for
+ * a user that must change their password and — the focus of issue #165 — that the 403 body is the
+ * uniform {@code ErrorResponse} envelope ({@code code}/{@code message}/{@code timestamp}) written
+ * by {@link io.qnop.web.ApiErrorWriter}, not the legacy ad-hoc {@code error} field.
+ */
+@ExtendWith(MockitoExtension.class)
+class PasswordChangeRequiredFilterTest {
+
+  private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+  @Mock private UserService userService;
+  @Mock private FilterChain filterChain;
+
+  private PasswordChangeRequiredFilter newFilter() {
+    return new PasswordChangeRequiredFilter(userService);
+  }
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName(
+      "blocks a protected path with the uniform ErrorResponse envelope when a change is required")
+  void blocksWithUniformEnvelope() throws Exception {
+    authenticateAs(USER_ID);
+    when(userService.passwordChangeRequired(USER_ID)).thenReturn(true);
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/users/me");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    newFilter().doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+    assertThat(response.getCharacterEncoding()).isEqualTo(StandardCharsets.UTF_8.name());
+    assertThat(response.getContentAsString())
+        .contains("\"code\":\"PASSWORD_CHANGE_REQUIRED\"")
+        .contains("\"message\":")
+        .contains("\"timestamp\":")
+        .doesNotContain("\"error\":");
+    verify(filterChain, never()).doFilter(request, response);
+  }
+
+  @Test
+  @DisplayName("never blocks an /api/v1/auth/ path so the user can change the password")
+  void allowsAuthPaths() throws Exception {
+    authenticateAs(USER_ID);
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/api/v1/auth/change-password");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    newFilter().doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+  }
+
+  @Test
+  @DisplayName("lets the request through when no password change is required")
+  void allowsWhenNoChangeRequired() throws Exception {
+    authenticateAs(USER_ID);
+    when(userService.passwordChangeRequired(USER_ID)).thenReturn(false);
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/users/me");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    newFilter().doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  private static void authenticateAs(UUID subject) {
+    Jwt jwt =
+        Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .subject(subject.toString())
+            .issuedAt(Instant.EPOCH)
+            .expiresAt(Instant.EPOCH.plusSeconds(900))
+            .build();
+    SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #165. `PasswordChangeRequiredFilter` was the only place in the app that
short-circuited a request with a hand-written error body:

```json
{"error":"PASSWORD_CHANGE_REQUIRED","message":"..."}
```

This diverged from the uniform `ErrorResponse` envelope (issue #45): wrong field
name (`error` vs `code`), no `timestamp`, and no UTF-8 charset. A schema-strict
client — including the SPA's generated `ErrorResponse` handler — could not read
the `code` for the `PASSWORD_CHANGE_REQUIRED` 403.

## Change

- Route the 403 through `ApiErrorWriter.write(response, FORBIDDEN, "PASSWORD_CHANGE_REQUIRED", "...")`, identical to the sibling `authenticationEntryPoint` (401) and `accessDeniedHandler` (403) beans in `SecurityConfiguration`.
- Drop the now-unused `MediaType` import.

## Test plan

- New `PasswordChangeRequiredFilterTest` (pure unit, no Docker):
  - 403 body is the uniform envelope (`code`/`message`/`timestamp`, UTF-8) and contains no legacy `error` field.
  - `/api/v1/auth/*` paths pass through (user can still reach change-password).
  - request passes through when no change is required.
- `./gradlew spotlessApply test` (filter test + ArchUnit) green locally. Full integration coverage of the filter is tracked separately in #189.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code