### PR TITLE
fix: add format:uri and maxLength to OIDC URI fields in the contract

### DIFF
--- a/qnop-api/qnop-api-model/build.gradle.kts
+++ b/qnop-api/qnop-api-model/build.gradle.kts
@@ -59,6 +59,11 @@ openApiGenerate {
             "hideGenerationTimestamp" to "true",
         ),
     )
+    // Keep `format: uri` string fields typed as String, not java.net.URI (issue #187):
+    // the annotation documents the contract for tooling (Swagger, the generated TS
+    // client) and adds a maxLength bound, without changing the server-side field type
+    // — the service layer's SSRF guard already enforces URI validity semantically.
+    typeMappings.set(mapOf("URI" to "String"))
     // MODELS ONLY — no apis, no supporting files. The `java` generator emits
     // plain POJOs (Jackson + Jakarta Bean Validation, java.time dates), so this
     // artifact stays Spring-free.

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2660,16 +2660,26 @@ components:
           maxLength: 1024
         issuerUri:
           type: string
+          format: uri
+          maxLength: 512
         scope:
           type: string
         authorizationUri:
           type: string
+          format: uri
+          maxLength: 512
         tokenUri:
           type: string
+          format: uri
+          maxLength: 512
         userInfoUri:
           type: string
+          format: uri
+          maxLength: 512
         jwkSetUri:
           type: string
+          format: uri
+          maxLength: 512
         userNameAttribute:
           type: string
         emailAttribute:
@@ -2698,16 +2708,26 @@ components:
           maxLength: 1024
         issuerUri:
           type: string
+          format: uri
+          maxLength: 512
         scope:
           type: string
         authorizationUri:
           type: string
+          format: uri
+          maxLength: 512
         tokenUri:
           type: string
+          format: uri
+          maxLength: 512
         userInfoUri:
           type: string
+          format: uri
+          maxLength: 512
         jwkSetUri:
           type: string
+          format: uri
+          maxLength: 512
         userNameAttribute:
           type: string
         emailAttribute:
@@ -2719,6 +2739,8 @@ components:
       properties:
         issuerUri:
           type: string
+          format: uri
+          maxLength: 512
       required:
         - issuerUri
     OidcDiscoveryResponse:


### PR DESCRIPTION
## Summary

Fixes #187. The OIDC URI request fields accepted any string (empty, path-only,
arbitrarily large) with no OpenAPI signal that a URI is expected and no bound
against oversized payloads.

Add `format: uri` + `maxLength: 512` to the URI fields of:
- `OidcProviderCreateRequest` (`issuerUri`, `authorizationUri`, `tokenUri`, `userInfoUri`, `jwkSetUri`)
- `OidcProviderUpdateRequest` (same fields)
- `OidcDiscoveryRequest` (`issuerUri`)

`512` matches the `VARCHAR(512)` columns (`0001-identity-schema`), keeping the API
bound consistent with the DB (rather than the `2048` the issue loosely suggested,
which would recreate a divergence).

## Generator note

The `spring`/`java` generator maps `format: uri` → `java.net.URI`, which would
change the server-side field type and break `OidcProviderController`. I added a
`typeMappings(URI -> String)` override in `qnop-api-model` so the annotation stays
in the published contract (Swagger + generated TS client see `format: uri`) and
adds the `@Size(512)` bound, while the Java DTO remains `String` — **no server-side
behaviour change**, and the service SSRF guard still enforces URI validity.

## Test plan

- `./gradlew spotlessApply :qnop-app:compileJava :qnop-app:test --tests 'io.qnop.architecture.*'` green.
- Verified the regenerated `OidcDiscoveryRequest.issuerUri` is `String` with `@Size(max=512)`.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code