### PR TITLE
fix(ci): set QNOP_AUTH_OIDC_FRONTEND_BASE_URL in the smoke compose

### DIFF
--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -44,6 +44,11 @@ services:
       QNOP_AUTH_ENCRYPTION_KEY: integration-test-encryption-key-0123456789
       QNOP_AUTH_ENCRYPTION_SALT: 0123456789abcdef0123456789abcdef
       QNOP_CORS_ALLOWED_ORIGINS: http://localhost:5173
+      # Post-OIDC-login redirect base (issue #178): a dedicated, CORS-independent
+      # setting. The smoke simulates an SPA on a separate origin, and smoke-oidc.sh
+      # asserts the redirect targets it; without this the default is blank, which
+      # redirects to the API root (http://localhost:8080/) and fails the check.
+      QNOP_AUTH_OIDC_FRONTEND_BASE_URL: http://localhost:5173
       # The Keycloak issuer is a private/container host; the SSRF guard blocks
       # discovery against it unless explicitly allowed (test deployment only).
       QNOP_AUTH_OIDC_ALLOW_PRIVATE_DISCOVERY_URIS: 'true'


### PR DESCRIPTION
## Summary

Fixes #230. The **Smoke (docker-compose deploy + testdata)** CI job has failed at
the OIDC login step on `main` and on every open PR:

```
[oidc-smoke] FAIL: unexpected post-login redirect: http://localhost:8080/
```

### Root cause

#178 (PR #216) decoupled the OIDC post-login redirect from `QNOP_CORS_ALLOWED_ORIGINS`
and moved it to a dedicated `qnop.auth.oidc.frontend-base-url` setting, default
**blank** (= same-origin relative redirect):

```java
response.sendRedirect(frontendBase() + "/");                       // → "/" when blank
private String frontendBase() { return properties.auth().oidc().frontendBaseUrl(); }
```

`docker-compose.smoke.yml` was never updated to set `QNOP_AUTH_OIDC_FRONTEND_BASE_URL`,
so in the smoke environment the redirect is `http://localhost:8080/`, while
`scripts/smoke-oidc.sh` asserts it targets the SPA origin `http://localhost:5173`.
The smoke last passed in #222 (run predated #216); every PR run after #216 fails here.

### Fix

Set `QNOP_AUTH_OIDC_FRONTEND_BASE_URL: http://localhost:5173` on the `app` service so
the smoke environment simulates a separate SPA origin and matches the script's
`FRONTEND_BASE`.

## Test plan

- One-line compose env addition (YAML validated; 6-space indent matches siblings).
- The OIDC login smoke in this PR's CI run is the verification (Docker is unavailable locally).
- Unblocks every open PR (e.g. #215), which fail only on this shared smoke step.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code