### PR TITLE
fix: give AvatarService.store read-back a diagnosable failure

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/avatar/AvatarService.java
+++ b/qnop-core/src/main/java/io/qnop/service/avatar/AvatarService.java
@@ -91,7 +91,15 @@ public class AvatarService {
             dimensions == null ? null : dimensions[0],
             dimensions == null ? null : dimensions[1],
             actor));
-    return storage.findUpdatedAt(userId).orElseThrow();
+    // The read-back runs in a separate transaction from the put above, so a concurrent
+    // remove/replace could in theory leave no row. Fail with context rather than a bare,
+    // undiagnosable NoSuchElementException.
+    return storage
+        .findUpdatedAt(userId)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "avatar was stored but could not be re-read for user " + userId));
   }
 
   /** The user's avatar bytes for serving, or empty when none is set. */

--- a/qnop-core/src/test/java/io/qnop/service/avatar/AvatarServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/avatar/AvatarServiceTest.java
@@ -149,6 +149,17 @@ class AvatarServiceTest {
   }
 
   @Test
+  void storeFailsWithContextWhenReadBackIsEmpty() throws IOException {
+    // A concurrent remove/replace between the put and the cross-transaction read-back can leave
+    // no row; the failure must carry context instead of a bare NoSuchElementException.
+    when(storage.findUpdatedAt(userId)).thenReturn(Optional.empty());
+    assertThatThrownBy(() -> service.store(userId, png(48, 48), actor))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(userId.toString());
+    verify(storage).put(any());
+  }
+
+  @Test
   void getRemoveAndUpdatedAtDelegateToStorage() {
     service.remove(userId);
     verify(storage).remove(userId);


### PR DESCRIPTION
## Summary

Fixes #166. `AvatarService.store()` writes the avatar via `storage.put(...)` and
then re-reads its `updated_at` to build the avatar URL. That read-back runs in a
**separate transaction**, so a concurrent `remove`/replace can leave no row. The
bare `findUpdatedAt(userId).orElseThrow()` then threw a context-free
`NoSuchElementException`, which `AvatarController` does not map (it only handles
`AvatarValidationException`) → an opaque 500 with no diagnostics. It was also the
only bare `orElseThrow()` in the production codebase.

## Change

- Supply an `IllegalStateException` with the user id so any unexpected empty
  read-back is diagnosable, matching the codebase's `orElseThrow(() -> ...)`
  convention. Behaviour on the happy path is unchanged.

## Test plan

- New `storeFailsWithContextWhenReadBackIsEmpty` asserts the contextful
  `IllegalStateException` (carries the user id) when the read-back is empty.
- `./gradlew spotlessApply :qnop-core:test --tests AvatarServiceTest` green (12 tests).

🤖 Co-Author: Claude (Opus 4.x) via Claude Code