### PR TITLE
fix: 409 EXTERNAL_ACCOUNT for change-password on OIDC accounts (#185)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1447,6 +1447,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: |
+            The account authenticates via an external provider (OIDC) and has no local
+            password to change (code `EXTERNAL_ACCOUNT`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /users/me:
     get:
       tags:

--- a/qnop-app/src/main/java/io/qnop/web/AuthController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AuthController.java
@@ -22,6 +22,7 @@ package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.AuthApi;
 import io.qnop.api.v1.model.ChangePasswordRequest;
+import io.qnop.api.v1.model.ErrorResponse;
 import io.qnop.api.v1.model.LoginRequest;
 import io.qnop.api.v1.model.TokenResponse;
 import io.qnop.security.QnopProperties;
@@ -33,6 +34,8 @@ import io.qnop.service.RefreshTokenService.IssuedRefreshToken;
 import io.qnop.service.RefreshTokenService.RotationResult;
 import io.qnop.service.TokenRevocationService;
 import io.qnop.web.security.RefreshTokenCookieFactory;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -41,6 +44,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -121,14 +125,31 @@ public class AuthController implements AuthApi {
         authService.changePassword(userId, request.getCurrentPassword(), request.getNewPassword());
     return switch (outcome) {
       case SUCCESS -> ResponseEntity.noContent().build();
-      case NOT_LOCAL ->
-          throw new ResponseStatusException(
-              HttpStatus.BAD_REQUEST, "Password change is not available for this account");
+      case NOT_LOCAL -> throw new ExternalAccountException();
       case WRONG_PASSWORD, USER_NOT_FOUND ->
           throw new ResponseStatusException(
               HttpStatus.UNAUTHORIZED, "Current password is incorrect");
     };
   }
+
+  /**
+   * A local password change was attempted on an account that authenticates via an external provider
+   * (OIDC). Mapped to 409 with code {@code EXTERNAL_ACCOUNT}, consistent with the admin endpoints'
+   * rejection of OIDC accounts (issue #185).
+   */
+  @ExceptionHandler(ExternalAccountException.class)
+  public ResponseEntity<ErrorResponse> onExternalAccount(ExternalAccountException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(
+            new ErrorResponse()
+                .code("EXTERNAL_ACCOUNT")
+                .message(
+                    "Password change is not available for an account that authenticates via an"
+                        + " external provider.")
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC)));
+  }
+
+  private static final class ExternalAccountException extends RuntimeException {}
 
   private ResponseEntity<TokenResponse> issueSession(UUID userId) {
     return issueSession(userId, refreshTokenService.issue(userId));

--- a/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
@@ -172,6 +172,23 @@ class AuthControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
+  void changePasswordRejectsExternalAccountsWith409() throws Exception {
+    User external = userRepository.saveAndFlush(User.external("Oscar", "oscar@oidc.example.com"));
+    String accessToken = jwtTokenService.issueAccessToken(external.getId());
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/change-password")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"currentPassword\":\"irrelevant\","
+                        + "\"newPassword\":\"a-brand-new-strong-password\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("EXTERNAL_ACCOUNT"));
+  }
+
+  @Test
   void changePasswordClearsTheForcedChangeRequirement() throws Exception {
     // Regression: a user created with "must change password on first login" was sent
     // back to the change-password screen after every login because the change never

--- a/qnop-app/src/test/java/io/qnop/web/SeededChangePasswordIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededChangePasswordIT.java
@@ -73,7 +73,8 @@ class SeededChangePasswordIT extends SeededIntegrationTest {
                 .header("Authorization", "Bearer " + token(EXTERNAL_ID))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body(SEED_PASSWORD, NEW_PASSWORD)))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("EXTERNAL_ACCOUNT"));
   }
 
   @Test


### PR DESCRIPTION
## What

`POST /auth/change-password` on an external/OIDC account (the `NOT_LOCAL` outcome) now returns a distinct **409** with machine-readable `code: EXTERNAL_ACCOUNT`, instead of an undocumented 400 that looked identical to a password-policy failure. Aligns with how the admin endpoints reject OIDC accounts. Closes #185.

- `AuthController` maps `NOT_LOCAL` to 409 via the shared `ErrorResponse` envelope (option (b) from the issue, your call).
- OpenAPI: added a `409` response to the operation; `400` now documents the password-policy case only.
- New `AuthControllerIT.changePasswordRejectsExternalAccountsWith409`.

## Test plan
- [x] compile, spotlessCheck, ArchUnit (local)
- [ ] `AuthControllerIT` (Testcontainers, CI) — new 409 case + existing flows

🤖 Co-Author: Claude (Opus 4.x) via Claude Code