### PR TITLE
build: pin the Gradle distribution checksum (distributionSha256Sum)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary

`gradle-wrapper.properties` had no `distributionSha256Sum`, so a cold `./gradlew` run trusts whatever the distribution URL returns. A network-level attacker (corporate proxy, compromised CDN mirror, split-DNS) could substitute a malicious Gradle and run arbitrary code on every developer machine and CI runner. `gradle/actions/setup-gradle` verifies the wrapper JAR but **not** the distribution ZIP.

Adds the canonical SHA-256 for `gradle-9.6.1-bin.zip`:

```
distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
```

sourced from Gradle's own `…/gradle-9.6.1-bin.zip.sha256`. Renovate's `gradle-wrapper` manager updates this field automatically on future bumps.

## Test plan

- [x] `./gradlew --version` runs cleanly with the checksum in place (Gradle 9.6.1); the value matches the official published `.sha256`.
- On a cold CI runner Gradle downloads the ZIP and verifies it against this hash before extraction.

Closes #194

🤖 Co-Author: Claude (Opus 4.x) via Claude Code