### PR TITLE
fix: align displayName maxLength to VARCHAR(255) across schemas

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2202,6 +2202,7 @@ components:
           format: uuid
         displayName:
           type: string
+          maxLength: 255
         email:
           type: string
         username:
@@ -2308,7 +2309,7 @@ components:
         displayName:
           type: string
           minLength: 1
-          maxLength: 200
+          maxLength: 255
         username:
           type: string
           minLength: 3
@@ -2337,7 +2338,7 @@ components:
         displayName:
           type: string
           minLength: 1
-          maxLength: 200
+          maxLength: 255
           nullable: true
         role:
           allOf:


### PR DESCRIPTION
## Summary

Fixes #186. The `displayName` field diverged in the OpenAPI contract:

| Schema | before | after |
|---|---|---|
| `RegisterRequest` | 255 | 255 (unchanged) |
| `AdminUserCreateRequest` | **200** | 255 |
| `AdminUserUpdateRequest` | **200** | 255 |
| `AdminUserSummary` (response) | *none* | 255 (added) |

A self-registered display name of 201–255 chars was valid, but an admin editing
it via `PATCH /admin/users/{id}` hit the 200 cap → 400. The `qnop_user.display_name`
column is `VARCHAR(255)` (`0001-identity-schema`), so 255 is the true bound.

## Test plan

- `./gradlew spotlessApply :qnop-app:compileJava :qnop-app:test --tests 'io.qnop.architecture.*'` green (OpenAPI regenerated, compiles, ArchUnit passes).
- No server code hardcoded 200 for display name (verified).

🤖 Co-Author: Claude (Opus 4.x) via Claude Code