### PR TITLE
build: align openapi-generator versions and group them in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,15 @@
   "prHourlyLimit": 10,
   "packageRules": [
     {
+      "description": "OpenAPI Generator — the Gradle plugin (Java DTOs + Spring interfaces) and the npm CLI (TypeScript client) run against the same openapi.yaml, so they must move in lockstep to avoid template/serialization drift",
+      "matchPackageNames": [
+        "/^org\\.openapi\\.generator/",
+        "/^@openapitools/"
+      ],
+      "groupName": "OpenAPI Generator",
+      "groupSlug": "openapi-generator"
+    },
+    {
       "description": "Spring Boot starters, BOM, security, and dependency-management plugin",
       "matchManagers": ["gradle", "gradle-wrapper"],
       "matchPackageNames": [

--- a/qnop-ui/openapitools.json
+++ b/qnop-ui/openapitools.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/schema/openapitools.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.12.0",
+    "version": "7.23.0",
     "generators": {
       "qnop-api": {
         "generatorName": "typescript-axios",


### PR DESCRIPTION
## Summary

The two openapi-generator instances that run against the **same** `openapi.yaml` had drifted: the Gradle plugin (Java DTOs + Spring interfaces) at `7.23.0`, the npm CLI (TypeScript-Axios client) at `7.12.0` — eleven minor releases apart. Minor releases change mustache templates / serialization options, risking silent model mismatches between the generated TS client and the backend DTOs.

- `qnop-ui/openapitools.json` → `7.23.0` (matches the Gradle plugin).
- New Renovate `packageRule` groups `org.openapi.generator` (gradle) and `@openapitools` (npm) under **"OpenAPI Generator"** so future bumps move both in lockstep.

## Test plan

- [x] Both JSON files validate.
- [ ] CI regenerates the TypeScript client with 7.23.0 (the generated `src/api/generated` is build-time only, not committed).

Closes #193

🤖 Co-Author: Claude (Opus 4.x) via Claude Code