### PR TITLE
fix: replace invalid Renovate `//` comment key with `description` (#267)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["github>qnophq/.github"],
   "schedule": ["at any time"],
   "prHourlyLimit": 10,
-  "//": "Hold updates until packages clear pnpm 11's supply-chain minimum release age (~24h), plus margin, so deps PRs never fail `pnpm install --frozen-lockfile` for being too fresh. See ADR-0017 / issue #264.",
+  "description": "Hold updates until packages clear pnpm 11's supply-chain minimum release age (~24h), plus margin, so deps PRs never fail `pnpm install --frozen-lockfile` for being too fresh. See ADR-0017 / issue #264.",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Fixes #267. Renovate stopped opening PRs with **"Invalid configuration option: //"**.

### Root cause

#264 (commit `2b68752`) added a top-level `"//"` comment key to `.github/renovate.json` to document the new `minimumReleaseAge`. `"//"` is a `package.json` comment convention that Renovate does **not** accept — it flags it as an unknown option and, as a precaution, halts all dependency PRs until the config is valid.

### Fix

Rename `"//"` to Renovate's supported top-level **`description`** field. Same rationale text, still strict JSON, and no behaviour change to `minimumReleaseAge`.

Verified locally:

```
$ renovate-config-validator .github/renovate.json
 INFO: Config validated successfully against 1 file(s)
```

## Test plan

- [x] `renovate-config-validator` passes on the fixed file.
- [ ] After merge: trigger the Renovate workflow and confirm the config error clears and #267 auto-closes.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code