### PR TITLE
perf: memoize the MUI theme in Root with useMemo

### DIFF
--- a/qnop-ui/src/main.tsx
+++ b/qnop-ui/src/main.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { StrictMode } from 'react';
+import { StrictMode, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
@@ -42,7 +42,9 @@ import { useUiStore } from './stores/uiStore';
 
 function Root() {
   const themeMode = useUiStore((s) => s.themeMode);
-  const theme = buildTheme(themeMode);
+  // Rebuild the MUI theme only when the mode changes, not on every Root re-render — a fresh theme
+  // identity would otherwise cascade a re-render through every themed component (issue #170).
+  const theme = useMemo(() => buildTheme(themeMode), [themeMode]);
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary

Fixes #170. `Root` called `buildTheme(themeMode)` on every render, producing a
new `Theme` object identity each time. Any `Root` re-render (e.g. React Query
state propagating) handed `ThemeProvider` a fresh theme and cascaded a re-render
through every themed component.

## Change

- `const theme = useMemo(() => buildTheme(themeMode), [themeMode]);` — the theme
  is rebuilt only when the mode actually changes.

## Test plan

- `eslint src/main.tsx` clean (incl. the `react-hooks` exhaustive-deps rule).
- `prettier --check src/main.tsx` clean.
- Full `tsc -b` / `vite build` run in CI: they depend on `generate:api`, which
  downloads the OpenAPI generator binary (needs network, unavailable in my local
  sandbox — the frontend analogue of Docker-only backend ITs).

🤖 Co-Author: Claude (Opus 4.x) via Claude Code