### PR TITLE
perf: gate password-change from a JWT claim instead of a per-request DB read

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/security/PasswordChangeRequiredFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/PasswordChangeRequiredFilter.java
@@ -20,14 +20,13 @@
  */
 package io.qnop.web.security;
 
-import io.qnop.service.UserService;
+import io.qnop.service.JwtTokenService;
 import io.qnop.web.ApiErrorWriter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,21 +36,19 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * Forces a password change before any non-auth resource is reachable (issue #20). When the
- * authenticated JWT subject is a user with {@code password_change_required = true}, every request
- * outside {@code /api/v1/auth/} is rejected with {@code 403}, so the only thing such a user can do
- * is change their password (and refresh/logout). Runs after the resource-server authentication has
- * populated the {@link JwtAuthenticationToken}.
+ * authenticated access token carries {@code pcr = true} (the user's {@code
+ * password_change_required} flag, baked in at mint time — issue #167), every request outside {@code
+ * /api/v1/auth/} is rejected with a {@code 403} {@code ErrorResponse}, so the only thing such a
+ * user can do is change their password (and refresh/logout). Reading the flag from the verified
+ * token avoids a per-request {@code qnop_user} lookup on the hot path; it stays correct because
+ * every transition that flips the flag also revokes the user's live tokens, forcing a fresh mint
+ * that reflects the new value. Runs after the resource-server authentication has populated the
+ * {@link JwtAuthenticationToken}.
  */
 @Component
 public class PasswordChangeRequiredFilter extends OncePerRequestFilter {
 
   private static final String AUTH_PREFIX = "/api/v1/auth/";
-
-  private final UserService userService;
-
-  public PasswordChangeRequiredFilter(UserService userService) {
-    this.userService = userService;
-  }
 
   @Override
   protected void doFilterInternal(
@@ -60,7 +57,7 @@ public class PasswordChangeRequiredFilter extends OncePerRequestFilter {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     if (authentication instanceof JwtAuthenticationToken jwt
         && !request.getRequestURI().startsWith(AUTH_PREFIX)
-        && requiresPasswordChange(jwt.getName())) {
+        && Boolean.TRUE.equals(jwt.getToken().getClaimAsBoolean(JwtTokenService.PCR_CLAIM))) {
       ApiErrorWriter.write(
           response,
           HttpStatus.FORBIDDEN,
@@ -69,20 +66,5 @@ public class PasswordChangeRequiredFilter extends OncePerRequestFilter {
       return;
     }
     filterChain.doFilter(request, response);
-  }
-
-  /**
-   * The JWT subject is the {@code qnop_user.id} (issue #17). A non-UUID subject can only come from
-   * a forged/legacy token; treat it as "no change required" so the auth filters reject it on the
-   * correct path rather than bleeding through as a 403.
-   */
-  private boolean requiresPasswordChange(String subject) {
-    final UUID userId;
-    try {
-      userId = UUID.fromString(subject);
-    } catch (IllegalArgumentException e) {
-      return false;
-    }
-    return userService.passwordChangeRequired(userId);
   }
 }

--- a/qnop-app/src/test/java/io/qnop/web/security/PasswordChangeRequiredFilterTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/PasswordChangeRequiredFilterTest.java
@@ -23,9 +23,8 @@ package io.qnop.web.security;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import io.qnop.service.UserService;
+import io.qnop.service.JwtTokenService;
 import jakarta.servlet.FilterChain;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -45,22 +44,18 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 /**
- * Unit tests for {@link PasswordChangeRequiredFilter}. Verifies the gate blocks protected paths for
- * a user that must change their password and — the focus of issue #165 — that the 403 body is the
- * uniform {@code ErrorResponse} envelope ({@code code}/{@code message}/{@code timestamp}) written
- * by {@link io.qnop.web.ApiErrorWriter}, not the legacy ad-hoc {@code error} field.
+ * Unit tests for {@link PasswordChangeRequiredFilter}. The gate is driven solely by the {@code pcr}
+ * claim on the verified access token (issue #167) — no DB lookup — and the 403 is the uniform
+ * {@code ErrorResponse} envelope (issue #165/#45).
  */
 @ExtendWith(MockitoExtension.class)
 class PasswordChangeRequiredFilterTest {
 
   private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
 
-  @Mock private UserService userService;
   @Mock private FilterChain filterChain;
 
-  private PasswordChangeRequiredFilter newFilter() {
-    return new PasswordChangeRequiredFilter(userService);
-  }
+  private final PasswordChangeRequiredFilter filter = new PasswordChangeRequiredFilter();
 
   @AfterEach
   void clearContext() {
@@ -68,15 +63,13 @@ class PasswordChangeRequiredFilterTest {
   }
 
   @Test
-  @DisplayName(
-      "blocks a protected path with the uniform ErrorResponse envelope when a change is required")
-  void blocksWithUniformEnvelope() throws Exception {
-    authenticateAs(USER_ID);
-    when(userService.passwordChangeRequired(USER_ID)).thenReturn(true);
+  @DisplayName("blocks a protected path with the uniform ErrorResponse envelope when pcr=true")
+  void blocksWhenPcrClaimTrue() throws Exception {
+    authenticateWithPcr(true);
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/users/me");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    newFilter().doFilter(request, response, filterChain);
+    filter.doFilter(request, response, filterChain);
 
     assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
     assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
@@ -91,38 +84,57 @@ class PasswordChangeRequiredFilterTest {
 
   @Test
   @DisplayName("never blocks an /api/v1/auth/ path so the user can change the password")
-  void allowsAuthPaths() throws Exception {
-    authenticateAs(USER_ID);
+  void allowsAuthPathsEvenWhenPcrTrue() throws Exception {
+    authenticateWithPcr(true);
     MockHttpServletRequest request =
         new MockHttpServletRequest("POST", "/api/v1/auth/change-password");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    newFilter().doFilter(request, response, filterChain);
+    filter.doFilter(request, response, filterChain);
 
     verify(filterChain).doFilter(request, response);
     assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
   }
 
   @Test
-  @DisplayName("lets the request through when no password change is required")
-  void allowsWhenNoChangeRequired() throws Exception {
-    authenticateAs(USER_ID);
-    when(userService.passwordChangeRequired(USER_ID)).thenReturn(false);
+  @DisplayName("lets the request through when pcr=false")
+  void allowsWhenPcrFalse() throws Exception {
+    authenticateWithPcr(false);
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/users/me");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    newFilter().doFilter(request, response, filterChain);
+    filter.doFilter(request, response, filterChain);
 
     verify(filterChain).doFilter(request, response);
   }
 
-  private static void authenticateAs(UUID subject) {
+  @Test
+  @DisplayName("lets the request through when the pcr claim is absent (legacy token)")
+  void allowsWhenPcrClaimAbsent() throws Exception {
     Jwt jwt =
         Jwt.withTokenValue("token")
             .header("alg", "none")
-            .subject(subject.toString())
+            .subject(USER_ID.toString())
             .issuedAt(Instant.EPOCH)
             .expiresAt(Instant.EPOCH.plusSeconds(900))
+            .build();
+    SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/users/me");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  private static void authenticateWithPcr(boolean pcr) {
+    Jwt jwt =
+        Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .subject(USER_ID.toString())
+            .issuedAt(Instant.EPOCH)
+            .expiresAt(Instant.EPOCH.plusSeconds(900))
+            .claim(JwtTokenService.PCR_CLAIM, pcr)
             .build();
     SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
   }

--- a/qnop-core/src/main/java/io/qnop/service/JwtTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/JwtTokenService.java
@@ -38,7 +38,12 @@ import org.springframework.stereotype.Service;
  * TokenRevocationService}) and the user's global {@link UserRole} as a {@value #ROLE_CLAIM} claim,
  * which the resource-server filter maps to a {@code ROLE_*} authority (issue #98). The role is
  * resolved at mint time — on both login and refresh — so a role change takes effect on the next
- * token. TTL and issuer come from {@code qnop.auth} (default 15m / {@code qnop}).
+ * token. The token also carries the user's {@value #PCR_CLAIM} (password-change-required) flag so
+ * the {@code PasswordChangeRequiredFilter} can gate every request from the token alone, with no
+ * per-request DB lookup (issue #167). Every transition that flips the flag (admin reset, generated
+ * password, self-service change) also revokes the user's live tokens, so a fresh mint always
+ * reflects the current flag — no stale-claim window. TTL and issuer come from {@code qnop.auth}
+ * (default 15m / {@code qnop}).
  */
 @Service
 public class JwtTokenService {
@@ -47,6 +52,12 @@ public class JwtTokenService {
    * Claim carrying the user's global role; mapped to {@code ROLE_<value>} by the resource server.
    */
   public static final String ROLE_CLAIM = "role";
+
+  /**
+   * Boolean claim: the user must change their password before any non-auth resource is reachable.
+   * Read by {@code PasswordChangeRequiredFilter} instead of a per-request DB lookup (issue #167).
+   */
+  public static final String PCR_CLAIM = "pcr";
 
   private final JwtEncoder jwtEncoder;
   private final QnopProperties properties;
@@ -59,13 +70,12 @@ public class JwtTokenService {
     this.userService = userService;
   }
 
-  /** Mints a signed access token for the given user id, embedding the user's current role. */
+  /**
+   * Mints a signed access token for the given user id, embedding the user's current role and
+   * password-change-required flag.
+   */
   public String issueAccessToken(UUID userId) {
-    UserRole role =
-        userService
-            .findById(userId)
-            .map(User::getRole)
-            .orElseThrow(() -> new UserNotFoundException(userId));
+    User user = userService.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
     QnopProperties.Auth auth = properties.auth();
     Instant now = Instant.now();
     JwtClaimsSet claims =
@@ -75,7 +85,8 @@ public class JwtTokenService {
             .issuedAt(now)
             .expiresAt(now.plus(auth.accessTokenTtl()))
             .subject(userId.toString())
-            .claim(ROLE_CLAIM, role.name())
+            .claim(ROLE_CLAIM, user.getRole().name())
+            .claim(PCR_CLAIM, user.isPasswordChangeRequired())
             .build();
     JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
     return jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -144,12 +144,6 @@ public class UserService {
     return user;
   }
 
-  /** Whether the given user must change their password before using the API (issue #17/#20). */
-  @Transactional(readOnly = true)
-  public boolean passwordChangeRequired(UUID id) {
-    return users.findById(id).map(User::isPasswordChangeRequired).orElse(false);
-  }
-
   /** Whether an internal user with the given username exists (bootstrap idempotency). */
   @Transactional(readOnly = true)
   public boolean internalUsernameExists(String username) {

--- a/qnop-core/src/test/java/io/qnop/service/JwtTokenServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/JwtTokenServiceTest.java
@@ -63,9 +63,14 @@ class JwtTokenServiceTest {
   private final JwtTokenService service = new JwtTokenService(encoder, properties(), userService);
 
   private UUID givenUserWithRole(UserRole role) {
+    return givenUser(role, false);
+  }
+
+  private UUID givenUser(UserRole role, boolean passwordChangeRequired) {
     UUID userId = UUID.randomUUID();
     User user = User.internal("Test User", "test@example.com", "test", "hash");
     user.setRole(role);
+    user.setPasswordChangeRequired(passwordChangeRequired);
     when(userService.findById(userId)).thenReturn(Optional.of(user));
     return userId;
   }
@@ -88,6 +93,8 @@ class JwtTokenServiceTest {
     assertThat(jwt.getIssuedAt()).isNotNull();
     assertThat(jwt.getExpiresAt()).isNotNull();
     assertThat(Duration.between(jwt.getIssuedAt(), jwt.getExpiresAt())).isEqualTo(TTL);
+    // pcr defaults to false for an ordinary account.
+    assertThat(jwt.getClaimAsBoolean(JwtTokenService.PCR_CLAIM)).isFalse();
   }
 
   @Test
@@ -98,6 +105,16 @@ class JwtTokenServiceTest {
     Jwt jwt = decoder.decode(service.issueAccessToken(userId));
 
     assertThat(jwt.getClaimAsString(JwtTokenService.ROLE_CLAIM)).isEqualTo("ADMIN");
+  }
+
+  @Test
+  @DisplayName("token carries the user's password-change-required flag as the 'pcr' claim")
+  void embedsPasswordChangeRequiredClaim() {
+    UUID userId = givenUser(UserRole.MEMBER, true);
+
+    Jwt jwt = decoder.decode(service.issueAccessToken(userId));
+
+    assertThat(jwt.getClaimAsBoolean(JwtTokenService.PCR_CLAIM)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #167. `PasswordChangeRequiredFilter` ran on **every** authenticated
non-`/auth` request and called `userService.passwordChangeRequired(userId)` — a
`SELECT` against `qnop_user` on the hot path, even when no change was required
(the common case).

Bake the flag into the access token as a boolean `pcr` claim at mint time. Both
login and refresh go through `JwtTokenService.issueAccessToken`, which already
loads the user for the `role` claim, so this adds **no** query. The filter now
reads `pcr` from the verified token and does no DB work.

## Why this is safe (no stale-claim bypass)

Every transition that flips the flag also invalidates the user's live tokens, so
the next usable token is always a fresh mint reflecting the current value:

- **Self-service change-password** → `updatePasswordHash` sets the flag `false`
  *and* `AuthService.changePassword` revokes all access + refresh tokens.
- **Admin reset / generated password** → set the flag `true` and bump
  `password_invalidated_before` + revoke refresh families.

A legacy token minted before this change simply lacks the claim and is treated
as `pcr=false` — a ≤15-minute window for the rare flagged user across a single
deploy.

`UserService.passwordChangeRequired(UUID)` was used only by this filter and is removed.

## Test plan

- `JwtTokenServiceTest`: token carries `pcr` (false by default; true when flagged).
- `PasswordChangeRequiredFilterTest` (pure unit, no DB): blocks on `pcr=true` with the uniform `ErrorResponse` envelope; passes through on `pcr=false`, absent claim, and `/api/v1/auth/*`.
- `./gradlew spotlessApply` + JWT/filter/ArchUnit tests green locally. Full filter integration coverage is tracked in #189.

## Note on overlap with #165

This rewrites `PasswordChangeRequiredFilter` and also emits the uniform
`ErrorResponse` envelope, so it **subsumes #165 (#210)**. Whichever merges
second should take this branch's claim-based version of the filter + test.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code