### PR TITLE
test: cover PasswordChangeRequiredFilter enforcement (#189)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AuthControllerIT.java
@@ -214,6 +214,33 @@ class AuthControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
+  void passwordChangeRequiredBlocksProtectedPathsButAllowsChangePassword() throws Exception {
+    // A valid JWT whose user still must change their password (pcr claim = true).
+    User user = createUser("olivia");
+    user.setPasswordChangeRequired(true);
+    userRepository.saveAndFlush(user);
+    String accessToken = jwtTokenService.issueAccessToken(user.getId());
+
+    // Protected endpoint: blocked with 403 and the PASSWORD_CHANGE_REQUIRED code.
+    mockMvc
+        .perform(get("/api/v1/users/me").header("Authorization", "Bearer " + accessToken))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("PASSWORD_CHANGE_REQUIRED"));
+
+    // Allow-listed path (/api/v1/auth/**): the change-password endpoint stays reachable.
+    String body =
+        "{\"currentPassword\":\"%s\",\"newPassword\":\"%s\"}"
+            .formatted(PASSWORD, "a-brand-new-strong-password");
+    mockMvc
+        .perform(
+            post("/api/v1/auth/change-password")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
   void changePasswordAcceptsTheEightCharacterPolicyMinimum() throws Exception {
     // Regression: the change-password minimum must stay at 8 — matching the other
     // password fields and the UI strength meter. A 12-char minimum here rejected


### PR DESCRIPTION
## What

Adds an integration test for the security-critical `PasswordChangeRequiredFilter`. Closes #189.

Creates a user with `passwordChangeRequired = true`, mints a JWT (which carries the `pcr` claim), then asserts:
- `GET /api/v1/users/me` → **403** with body `code = PASSWORD_CHANGE_REQUIRED`,
- `POST /api/v1/auth/change-password` (the allow-listed `/api/v1/auth/**` path) → **204**.

This pins the enforcement so a change to `AUTH_PREFIX` or filter ordering cannot silently regress. (The 403 body uses the `code` envelope field; the issue example `{"error":...}` was outdated.)

## Test plan
- [x] compile, spotlessCheck, ArchUnit (local)
- [ ] AuthControllerIT (Testcontainers, CI)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code