### PR TITLE
fix: OIDC provider duplicate-name returns 409 not 400 (#184)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -232,6 +232,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Conflict — a provider with that name already exists (code `NAME_TAKEN`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /admin/oidc-providers/discover:
     post:
       tags:

--- a/qnop-app/src/main/java/io/qnop/web/OidcProviderController.java
+++ b/qnop-app/src/main/java/io/qnop/web/OidcProviderController.java
@@ -21,6 +21,7 @@
 package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.AdminOidcProvidersApi;
+import io.qnop.api.v1.model.ErrorResponse;
 import io.qnop.api.v1.model.OidcDiscoveryRequest;
 import io.qnop.api.v1.model.OidcDiscoveryResponse;
 import io.qnop.api.v1.model.OidcProviderCreateRequest;
@@ -28,6 +29,7 @@ import io.qnop.api.v1.model.OidcProviderDto;
 import io.qnop.api.v1.model.OidcProviderListResponse;
 import io.qnop.api.v1.model.OidcProviderTypeDto;
 import io.qnop.api.v1.model.OidcProviderUpdateRequest;
+import io.qnop.service.oidc.OidcProviderConflictException;
 import io.qnop.service.oidc.OidcProviderNotFoundException;
 import io.qnop.service.oidc.OidcProviderService;
 import io.qnop.service.oidc.OidcProviderService.OidcDiscoveryOutcome;
@@ -37,9 +39,9 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -88,11 +90,19 @@ public class OidcProviderController implements AdminOidcProvidersApi {
               request.getDisplayNameAttribute());
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
-    } catch (DataIntegrityViolationException e) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "A provider with that name already exists");
     }
     return ResponseEntity.status(HttpStatus.CREATED).body(toDto(created));
+  }
+
+  /** Duplicate provider name → 409, consistent with the teams/users conflict responses (#184). */
+  @ExceptionHandler(OidcProviderConflictException.class)
+  public ResponseEntity<ErrorResponse> onConflict(OidcProviderConflictException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(
+            new ErrorResponse()
+                .code(ex.getCode())
+                .message(ex.getMessage())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC)));
   }
 
   @Override

--- a/qnop-app/src/test/java/io/qnop/web/SeededOidcProviderIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededOidcProviderIT.java
@@ -86,7 +86,8 @@ class SeededOidcProviderIT extends SeededIntegrationTest {
                 .content(
                     "{\"name\":\"Seeded Google\",\"providerType\":\"OIDC\","
                         + "\"clientId\":\"dup\",\"clientSecret\":\"dup-secret\"}"))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("NAME_TAKEN"));
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderConflictException.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderConflictException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.oidc;
+
+/**
+ * A conflicting OIDC-provider request (issue #21/#184): a duplicate provider name. Carries a stable
+ * {@code code} for the uniform error envelope; mapped to HTTP 409, consistent with the teams/users
+ * conflict responses.
+ */
+public class OidcProviderConflictException extends RuntimeException {
+
+  private final String code;
+
+  public OidcProviderConflictException(String code, String message) {
+    super(message);
+    this.code = code;
+  }
+
+  public String getCode() {
+    return code;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
@@ -165,6 +165,10 @@ public class OidcProviderService {
       String userNameAttribute,
       String emailAttribute,
       String displayNameAttribute) {
+    if (providers.findByName(name).isPresent()) {
+      throw new OidcProviderConflictException(
+          "NAME_TAKEN", "A provider with that name already exists.");
+    }
     OidcProviderType type = OidcProviderType.valueOf(providerType);
     if (type == OidcProviderType.OAUTH2) {
       ssrfPolicy.requirePublicHttpUri(authorizationUri, "authorizationUri", true);


### PR DESCRIPTION
## What

Duplicate-name conflict on `POST /admin/oidc-providers` now returns **409** (was 400), consistent with teams/users. Closes #184.

- New `OidcProviderConflictException(code, message)` in `io.qnop.service.oidc` (mirrors `TeamConflictException`).
- `OidcProviderService.create` pre-checks `findByName` and throws it with code `NAME_TAKEN` — moving conflict detection out of the web layer (no more catching the raw `DataIntegrityViolationException` in the controller).
- `OidcProviderController` maps it to 409 via the shared `ErrorResponse` envelope.
- OpenAPI: added `409` to the create operation.
- Updated `SeededOidcProviderIT.rejectsADuplicateName` to assert 409 + `code=NAME_TAKEN`.

## Test plan
- [x] compile, spotlessCheck, ArchUnit (local)
- [ ] `SeededOidcProviderIT` (Testcontainers, CI)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code