### PR TITLE
ci: per-PR dependency vulnerability audit gates (frontend pnpm audit + backend OWASP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,30 @@ jobs:
       # conformance tests via the `check` task.
       - run: ./gradlew build --stacktrace
 
+  backend-audit:
+    name: Backend dependency audit (OWASP)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+      # Per-PR backend CVE gate (#195): OWASP Dependency-Check fails on CVSS >= 7.
+      # It needs a (free) NVD API key to hit the NVD feed without heavy rate-limiting,
+      # so the step is a no-op until the NVD_API_KEY repository secret is set — then it
+      # becomes an active gate. NVD_API_KEY is read from the env (never the CLI).
+      - name: OWASP Dependency-Check (aggregate)
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: |
+          if [ -z "$NVD_API_KEY" ]; then
+            echo "::notice::NVD_API_KEY secret not set — skipping the OWASP backend audit. Request a free key at https://nvd.nist.gov/developers/request-an-api-key and add it as the NVD_API_KEY secret to enable the per-PR backend CVE gate."
+            exit 0
+          fi
+          ./gradlew dependencyCheckAggregate --stacktrace
+
   qnop-ui:
     name: Frontend (lint + format + test + build)
     runs-on: ubuntu-latest
@@ -52,6 +76,9 @@ jobs:
           distribution: temurin
           java-version: '21'
       - run: pnpm install --frozen-lockfile
+      # Per-PR vulnerability gate (#195): fail on a high/critical advisory in the
+      # frontend dependency tree, independent of Renovate's scheduled runs.
+      - run: pnpm audit --audit-level high
       # Generate the API client up front so lint/test/build see it (build also
       # regenerates it via its own script; this keeps test:run self-sufficient).
       - run: pnpm generate:api

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,23 @@
 plugins {
     alias(libs.plugins.spring.boot) apply false
     alias(libs.plugins.openapi.generator) apply false
+    // OWASP Dependency-Check (issue #195): applied at the root so
+    // `dependencyCheckAggregate` scans every module against the NVD. It is NOT wired
+    // into `check`/`build`, so the local gate is unaffected; the CI `backend-audit`
+    // job invokes it only when an NVD API key secret is present (otherwise the NVD
+    // feed is heavily rate-limited).
+    alias(libs.plugins.dependency.check)
+}
+
+dependencyCheck {
+    // Fail on a high/critical advisory (CVSS >= 7.0) in any module's runtime deps.
+    failBuildOnCVSS = 7.0f
+    formats = listOf("HTML", "SARIF")
+    // NVD API key from the NVD_API_KEY env var (CI secret) or a -PnvdApiKey property;
+    // kept off the command line so it does not leak into build logs.
+    (findProperty("nvdApiKey") as String? ?: System.getenv("NVD_API_KEY"))
+        ?.takeIf { it.isNotBlank() }
+        ?.let { nvd.apiKey = it }
 }
 
 tasks.register("buildAll") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,10 @@ archunit = "1.4.2"
 # NOTE: keep `spotless` in sync with build-logic/build.gradle.kts (precompiled
 # script plugins cannot read this catalog at plugin-resolution time).
 spotless = "8.7.0"
+# OWASP Dependency-Check — backend per-PR CVE gate (issue #195). Applied at the
+# root; the CI job runs dependencyCheckAggregate only when an NVD API key secret
+# is present.
+dependencyCheck = "12.1.0"
 # Spring Boot plugin + BOM. The BOM (spring-boot-dependencies) manages the
 # versions of the Spring stack, JPA/Hibernate, the PostgreSQL driver, Liquibase
 # and Testcontainers — so those artifacts are declared below WITHOUT versions.
@@ -111,3 +115,4 @@ testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-jun
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGenerator" }
+dependency-check = { id = "org.owasp.dependencycheck", version.ref = "dependencyCheck" }


### PR DESCRIPTION
## Summary

CI had no per-PR CVE gate — detection relied solely on Renovate's weekday-04:00 schedule, so an advisory published between runs wouldn't block a merge. Adds a gate for each stack.

### Frontend
`pnpm audit --audit-level high` step in the `qnop-ui` job — non-zero exit on high/critical advisories. Verified locally: **no known vulnerabilities** today, so it passes.

### Backend
OWASP Dependency-Check applied at the root build (fails on **CVSS ≥ 7** via `dependencyCheckAggregate`), driven by a new `backend-audit` job.

- The NVD feed is heavily rate-limited without an API key, so the step is a **no-op (green) until the `NVD_API_KEY` repository secret is set**, then it becomes an active gate. The key is read from the env, never the CLI (no log leak).
- The plugin is **not** wired into `check`/`build` — the local `./gradlew build` gate is unchanged.

> **Why not GitHub Dependency Review?** It requires GitHub Advanced Security, which is **not enabled** on this private repo (verified: `security_and_analysis` empty, vulnerability-alerts 404) — the action would hard-fail. OWASP + the free NVD key is the portable choice.

## Test plan

- [x] `pnpm audit --audit-level high` runs clean locally.
- [x] Root build config applies with the OWASP plugin; `dependencyCheckAggregate` task registered; Docker-free compile + ArchUnit green (plugin doesn't disturb normal tasks).
- [x] `ci.yml` job structure validated.
- [ ] Full `./gradlew build` + the backend-audit no-op path run in CI.

**Follow-up for a maintainer:** add the free `NVD_API_KEY` secret to activate the backend gate.

Closes #195

🤖 Co-Author: Claude (Opus 4.x) via Claude Code