### PR TITLE
fix: accessible name for the UsersPage search field (#173)

### DIFF
--- a/qnop-ui/src/pages/admin/UsersPage.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.tsx
@@ -196,6 +196,7 @@ export function UsersPage() {
           sx={{ flex: 1, minWidth: 240, maxWidth: 420 }}
           slotProps={{
             input: {
+              'aria-label': 'Search users',
               startAdornment: (
                 <InputAdornment position="start">
                   <Search size={16} />


### PR DESCRIPTION
## What

Adds `aria-label="Search users"` to the admin UsersPage search `TextField` (via `slotProps.input`), which previously relied on placeholder text only and had no accessible name. Closes #173.

## Test plan
- [x] lint, format:check, typecheck, vitest (src/pages/admin — 20 passed)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code