### PR TITLE
build: align Renovate minimumReleaseAge with pnpm 11 supply-chain karenz (#264)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,8 @@
   "extends": ["github>qnophq/.github"],
   "schedule": ["at any time"],
   "prHourlyLimit": 10,
+  "//": "Hold updates until packages clear pnpm 11's supply-chain minimum release age (~24h), plus margin, so deps PRs never fail `pnpm install --frozen-lockfile` for being too fresh. See ADR-0017 / issue #264.",
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "description": "Spring Boot starters, BOM, security, and dependency-management plugin",


### PR DESCRIPTION
Closes #264.

## Why
pnpm 11 enforces a ~24 h **supply-chain minimum release age** on `pnpm install --frozen-lockfile` — freshly published packages are rejected (`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`). It's a pnpm-11 default, not configured in the repo. Renovate had **no** matching setting, so it opened deps PRs for versions younger than that karenz, which then failed the Frontend job until the package matured (e.g. **#263**: `lucide-react@1.23.0`, published <24 h ago). This recurred for basically every `npm-deps` PR — pure red-PR noise, not a real failure.

## Change
`.github/renovate.json`: add `"minimumReleaseAge": "3 days"` (comfortably above pnpm's ~24 h) so Renovate only proposes versions CI will accept. The pnpm supply-chain protection stays; Renovate just stops racing ahead of it.

- Lower to `"1 day"` if you'd rather mirror pnpm exactly for faster updates — 3 days is the safer/standard supply-chain value and matches qnop's pin-everything posture.
- Could later be promoted to the org preset (`qnophq/.github`) since the pnpm-11 default affects every pnpm repo.

## Effect on #263
Once this merges and Renovate reruns, it regenerates the `npm-deps` PR **without** the too-fresh `lucide-react@1.23.0` → conflict + Frontend both clear. (#263 also self-heals tomorrow when that version matures.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code