### PR TITLE
test(ci): OIDC login smoke test against Keycloak (#225)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
         run: docker compose -f docker-compose.smoke.yml up -d --build
       - name: Run smoke tests
         run: bash scripts/smoke-test.sh
+      # OIDC login smoke test (#225): a sidecar that shares the app's network
+      # namespace drives the full authorization-code flow against the bundled
+      # Keycloak. Runs after the basic smoke (which seeds the database).
+      - name: Run OIDC login smoke test
+        run: docker compose -f docker-compose.smoke.yml run --rm smoke-oidc
       - name: Dump container logs on failure
         if: failure()
         run: docker compose -f docker-compose.smoke.yml logs --no-color

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# Test-deployment stack for the CI smoke tests (issue #207): a standalone
-# PostgreSQL plus the qnop server built from the repo Dockerfile. This is NOT a
-# production or local-dev stack — the QNOP_AUTH_* values below are throwaway test
-# secrets that intentionally match the encryption key/salt used to produce
-# testdata/db/seed.sql, so the seeded rows (e.g. the OIDC client secret) stay
-# decryptable. MinIO is omitted: object storage is not consumed yet.
+# Test-deployment stack for the CI smoke tests (issues #207, #225): a standalone
+# PostgreSQL, the qnop server built from the repo Dockerfile, and a Keycloak
+# identity provider for the OIDC login smoke test. This is NOT a production or
+# local-dev stack — the QNOP_AUTH_* values below are throwaway test secrets that
+# intentionally match the encryption key/salt used to produce testdata/db/seed.sql,
+# so the seeded rows (e.g. the OIDC client secret) stay decryptable. MinIO is
+# omitted: object storage is not consumed yet.
 #
 # Usage:  docker compose -f docker-compose.smoke.yml up -d --build
 #         bash scripts/smoke-test.sh
+#         docker compose -f docker-compose.smoke.yml run --rm smoke-oidc
 #         docker compose -f docker-compose.smoke.yml down -v
 
 services:
@@ -42,5 +44,59 @@ services:
       QNOP_AUTH_ENCRYPTION_KEY: integration-test-encryption-key-0123456789
       QNOP_AUTH_ENCRYPTION_SALT: 0123456789abcdef0123456789abcdef
       QNOP_CORS_ALLOWED_ORIGINS: http://localhost:5173
+      # The Keycloak issuer is a private/container host; the SSRF guard blocks
+      # discovery against it unless explicitly allowed (test deployment only).
+      QNOP_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS: 'true'
+      # The smoke deployment serves plain HTTP, so the refresh cookie must not be
+      # Secure-only (otherwise it could not be replayed over http in a test).
+      QNOP_AUTH_COOKIE_SECURE: 'false'
     ports:
       - '8080:8080'
+
+  # Local OIDC provider for the login smoke test (issue #225). Imports the same
+  # realm shipped for local dev (realm `qnop`, confidential client `qnop-local`,
+  # users alice/bob). No host port is published — the app reaches it on the
+  # compose network as http://keycloak:8080 and the smoke-oidc sidecar shares the
+  # app's network namespace, so both use that single issuer hostname.
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.6@sha256:9b0330756022422149aa6502eb2def8cd47c6e1b000c7c65cdb13e7c0133e992
+    command: ['start-dev', '--import-realm']
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: 'true'
+    volumes:
+      - ./docker/keycloak:/opt/keycloak/data/import:ro
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q '200'",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  # OIDC login smoke runner (issue #225). Runs on demand:
+  #   docker compose -f docker-compose.smoke.yml run --rm smoke-oidc
+  # It shares the app's network namespace so `localhost:8080` is the app (an
+  # already-whitelisted redirect host in the realm) and `keycloak:8080` resolves
+  # the same way the app sees it — keeping the OIDC issuer consistent across the
+  # back-channel (app↔Keycloak) and front-channel (curl↔Keycloak) without editing
+  # the dev realm. Requires the database to have been seeded first (smoke-test.sh).
+  smoke-oidc:
+    # Tag-only (no digest): a throwaway test runner; Renovate pins the digest.
+    image: alpine:3.20
+    profiles: ['oidc']
+    network_mode: 'service:app'
+    depends_on:
+      app:
+        condition: service_started
+      keycloak:
+        condition: service_healthy
+    volumes:
+      - .:/work:ro
+    working_dir: /work
+    entrypoint:
+      ['sh', '-c', 'apk add --no-cache bash curl jq >/dev/null && exec bash scripts/smoke-oidc.sh']

--- a/scripts/smoke-oidc.sh
+++ b/scripts/smoke-oidc.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# OIDC login smoke test against Keycloak (issue #225). Drives the full
+# authorization-code flow over HTTP and asserts that a real deployment can log a
+# user in via an OIDC provider end-to-end:
+#
+#   admin token -> register+enable the Keycloak provider (discover/create/enable)
+#   -> initiate /oauth2/authorization/{id} -> Keycloak login form -> callback
+#   -> assert success redirect to the SPA + qnop_refresh cookie + JIT provisioning.
+#
+# Designed to run in a container that SHARES the app's network namespace
+# (network_mode: service:app), so `localhost:8080` is the app (a redirect host
+# the realm already whitelists) and `keycloak:8080` resolves exactly as the app
+# sees it — keeping the OIDC issuer consistent on both channels. The database must
+# already be seeded (scripts/smoke-test.sh runs first in CI).
+set -euo pipefail
+
+APP="${SMOKE_APP_URL:-http://localhost:8080}"
+KC="${SMOKE_KC_URL:-http://keycloak:8080}"
+ISSUER="${KC}/realms/qnop"
+FRONTEND_BASE="http://localhost:5173"
+
+ADMIN_USER="admin"
+ADMIN_PASS="Test-Pass-1234!"
+KC_USER="alice"
+KC_PASS="password"
+KC_EMAIL="alice@qnop.test"
+CLIENT_ID="qnop-local"
+CLIENT_SECRET="local-dev-secret-do-not-use-in-prod"
+
+JAR="$(mktemp)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$JAR" "$TMP"' EXIT
+
+log() { echo "[oidc-smoke] $*"; }
+fail() {
+  echo "[oidc-smoke] FAIL: $*" >&2
+  exit 1
+}
+# Location header value of a saved response (CR-stripped).
+location() { grep -i '^location:' "$1" | tr -d '\r' | sed -E 's/^[Ll]ocation:[[:space:]]*//'; }
+
+wait_for() {
+  local name="$1" url="$2" ok=
+  for _ in $(seq 1 60); do
+    if curl -sf "$url" >/dev/null 2>&1; then
+      ok=1
+      break
+    fi
+    sleep 3
+  done
+  [ -n "$ok" ] || fail "$name did not become ready in time ($url)"
+}
+
+# 0) Wait for the app and the Keycloak realm.
+wait_for "app" "${APP}/actuator/health"
+log "app healthy"
+wait_for "keycloak realm" "${ISSUER}/.well-known/openid-configuration"
+log "keycloak realm ready"
+
+# 1) Admin token (the DB was seeded by smoke-test.sh).
+token="$(
+  curl -sf -X POST "${APP}/api/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"usernameOrEmail\":\"${ADMIN_USER}\",\"password\":\"${ADMIN_PASS}\"}" | jq -r '.accessToken'
+)"
+[ -n "$token" ] && [ "$token" != "null" ] || fail "admin login failed (was the DB seeded by smoke-test.sh first?)"
+AUTH=(-H "Authorization: Bearer ${token}")
+log "admin token acquired"
+
+# 2) Discover the Keycloak issuer (proves app->Keycloak reachability + SSRF allowance).
+disc="$(
+  curl -sf "${AUTH[@]}" -X POST "${APP}/api/v1/admin/oidc-providers/discover" \
+    -H 'Content-Type: application/json' -d "{\"issuerUri\":\"${ISSUER}\"}" || true
+)"
+[ -n "$(echo "$disc" | jq -r '.authorizationUri // empty')" ] || fail "issuer discovery failed: ${disc}"
+log "issuer discovered"
+
+# 3) Create + enable the provider (created disabled).
+pid="$(
+  curl -sf "${AUTH[@]}" -X POST "${APP}/api/v1/admin/oidc-providers" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"keycloak\",\"providerType\":\"OIDC\",\"clientId\":\"${CLIENT_ID}\",\"clientSecret\":\"${CLIENT_SECRET}\",\"issuerUri\":\"${ISSUER}\",\"scope\":\"openid email profile\"}" |
+    jq -r '.id'
+)"
+[ -n "$pid" ] && [ "$pid" != "null" ] || fail "provider creation failed"
+curl -sf "${AUTH[@]}" -X PATCH "${APP}/api/v1/admin/oidc-providers/${pid}" \
+  -H 'Content-Type: application/json' -d '{"enabled":true}' >/dev/null || fail "enabling the provider failed"
+log "provider ${pid} created + enabled"
+
+# 4) Initiate the authorization request -> 302 to Keycloak's authorization endpoint.
+curl -s -c "$JAR" -b "$JAR" -o /dev/null -D "${TMP}/a" "${APP}/oauth2/authorization/${pid}"
+auth_url="$(location "${TMP}/a")"
+case "$auth_url" in
+  *"/protocol/openid-connect/auth"*) : ;;
+  *) fail "no Keycloak authorization redirect (got: ${auth_url:-<none>})" ;;
+esac
+log "authorization request initiated"
+
+# 5) Fetch the Keycloak login page and extract the form POST action.
+curl -s -c "$JAR" -b "$JAR" -o "${TMP}/login.html" "$auth_url"
+form_action="$(
+  grep -oiE '<form[^>]+id="kc-form-login"[^>]+action="[^"]+"' "${TMP}/login.html" |
+    sed -E 's/.*action="([^"]+)".*/\1/' | sed 's/&amp;/\&/g'
+)"
+if [ -z "$form_action" ]; then
+  form_action="$(
+    grep -oiE '<form[^>]+action="[^"]+"' "${TMP}/login.html" | head -1 |
+      sed -E 's/.*action="([^"]+)".*/\1/' | sed 's/&amp;/\&/g'
+  )"
+fi
+[ -n "$form_action" ] || fail "could not find the Keycloak login form action"
+log "login form parsed"
+
+# 6) Submit credentials -> 302 back to the app's callback with the authorization code.
+curl -s -c "$JAR" -b "$JAR" -o /dev/null -D "${TMP}/c" \
+  --data-urlencode "username=${KC_USER}" \
+  --data-urlencode "password=${KC_PASS}" \
+  --data-urlencode "credentialId=" \
+  "$form_action"
+callback="$(location "${TMP}/c")"
+case "$callback" in
+  *"/login/oauth2/code/${pid}"*) : ;;
+  *) fail "Keycloak did not redirect to the app callback (got: ${callback:-<none>}) — bad credentials?" ;;
+esac
+log "authenticated at Keycloak"
+
+# 7) Hit the callback -> the app exchanges the code, provisions the user, sets the
+#    refresh cookie, and redirects to the SPA on success (or /login?error=… on failure).
+curl -s -c "$JAR" -b "$JAR" -o /dev/null -D "${TMP}/d" "$callback"
+final="$(location "${TMP}/d")"
+case "$final" in
+  *error*) fail "OIDC login redirected to an error page: ${final}" ;;
+  "${FRONTEND_BASE}"*) : ;;
+  *) fail "unexpected post-login redirect: ${final:-<none>}" ;;
+esac
+if ! grep -i '^set-cookie:' "${TMP}/d" | grep -q 'qnop_refresh='; then
+  fail "no qnop_refresh cookie was issued on OIDC login"
+fi
+log "OIDC login completed (refresh cookie set, redirect=${final})"
+
+# 8) The Keycloak user was JIT-provisioned as a local account.
+total="$(curl -sf "${AUTH[@]}" "${APP}/api/v1/admin/users?q=${KC_EMAIL}" | jq -r '.total')"
+[ "$total" -ge 1 ] 2>/dev/null || fail "${KC_EMAIL} was not provisioned (total=${total})"
+log "JIT-provisioned ${KC_EMAIL}"
+
+log "ALL OIDC SMOKE CHECKS PASSED"


### PR DESCRIPTION
## Summary

Closes #225. Extends the smoke deployment (#207) with a **Keycloak** identity provider and a smoke check that performs a full **OIDC login** end-to-end over HTTP — covering the "Sign in with …" path a real deployment exposes (dynamic client registration from the `oidc_provider` table, Spring `oauth2Login`, JIT user provisioning, qnop session issuance), which the in-process suite can't.

### How the issuer/hostname trap is avoided

The OIDC smoke runs in a **sidecar that shares the app's network namespace** (`network_mode: service:app`):
- `localhost:8080` → the app (already a realm-whitelisted redirect host), so the derived `redirect_uri` is accepted with **no dev-realm edit**.
- `keycloak:8080` resolves exactly as the app sees it, so the discovered issuer matches on both the back-channel (app ↔ Keycloak token exchange) and front-channel (curl ↔ Keycloak), avoiding the classic dockerized-Keycloak issuer mismatch.

### What's added

- **`docker-compose.smoke.yml`** — `keycloak` (imports the shipped `docker/keycloak/qnop-realm.json`: realm `qnop`, confidential client `qnop-local`, users `alice`/`bob`) + the `smoke-oidc` sidecar. App gets `QNOP_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS=true` (private issuer) and `QNOP_AUTH_COOKIE_SECURE=false` (HTTP deployment).
- **`scripts/smoke-oidc.sh`** — admin token → `discover`/`create`/`enable` the Keycloak provider via the admin API → `/oauth2/authorization/{id}` → Keycloak login form (POST `alice`/`password`) → callback. Asserts: success redirect to the SPA base (not `/login?error=`), a `qnop_refresh` cookie, and that `alice@qnop.test` was JIT-provisioned.
- **`ci.yml`** — runs the OIDC sidecar after the basic smoke (which seeds the DB).

## Test plan

- [x] `scripts/smoke-oidc.sh` passes `bash -n`.
- [ ] CI `smoke` job green: basic smoke + the new OIDC login flow against Keycloak (runs only in CI; Docker is unavailable locally).

🤖 Co-Author: Claude (Opus 4.x) via Claude Code