### PR TITLE
build: enforce SPDX headers on Kotlin DSL files via Spotless

### DIFF
--- a/build-logic/src/main/kotlin/qnop.java-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/qnop.java-conventions.gradle.kts
@@ -42,6 +42,18 @@ spotless {
         trimTrailingWhitespace()
         endWithNewline()
     }
+    kotlinGradle {
+        // ADR-0007 + ADR-0019: Kotlin-DSL build scripts also carry the SPDX header,
+        // now auto-inserted/checked by `spotlessApply`/`build` instead of only the CI
+        // grep (issue #196). Kotlin uses a short `//` header (not the Java block), so a
+        // dedicated header file. The delimiter ends the header region at the first line
+        // that is neither the copyright nor the SPDX line, so descriptive `//` comments
+        // (and a blank line) below the header are preserved rather than stripped.
+        licenseHeaderFile(
+            rootProject.file("license-header-kts.txt"),
+            "(?!// (?:Copyright|SPDX-License-Identifier)).*",
+        )
+    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/license-header-kts.txt
+++ b/license-header-kts.txt
@@ -1,0 +1,2 @@
+// Copyright (c) 2026-present devtank42 GmbH
+// SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
## Summary

The `qnop.java-conventions` Spotless config only had a `java { … }` target, so `.kts` build scripts were checked for the SPDX header **only** by the bash `grep` in the `license-headers` CI job — not by Spotless. A developer adding a new `.kts` without a header would have `./gradlew spotlessApply` pass silently while CI fails, diverging from the local `./gradlew build` gate.

Adds a `kotlinGradle { … }` Spotless target to the convention plugin so `spotlessApply` is the single tool for both Java and Kotlin DSL headers.

### The tricky part

`.kts` files use a **short `//` header** (copyright + SPDX), not the Java block comment, and most carry descriptive `//` comments right below it. A naive `licenseHeaderFile` would treat those descriptions as part of the header region and strip them. So:

- a dedicated `license-header-kts.txt` (the 2-line `//` header);
- a delimiter — `(?!// (?:Copyright|SPDX-License-Identifier)).*` — that ends the header region at the first line that is neither the copyright nor the SPDX line, preserving the descriptions and any blank line below.

## Test plan

- [x] `./gradlew spotlessApply` leaves **all existing `.kts` unchanged** (delimiter preserves headers + descriptions) — verified via clean `git status`.
- [x] A header-less probe `.kts` gets the 2-line header inserted by `spotlessApply` (and thus fails `spotlessCheck`, which is wired into `build`).

Closes #196

🤖 Co-Author: Claude (Opus 4.x) via Claude Code