### PR TITLE
docs: note QNOP_AUTH_* secret setup before bootRun in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ cp .env.example .env && docker compose up -d
 # Backend — compile + format check + architecture & context tests
 ./gradlew build
 
-# Run the server (uses the docker-compose Postgres)
+# Run the server (uses the docker-compose Postgres).
+# Unlike `docker compose`, Gradle's bootRun does NOT auto-load .env, and the server
+# fails fast unless QNOP_AUTH_JWT_SECRET / QNOP_AUTH_ENCRYPTION_KEY / QNOP_AUTH_ENCRYPTION_SALT
+# hold real values (>= 32 chars). Replace the CHANGE_ME placeholders in .env, then export it:
+set -a; source .env; set +a
 ./gradlew :qnop-app:bootRun
 
 # Frontend


### PR DESCRIPTION
## Summary

Fixes #201. The README Getting Started block went straight from
`cp .env.example .env` to `./gradlew :qnop-app:bootRun`. But `bootRun` does **not**
auto-load `.env` (unlike `docker compose`), and the server fails fast on the
`@ValidSecret` guard while `QNOP_AUTH_JWT_SECRET` / `QNOP_AUTH_ENCRYPTION_KEY` /
`QNOP_AUTH_ENCRYPTION_SALT` are still the `CHANGE_ME` placeholders — an opaque
startup failure for new contributors.

## Change

- Add a callout to replace the `CHANGE_ME` values and export the file
  (`set -a; source .env; set +a`) before `bootRun`, matching the guidance already
  in `.env.example`, and call out that `bootRun` (unlike `docker compose`) does
  not auto-load `.env`.

## Test plan

- Docs-only change.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code