### PR TITLE
fix: application_asset.uploaded_by FK uses ON DELETE SET NULL

### DIFF
--- a/docs/adr/0024-branding-asset-storage.md
+++ b/docs/adr/0024-branding-asset-storage.md
@@ -44,8 +44,8 @@ Rationale:
   object store on the (cacheable) read path.
 
 The Postgres-only invariants — the `slot` and `content_type` CHECK domains, the
-`(slot)` uniqueness, and the no-cascade `uploaded_by → qnop_user` foreign key —
-live in Liquibase, not JPA annotations (ADR-0020). The `slot` column stores the
+`(slot)` uniqueness, and the `ON DELETE SET NULL` `uploaded_by → qnop_user` foreign
+key (issue #180) — live in Liquibase, not JPA annotations (ADR-0020). The `slot` column stores the
 snake_case `BrandingSlot.dbValue` via an `AttributeConverter`, keeping the
 persisted values aligned with the CHECK domain and with the URL form used in
 issue #23.
@@ -57,9 +57,10 @@ issue #23.
 - Large/numerous binary assets must **not** follow this pattern — review
   documents stay in object storage. This decision is scoped to small, bounded,
   config-like branding assets.
-- `uploaded_by` does not cascade: a user who uploaded a branding asset cannot be
-  deleted until the asset row is reassigned or removed. Acceptable because
-  branding rows are few and admin-managed.
+- `uploaded_by` is audit-only and uses `ON DELETE SET NULL` (issue #180,
+  consistent with `application_setting.updated_by`): deleting an uploader nulls the
+  attribution rather than blocking the delete. (The original no-cascade choice made
+  uploaders undeletable — a 500 on user delete — which this corrects.)
 - SVG sanitization, size caps, SHA-256/size computation, and the upload/read
   endpoints are deferred to the branding service work (issue #23); #15 is schema
   + entity + repository only.

--- a/qnop-app/src/test/java/io/qnop/branding/ApplicationAssetSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/branding/ApplicationAssetSchemaIT.java
@@ -29,6 +29,8 @@ import io.qnop.entity.BrandingSlot;
 import io.qnop.entity.User;
 import io.qnop.repository.ApplicationAssetRepository;
 import io.qnop.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,9 +41,9 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Verifies the application-asset / branding schema (issue #15) against a real PostgreSQL
  * (ADR-0020): UUIDv7 generation, the {@code bytea} round-trip, the snake_case slot mapping, the
- * Postgres-only CHECK and {@code (slot)} unique constraints that JPA cannot express, and the
- * no-cascade {@code uploaded_by} foreign key. Each test runs in a rolled-back transaction for
- * isolation. Extends {@link AbstractIntegrationTest}, which boots the full context against
+ * Postgres-only CHECK and {@code (slot)} unique constraints that JPA cannot express, and the {@code
+ * ON DELETE SET NULL} {@code uploaded_by} foreign key. Each test runs in a rolled-back transaction
+ * for isolation. Extends {@link AbstractIntegrationTest}, which boots the full context against
  * Testcontainers. Requires Docker.
  */
 @Transactional
@@ -52,6 +54,7 @@ class ApplicationAssetSchemaIT extends AbstractIntegrationTest {
   @Autowired ApplicationAssetRepository assets;
   @Autowired UserRepository users;
   @Autowired JdbcTemplate jdbc;
+  @PersistenceContext EntityManager entityManager;
 
   private static ApplicationAsset asset(BrandingSlot slot, UUID uploadedBy) {
     return ApplicationAsset.create(slot, "image/png", PNG, "deadbeef", PNG.length, uploadedBy);
@@ -141,15 +144,16 @@ class ApplicationAssetSchemaIT extends AbstractIntegrationTest {
   }
 
   @Test
-  void blocksUserDeletionWhileAssetReferencesThem() {
+  void nullsUploadedByWhenUploaderIsDeleted() {
     User uploader = users.saveAndFlush(User.external("Uploader", "uploader@example.com"));
-    assets.saveAndFlush(asset(BrandingSlot.LOGO_DARK, uploader.getId()));
+    UUID assetId = assets.saveAndFlush(asset(BrandingSlot.LOGO_DARK, uploader.getId())).getId();
 
-    assertThatThrownBy(
-            () -> {
-              users.deleteById(uploader.getId());
-              users.flush(); // force the DELETE so the no-cascade FK rejects it
-            })
-        .isInstanceOf(DataIntegrityViolationException.class);
+    // ON DELETE SET NULL (issue #180): deleting the uploader must succeed and null the attribution,
+    // not block the delete with a FK violation.
+    users.deleteById(uploader.getId());
+    users.flush();
+    entityManager.clear(); // the SET NULL happens in the DB, outside Hibernate's L1 cache
+
+    assertThat(assets.findById(assetId).orElseThrow().getUploadedBy()).isNull();
   }
 }

--- a/qnop-core/src/main/java/io/qnop/entity/ApplicationAsset.java
+++ b/qnop-core/src/main/java/io/qnop/entity/ApplicationAsset.java
@@ -38,10 +38,10 @@ import org.hibernate.annotations.UuidGenerator;
  *
  * <p>The bytes live in Postgres ({@code bytea}) rather than object storage so a database backup is
  * a complete restore; see ADR-0024 (and plugwerk's ADR-0037 as prior art). The {@code slot} and
- * {@code content_type} domains, the {@code (slot)} uniqueness, and the no-cascade {@code
- * uploaded_by → qnop_user} foreign key are enforced in Liquibase (migration {@code 0005}), not in
- * JPA annotations (ADR-0020); JPA runs {@code ddl-auto=none}. Identifiers are UUIDv7, generated
- * application-side by Hibernate.
+ * {@code content_type} domains, the {@code (slot)} uniqueness, and the {@code ON DELETE SET NULL}
+ * {@code uploaded_by → qnop_user} foreign key are enforced in Liquibase (migration {@code 0005}),
+ * not in JPA annotations (ADR-0020); JPA runs {@code ddl-auto=none}. Identifiers are UUIDv7,
+ * generated application-side by Hibernate.
  */
 @Entity
 @Table(name = "application_asset")
@@ -74,7 +74,8 @@ public class ApplicationAsset {
   private Instant uploadedAt;
 
   /**
-   * The user who uploaded the asset, if known. Nullable; the FK does not cascade on user delete.
+   * The user who uploaded the asset, if known. Nullable, audit-only; the FK is {@code ON DELETE SET
+   * NULL}, so deleting the uploader nulls this rather than blocking the delete (issue #180).
    */
   @Column(name = "uploaded_by")
   private UUID uploadedBy;

--- a/qnop-core/src/main/resources/db/changelog/migrations/0005-application-asset-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0005-application-asset-schema.yaml
@@ -48,15 +48,17 @@ databaseChangeLog:
             tableName: application_asset
             columnNames: slot
             constraintName: ux_application_asset_slot
-        # No ON DELETE action (no cascade, issue #15): a user who uploaded a
-        # branding asset cannot be deleted until the asset row is reassigned or
-        # removed. Contrast oidc_identity, whose user FK cascades.
+        # uploaded_by is a nullable, audit-only reference. ON DELETE SET NULL so
+        # deleting an uploader nulls the attribution rather than blocking the delete
+        # (issue #180) — consistent with application_setting.updated_by. No FK index:
+        # the table holds at most one row per branding slot, so a scan is trivial.
         - addForeignKeyConstraint:
             baseTableName: application_asset
             baseColumnNames: uploaded_by
             referencedTableName: qnop_user
             referencedColumnNames: id
             constraintName: fk_application_asset_user
+            onDelete: SET NULL
         - sql:
             comment: Postgres-only CHECK constraints on the slot + content_type domains.
             splitStatements: true


### PR DESCRIPTION
## Summary

`fk_application_asset_user` had no `ON DELETE` action → defaults to `RESTRICT`, so deleting any user who had ever uploaded a branding asset failed at the DB level. `AdminUserService.delete()` let the `DataIntegrityViolationException` propagate as a generic **500**, with no way for the admin to unlock the delete.

`uploaded_by` is nullable and audit-only, so **`ON DELETE SET NULL`** is the natural fix (consistent with `application_setting.updated_by`): deleting an uploader nulls the attribution rather than blocking the delete.

## Notes

- **Pre-production**, so the existing `0005` changeset is edited in place rather than adding a new migration (fresh DBs re-run the changelog; dev DBs are disposable). Existing local dev DBs need a recreate.
- No FK index added — `application_asset` holds at most one row per branding slot, so a scan on the SET NULL is trivial (unlike `application_setting`).
- `ADR-0024` consequence + entity Javadoc updated from "no-cascade" to `ON DELETE SET NULL`.

## Test plan

- [x] `:qnop-core:build` + `:qnop-app` compile + `ArchitectureRulesTest` green.
- [ ] `ApplicationAssetSchemaIT` (Testcontainers, CI): the old "delete is blocked" test is replaced by `nullsUploadedByWhenUploaderIsDeleted` — the uploader can be deleted and `uploaded_by` becomes null.

Closes #180

🤖 Co-Author: Claude (Opus 4.x) via Claude Code