### PR TITLE
docs: declare the four missing OpenAPI tags (#183)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -54,6 +54,20 @@ tags:
       Admin-only team management (issue #105): list/search teams with pagination,
       create / edit / delete teams, and manage memberships with a per-team role
       (LEAD / MEMBER). Teams group reviewers for the review workflow.
+  - name: AdminOidcProviders
+    description: |
+      Superadmin-only management of DB-configured OIDC/OAuth2 login providers,
+      including issuer-endpoint discovery (issue #21).
+  - name: AdminEmail
+    description: |
+      Superadmin-only mail configuration — SMTP connection test, mail-template
+      overrides and preview (issue #19).
+  - name: AuthRegistration
+    description: |
+      Public self-registration and email-verification endpoints (issue #20).
+  - name: AuthPasswordReset
+    description: |
+      Public self-service password-reset request and confirmation flow (issue #20).
 paths:
   /config:
     get:


### PR DESCRIPTION
## What

Adds the four operation tags used on paths but missing from the top-level `tags:` list — `AdminOidcProviders`, `AdminEmail`, `AuthRegistration`, `AuthPasswordReset` — each with a description, so rendered docs group and describe these operations. Closes #183.

No generated-interface change (the tags were already referenced on operations); this only adds the top-level descriptions. Spec re-generates and compiles cleanly.

## Test plan
- [x] openApiGenerate (both modules), compileJava, spotlessCheck

🤖 Co-Author: Claude (Opus 4.x) via Claude Code