### PR TITLE
fix: surface OIDC discovery failures instead of swallowing them (#175)

### DIFF
--- a/qnop-ui/src/components/admin/oidc/OidcProviderFormDialog.tsx
+++ b/qnop-ui/src/components/admin/oidc/OidcProviderFormDialog.tsx
@@ -183,13 +183,20 @@ export function OidcProviderFormDialog({
     submitAttempted ? errors[field] : undefined;
 
   const runDiscover = async () => {
-    await discover.mutateAsync(issuerUri.trim()).then((result) => {
+    setError(null);
+    try {
+      const result = await discover.mutateAsync(issuerUri.trim());
       if (!result.success) return;
       if (result.authorizationUri) setAuthorizationUri(result.authorizationUri);
       if (result.tokenUri) setTokenUri(result.tokenUri);
       if (result.userInfoUri) setUserInfoUri(result.userInfoUri);
       if (result.jwkSetUri) setJwkSetUri(result.jwkSetUri);
-    });
+    } catch (err) {
+      // mutateAsync rethrows on TCP failure / 5xx / rate limit (unlike the
+      // endpoint's 200 + success:false). Surface it instead of leaving an
+      // unhandled rejection.
+      setError(apiErrorMessage(err, 'Could not reach the issuer to discover its endpoints.'));
+    }
   };
 
   // Editing the issuer invalidates a previous discovery result so the banner


### PR DESCRIPTION
## What

`runDiscover` awaited `discover.mutateAsync` with no `try/catch`, used directly as `onClick`. On a TCP failure, 5xx, or rate limit (which `mutateAsync` rethrows — unlike the endpoint's `200` + `success:false`), the rejection was unhandled and the user saw nothing. Wrap it in `try/catch` and surface the error through the dialog's existing error `Alert` (the same `setError` path `onSubmit` uses). Closes #175.

## Test plan
- [x] lint, format:check, typecheck, vitest (oidc dialog — 3 passed)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code