### PR TITLE
refactor: LAZY fetch for verification/reset token user association (#181)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/entity/EmailVerificationToken.java
+++ b/qnop-core/src/main/java/io/qnop/entity/EmailVerificationToken.java
@@ -42,10 +42,12 @@ import org.hibernate.annotations.UuidGenerator;
  * inbound {@code ?token=…} query parameter. {@code consumedAt} flips when the link is used; the row
  * is kept for audit until a scheduled sweep removes expired rows.
  *
- * <p>Unlike the other token entities, {@code user} is an <strong>EAGER {@code @ManyToOne}</strong>:
- * the verify-email consumers read the linked user outside the service transaction (to flip {@code
- * enabled} / send to {@code email}), and LAZY would raise {@code LazyInitializationException}. The
- * FK to {@code qnop_user} cascades on delete (Liquibase, ADR-0020).
+ * <p>{@code user} is a <strong>LAZY {@code @ManyToOne}</strong>: every access happens inside the
+ * active service transaction ({@code consume()} resolves {@code getUser()} before the atomic
+ * update, while the issue/sweep paths never read the user), so LAZY avoids the forced join on every
+ * token lookup and on the daily expiry sweep. The FK to {@code qnop_user} cascades on delete
+ * (Liquibase, ADR-0020). A caller needing the user outside a transaction should use an explicit
+ * JOIN FETCH query.
  */
 @Entity
 @Table(name = "email_verification_token")
@@ -56,7 +58,7 @@ public class EmailVerificationToken {
   @Column(name = "id", nullable = false, updatable = false)
   private UUID id;
 
-  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "user_id", nullable = false, updatable = false)
   private User user;
 

--- a/qnop-core/src/main/java/io/qnop/entity/PasswordResetToken.java
+++ b/qnop-core/src/main/java/io/qnop/entity/PasswordResetToken.java
@@ -43,9 +43,10 @@ import org.hibernate.annotations.UuidGenerator;
  * the token is exchanged for a new password; the row is kept for audit until a scheduled sweep
  * removes it.
  *
- * <p>{@code user} is an EAGER {@code @ManyToOne} for the same reason as {@link
- * EmailVerificationToken} (the reset-password consumer reads the user outside the service
- * transaction). The FK to {@code qnop_user} cascades on delete (Liquibase, ADR-0020).
+ * <p>{@code user} is a LAZY {@code @ManyToOne} for the same reason as {@link
+ * EmailVerificationToken}: {@code consume()} resolves the user inside the active transaction and
+ * the issue/sweep paths never read it, so LAZY avoids a forced join on every lookup and on the
+ * sweep. The FK to {@code qnop_user} cascades on delete (Liquibase, ADR-0020).
  */
 @Entity
 @Table(name = "password_reset_token")
@@ -56,7 +57,7 @@ public class PasswordResetToken {
   @Column(name = "id", nullable = false, updatable = false)
   private UUID id;
 
-  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "user_id", nullable = false, updatable = false)
   private User user;
 


### PR DESCRIPTION
## What

Switches the `@ManyToOne user` association on `EmailVerificationToken` and `PasswordResetToken` from `EAGER` to `LAZY`, removing the forced `qnop_user` join on every token lookup and on the daily expiry sweep. Closes #181.

Safe because all access is in-transaction: `consume()` reads `token.getUser()` inside its `@Transactional` method, and both callers (`RegistrationService.verify`, `PasswordResetFlowService.reset`) are `@Transactional` and only read `user.getId()` (no proxy initialization needed). The issue/sweep paths never touch `user`. Javadoc rationale corrected.

## Test plan
- [x] compile, spotlessCheck, ArchUnit (local)
- [ ] token consume ITs (Testcontainers, CI) exercise the lazy load inside the transaction

🤖 Co-Author: Claude (Opus 4.x) via Claude Code