### PR TITLE
fix: re-apply the SSRF policy when (re)building OIDC registrations

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/oidc/DbClientRegistrationRepository.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/DbClientRegistrationRepository.java
@@ -56,11 +56,14 @@ public class DbClientRegistrationRepository
   private static final Logger log = LoggerFactory.getLogger(DbClientRegistrationRepository.class);
 
   private final io.qnop.repository.OidcProviderRepository providers;
+  private final OidcSsrfPolicy ssrfPolicy;
   private final AtomicReference<Map<String, ClientRegistration>> cache =
       new AtomicReference<>(Map.of());
 
-  public DbClientRegistrationRepository(io.qnop.repository.OidcProviderRepository providers) {
+  public DbClientRegistrationRepository(
+      io.qnop.repository.OidcProviderRepository providers, OidcSsrfPolicy ssrfPolicy) {
     this.providers = providers;
+    this.ssrfPolicy = ssrfPolicy;
   }
 
   @PostConstruct
@@ -107,6 +110,11 @@ public class DbClientRegistrationRepository
   }
 
   private ClientRegistration buildRegistration(OidcProvider provider, String registrationId) {
+    // Re-validate the stored URIs against the SSRF policy at use time, not only when the operator
+    // saved them (issue #168): discovery (fromIssuerLocation) and the OAuth2 endpoints below issue
+    // outbound requests, so a row whose URI is internal — e.g. via a policy change or a direct DB
+    // edit — must be blocked here too. A violation throws, and refresh() logs and skips the row.
+    validateOutboundUris(provider);
     ClientRegistration.Builder builder =
         switch (provider.getProviderType()) {
           case OIDC ->
@@ -143,6 +151,26 @@ public class DbClientRegistrationRepository
         .redirectUri(REDIRECT_URI)
         .scope(scopes(provider))
         .build();
+  }
+
+  /**
+   * Re-applies the {@link OidcSsrfPolicy} to the URIs this provider will fetch, mirroring the
+   * write-time validation in {@code OidcProviderService}. The hosted providers (Google/GitHub/
+   * Facebook) use hard-coded public endpoints and need no check.
+   */
+  private void validateOutboundUris(OidcProvider provider) {
+    switch (provider.getProviderType()) {
+      case OIDC -> ssrfPolicy.requirePublicHttpUri(provider.getIssuerUri(), "issuerUri", true);
+      case OAUTH2 -> {
+        ssrfPolicy.requirePublicHttpUri(provider.getAuthorizationUri(), "authorizationUri", true);
+        ssrfPolicy.requirePublicHttpUri(provider.getTokenUri(), "tokenUri", true);
+        ssrfPolicy.requirePublicHttpUri(provider.getUserInfoUri(), "userInfoUri", true);
+        ssrfPolicy.requirePublicHttpUri(provider.getJwkSetUri(), "jwkSetUri", false);
+      }
+      default -> {
+        // GOOGLE/GITHUB/FACEBOOK: hard-coded public endpoints, nothing operator-supplied to fetch.
+      }
+    }
   }
 
   private static List<String> scopes(OidcProvider provider) {

--- a/qnop-core/src/test/java/io/qnop/service/oidc/DbClientRegistrationRepositoryTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/DbClientRegistrationRepositoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.OidcProvider;
+import io.qnop.entity.OidcProviderType;
+import io.qnop.repository.OidcProviderRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for the SSRF re-validation in {@link DbClientRegistrationRepository#refresh()} (issue
+ * #168): a stored provider whose issuer/endpoint resolves to a private/loopback/metadata host must
+ * be blocked at use time and skipped, with no outbound discovery fetch attempted.
+ */
+class DbClientRegistrationRepositoryTest {
+
+  private final OidcProviderRepository providers = mock(OidcProviderRepository.class);
+  private final OidcSsrfPolicy denyPrivate = new OidcSsrfPolicy(false);
+  private final DbClientRegistrationRepository repository =
+      new DbClientRegistrationRepository(providers, denyPrivate);
+
+  @Test
+  @DisplayName(
+      "skips an enabled OIDC provider whose stored issuer targets a metadata/internal host")
+  void skipsProviderWithBlockedIssuerOnRefresh() {
+    OidcProvider internal = enabledOidcProvider("http://169.254.169.254/.well-known");
+    when(providers.findAll()).thenReturn(List.of(internal));
+
+    repository.refresh();
+
+    // Blocked by the SSRF policy before any discovery fetch → not in the cache.
+    assertThat(repository.findByRegistrationId(OidcRegistrationIds.of(internal.getId()))).isNull();
+    assertThat(repository).isEmpty();
+  }
+
+  @Test
+  @DisplayName("skips an enabled OIDC provider whose stored issuer is localhost")
+  void skipsProviderWithLocalhostIssuerOnRefresh() {
+    OidcProvider internal = enabledOidcProvider("https://localhost:8443/realms/internal");
+    when(providers.findAll()).thenReturn(List.of(internal));
+
+    repository.refresh();
+
+    assertThat(repository).isEmpty();
+  }
+
+  private static OidcProvider enabledOidcProvider(String issuerUri) {
+    OidcProvider provider = new OidcProvider("internal", OidcProviderType.OIDC, "client-id");
+    // The id is Hibernate-assigned at persist time; set it here so OidcRegistrationIds.of works.
+    ReflectionTestUtils.setField(provider, "id", UUID.randomUUID());
+    provider.setEnabled(true);
+    provider.setClientSecret("secret");
+    provider.setIssuerUri(issuerUri);
+    return provider;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #168. `OidcProviderService` validates every operator-supplied URI against
`OidcSsrfPolicy` at **write** time, but `DbClientRegistrationRepository.refresh()`
rebuilt the registrations directly from the stored rows and ran OIDC discovery
(`ClientRegistrations.fromIssuerLocation`) — an outbound fetch — **without**
re-checking. A row whose issuer/endpoint resolves to an internal target (via a
relaxed policy, a direct DB edit, or a future import path) would be fetched: a
classic validate-at-use SSRF gap.

## Change

- Inject `OidcSsrfPolicy` into `DbClientRegistrationRepository` and re-validate
  the URIs a provider will fetch inside `buildRegistration`, mirroring the
  write-time rules:
  - **OIDC** → `issuerUri` (required)
  - **OAUTH2** → `authorizationUri` / `tokenUri` / `userInfoUri` (required), `jwkSetUri` (optional)
  - Google/GitHub/Facebook use hard-coded public endpoints → no check.
- A blocked URI throws; the existing `refresh()` `catch` logs and **skips** just
  that provider, so one bad row never fails the whole refresh.

## Test plan

- New `DbClientRegistrationRepositoryTest` (pure unit, no network): an enabled
  OIDC provider whose stored issuer is `169.254.169.254` (cloud metadata) or
  `localhost` is blocked at `refresh()` and absent from the cache — proving the
  guard fires **before** any discovery fetch.
- `./gradlew spotlessApply :qnop-core:test` + ArchUnit green locally.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code