### PR TITLE
perf: skip the guaranteed-empty avatar lookup on user creation

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminUserController.java
@@ -96,8 +96,9 @@ public class AdminUserController implements AdminUsersApi {
             request.getEmail(),
             request.getRole().name(),
             request.getInitialPassword());
-    return ResponseEntity.status(HttpStatus.CREATED)
-        .body(toDetail(created, avatarUpdatedAt(created)));
+    // A brand-new user has no avatar yet, so pass null directly and skip the
+    // guaranteed-empty avatar lookup (issue #179).
+    return ResponseEntity.status(HttpStatus.CREATED).body(toDetail(created, null));
   }
 
   @Override


### PR DESCRIPTION
## Summary

`AdminUserController.createUser()` called `avatarUpdatedAt(created)`, which runs `avatars.updatedAt(userId)` → `storage.findUpdatedAt(userId)` unconditionally. A user created moments earlier cannot have an avatar, so this is a wasted DB round-trip on every creation. Pass `null` directly to `toDetail()`.

The response is unchanged: a brand-new user's `avatarUrl` carries no cache-bust timestamp whether derived from `null` or from an empty lookup.

(`getUser()`'s single lookup is left as-is — acceptable per the issue.)

## Test plan

- [x] `:qnop-app` compile + `ArchitectureRulesTest` green.
- [ ] `AdminUserControllerIT` (Testcontainers, CI) — created-user response unchanged.

Closes #179

🤖 Co-Author: Claude (Opus 4.x) via Claude Code