### PR TITLE
test: OidcLoginService provider-resolution branches (#191)

### DIFF
--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcLoginServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcLoginServiceTest.java
@@ -102,4 +102,37 @@ class OidcLoginServiceTest {
     assertThat(result.userId()).isEqualTo(userId);
     assertThat(result.upstreamIdToken()).isEqualTo("idtok");
   }
+
+  @Test
+  @DisplayName("rejects a registrationId that does not resolve to a provider id")
+  void rejectsUnparseableRegistrationId() {
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn("not-a-uuid");
+
+    assertThatThrownBy(() -> service.completeLogin(authentication, "tok"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("rejects a login for an unknown provider id")
+  void rejectsUnknownProvider() {
+    UUID providerId = UUID.randomUUID();
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(providerId.toString());
+    when(providers.findById(providerId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.completeLogin(authentication, "tok"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("rejects a replayed callback for a disabled provider before provisioning")
+  void rejectsDisabledProvider() {
+    UUID providerId = UUID.randomUUID();
+    OidcProvider provider = mock(OidcProvider.class);
+    when(provider.isEnabled()).thenReturn(false);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(providerId.toString());
+    when(providers.findById(providerId)).thenReturn(Optional.of(provider));
+
+    assertThatThrownBy(() -> service.completeLogin(authentication, "tok"))
+        .isInstanceOf(IllegalStateException.class);
+  }
 }


### PR DESCRIPTION
## What

Adds three cases to `OidcLoginServiceTest` for the provider-resolution branches of `completeLogin` that ran before the account check and were untested. Closes #191.

- unparseable `registrationId` (`OidcRegistrationIds.toProviderId` empty) → `IllegalStateException`
- unknown provider id (`findById` empty) → `IllegalStateException`
- **disabled provider** (`filter(isEnabled)` removes it) → `IllegalStateException` — the security-relevant one: a replayed OAuth2 callback for a provider disabled in the admin UI is rejected before any user provisioning.

DB-free Mockito unit test (verified locally).

## Test plan
- [x] `:qnop-core:test --tests OidcLoginServiceTest` (green locally), spotlessCheck

🤖 Co-Author: Claude (Opus 4.x) via Claude Code