### PR TITLE
fix: close encoded open-redirect bypass in safeRedirectPath

### DIFF
--- a/qnop-ui/src/utils/safeRedirectPath.test.ts
+++ b/qnop-ui/src/utils/safeRedirectPath.test.ts
@@ -38,6 +38,17 @@ describe('safeRedirectPath', () => {
     expect(safeRedirectPath('//evil.example')).toBe('/');
   });
 
+  it('rejects percent-encoded and backslash open-redirect variants', () => {
+    expect(safeRedirectPath('/%2F%2Fevil.example.com')).toBe('/');
+    expect(safeRedirectPath('/%5C%5Cevil.example.com')).toBe('/');
+    expect(safeRedirectPath('/\\evil.example.com')).toBe('/');
+    expect(safeRedirectPath('/\\/evil.example.com')).toBe('/');
+  });
+
+  it('preserves query and hash on a same-origin path', () => {
+    expect(safeRedirectPath('/reviews/42?tab=open#c1')).toBe('/reviews/42?tab=open#c1');
+  });
+
   it('honours a custom fallback', () => {
     expect(safeRedirectPath(null, '/home')).toBe('/home');
   });

--- a/qnop-ui/src/utils/safeRedirectPath.ts
+++ b/qnop-ui/src/utils/safeRedirectPath.ts
@@ -20,13 +20,41 @@
  */
 
 /**
- * Normalizes a post-login redirect target to a safe, same-origin relative path.
- * Rejects absolute URLs and protocol-relative (`//host`) values to prevent open
- * redirects, falling back to the app root.
+ * Normalizes a post-login redirect target to a safe, same-origin relative path,
+ * falling back to the app root for anything else.
+ *
+ * Canonicalising with {@link URL} against the app origin is what makes this robust:
+ * it collapses backslashes and protocol-relative forms (`//host`, `/\host`) and
+ * surfaces the true target origin regardless of percent-encoding, so encoded open
+ * redirects like `/%2F%2Fevil.example.com` (which a literal `//` check would miss)
+ * are rejected too.
  */
 export function safeRedirectPath(target: string | null | undefined, fallback = '/'): string {
-  if (!target || !target.startsWith('/') || target.startsWith('//')) {
+  if (!target || !target.startsWith('/')) {
     return fallback;
   }
-  return target;
+  let resolved: URL;
+  try {
+    resolved = new URL(target, window.location.origin);
+  } catch {
+    return fallback;
+  }
+  if (resolved.origin !== window.location.origin) {
+    return fallback;
+  }
+  // Guard against a path that only becomes protocol-relative once decoded (e.g.
+  // `/%2F%2Fevil` → `//evil`), which a downstream decode could turn off-origin.
+  const decodedPath = safeDecode(resolved.pathname);
+  if (decodedPath === null || decodedPath.startsWith('//') || decodedPath.startsWith('/\\')) {
+    return fallback;
+  }
+  return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+}
+
+function safeDecode(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

`safeRedirectPath` rejected `//host` but not percent-encoded (`/%2F%2Fevil.example.com`) or backslash (`/\evil.example.com`) variants that decode to a protocol-relative, off-origin target — an open redirect reachable via a phished `?from=` login link.

Canonicalise with `new URL(target, window.location.origin)` and accept only when `resolved.origin === window.location.origin`; additionally reject a path that becomes protocol-relative once decoded (`/%2F%2F…` → `//…`). Same-origin query/hash are preserved.

## Test plan

- [x] `pnpm lint` clean.
- [x] `vitest run src/utils/safeRedirectPath.test.ts` — 6/6, including new percent-encoded + backslash cases.

Closes #177

🤖 Co-Author: Claude (Opus 4.x) via Claude Code