### PR TITLE
feat(core): durable async job queue on Postgres (#242)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
@@ -55,5 +55,10 @@ public abstract class AbstractIntegrationTest {
     registry.add("qnop.auth.encryption-key", () -> "integration-test-encryption-key-0123456789");
     registry.add("qnop.auth.encryption-salt", () -> "0123456789abcdef0123456789abcdef");
     registry.add("qnop.cors.allowed-origins", () -> "http://localhost:5173");
+    // Effectively disable the background job poller/reaper in tests (interval == initial delay ==
+    // 1h): tests drive the queue via direct poll()/reap() calls, so a stray scheduled tick must not
+    // race them (ADR-0033).
+    registry.add("qnop.jobs.poll-interval-ms", () -> "3600000");
+    registry.add("qnop.jobs.reaper-interval-ms", () -> "3600000");
   }
 }

--- a/qnop-app/src/test/java/io/qnop/job/JobQueueIT.java
+++ b/qnop-app/src/test/java/io/qnop/job/JobQueueIT.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.Job;
+import io.qnop.entity.JobStatus;
+import io.qnop.repository.JobRepository;
+import io.qnop.service.job.JobHandler;
+import io.qnop.service.job.JobQueuePoller;
+import io.qnop.service.job.JobService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/** End-to-end tests for the durable async job queue (issue #242, ADR-0033). Requires Docker. */
+@Import(JobQueueIT.TestHandlerConfig.class)
+class JobQueueIT extends AbstractIntegrationTest {
+
+  static final String TYPE = "test.job";
+
+  @Autowired private JobService jobService;
+  @Autowired private JobQueuePoller poller;
+  @Autowired private JobRepository jobRepository;
+  @Autowired private TestJobHandler handler;
+  @Autowired private JdbcTemplate jdbc;
+  @Autowired private PlatformTransactionManager txManager;
+
+  @BeforeEach
+  void clean() {
+    jdbc.update("DELETE FROM job");
+    handler.reset();
+  }
+
+  @Test
+  @DisplayName("an enqueued job is claimed, handled, and marked DONE")
+  void enqueuedJobRunsToDone() {
+    UUID id = jobService.enqueue(TYPE, "{\"k\":\"v\"}");
+
+    poller.poll();
+
+    assertThat(handler.invocations.get()).isEqualTo(1);
+    assertThat(jobRepository.findById(id).orElseThrow().getStatus()).isEqualTo(JobStatus.DONE);
+  }
+
+  @Test
+  @DisplayName("a failing handler is retried with backoff, then succeeds")
+  void handlerFailureRetriesThenSucceeds() {
+    handler.failFirstN = 1; // fail the first attempt only
+    UUID id = jobService.enqueue(TYPE, "{}");
+
+    poller.poll(); // attempt 1 fails → scheduled retry
+
+    Job afterFail = jobRepository.findById(id).orElseThrow();
+    assertThat(afterFail.getStatus()).isEqualTo(JobStatus.PENDING);
+    assertThat(afterFail.getAttempts()).isEqualTo(1);
+    assertThat(afterFail.getRunAfter()).isAfter(Instant.now()); // backoff pushed it forward
+    assertThat(afterFail.getLastError()).contains("boom");
+
+    makeDue(id);
+    poller.poll(); // attempt 2 succeeds
+
+    Job afterSuccess = jobRepository.findById(id).orElseThrow();
+    assertThat(afterSuccess.getStatus()).isEqualTo(JobStatus.DONE);
+    assertThat(afterSuccess.getAttempts()).isEqualTo(2);
+    assertThat(handler.invocations.get()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("a job that never succeeds is marked FAILED once attempts are exhausted")
+  void exhaustsRetriesAndFails() {
+    handler.failFirstN = 99; // always fail
+    UUID id = insertPendingJob(1); // max_attempts = 1 → one failure exhausts it
+
+    poller.poll();
+
+    Job job = jobRepository.findById(id).orElseThrow();
+    assertThat(job.getStatus()).isEqualTo(JobStatus.FAILED);
+    assertThat(job.getAttempts()).isEqualTo(1);
+    assertThat(job.getLastError()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("the reaper returns crash-stranded RUNNING jobs to PENDING")
+  void reaperReclaimsStaleRunning() {
+    UUID id = insertRunningJob(Instant.now().minus(10, ChronoUnit.MINUTES));
+
+    poller.reap();
+
+    assertThat(jobRepository.findById(id).orElseThrow().getStatus()).isEqualTo(JobStatus.PENDING);
+  }
+
+  @Test
+  @DisplayName("enqueue is transactional with the caller (outbox): a rollback drops the job")
+  void enqueueRollsBackWithCaller() {
+    TransactionTemplate tx = new TransactionTemplate(txManager);
+
+    assertThatThrownBy(
+            () ->
+                tx.executeWithoutResult(
+                    status -> {
+                      jobService.enqueue(TYPE, "{}");
+                      throw new IllegalStateException("caller failed after enqueue");
+                    }))
+        .isInstanceOf(IllegalStateException.class);
+
+    assertThat(jobRepository.count()).isZero();
+  }
+
+  @Test
+  @DisplayName("re-running an already-DONE job is a no-op (idempotency guard)")
+  void runOneIsIdempotentOnDoneJob() {
+    UUID id = jobService.enqueue(TYPE, "{}");
+    poller.poll();
+    assertThat(handler.invocations.get()).isEqualTo(1);
+
+    jobService.runOne(id); // simulate a re-delivery of a completed job
+
+    assertThat(handler.invocations.get()).isEqualTo(1); // not handled twice
+    assertThat(jobRepository.findById(id).orElseThrow().getStatus()).isEqualTo(JobStatus.DONE);
+  }
+
+  private void makeDue(UUID id) {
+    jdbc.update(
+        "UPDATE job SET run_after = ? WHERE id = ?::uuid",
+        Timestamp.from(Instant.now().minusSeconds(1)),
+        id.toString());
+  }
+
+  private UUID insertPendingJob(int maxAttempts) {
+    UUID id = UUID.randomUUID();
+    jdbc.update(
+        "INSERT INTO job (id, type, payload, status, attempts, max_attempts, run_after,"
+            + " created_at, updated_at, version)"
+            + " VALUES (?::uuid, ?, ?::jsonb, 'PENDING', 0, ?, now(), now(), now(), 0)",
+        id.toString(),
+        TYPE,
+        "{}",
+        maxAttempts);
+    return id;
+  }
+
+  private UUID insertRunningJob(Instant updatedAt) {
+    UUID id = UUID.randomUUID();
+    jdbc.update(
+        "INSERT INTO job (id, type, payload, status, attempts, max_attempts, run_after,"
+            + " created_at, updated_at, version)"
+            + " VALUES (?::uuid, ?, ?::jsonb, 'RUNNING', 1, 5, now(), now(), ?, 0)",
+        id.toString(),
+        TYPE,
+        "{}",
+        Timestamp.from(updatedAt));
+    return id;
+  }
+
+  /** A handler whose failure behaviour and invocation count the tests control. */
+  static class TestJobHandler implements JobHandler {
+    final AtomicInteger invocations = new AtomicInteger();
+    volatile int failFirstN = 0;
+
+    @Override
+    public String type() {
+      return TYPE;
+    }
+
+    @Override
+    public void handle(String payload) {
+      int n = invocations.incrementAndGet();
+      if (n <= failFirstN) {
+        throw new IllegalStateException("boom on attempt " + n);
+      }
+    }
+
+    void reset() {
+      invocations.set(0);
+      failFirstN = 0;
+    }
+  }
+
+  @TestConfiguration
+  static class TestHandlerConfig {
+    @Bean
+    TestJobHandler testJobHandler() {
+      return new TestJobHandler();
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/Job.java
+++ b/qnop-core/src/main/java/io/qnop/entity/Job.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * A durable async job (issue #242, ADR-0033). Rows are enqueued transactionally with the triggering
+ * write (outbox), claimed by the poll-loop via {@code FOR UPDATE SKIP LOCKED}, and retried with
+ * capped backoff. The {@link #type} selects the handler; the {@link #payload} is opaque jsonb the
+ * handler parses. Identity is UUIDv7 (Hibernate); {@code @Version} guards concurrent status writes.
+ */
+@Entity
+@Table(name = "job")
+public class Job {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "type", nullable = false, length = 64, updatable = false)
+  private String type;
+
+  /** Opaque jsonb payload; the handler for {@link #type} deserializes it. */
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "payload", nullable = false, updatable = false)
+  private String payload;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 16)
+  private JobStatus status;
+
+  @Column(name = "attempts", nullable = false)
+  private int attempts;
+
+  @Column(name = "max_attempts", nullable = false, updatable = false)
+  private int maxAttempts;
+
+  @Column(name = "run_after", nullable = false)
+  private Instant runAfter;
+
+  @Column(name = "last_error", columnDefinition = "TEXT")
+  private String lastError;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @Version
+  @Column(name = "version", nullable = false)
+  private long version;
+
+  protected Job() {
+    // for JPA
+  }
+
+  public Job(String type, String payload, int maxAttempts, Instant runAfter) {
+    this.type = type;
+    this.payload = payload;
+    this.status = JobStatus.PENDING;
+    this.maxAttempts = maxAttempts;
+    this.runAfter = runAfter;
+  }
+
+  /** Marks the job completed; clears any prior error. */
+  public void markDone() {
+    this.status = JobStatus.DONE;
+    this.lastError = null;
+  }
+
+  /** Re-queues the job for a later attempt after a transient failure. */
+  public void scheduleRetry(Instant nextRunAfter, String error) {
+    this.status = JobStatus.PENDING;
+    this.runAfter = nextRunAfter;
+    this.lastError = error;
+  }
+
+  /** Gives up on the job after exhausting its retries. */
+  public void markFailed(String error) {
+    this.status = JobStatus.FAILED;
+    this.lastError = error;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getPayload() {
+    return payload;
+  }
+
+  public JobStatus getStatus() {
+    return status;
+  }
+
+  public int getAttempts() {
+    return attempts;
+  }
+
+  public int getMaxAttempts() {
+    return maxAttempts;
+  }
+
+  public Instant getRunAfter() {
+    return runAfter;
+  }
+
+  public String getLastError() {
+    return lastError;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Job other)) {
+      return false;
+    }
+    return id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/JobStatus.java
+++ b/qnop-core/src/main/java/io/qnop/entity/JobStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+/** Lifecycle of a durable async job (ADR-0033): {@code PENDING → RUNNING → DONE | FAILED}. */
+public enum JobStatus {
+  /** Queued and due to run once {@code run_after} has passed. */
+  PENDING,
+  /** Claimed by a worker and executing (or left here by a crash — reclaimed by the reaper). */
+  RUNNING,
+  /** Completed successfully. */
+  DONE,
+  /** Exhausted its retries; a human must inspect {@code last_error}. */
+  FAILED
+}

--- a/qnop-core/src/main/java/io/qnop/repository/JobRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/JobRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.Job;
+import io.qnop.entity.JobStatus;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Data access for the durable async job queue (ADR-0033). */
+public interface JobRepository extends JpaRepository<Job, UUID>, JobRepositoryCustom {
+
+  long countByStatus(JobStatus status);
+}

--- a/qnop-core/src/main/java/io/qnop/repository/JobRepositoryCustom.java
+++ b/qnop-core/src/main/java/io/qnop/repository/JobRepositoryCustom.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/** Native-SQL job-queue operations that Spring Data derivation can't express (ADR-0033). */
+public interface JobRepositoryCustom {
+
+  /**
+   * Atomically claims up to {@code limit} due {@code PENDING} jobs: locks them with {@code FOR
+   * UPDATE SKIP LOCKED} (so parallel pollers never grab the same row), flips them to {@code
+   * RUNNING} and bumps {@code attempts}, and returns their ids. Must run inside a transaction.
+   */
+  List<UUID> claimDuePending(Instant now, int limit);
+
+  /**
+   * Reclaims jobs left {@code RUNNING} by a crash — those not touched since {@code staleBefore} —
+   * by resetting them to {@code PENDING}, due immediately. Returns how many were reclaimed.
+   */
+  int reapStaleRunning(Instant staleBefore, Instant now);
+}

--- a/qnop-core/src/main/java/io/qnop/repository/JobRepositoryImpl.java
+++ b/qnop-core/src/main/java/io/qnop/repository/JobRepositoryImpl.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Native-SQL claim/reaper for the job queue (ADR-0033). Spring Data wires this in automatically as
+ * the {@code Impl} fragment of {@link JobRepository}.
+ *
+ * <p>Claiming is two steps in one transaction: a {@code SELECT … FOR UPDATE SKIP LOCKED} locks the
+ * due rows (a plain select returns their ids reliably, avoiding Hibernate's awkward handling of
+ * {@code UPDATE … RETURNING}), then an {@code UPDATE} flips the already-locked rows to {@code
+ * RUNNING}. Parallel pollers skip locked rows, so no job is claimed twice.
+ */
+public class JobRepositoryImpl implements JobRepositoryCustom {
+
+  @PersistenceContext private EntityManager entityManager;
+
+  @Override
+  public List<UUID> claimDuePending(Instant now, int limit) {
+    List<?> raw =
+        entityManager
+            .createNativeQuery(
+                """
+                SELECT id FROM job
+                WHERE status = 'PENDING' AND run_after <= :now
+                ORDER BY run_after, created_at
+                LIMIT :limit
+                FOR UPDATE SKIP LOCKED
+                """)
+            .setParameter("now", now)
+            .setParameter("limit", limit)
+            .getResultList();
+
+    List<UUID> ids = raw.stream().map(UUID.class::cast).toList();
+    if (ids.isEmpty()) {
+      return List.of();
+    }
+
+    entityManager
+        .createNativeQuery(
+            """
+            UPDATE job SET status = 'RUNNING', attempts = attempts + 1, updated_at = :now
+            WHERE id IN (:ids)
+            """)
+        .setParameter("now", now)
+        .setParameter("ids", ids)
+        .executeUpdate();
+
+    return ids;
+  }
+
+  @Override
+  public int reapStaleRunning(Instant staleBefore, Instant now) {
+    return entityManager
+        .createNativeQuery(
+            """
+            UPDATE job SET status = 'PENDING', run_after = :now, updated_at = :now
+            WHERE status = 'RUNNING' AND updated_at < :staleBefore
+            """)
+        .setParameter("now", now)
+        .setParameter("staleBefore", staleBefore)
+        .executeUpdate();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/job/JobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+/**
+ * Processes one job type in the durable queue (ADR-0033). Implementations are Spring beans; {@link
+ * JobService} dispatches by {@link #type()}. Consumers (ingest extraction #245, re-anchoring #248,
+ * diff #249) implement this.
+ */
+public interface JobHandler {
+
+  /**
+   * The job type this handler processes, matching {@code Job.type} (e.g. {@code
+   * "document.extraction"}).
+   */
+  String type();
+
+  /**
+   * Processes the job. **Must be idempotent** — a job may run more than once (a crash after side
+   * effects but before commit re-runs it). Throwing signals a failure, which the queue retries with
+   * capped backoff and eventually marks {@code FAILED}.
+   */
+  void handle(String payload);
+}

--- a/qnop-core/src/main/java/io/qnop/service/job/JobQueuePoller.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobQueuePoller.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import java.util.List;
+import java.util.UUID;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Drives the durable job queue (ADR-0033). A separate bean from {@link JobService} so its calls
+ * into the service cross the transactional proxy (claim, run, and failure each get their own
+ * transaction). {@code @SchedulerLock} (ShedLock, ADR-0029) makes each tick run at most once across
+ * app instances. A failing job never aborts the batch.
+ */
+@Component
+public class JobQueuePoller {
+
+  private static final Logger log = LoggerFactory.getLogger(JobQueuePoller.class);
+
+  private final JobService jobService;
+
+  public JobQueuePoller(JobService jobService) {
+    this.jobService = jobService;
+  }
+
+  /**
+   * Claims due jobs and runs each; a handler failure is recorded (retry/backoff) without aborting
+   * the batch.
+   */
+  @Scheduled(
+      fixedDelayString = "${qnop.jobs.poll-interval-ms:5000}",
+      initialDelayString = "${qnop.jobs.poll-interval-ms:5000}")
+  @SchedulerLock(name = "jobQueuePoller", lockAtMostFor = "PT2M")
+  public void poll() {
+    List<UUID> claimed = jobService.claimBatch();
+    for (UUID id : claimed) {
+      try {
+        jobService.runOne(id);
+      } catch (RuntimeException e) {
+        try {
+          jobService.recordFailure(id, e);
+        } catch (RuntimeException recordError) {
+          log.error("Could not record failure for job {}", id, recordError);
+        }
+      }
+    }
+  }
+
+  /** Reclaims jobs stranded RUNNING by a crash. */
+  @Scheduled(
+      fixedDelayString = "${qnop.jobs.reaper-interval-ms:60000}",
+      initialDelayString = "${qnop.jobs.reaper-interval-ms:60000}")
+  @SchedulerLock(name = "jobQueueReaper", lockAtMostFor = "PT2M")
+  public void reap() {
+    int reclaimed = jobService.reapStale();
+    if (reclaimed > 0) {
+      log.warn("Reaped {} stale RUNNING job(s) back to PENDING", reclaimed);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/job/JobService.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobService.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import io.qnop.entity.Job;
+import io.qnop.entity.JobStatus;
+import io.qnop.repository.JobRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The durable async job queue (issue #242, ADR-0033). {@link #enqueue} writes a job in the caller's
+ * transaction (outbox); {@link JobQueuePoller} then drives execution by calling {@link
+ * #claimBatch}, {@link #runOne} and {@link #recordFailure} — kept as separate transactional units
+ * (not self-invoked) so a handler failure rolls back its own effects without losing the failure
+ * bookkeep, and so {@link #reapStale} can recover jobs stranded {@code RUNNING} by a crash.
+ * Handlers are dispatched by {@code Job.type} and must be idempotent.
+ */
+@Service
+public class JobService {
+
+  private static final Logger log = LoggerFactory.getLogger(JobService.class);
+
+  static final int POLL_BATCH = 20;
+  static final int DEFAULT_MAX_ATTEMPTS = 5;
+  static final Duration BACKOFF_BASE = Duration.ofSeconds(10);
+  static final Duration BACKOFF_CAP = Duration.ofMinutes(10);
+  static final Duration STALE_AFTER = Duration.ofMinutes(5);
+  private static final int MAX_ERROR_LENGTH = 2000;
+
+  private final JobRepository repository;
+  private final Map<String, JobHandler> handlers;
+
+  public JobService(JobRepository repository, List<JobHandler> handlers) {
+    this.repository = repository;
+    this.handlers =
+        handlers.stream()
+            .collect(Collectors.toUnmodifiableMap(JobHandler::type, Function.identity()));
+  }
+
+  /**
+   * Enqueues a job to run as soon as the poller picks it up. Runs in the caller's transaction
+   * (outbox): the job and the triggering write commit together, or neither does.
+   */
+  @Transactional
+  public UUID enqueue(String type, String payload) {
+    Job job = new Job(type, payload, DEFAULT_MAX_ATTEMPTS, Instant.now());
+    return repository.save(job).getId();
+  }
+
+  /** Claims a batch of due jobs (flips them to {@code RUNNING}) and returns their ids. */
+  @Transactional
+  public List<UUID> claimBatch() {
+    return repository.claimDuePending(Instant.now(), POLL_BATCH);
+  }
+
+  /**
+   * Runs one claimed job: dispatches its handler and marks it {@code DONE}. Handler effects and the
+   * {@code DONE} write are one transaction; a throwing handler rolls both back, and the caller
+   * records the failure separately. The {@code RUNNING} guard makes a re-run a no-op (idempotency).
+   */
+  @Transactional
+  public void runOne(UUID id) {
+    Job job = repository.findById(id).orElse(null);
+    if (job == null || job.getStatus() != JobStatus.RUNNING) {
+      return;
+    }
+    JobHandler handler = handlers.get(job.getType());
+    if (handler == null) {
+      throw new IllegalStateException("No JobHandler registered for type: " + job.getType());
+    }
+    handler.handle(job.getPayload());
+    job.markDone();
+    repository.save(job);
+  }
+
+  /**
+   * Records a failed attempt in its own transaction: retry with backoff while attempts remain, else
+   * {@code FAILED}.
+   */
+  @Transactional
+  public void recordFailure(UUID id, Throwable cause) {
+    Job job = repository.findById(id).orElse(null);
+    if (job == null || job.getStatus() != JobStatus.RUNNING) {
+      return;
+    }
+    String error = errorText(cause);
+    if (job.getAttempts() >= job.getMaxAttempts()) {
+      log.warn(
+          "Job {} ({}) failed permanently after {} attempts", id, job.getType(), job.getAttempts());
+      job.markFailed(error);
+    } else {
+      Instant next = Instant.now().plus(backoff(job.getAttempts()));
+      log.info(
+          "Job {} ({}) attempt {} failed; retrying at {}",
+          id,
+          job.getType(),
+          job.getAttempts(),
+          next);
+      job.scheduleRetry(next, error);
+    }
+    repository.save(job);
+  }
+
+  /**
+   * Reclaims jobs stuck {@code RUNNING} past the stale threshold (a crashed worker) back to {@code
+   * PENDING}.
+   */
+  @Transactional
+  public int reapStale() {
+    Instant now = Instant.now();
+    return repository.reapStaleRunning(now.minus(STALE_AFTER), now);
+  }
+
+  /** Capped exponential backoff: {@code base * 2^(attempts-1)}, clamped to the cap. */
+  static Duration backoff(int attempts) {
+    int shift = Math.min(Math.max(attempts - 1, 0), 20);
+    long seconds = BACKOFF_BASE.getSeconds() << shift;
+    return Duration.ofSeconds(Math.min(seconds, BACKOFF_CAP.getSeconds()));
+  }
+
+  private static String errorText(Throwable cause) {
+    String text = cause.getClass().getName() + ": " + cause.getMessage();
+    return text.length() > MAX_ERROR_LENGTH ? text.substring(0, MAX_ERROR_LENGTH) : text;
+  }
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -38,3 +38,6 @@ databaseChangeLog:
   - include:
       file: migrations/0009-user-avatar-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0010-job-queue-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0010-job-queue-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0010-job-queue-schema.yaml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Durable async job queue (issue #242, ADR-0033). A generic, Postgres-backed work
+# queue: enqueue is transactional with the triggering write (outbox); a poll-loop
+# claims due PENDING rows with FOR UPDATE SKIP LOCKED, retries with capped
+# exponential backoff, and a reaper reclaims jobs left RUNNING by a crash. The
+# `payload` is jsonb (the first jsonb column in the schema). JPA runs
+# ddl-auto=none, so the entity mapping must match these definitions exactly.
+databaseChangeLog:
+  - changeSet:
+      id: 0010-job-queue
+      author: qnop
+      comment: Durable async job queue (ADR-0033) — generic Postgres-backed work items.
+      changes:
+        - createTable:
+            tableName: job
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: type
+                  type: VARCHAR(64)
+                  constraints: { nullable: false }
+              - column:
+                  name: payload
+                  type: JSONB
+                  constraints: { nullable: false }
+              - column:
+                  name: status
+                  type: VARCHAR(16)
+                  constraints: { nullable: false }
+              - column:
+                  name: attempts
+                  type: INTEGER
+                  defaultValueNumeric: 0
+                  constraints: { nullable: false }
+              - column:
+                  name: max_attempts
+                  type: INTEGER
+                  defaultValueNumeric: 5
+                  constraints: { nullable: false }
+              - column:
+                  name: run_after
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column: { name: last_error, type: TEXT }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints: { nullable: false }
+        - sql:
+            comment: |
+              Status is a closed set. Two partial indexes serve the hot paths: the
+              poller claiming due PENDING jobs, and the reaper reclaiming stale RUNNING ones.
+            sql: |
+              ALTER TABLE job ADD CONSTRAINT ck_job_status
+                CHECK (status IN ('PENDING', 'RUNNING', 'DONE', 'FAILED'));
+              CREATE INDEX ix_job_pending_run_after
+                ON job (run_after) WHERE status = 'PENDING';
+              CREATE INDEX ix_job_running_updated_at
+                ON job (updated_at) WHERE status = 'RUNNING';

--- a/qnop-core/src/test/java/io/qnop/service/job/JobServiceBackoffTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/job/JobServiceBackoffTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JobServiceBackoffTest {
+
+  @Test
+  @DisplayName("backoff doubles per attempt and is clamped to the cap")
+  void backoffIsCappedExponential() {
+    assertThat(JobService.backoff(1)).isEqualTo(Duration.ofSeconds(10)); // base
+    assertThat(JobService.backoff(2)).isEqualTo(Duration.ofSeconds(20));
+    assertThat(JobService.backoff(3)).isEqualTo(Duration.ofSeconds(40));
+    assertThat(JobService.backoff(4)).isEqualTo(Duration.ofSeconds(80));
+    assertThat(JobService.backoff(7)).isEqualTo(Duration.ofMinutes(10)); // 640s clamped to 600s cap
+    assertThat(JobService.backoff(30))
+        .isEqualTo(Duration.ofMinutes(10)); // clamp holds, no overflow
+  }
+
+  @Test
+  @DisplayName("backoff guards non-positive attempts")
+  void backoffGuardsLowAttempts() {
+    assertThat(JobService.backoff(0)).isEqualTo(Duration.ofSeconds(10));
+    assertThat(JobService.backoff(-5)).isEqualTo(Duration.ofSeconds(10));
+  }
+}


### PR DESCRIPTION
Closes #242. First foundation piece of the document-review core epic (#241), implementing **ADR-0033**.

A generic, crash-durable background-job queue on Postgres — the substrate for ingest extraction (#245), re-anchoring (#248) and diff (#249). **No Redis** (Postgres + ShedLock, ADR-0029/ADR-0013).

## What's here
- **Schema** (migration `0010`): `job` table with a `jsonb` `payload` (the schema's first jsonb column, mapped via Hibernate `@JdbcTypeCode(SqlTypes.JSON)`), a status `CHECK`, optimistic `@Version`, and two partial indexes for the poll/reaper hot paths.
- **Claim** (`JobRepositoryImpl`): `SELECT … FOR UPDATE SKIP LOCKED` then `UPDATE` to `RUNNING` (two steps, one tx) — parallel pollers never grab the same row, and it sidesteps Hibernate's awkward `UPDATE … RETURNING`.
- **`JobService`**: `enqueue` participates in the **caller's transaction** (outbox — the job and the triggering write commit together or not at all); `claim → execute → finish` are **separate transactional units** so a throwing handler rolls back its own effects without losing the failure bookkeep; **capped exponential backoff**; a **reaper** reclaims crash-stranded `RUNNING` jobs. Handlers dispatched by string `type`, and **must be idempotent**.
- **`JobQueuePoller`**: `@Scheduled` + `@SchedulerLock` (at most once across instances); a failing job never aborts the batch.

## Lifecycle
```
enqueue → PENDING → (claim) RUNNING → DONE
                                    ↘ fail → PENDING (backoff, attempts<max) | FAILED
reaper: RUNNING stale (crash) → PENDING
```

## Test plan
- [x] `./gradlew build` — Spotless + ArchUnit + Testcontainers ITs.
- [x] Backoff unit test (capped-exponential, overflow-guarded).
- [x] Queue ITs: enqueue→DONE, retry+backoff→success, FAILED after max attempts, reaper reclaims stale RUNNING, **outbox** (caller rollback drops the job), idempotency (re-running a DONE job is a no-op).
- Note: the poller is quieted in ITs (interval == initial delay == 1h) so a stray scheduled tick can't race the manual `poll()`/`reap()` calls — a fixed-delay poller fires during tests, unlike the cron token sweeps.

No consumers yet — the first handlers arrive with #245/#248/#249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code