### PR TITLE
fix: decouple OIDC post-login redirect from CORS allowed-origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ QNOP_AUTH_ENCRYPTION_SALT=CHANGE_ME
 # Comma-separated list of exact origins allowed to call the API (the Vite dev server).
 QNOP_CORS_ALLOWED_ORIGINS=http://localhost:5173
 
+# Post-OIDC-login redirect base (issue #178). Leave blank for same-origin relative
+# redirects (SPA served from the API origin); set to the SPA's absolute origin
+# (e.g. https://app.example.com) when the SPA is hosted separately. Independent of
+# QNOP_CORS_ALLOWED_ORIGINS.
+QNOP_AUTH_OIDC_FRONTEND_BASE_URL=
+
 # --- Keycloak (local OIDC provider for testing "Sign in with …", issue #106) ---
 # Only used by the `keycloak` compose profile:  docker compose --profile keycloak up -d
 # Admin console + issuer live at http://localhost:8081. LOCAL DEV ONLY.

--- a/qnop-app/src/main/java/io/qnop/web/security/OidcLoginSuccessHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/OidcLoginSuccessHandler.java
@@ -30,7 +30,6 @@ import io.qnop.service.oidc.OidcLoginService.LoginResult;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -83,7 +82,7 @@ public class OidcLoginSuccessHandler implements AuthenticationSuccessHandler {
       response.addHeader(
           HttpHeaders.SET_COOKIE,
           cookieFactory.build(refresh.plaintext(), refresh.maxAge()).toString());
-      response.sendRedirect(frontendBase());
+      response.sendRedirect(frontendBase() + "/");
     } catch (RuntimeException e) {
       log.warn("OIDC login could not be completed: {}", e.getMessage());
       response.sendRedirect(frontendBase() + "/login?error=" + errorCode(e));
@@ -113,12 +112,12 @@ public class OidcLoginSuccessHandler implements AuthenticationSuccessHandler {
         : client.getAccessToken().getTokenValue();
   }
 
+  /**
+   * The post-OIDC-login redirect base (issue #178): a dedicated, CORS-independent setting. Blank
+   * means same-origin relative redirects (SPA served from the API origin); a configured value is an
+   * absolute, trailing-slash-trimmed {@code https://…} base for a separately-hosted SPA.
+   */
   private String frontendBase() {
-    List<String> origins = properties.cors().allowedOrigins();
-    if (origins == null || origins.isEmpty()) {
-      return "";
-    }
-    String base = origins.get(0);
-    return base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+    return properties.auth().oidc().frontendBaseUrl();
   }
 }

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -52,5 +52,9 @@ qnop:
     # NEVER enable in production.
     oidc:
       allow-private-discovery-uris: ${QNOP_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS:false}
+      # Post-OIDC-login redirect base (issue #178). Blank → same-origin relative redirects
+      # (SPA served from the API origin). Set to the SPA's absolute origin when hosted
+      # separately. Independent of CORS allowed-origins.
+      frontend-base-url: ${QNOP_AUTH_OIDC_FRONTEND_BASE_URL:}
   cors:
     allowed-origins: ${QNOP_CORS_ALLOWED_ORIGINS:http://localhost:5173}

--- a/qnop-app/src/test/java/io/qnop/service/RefreshTokenServiceTest.java
+++ b/qnop-app/src/test/java/io/qnop/service/RefreshTokenServiceTest.java
@@ -60,7 +60,8 @@ class RefreshTokenServiceTest {
                 Duration.ofMinutes(15),
                 Duration.ofDays(7),
                 "qnop",
-                Boolean.TRUE),
+                Boolean.TRUE,
+                null),
             new QnopProperties.Cors(null));
     RefreshTokenHasher hasher = new RefreshTokenHasher(new JwtKeyService(properties));
     service = new RefreshTokenService(repository, hasher, properties);

--- a/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
+++ b/qnop-core/src/main/java/io/qnop/security/QnopProperties.java
@@ -56,6 +56,7 @@ public record QnopProperties(@Valid Auth auth, @Valid Cors cors) {
    * @param issuer the {@code iss} claim of self-issued tokens (default {@code qnop})
    * @param cookieSecure whether the refresh cookie carries {@code Secure} (default true; set false
    *     only for local HTTP dev — browsers drop {@code Secure} cookies on plain HTTP)
+   * @param oidc OIDC/OAuth2 login settings (post-login redirect base, issue #178)
    */
   public record Auth(
       @ValidSecret String jwtSecret,
@@ -69,13 +70,38 @@ public record QnopProperties(@Valid Auth auth, @Valid Cors cors) {
       Duration accessTokenTtl,
       Duration refreshTokenTtl,
       String issuer,
-      Boolean cookieSecure) {
+      Boolean cookieSecure,
+      @Valid Oidc oidc) {
 
     public Auth {
       accessTokenTtl = accessTokenTtl != null ? accessTokenTtl : Duration.ofMinutes(15);
       refreshTokenTtl = refreshTokenTtl != null ? refreshTokenTtl : Duration.ofDays(7);
       issuer = (issuer == null || issuer.isBlank()) ? "qnop" : issuer;
       cookieSecure = cookieSecure == null ? Boolean.TRUE : cookieSecure;
+      oidc = oidc != null ? oidc : new Oidc(null);
+    }
+  }
+
+  /**
+   * OIDC/OAuth2 login settings (issue #178).
+   *
+   * @param frontendBaseUrl absolute base URL the browser is redirected to after an OIDC login (e.g.
+   *     {@code https://app.example.com}). Deliberately separate from the CORS origin list, which
+   *     governs API access only. Blank (the default) means same-origin relative redirects — correct
+   *     when the SPA is served from the API origin. A non-blank value must be an http(s) URL; a
+   *     trailing slash is trimmed.
+   */
+  public record Oidc(
+      @Pattern(
+              regexp = "^(https?://.+)?$",
+              message = "qnop.auth.oidc.frontend-base-url must be blank or an http(s) URL")
+          String frontendBaseUrl) {
+
+    public Oidc {
+      frontendBaseUrl = frontendBaseUrl == null ? "" : frontendBaseUrl.trim();
+      if (frontendBaseUrl.endsWith("/")) {
+        frontendBaseUrl = frontendBaseUrl.substring(0, frontendBaseUrl.length() - 1);
+      }
     }
   }
 

--- a/qnop-core/src/test/java/io/qnop/security/CryptoConfigurationTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/CryptoConfigurationTest.java
@@ -44,6 +44,7 @@ class CryptoConfigurationTest {
             null,
             null,
             null,
+            null,
             null),
         new QnopProperties.Cors(List.of()));
   }

--- a/qnop-core/src/test/java/io/qnop/security/JwtKeyServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/security/JwtKeyServiceTest.java
@@ -42,6 +42,7 @@ class JwtKeyServiceTest {
                 null,
                 null,
                 null,
+                null,
                 null),
             new QnopProperties.Cors(List.of()));
     return new JwtKeyService(properties);

--- a/qnop-core/src/test/java/io/qnop/service/JwtTokenServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/JwtTokenServiceTest.java
@@ -130,6 +130,7 @@ class JwtTokenServiceTest {
             TTL,
             Duration.ofDays(7),
             ISSUER,
+            null,
             null),
         new QnopProperties.Cors(List.of()));
   }

--- a/qnop-core/src/test/java/io/qnop/service/TokenRevocationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TokenRevocationServiceTest.java
@@ -204,6 +204,7 @@ class TokenRevocationServiceTest {
             Duration.ofMinutes(15),
             Duration.ofDays(7),
             "qnop-test",
+            null,
             null),
         new QnopProperties.Cors(List.of()));
   }


### PR DESCRIPTION
## Summary

`OidcLoginSuccessHandler.frontendBase()` derived the post-login redirect from `cors().allowedOrigins().get(0)`. CORS origins govern *who may call the API*; the post-login redirect governs *where the browser goes after auth*. The moment a second CORS origin is added (an API client, Swagger UI, the enterprise overlay), OIDC login silently redirects to the first list element — and `sendRedirect()` never surfaces an error.

Adds a dedicated **`qnop.auth.oidc.frontend-base-url`** (`QnopProperties.Auth.Oidc`):

- **blank (default)** → same-origin relative redirects, correct when the SPA is served from the API origin;
- a configured value is validated as an `http(s)` URL (fail fast on a malformed setting; trailing slash trimmed).

`OidcLoginSuccessHandler` reads the property; the success redirect targets `<base>/` so it works for both an absolute base and the blank same-origin case. CORS origins now drive CORS only. Wired in `application.yml` + `.env.example`.

> The issue also suggested failing fast "when OIDC providers are configured." Providers are **DB-dynamic** (admin API), so they aren't known at startup binding time — instead the property is validated when set, and blank is a safe documented default. Noted for transparency.

## Test plan

- [x] `:qnop-core:build`, `:qnop-app` compile, `ArchitectureRulesTest`, `QnopPropertiesBindingTest` green; the 5 direct `QnopProperties.Auth` test constructors updated for the new arg.
- No existing test asserts the OIDC redirect base (no behavioural test broke).

Closes #178

🤖 Co-Author: Claude (Opus 4.x) via Claude Code