### PR TITLE
test: cover UserService self-registration, existence and password-reset paths

### DIFF
--- a/qnop-core/src/test/java/io/qnop/service/UserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/UserServiceTest.java
@@ -22,11 +22,13 @@ package io.qnop.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.qnop.entity.User;
 import io.qnop.entity.UserRole;
+import io.qnop.entity.UserSource;
 import io.qnop.repository.UserRepository;
 import io.qnop.service.UserService.UserProfileView;
 import java.util.Optional;
@@ -66,5 +68,70 @@ class UserServiceTest {
     when(users.findById(id)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.getProfile(id)).isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("createSelfRegistered falls back to the username when the display name is blank")
+  void createSelfRegisteredFallsBackToUsername() {
+    when(passwordEncoder.encode("secret")).thenReturn("hashed");
+    when(users.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    User created =
+        service.createSelfRegistered("jdoe", "jdoe@example.com", "secret", "  ", UserRole.MEMBER);
+
+    assertThat(created.getDisplayName()).isEqualTo("jdoe");
+    assertThat(created.getRole()).isEqualTo(UserRole.MEMBER);
+    assertThat(created.isEnabled()).isFalse();
+    assertThat(created.getEmail()).isEqualTo("jdoe@example.com");
+  }
+
+  @Test
+  @DisplayName("createSelfRegistered tolerates a null email (normalizeEmail short-circuits)")
+  void createSelfRegisteredWithNullEmail() {
+    when(passwordEncoder.encode("secret")).thenReturn("hashed");
+    when(users.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    User created =
+        service.createSelfRegistered("jdoe", null, "secret", "Jane Doe", UserRole.MEMBER);
+
+    assertThat(created.getEmail()).isNull();
+    assertThat(created.getDisplayName()).isEqualTo("Jane Doe");
+  }
+
+  @Test
+  @DisplayName("internalUserExists returns true on an email match alone, normalizing case")
+  void internalUserExistsOnEmailOnly() {
+    when(users.existsByEmailIgnoreCaseAndSource("bob@example.com", UserSource.INTERNAL))
+        .thenReturn(true);
+
+    // The email branch short-circuits the OR, so the username lookup is never consulted.
+    assertThat(service.internalUserExists("bob", "Bob@Example.com")).isTrue();
+  }
+
+  @Test
+  @DisplayName(
+      "applyPasswordReset re-hashes, clears the forced-change flag and invalidates sessions")
+  void applyPasswordResetInvalidatesSessions() {
+    UUID id = UUID.randomUUID();
+    User user = User.internal("Bob", "bob@example.com", "bob", "old-hash");
+    user.setPasswordChangeRequired(true);
+    when(users.findById(id)).thenReturn(Optional.of(user));
+    when(passwordEncoder.encode("new-password")).thenReturn("new-hash");
+
+    User result = service.applyPasswordReset(id, "new-password");
+
+    assertThat(result.getPasswordHash()).isEqualTo("new-hash");
+    assertThat(result.isPasswordChangeRequired()).isFalse();
+    assertThat(result.getPasswordInvalidatedBefore()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("applyPasswordReset throws for an unknown user")
+  void applyPasswordResetRejectsUnknownUser() {
+    UUID id = UUID.randomUUID();
+    when(users.findById(id)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.applyPasswordReset(id, "new-password"))
+        .isInstanceOf(UserNotFoundException.class);
   }
 }


### PR DESCRIPTION
## Summary

Extends `UserServiceTest` to cover the `UserService` branches that were previously untested (issue #192). **Additive tests only — no production code changes.**

New cases:
- `createSelfRegistered` falls back to the username when the display name is blank, and creates the account disabled.
- `createSelfRegistered` tolerates a `null` email (`normalizeEmail` short-circuits, no NPE).
- `internalUserExists` returns `true` on an email match alone, normalizing case (the email branch short-circuits the OR, so no username lookup is stubbed).
- `applyPasswordReset` re-hashes, clears the forced-change flag and stamps `passwordInvalidatedBefore` (token invalidation), plus its unknown-user rejection.

## Test plan
- [x] `./gradlew spotlessApply spotlessCheck :qnop-core:test --tests "io.qnop.service.UserServiceTest"` — green locally
- [ ] CI green

Closes #192

🤖 Co-Author: Claude (Opus 4.x) via Claude Code