### PR TITLE
docs: correct the frontend commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,11 @@ Frontend (`cd qnop-ui`):
 
 ```bash
 pnpm install
-pnpm dev            # vite dev server
-pnpm build          # tsc -b && vite build
+pnpm generate:api   # openapi-generator-cli — regenerate the typed API client (needs a JDK)
+pnpm dev            # generate:api + vite dev server
+pnpm build          # generate:api + tsc -b + vite build
+pnpm typecheck      # generate:api + tsc -b --noEmit
+pnpm test           # vitest (watch); pnpm test:run for a one-shot run
 pnpm lint           # eslint
 pnpm format         # prettier --write
 pnpm format:check


### PR DESCRIPTION
## Summary

Fixes #202. The CLAUDE.md frontend command comments were stale: `pnpm dev` and
`pnpm build` both run `generate:api` first (openapi-generator-cli — needs a JDK)
before vite/tsc, because the generated API client must exist or `tsc` fails. The
block also omitted `generate:api`, `typecheck`, and `test`/`test:run`, all
defined in `qnop-ui/package.json`.

## Change

- Update the frontend commands block to match the real scripts, so following the
  doc (e.g. running only `tsc -b && vite build`) no longer leads to unexplained
  type errors from missing generated types.

## Test plan

- Docs-only change; cross-checked against `qnop-ui/package.json`.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code