### PR TITLE
docs(adr): document-review core architecture (#239)

### DIFF
--- a/docs/adr/0009-multi-layer-annotation-anchoring.md
+++ b/docs/adr/0009-multi-layer-annotation-anchoring.md
@@ -1,28 +1,49 @@
 # ADR-0009: Multi-layer annotation anchoring
 
-- **Status:** Proposed
-- **Date:** 2026-06-13
-- **Deciders:** qnop core team
+- **Status:** Accepted
+- **Date:** 2026-06-13 (finalized 2026-06-28)
+- **Deciders:** qnop core team; finalized by bigpuritz, devtank42 (with Claude)
 
 ## Context
 
-Annotations attach to lines/regions of a document version. A content change produces a **new** version (versions are immutable), and annotations must survive re-versioning rather than orphaning — this is the product's core differentiator and the hardest algorithmic piece. Position-only anchoring breaks as soon as text reflows.
+Annotations attach to lines/regions of a document version. A content change produces a **new** version (versions are immutable, [ADR-0011](0011-review-workflow-state-model.md)), and annotations must survive re-versioning rather than orphaning — this is the product's core differentiator and the hardest algorithmic piece. Position-only anchoring breaks the moment text reflows. The model must also cover **non-textual documents** (images), which have no text to quote at all.
 
-## Decision (direction — to be finalized in Phase 1)
+## Decision
 
-Store multiple independent localization strategies per anchor (as `jsonb`), following the W3C Web Annotation Data Model:
+Store **multiple independent localization strategies per anchor** (as `jsonb`), following the W3C Web Annotation Data Model. The anchor is bound to *content + context*, not to a coordinate:
 
-1. **Text-quote anchor** (primary): exact quote + prefix/suffix context — robust to reflow.
-2. **Text-position anchor** (secondary): start/end offsets in the extracted text — fast, brittle; a tiebreaker.
-3. **Layout anchor**: page + normalized bounding boxes — for visually overlaying the highlight.
+1. **Region anchor (universal, always present):** `{ surfaceIndex, box }` in normalized 0..1 coordinates of the surface ([ADR-0032](0032-document-representation-and-rendering-pipeline.md)). This is the one layer that *always* exists — for an image it is the only anchor.
+2. **Text-quote anchor (primary when a text layer exists):** exact quote + prefix/suffix context — robust to reflow.
+3. **Text-position anchor (secondary):** start/end offsets in the extracted text — fast, brittle; a tiebreaker.
 
-Model an annotation's identity as version-independent, with a per-version `AnnotationPlacement(annotationId, documentVersionId, anchorJson, status)`. On a new version, a re-anchoring job re-resolves open annotations (exact → fuzzy); unresolved ones become `ORPHANED` and surface to a human, never silently guessed.
+So region anchoring is the universal base layer and text-quote is an *additional* strategy available only when the surface has a text layer — not the other way round.
+
+**Identity vs. placement.** An annotation's identity (and its comment thread, status) is **version-independent**: `Annotation`. Physical location is **per version**: `AnnotationPlacement(annotationId, documentVersionId, anchorJson, status)`.
+
+**Re-anchoring** runs as a **durable async job** ([ADR-0033](0033-durable-async-job-execution-on-postgres.md)) on every new version, resolving each open annotation through a cascade:
+
+- **Exact** — quote + context occur unchanged exactly once → unique re-placement.
+- **Fuzzy** — slightly changed/duplicated text; the similarity-best match weighted by context wins if above a threshold and unambiguous → re-placed and flagged **MOVED** (changed) for the reviewer.
+- **Orphaned** — no match above threshold → status `ORPHANED`; **never silently guessed or mis-placed**, surfaced to the owner for manual handling.
+
+The placement lifecycle is therefore:
+
+```
+PENDING → PLACED | MOVED | ORPHANED | FAILED
+```
+
+`PENDING` exists because the version is visible immediately while the job runs (ADR-0033). For **images**, there is no content-based re-anchoring in Community: the region keeps its 0..1 coordinates and is flagged "to review" on a new version (visual region matching is enterprise/AI behind the SPI).
 
 ## Consequences
 
-- Discussion/lifecycle persists across versions; physical placement is per version.
-- Re-anchoring correctness is the top product risk — start conservative with human-in-the-loop.
+- Discussion/lifecycle persists across versions; physical placement is per version and recomputed deterministically.
+- Re-anchoring correctness is the top product risk — the cascade is conservative and **human-in-the-loop** (orphans are honest, never wrong).
+- The same anchor model serves text and non-text documents; adding image review needs no anchoring change.
+- A version with `PENDING`/un-decided placements is "not yet finalizable" (ADR-0011), a clean precondition rather than a special case.
 
-## Status note
+## Alternatives considered
 
-Recorded now because it shapes the persistence schema. Implementation and the fuzzy-matching details are deferred to Phase 1.
+- **Position-only anchoring.** Rejected: breaks on any reflow.
+- **Text-quote as the sole/primary strategy with layout as a mere fallback.** Rejected: images have no quote; geometry must be a first-class, always-present layer.
+- **Synchronous re-anchoring at upload.** Rejected: blocks the upload for large documents/many annotations; async with a `PENDING` lifecycle is the chosen shape ([ADR-0033](0033-durable-async-job-execution-on-postgres.md)).
+- **Auto-placing low-confidence matches.** Rejected: a mis-attached objection on a contract is worse than a visible orphan.

--- a/docs/adr/0010-docx-representation-strategy.md
+++ b/docs/adr/0010-docx-representation-strategy.md
@@ -1,23 +1,37 @@
 # ADR-0010: DOCX representation strategy
 
-- **Status:** Proposed (open question)
-- **Date:** 2026-06-13
-- **Deciders:** qnop core team
+- **Status:** Accepted
+- **Date:** 2026-06-13 (resolved 2026-06-28)
+- **Deciders:** qnop core team; resolved by bigpuritz, devtank42 (with Claude)
 
 ## Context
 
-Documents arrive as PDF or DOCX. The browser must render them with line-accurate selection for annotation. There are two defensible approaches, and the design review surfaced a genuine disagreement to resolve in Phase 1.
-
-## Options
-
-- **Option A — PDF as canonical format.** Convert DOCX → PDF on ingest (LibreOffice headless / JODConverter, as a separate process; keep the original DOCX). One rendering + anchoring model (PDF.js text layer + glyph boxes via PDFBox). Simpler frontend; coordinate anchors can break when an edited DOCX is re-converted and the layout shifts.
-- **Option B — HTML/DOM rendering + text-range anchoring.** Render DOCX to HTML (docx-preview / mammoth.js) and anchor via text-quote/DOM ranges that survive edits and re-version cleanly; PDF still uses PDF.js. Two rendering paths, but anchoring aligns with the immutable-version model ([ADR-0009](0009-multi-layer-annotation-anchoring.md)).
+Documents arrive as PDF, DOCX, or Markdown. The browser must render them faithfully with region-accurate selection for annotation. Phase 0 left a genuine disagreement open: PDF-as-canonical (convert DOCX→PDF) vs. HTML/DOM rendering (docx-preview/mammoth) with DOM-range anchoring. The Phase-0 record explicitly named a **hybrid** — "PDF snapshot for fidelity + text-quote anchoring for resilience" — as the likely resolution.
 
 ## Decision
 
-**Deferred.** Phase 0 only defines the `DocumentConverter` and `TextExtractor` ports, keeping both options open. The choice (or a hybrid: PDF snapshot for fidelity + text-quote anchoring for resilience) will be made and recorded as an Accepted update when the ingest pipeline is built in Phase 1.
+**Resolve to the hybrid, via the canonical pipeline of [ADR-0032](0032-document-representation-and-rendering-pipeline.md).**
+
+- **DOCX is converted to PDF on ingest**, out-of-process (LibreOffice headless / JODConverter as a separate process — never linked, see constraint below). The original DOCX is always retained in object storage ([ADR-0005](0005-binary-documents-in-object-storage.md)).
+- The converted PDF then flows through the **same `RenderedDocument` pipeline as native PDF**: PDFBox extracts the per-surface text spans + normalized boxes; the client renders the converted PDF with PDF.js. DOCX is therefore *not* a second rendering/anchoring path — it funnels into the one canonical model.
+- **Anchoring resilience comes from the text-quote layer** ([ADR-0009](0009-multi-layer-annotation-anchoring.md)), not from layout coordinates: when an edited DOCX is re-converted and the layout shifts, annotations re-anchor on quote + context, and the per-version `AnnotationPlacement` carries the new boxes. This neutralizes the main weakness of "PDF as canonical" (coordinate drift on re-conversion).
+- Conversion runs as a durable async job ([ADR-0033](0033-durable-async-job-execution-on-postgres.md)), like every other extraction.
+
+Concretely: the `DocumentExtractor` SPI has a DOCX implementation = "convert to PDF out-of-process, then delegate to the PDF extractor". Markdown takes an HTML path; PDF and images are native.
+
+## Consequences
+
+- One rendering model and one anchoring model for PDF and DOCX — simpler frontend, shared diff and re-anchoring.
+- DOCX fidelity depends on LibreOffice's conversion quality; acceptable, and the original is always downloadable.
+- Adds an out-of-process LibreOffice dependency to the ingest environment (containerized); only invoked for DOCX, async.
+- DOCX is **not** in the first vertical slice (PDF-first); this ADR fixes the *direction* so the seam (`DocumentExtractor`, convert-then-extract) is built right from the start.
 
 ## Constraints already fixed
 
 - Any DOCX→PDF conversion runs **out-of-process** (LibreOffice is MPL/LGPL — no linking into the AGPL core or commercial add-ons).
 - Original uploads are always retained in object storage ([ADR-0005](0005-binary-documents-in-object-storage.md)).
+
+## Alternatives considered
+
+- **Option B — HTML/DOM rendering + DOM-range anchoring (docx-preview/mammoth).** Rejected for the core: a second rendering and anchoring path, and it forfeits exact original layout. Re-anchoring resilience is already solved by the text-quote layer without it.
+- **Render DOCX in the client directly.** Rejected: format-specific client path, against the format-agnostic, server-authoritative representation of ADR-0032.

--- a/docs/adr/0011-review-workflow-state-model.md
+++ b/docs/adr/0011-review-workflow-state-model.md
@@ -1,34 +1,49 @@
-# ADR-0011: Review workflow state model
+# ADR-0011: Review workflow & domain model
 
-- **Status:** Proposed
-- **Date:** 2026-06-13
-- **Deciders:** qnop core team
+- **Status:** Accepted
+- **Date:** 2026-06-13 (finalized 2026-06-28)
+- **Deciders:** qnop core team; finalized by bigpuritz, devtank42 (with Claude)
 
 ## Context
 
-A review moves through a coordinated workflow: a document is reviewed, reviewers comment, comments are accepted/rejected, changes produce new versions, and the review finalizes when no open annotations remain. Reviewers may be individual users or teams.
+A review moves through a coordinated workflow: a document is reviewed, reviewers comment, comments are accepted/rejected, changes produce new versions, and the review finalizes when no open annotations remain. Reviewers may be individual users or whole teams. Phase 0 fixed the *state machine* direction; this finalization also pins the **domain model** it operates on (document/version/participant/annotation), since they are inseparable.
 
-## Decision (direction — to be finalized in Phase 1)
+## Decision
 
-Use an **explicit, enum-based state machine** in the service layer (`qnop-core`, `io.qnop.service`), kept as plain DB-free testable logic ([ADR-0004](0004-layered-architecture-enforced-by-archunit.md)), not Spring Statemachine.
+### Domain model
 
-Proposed states:
+- **Review = not editing.** qnop reviews documents; it does not edit them. There is no in-app editor — the viewer is read-only plus an annotation layer. A new version is created **only by the owner re-uploading** a revised document (changes were applied externally), matching "Qualified Notes *on* Papers".
+- **Document = Review (1:1 aggregate).** The `Document` is the aggregate root: it carries metadata, the workflow state, the participants, the annotations, and an ordered list of **immutable `DocumentVersion`s** (each an uploaded binary + its `RenderedDocument`, [ADR-0032](0032-document-representation-and-rendering-pipeline.md)). There is no separate long-lived "document shared across multiple reviews" — a fresh review of the same paper is a new `Document`. (A shared-document, multi-cycle history is a future additive enterprise concern, not a rebuild.)
+- **`ReviewParticipant`** is its own relation: `{ documentId, principal = user | team, role = OWNER | REVIEWER }`. Reviewers can be individuals or teams; the owner uploads versions and decides annotation outcomes.
+- **Annotation = a mark + a comment thread.** An `Annotation` is the version-independent anchored mark ([ADR-0009](0009-multi-layer-annotation-anchoring.md)) carrying status `OPEN | ACCEPTED | REJECTED`; it owns a `Comment[]` thread (the discussion). Status lives on the annotation (the owner's decision), not on individual comments.
+
+### Workflow state machine
+
+An **explicit, enum-based state machine** in the service layer (`qnop-core`, `io.qnop.service`), kept as plain DB-free testable logic ([ADR-0004](0004-layered-architecture-enforced-by-archunit.md)) — not Spring Statemachine. Modeled as a transition table + guard functions applied through a single `transition()` choke-point.
 
 ```
 DRAFT → IN_REVIEW → CHANGES_REQUESTED → IN_REVIEW (after new version) → FINALIZED
                                                                        ↘ CANCELLED
 ```
 
-- **Core invariant:** transition to `FINALIZED` is allowed only when there are **zero** annotations in status `OPEN`. This lives as a domain invariant, not in a controller.
-- Annotation lifecycle is a small sub-machine: `OPEN → ACCEPTED | REJECTED`.
+- **Core invariant:** transition to `FINALIZED` is allowed only when there are **zero** annotations in status `OPEN` — *and* no `AnnotationPlacement` is still `PENDING` (re-anchoring must have completed, [ADR-0033](0033-durable-async-job-execution-on-postgres.md)). This is a domain invariant, not a controller check.
+- Annotation lifecycle is a small sub-machine: `OPEN → ACCEPTED | REJECTED` (owner-decided), which drives `IN_REVIEW → CHANGES_REQUESTED`.
 - Every transition emits an append-only `AuditEvent`.
-
-Model transitions as a transition table + guard functions, applied through a single `transition()` choke-point in the service layer.
 
 ## Rationale
 
-The workflow is small and nearly linear; ~150 lines of tested Java is clearer and dependency-free. Spring Statemachine is in maintenance mode and validates against Spring Boot 3.5.x, not 4.x — wrong risk for long-lived core infra. Keep the shape framework-like (guard interface + single choke-point) so a configurable engine could be introduced later (likely as an enterprise feature) if custom workflows are needed.
+The workflow is small and nearly linear; ~150 lines of tested Java is clearer and dependency-free. Spring Statemachine is in maintenance mode and validates against Spring Boot 3.5.x, not 4.x — wrong risk for long-lived core infra. Keeping the shape framework-like (guard interface + single choke-point) leaves room for a configurable engine later (likely enterprise) if custom workflows are needed.
 
-## Status note
+## Consequences
 
-Recorded now because it shapes the domain model. Implementation is deferred to Phase 1.
+- The model is schema-shaping: `Document`, `DocumentVersion`, `ReviewParticipant`, `Annotation`, `Comment`, `AnnotationPlacement`, `AuditEvent`.
+- Versioning is dead simple (re-upload), and the diff ([ADR-0034](0034-inter-version-diff.md)) compares two uploaded versions, not an edit history.
+- Team-as-reviewer needs a principal abstraction in participants and in annotation authorship/permissions.
+- The `FINALIZED` precondition ties the workflow to async re-anchoring cleanly.
+
+## Alternatives considered
+
+- **In-app editing / co-editing (Google-Docs style).** Rejected: qnop is a review tool; versions come from owner re-upload. Lightweight in-app markup may be revisited but is out of the core.
+- **Document : Review = 1 : N (separate Review entity).** Rejected for now (YAGNI): a 1:1 aggregate covers the prototype's review-centric model and stays lean; a second review is a new document.
+- **Spring Statemachine.** Rejected: maintenance mode, not Boot-4 validated; overkill for a near-linear flow.
+- **Annotation and comment as strictly separate top-level entities.** Rejected: an annotation *is* a mark plus its thread; coupling them models the domain directly.

--- a/docs/adr/0032-document-representation-and-rendering-pipeline.md
+++ b/docs/adr/0032-document-representation-and-rendering-pipeline.md
@@ -1,0 +1,53 @@
+# ADR-0032: Document representation & rendering pipeline
+
+- **Status:** Accepted
+- **Date:** 2026-06-28
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+The review surface must show a document **faithfully** (legal/compliance documents demand visual fidelity to the original) *and* let annotations attach to a stable substrate that survives re-versioning ([ADR-0009](0009-multi-layer-annotation-anchoring.md)). The initial scope is textual documents — PDF first, then DOCX and Markdown — but the product intends to also review non-textual formats later (images, and possibly more), which have **no text layer at all**. We need one representation model that:
+
+- preserves the original's look,
+- gives annotations both a text anchor (when text exists) and a geometric anchor (always),
+- is the same shape regardless of source format, so a new format is an added implementation, not a core rewrite,
+- keeps the frontend "dumb" — it renders pixels and boxes, it is not the authority on where text is.
+
+## Decision
+
+**Hybrid rendering with a server-authoritative, format-agnostic canonical representation.**
+
+1. **Hybrid rendering.** The client renders the *original* for fidelity (PDF.js for PDF; `<img>` for images; converted PDF for DOCX, see [ADR-0010](0010-docx-representation-strategy.md)). It does **not** derive anchoring data from that rendering.
+
+2. **`RenderedDocument` is the canonical model**, produced server-side at ingest and stored as part of the immutable `DocumentVersion`:
+
+   ```
+   RenderedDocument
+    └── Surface[0..N]              a PDF page / an image plane / a converted DOCX page
+         ├── width, height         intrinsic size; anchors are normalized to 0..1 of it
+         ├── visual                how the pixel image is produced (pdf.js / img / converted)
+         └── textLayer?            OPTIONAL: ordered spans { text, charOffsetRange, box(0..1) }
+   ```
+
+   - **Coordinates are normalized to 0..1** of each surface, so a highlight box sits correctly independent of the client's zoom/DPI.
+   - **The text layer is optional.** An image is simply "a document with one surface and no text layer"; region anchoring still works (ADR-0009).
+
+3. **Server-authoritative extraction at ingest.** On upload, the server extracts per surface the text spans (text + offsets) **and** their normalized boxes, using **Apache PDFBox** (Apache-2.0, AGPL-compatible) for PDF. This makes anchoring and re-anchoring deterministic and server-side, and keeps every format funneling into the same `RenderedDocument`. Extraction runs as a durable async job ([ADR-0033](0033-durable-async-job-execution-on-postgres.md)).
+
+4. **A per-format `DocumentExtractor` SPI** ([ADR-0003](0003-agpl-boundary-is-the-spi.md)) turns a raw upload into a `RenderedDocument`. Community ships PDF, image, and Markdown extractors (and DOCX via out-of-process conversion); exotic formats are an enterprise implementation behind the same seam.
+
+5. **Server-mediated upload and serving.** Uploads go client → server → object store: the server validates (MIME/size), computes the content hash, creates the `DocumentVersion`, and enqueues extraction. The original binary and any derived render are served **through the server with per-request authorization**, never via presigned URLs — a review document must only be reachable by its participants, and a shareable presigned URL would bypass that authz. (This builds on the object-store decision in [ADR-0005](0005-binary-documents-in-object-storage.md), which already defines the `StorageProvider` SPI.)
+
+## Consequences
+
+- The frontend is format-agnostic: it renders the original pixels and overlays highlights from stored normalized boxes — the same code for PDF, image, or converted DOCX.
+- Re-anchoring (ADR-0009) and inter-version diff ([ADR-0034](0034-inter-version-diff.md)) both run server-side against the stored text layer — they get it for free.
+- Ingest is heavier (server-side extraction per upload) and must be async + retryable; the PDFBox box coordinates must agree pixel-wise with the PDF.js rendering — guarded by the 0..1 normalization and tests.
+- Adding a format = implementing one `DocumentExtractor`; the viewer, anchoring, diff, and workflow are untouched.
+- Serving through the server keeps the server in the bandwidth path; presigned GET with short TTL remains a deliberate **later** optimization (Phase 2) if load demands it, not a default.
+
+## Alternatives considered
+
+- **A — Render the original in the client and derive anchoring there (PDF.js text layer live).** Rejected as the authority: format-specific (images/DOCX each need a bespoke client path), and re-anchoring would still need server-side text. We keep client rendering for *pixels only*.
+- **B — A canonical server-rendered representation the client displays (DOCX/PDF → unified HTML).** Rejected for the core: loses the original's exact layout, which is non-negotiable for the documents qnop reviews.
+- **Storing only text-quote anchors, no boxes.** Rejected: images have no quotes, and visually locating a highlight needs geometry; region/box anchoring must be a first-class, always-present layer.

--- a/docs/adr/0033-durable-async-job-execution-on-postgres.md
+++ b/docs/adr/0033-durable-async-job-execution-on-postgres.md
@@ -1,0 +1,39 @@
+# ADR-0033: Durable async job execution on Postgres
+
+- **Status:** Accepted
+- **Date:** 2026-06-28
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+The document-review core introduces the first real background work in qnop:
+
+- **Ingest extraction** — turning an uploaded binary into the canonical `RenderedDocument` ([ADR-0032](0032-document-representation-and-rendering-pipeline.md)) is too slow to block the upload response.
+- **Re-anchoring** — on a new version, every open annotation is re-resolved against the new text layer ([ADR-0009](0009-multi-layer-annotation-anchoring.md)); we decided this runs **asynchronously** so the version is visible immediately while anchors "catch up".
+- **Inter-version diff** — computed off the extracted layers ([ADR-0034](0034-inter-version-diff.md)), potentially large.
+
+These are **data-critical**: losing a re-anchoring job would leave annotations stranded `PENDING` forever. We have PostgreSQL and ShedLock ([ADR-0029](0029-distributed-scheduler-locks.md)); Redis and a message broker are deliberately deferred ([ADR-0013](0013-redis-and-search-deferred.md)).
+
+## Decision
+
+**A durable, Postgres-backed job queue using the transactional-outbox pattern — no Redis, no broker.**
+
+- A `job` table holds work items with `type`, `payload` (jsonb), `status` (`PENDING → RUNNING → DONE | FAILED`), `attempts`, `run_after`, and an optimistic `version`.
+- **Enqueue is transactional with the triggering write.** Uploading a version writes the `DocumentVersion` *and* its extraction job in the same DB transaction — the job cannot be lost if the request succeeds, and cannot fire if it rolls back.
+- A **worker poll-loop** claims due `PENDING` jobs (`SELECT … FOR UPDATE SKIP LOCKED`), runs the handler, and marks `DONE`/`FAILED` with **retry + capped exponential backoff**; the poller's scheduling is coordinated across instances by **ShedLock** (ADR-0029), so multiple app nodes don't double-run the cron tick.
+- **Handlers are idempotent.** A job may run more than once (crash after work, before commit); each handler is written to be safe on replay (e.g. re-anchoring recomputes placements deterministically).
+- It is a **generic** facility (`JobType` + a registered handler per type), not re-anchoring-specific — extraction, re-anchoring, and diff are its first three consumers.
+
+## Consequences
+
+- A version upload returns immediately; extraction and re-anchoring complete in the background and surface their results (placement lifecycle, diff cache) when done.
+- Jobs survive restarts and crashes — the durability the data-criticality demands; `@Async`/in-memory executors cannot offer this.
+- No new infrastructure: reuses Postgres + ShedLock, keeping ADR-0013 intact. The trade-off is more in-house code (table, poller, retry/backoff, idempotency) than an off-the-shelf queue, and polling latency in the seconds range (fine for ingest/re-anchoring; not a low-latency bus).
+- The workflow couples cleanly: a version with `PENDING` placements is "not yet decidable", so `FINALIZED` (zero open annotations, [ADR-0011](0011-review-workflow-state-model.md)) is only reachable once its jobs complete.
+- When real-time presence arrives (Phase 2) and Redis enters the stack, a broker-backed queue can supersede this for low-latency needs; durable bulk work can stay here.
+
+## Alternatives considered
+
+- **Spring `@Async` + thread pool.** Rejected: in-memory; a crash/restart mid-job loses the work and strands annotations `PENDING` permanently — unacceptable for re-anchoring.
+- **Redis / RabbitMQ / Kafka queue.** Rejected for now: pulls a broker into the On-Prem story early, against ADR-0013; Postgres-backed queues are well-proven at this scale (`FOR UPDATE SKIP LOCKED`).
+- **Spring Batch / Quartz.** Rejected: heavier than needed; we want a small, explicit, idempotent job table, not a scheduling framework.

--- a/docs/adr/0034-inter-version-diff.md
+++ b/docs/adr/0034-inter-version-diff.md
@@ -1,0 +1,35 @@
+# ADR-0034: Inter-version diff
+
+- **Status:** Accepted
+- **Date:** 2026-06-28
+- **Deciders:** bigpuritz, devtank42 (with Claude)
+
+## Context
+
+A reviewer's most common question on a new version is "what changed since the last one?". The design prototype has a dedicated diff surface. This is a **Community-core** feature, not enterprise. We must decide what is diffed, how it is shown, and when it is computed — and avoid confusing it with re-anchoring.
+
+The architecture already gives us a strong starting point: every `DocumentVersion` carries a server-extracted text layer ([ADR-0032](0032-document-representation-and-rendering-pipeline.md)), so both sides of a comparison are already on hand.
+
+## Decision
+
+**A text diff over the extracted text layer, visually located on the original via the stored boxes.**
+
+- **Substrate: the extracted text layer.** A Myers/LCS diff (library: `diff-match-patch` or `java-diff-utils`, both Apache-2.0) over the two versions' text, at word/sentence granularity. Format-agnostic — PDF, DOCX, and Markdown all expose a text layer, so one diff path serves all text formats.
+- **Visually located, not a bare two-column view.** The diff yields changed spans; we map each changed span back to its normalized box and highlight the change (inserted / deleted / modified) **on the rendered original**. The boxes from ADR-0032 make this almost free; a plain side-by-side text view is the fallback, not the primary presentation.
+- **Images: no semantic diff.** With no text layer, the Community presentation is **side-by-side** (a simple pixel overlay may come later). Content-based visual region diff is AI/enterprise territory behind the SPI.
+- **Computed on-demand and cached.** Because versions are immutable, a diff between any two versions is **stable forever** → compute lazily, cache indefinitely (never invalidated). Arbitrary pairs are diffable (v1↔v3), not only adjacent ones. Large diffs may be offloaded to the durable job queue ([ADR-0033](0033-durable-async-job-execution-on-postgres.md)) — no new infrastructure.
+
+**Diff is not re-anchoring.** Both read the two text layers, but answer different questions: re-anchoring is *"where is this one annotated spot now?"* (per-anchor), diff is *"what changed overall?"* (global). They stay separate operations; a known diff may later optimize re-anchoring (which regions are stable/moved/deleted), but that coupling is deferred.
+
+## Consequences
+
+- The diff reuses data we already store (text layer + boxes) — little new machinery, and it lands visually on the real document instead of as raw text columns.
+- Works uniformly across PDF/DOCX/MD; images degrade honestly to side-by-side.
+- Caching is trivially correct (immutable versions); cache entries are keyed by the (from-version, to-version) pair.
+- A semantic/structural diff (clause-aware) and image region diff are explicitly **deferred** (enterprise / later).
+
+## Alternatives considered
+
+- **Diffing the rendered pixels.** Rejected as the core: not semantic, noisy on re-flow, and unavailable as text for downstream use. Kept only as the image fallback.
+- **Diffing the source bytes (PDF/DOCX internals).** Rejected: format-specific and meaningless to a reviewer; the extracted text is the human-relevant substrate.
+- **Precompute every adjacent diff at ingest.** Rejected as the default: wastes work on versions never compared; on-demand + permanent cache covers it, with the option to offload heavy cases to the job queue.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,9 +20,9 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0006](0006-gradle-kotlin-dsl-jdk21.md) | Gradle Kotlin DSL, convention plugins, JDK 21 | Accepted |
 | [0007](0007-spdx-dco-license-scanning.md) | SPDX headers, DCO, license scanning in CI | Accepted |
 | [0008](0008-contribution-and-branching-workflow.md) | Contribution & branching workflow | Accepted |
-| [0009](0009-multi-layer-annotation-anchoring.md) | Multi-layer annotation anchoring | Proposed |
-| [0010](0010-docx-representation-strategy.md) | DOCX representation strategy | Proposed |
-| [0011](0011-review-workflow-state-model.md) | Review workflow state model | Proposed |
+| [0009](0009-multi-layer-annotation-anchoring.md) | Multi-layer annotation anchoring | Accepted |
+| [0010](0010-docx-representation-strategy.md) | DOCX representation strategy | Accepted |
+| [0011](0011-review-workflow-state-model.md) | Review workflow & domain model | Accepted |
 | [0012](0012-edition-vs-entitlements.md) | Edition vs. entitlements / license gating | Proposed |
 | [0013](0013-redis-and-search-deferred.md) | Redis & search index deferred | Proposed |
 | [0014](0014-frontend-enterprise-separation.md) | Frontend enterprise separation | Proposed |
@@ -43,6 +43,9 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0029](0029-distributed-scheduler-locks.md) | Distributed scheduler locks for @Scheduled jobs (ShedLock) | Accepted |
 | [0030](0030-concurrency-control-strategy.md) | Concurrency control for entity writes (optimistic locking + atomic updates) | Accepted |
 | [0031](0031-profile-avatar-storage.md) | Profile-avatar storage in Postgres bytea behind an AvatarStorage port | Accepted |
+| [0032](0032-document-representation-and-rendering-pipeline.md) | Document representation & rendering pipeline | Accepted |
+| [0033](0033-durable-async-job-execution-on-postgres.md) | Durable async job execution on Postgres | Accepted |
+| [0034](0034-inter-version-diff.md) | Inter-version diff | Accepted |
 
 ## Template
 


### PR DESCRIPTION
Closes #239.

Records the target architecture for the **document-review core** from the architecture discussion — three new ADRs plus three Phase-0 "Proposed" direction-setters finalized to **Accepted**. No implementation; this is the decision record that Phase-1 work will build against.

## New
- **ADR-0032 — Document representation & rendering pipeline.** Hybrid rendering (original for fidelity + extracted text layer for resilient anchoring); a server-authoritative, format-agnostic `RenderedDocument` (surfaces + optional text layer + normalized 0..1 boxes); PDFBox extraction; per-format `DocumentExtractor` SPI; server-mediated upload/serving with per-request authz. Images are first-class (region-only).
- **ADR-0033 — Durable async job execution on Postgres.** Transactional-outbox job table + worker poll-loop + ShedLock; no Redis (keeps ADR-0013). Powers extraction, re-anchoring, and diff.
- **ADR-0034 — Inter-version diff.** Text diff over the extracted layer, visually located on the original via the boxes; `diff-match-patch`; on-demand + cached (immutable versions). Community-core.

## Finalized (Proposed → Accepted)
- **ADR-0009 — Anchoring.** Region anchoring universal (images), text-quote optional; async re-anchoring; `AnnotationPlacement` lifecycle `PENDING → PLACED | MOVED | ORPHANED | FAILED`.
- **ADR-0010 — DOCX.** Resolved to the hybrid: DOCX→PDF out-of-process → the canonical pipeline of ADR-0032.
- **ADR-0011 — Review workflow & domain model.** `Document = Review` (1:1 aggregate); `ReviewParticipant` (user|team, OWNER|REVIEWER); Annotation = mark + comment thread; versions only via owner re-upload; state machine + `FINALIZED` invariant (zero OPEN, none PENDING).

`ADR-0005` (object storage + `StorageProvider` SPI) was already Accepted and is unchanged; ADR-0032 only layers the upload/serving path on top. Index updated; all cross-links verified.

## Decision trail (this PR captures)
Hybrid rendering (C) · PDF-first with image/DOCX/MD seams · server-authoritative representation · content+context anchoring with human-in-the-loop orphans · async re-anchoring on a Postgres durable queue · Document=Review 1:1 · ReviewParticipant · server-mediated storage access · visually-located text diff as a Community feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code