### PR TITLE
docs: README status badge — Phase 0 → Phase 1 (#197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reviewers — individual users or whole teams — mark up lines and regions of a
 
 The focus is on **textual documents first — PDF, Word (DOCX), and Markdown**. Support for further formats (for example images) may follow once the text review workflow is solid, and such formats are a likely **Enterprise** feature rather than part of the Community scope.
 
-> **Status: Phase 0 — project skeleton.** The structure, build, conventions and local infrastructure are in place; the domain core and the running server arrive in Phase 1. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and the roadmap there.
+> **Status: Phase 1 — identity & administration layer shipped.** The server boots (PostgreSQL + Liquibase + JPA) with the full identity/auth subsystem — local login with JWT access + rotating refresh tokens, revocation, OIDC/OAuth2 providers, self-registration, email verification and password reset, rate limiting — plus users & teams, application settings, mail templates, branding upload (with SVG sanitization) and profile avatars. The document-review domain (ingest, annotation anchoring, the review workflow state machine) is Phase 2. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and the roadmap there.
 
 ## Editions
 


### PR DESCRIPTION
## What

Updates the README status badge (line 9), which still advertised "Phase 0 — project skeleton … the running server arrives in Phase 1". The bootable server and the whole identity/administration layer have shipped (auth/JWT/refresh/revocation, OIDC, registration, email verification, password reset, rate limiting, users & teams, application settings, mail templates, branding upload + SVG sanitization, profile avatars). The badge now reflects Phase 1 and marks the document-review domain as Phase 2. Closes #197.

Verified against the actual tree (14 JPA entities, 21 @Service classes, the io.qnop.security layer, ADRs through 0031); the badge describes capabilities rather than brittle counts. No other stale Phase-0 claims remain in the README.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code