### PR TITLE
fix: enable "strict": true in tsconfig.app.json (#174)

### DIFF
--- a/qnop-ui/tsconfig.app.json
+++ b/qnop-ui/tsconfig.app.json
@@ -8,6 +8,7 @@
     // `import { URL } from 'url'`; at runtime a Vite alias maps it to a shim.
     "types": ["vite/client", "node"],
     "skipLibCheck": true,
+    "strict": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## What

Adds `"strict": true` to `qnop-ui/tsconfig.app.json`, enabling null-safety, implicit-any, strict-function-type and strict-property-init checks across the hand-written `src/` tree. Closes #174.

A forced clean type-check (`tsc -b --noEmit --force`, with the incremental buildinfo removed) reports **0 errors** — the existing code and the generated `typescript-axios` client are already strict-clean, so this is preventive: future null-unsafe / implicit-any regressions now fail `tsc`.

## Test plan
- [x] `tsc -b --force` (0 errors), lint, format:check

🤖 Co-Author: Claude (Opus 4.x) via Claude Code