### PR TITLE
perf: partial index on refresh_token.family_id (#182)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/token/TokenSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/token/TokenSchemaIT.java
@@ -42,6 +42,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -61,7 +62,20 @@ class TokenSchemaIT extends AbstractIntegrationTest {
   @Autowired EmailVerificationTokenRepository emailTokens;
   @Autowired PasswordResetTokenRepository passwordResetTokens;
   @Autowired UserRepository users;
+  @Autowired JdbcTemplate jdbc;
   @PersistenceContext EntityManager entityManager;
+
+  @Test
+  void indexesFamilyIdForActiveTokens() {
+    // revokeFamily() filters on family_id WHERE revoked_at IS NULL; that hot path must be
+    // backed by a partial index, not a sequential scan (issue #182).
+    Integer count =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM pg_indexes WHERE tablename = 'refresh_token'"
+                + " AND indexname = 'ix_refresh_token_active_family'",
+            Integer.class);
+    assertThat(count).isEqualTo(1);
+  }
 
   private User newUser() {
     return users.saveAndFlush(

--- a/qnop-core/src/main/resources/db/changelog/migrations/0004-token-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0004-token-schema.yaml
@@ -66,10 +66,14 @@ databaseChangeLog:
             columns:
               - column: { name: expires_at }
         - sql:
-            comment: Partial index for active (unrevoked) tokens — the revoke-by-user/family hot path.
+            comment: |
+              Partial indexes over active (unrevoked) tokens for the two revoke hot paths:
+              revoke-by-user and revoke-by-family (reuse-detection / logout, issue #182).
             sql: |
               CREATE INDEX ix_refresh_token_active
                 ON refresh_token (user_id) WHERE revoked_at IS NULL;
+              CREATE INDEX ix_refresh_token_active_family
+                ON refresh_token (family_id) WHERE revoked_at IS NULL;
 
   - changeSet:
       id: 0004-token-revoked-token


### PR DESCRIPTION
## What

Adds a partial index `ix_refresh_token_active_family` on `refresh_token (family_id) WHERE revoked_at IS NULL`. `revokeFamily()` (reuse-detection / logout) filters on `family_id AND revoked_at IS NULL` with no supporting index — a sequential scan on every theft-response/logout, expensive as the table grows and during credential-stuffing. Mirrors the existing `ix_refresh_token_active` design. Closes #182.

Per the established convention (no production DB yet, schema rebuilt each CI run) the index was added into the existing `0004-token-schema.yaml` changeset rather than a new one.

## Test plan
- [x] compile, spotlessCheck, ArchUnit (local)
- [ ] `TokenSchemaIT.indexesFamilyIdForActiveTokens` (Testcontainers, CI) asserts the index exists

🤖 Co-Author: Claude (Opus 4.x) via Claude Code