### PR TITLE
feat(core): StorageProvider SPI + S3/MinIO adapter (ADR-0005, #243)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,12 +14,18 @@ QNOP_DB_PASSWORD=qnop
 QNOP_DB_PORT=5432
 # QNOP_DB_HOST=localhost   # only needed when the server runs apart from the DB
 
-# --- Object storage (S3 API / MinIO) ---
+# --- Object storage (S3 API / MinIO, issue #243, ADR-0005) ---
 QNOP_S3_ACCESS_KEY=qnop
 QNOP_S3_SECRET_KEY=qnop_secret
 QNOP_S3_PORT=9000
 QNOP_S3_CONSOLE_PORT=9001
 QNOP_S3_BUCKET=qnop-documents
+# The server reaches the docker-compose MinIO here (path-style, auto-create the
+# bucket on first run). Leave QNOP_S3_ENDPOINT blank to target real AWS S3.
+QNOP_S3_ENDPOINT=http://localhost:9000
+QNOP_S3_REGION=us-east-1
+QNOP_S3_PATH_STYLE_ACCESS=true
+QNOP_S3_AUTO_CREATE_BUCKET=true
 
 # --- Security & crypto (issue #10) ---
 # The server FAILS TO START with these placeholders (they trip @ValidSecret).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Commits are signed off (`git commit -s`, DCO). See `CONTRIBUTING.md`.
 
 The Spring Boot server **boots and runs** (PostgreSQL + Liquibase + JPA, ADR-0020) with the full identity & administration layer of epic #7 in place — `io.qnop.entity` (JPA model), `io.qnop.repository` (Spring Data), `io.qnop.service` (business services) and the framework-light `io.qnop.security` (crypto/key-derivation, ADR-0022) are all populated. **Shipped:** local login with JWT access + rotating refresh tokens and revocation (ADR-0026), OIDC/OAuth2 providers, self-registration, email verification and password reset, auth rate limiting (ADR-0027), users & teams, application settings (ADR-0025), mail templates, branding upload with SVG sanitization (ADR-0028; assets stored as Postgres `bytea`, ADR-0024), profile avatars (ADR-0031), ShedLock distributed scheduling (ADR-0029) and optimistic concurrency control (ADR-0030). The REST contract is OpenAPI-first (ADR-0021) and the `qnop-ui` SPA (login, profile, admin surfaces) consumes it; `/config` exposes the running edition.
 
-**Genuinely still pending (do not assume they exist):** the document-review domain core — the review workflow state machine, annotation anchoring/re-anchoring, and the ingest pipeline; the `qnop-spi` extension-point interfaces + Community defaults (still only a `package-info` placeholder); and S3/object-storage (`StorageProvider`) wiring for binary documents — MinIO is provisioned in `docker-compose.yml` but **not yet consumed**. `docker-compose.yml` provides local Postgres (+ MinIO) for `bootRun`; the test suite spins up its own Postgres via **Testcontainers** (Docker required).
+**Genuinely still pending (do not assume they exist):** the document-review domain core — the review workflow state machine, annotation anchoring/re-anchoring, and the ingest pipeline. The `qnop-spi` extension-point boundary now carries its first published contract, the `StorageProvider` SPI, with the S3/MinIO Community default in `io.qnop.service.storage` (issue #243, ADR-0005/0036) — so MinIO **is now consumed** (object bytes for `document_version.storage_key`), with an upload-then-commit staging registry (`storage_object`) and orphan reaper. `docker-compose.yml` provides local Postgres (+ MinIO) for `bootRun`; the test suite spins up its own Postgres **and MinIO** via **Testcontainers** (Docker required).
 
 ## Stack
 
@@ -67,7 +67,7 @@ pnpm format:check
 Local infra:
 
 ```bash
-cp .env.example .env && docker compose up -d   # Postgres + MinIO (not yet consumed by the app)
+cp .env.example .env && docker compose up -d   # Postgres + MinIO (object storage, ADR-0005)
 ```
 
 ## Architecture (essentials)

--- a/docs/adr/0036-object-storage-lifecycle-staging-and-reaper.md
+++ b/docs/adr/0036-object-storage-lifecycle-staging-and-reaper.md
@@ -1,0 +1,29 @@
+# ADR-0036: Object-storage lifecycle — staging registry + orphan reaper
+
+- **Status:** Accepted
+- **Date:** 2026-07-02
+- **Deciders:** qnop core team
+
+## Context
+
+ADR-0005 puts binary documents in S3-compatible object storage behind a `StorageProvider` SPI, and mandates an "upload-then-commit pattern with a reaper for orphaned objects" — but not *how*. Object storage and PostgreSQL cannot share a transaction: if we upload a blob and then the domain row that references it (e.g. `document_version.storage_key`) fails to commit, the object is orphaned; conversely, deleting the DB row does not delete the object. We need a mechanism that (a) never leaves an object no process can find, and (b) is testable independently of the document domain (this is foundation issue #243, landing before the ingest wiring in #245).
+
+## Decision
+
+- A **`storage_object` staging registry** table records every uploaded object with a lifecycle status: `PENDING` (uploaded, not yet referenced by a committed domain row) → `COMMITTED` (referenced, must be kept).
+- **Upload-then-commit** in `StorageService`: `stage()` durably inserts the `PENDING` row **before** the object is put to storage; the caller persists its domain row referencing the returned key and then calls `commit(key)`.
+- **Content-addressed keys**: the key is derived from the content SHA-256 (`sha256/<xx>/<full-hex>`), so `object_key` is unique and identical content deduplicates to one object and one row. The hash doubles as `document_version.content_hash`.
+- An **orphan reaper** (`@Scheduled` + ShedLock, ADR-0029) deletes `PENDING` rows — and their objects — older than a configurable grace period (`qnop.s3.reaper-grace-period`, default 1h). The object is deleted before its row, so a crash mid-sweep just retries (deletes are idempotent).
+- Garbage-collection of **committed** objects (when a version is deleted) is out of scope here and handled with the document domain later.
+
+## Consequences
+
+- No object can outlive knowledge of it: a `PENDING` row exists before the blob, so the reaper always has something to reclaim; a crash after upload leaves a reclaimable row, not an invisible object.
+- The reaper is a trivial indexed query (`status = 'PENDING' AND created_at < cutoff`) and never enumerates the bucket or needs to know every consumer table.
+- One extra table and one extra write per upload; content-addressing gives free dedup and immutability, aligning with the append-only version model (ADR-0011/0034).
+
+## Alternatives considered
+
+- **Bucket-listing reaper** (no table): list objects and delete those unreferenced by any domain table older than their age. Rejected: couples the reaper to every present and future consumer, scales poorly on large buckets, and is racy without a per-object grace signal.
+- **Single-transaction upload** (put inside the DB transaction): impossible to make consistent — a commit failure after the put still orphans the object, with no row to reclaim it.
+- **Move-on-commit via a staging prefix** (`staging/…` → final key): avoids a table but adds a server-side copy per commit and still needs an age-based sweep; the registry is simpler and DB-native (consistent with the Postgres job queue, ADR-0033).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,6 +47,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0033](0033-durable-async-job-execution-on-postgres.md) | Durable async job execution on Postgres | Accepted |
 | [0034](0034-inter-version-diff.md) | Inter-version diff | Accepted |
 | [0035](0035-esignature-approval-enterprise-feature.md) | E-signature approval as a post-finalization enterprise feature | Accepted |
+| [0036](0036-object-storage-lifecycle-staging-and-reaper.md) | Object-storage lifecycle: staging registry + orphan reaper | Accepted |
 
 ## Template
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,9 +36,12 @@ shedlock = "7.7.0"
 # safe to render untrusted template bodies. SMTP via spring-boot-starter-mail
 # (version managed by the Spring Boot BOM).
 jmustache = "1.16"
+# Object storage (issue #243, ADR-0005): the AWS SDK v2 S3 client, used with
+# endpointOverride + path-style so MinIO (On-Prem) and S3/GCS (SaaS) are a
+# deploy-time config switch. Not in the Spring Boot BOM → explicit version.
+awsSdk = "2.31.6"
 
 # --- Pinned for later phases (NOT yet applied) -------------------------
-awsSdk = "2.31.6"            # software.amazon.awssdk:s3 — vendor-neutral S3 client
 pdfbox = "3.0.5"            # PDF text extraction with glyph positions
 poi = "5.4.1"              # .docx structural extraction (XWPF)
 
@@ -99,6 +102,10 @@ shedlock-provider-jdbc-template = { module = "net.javacrumbs.shedlock:shedlock-p
 spring-boot-starter-mail = { module = "org.springframework.boot:spring-boot-starter-mail" }
 jmustache = { module = "com.samskivert:jmustache", version.ref = "jmustache" }
 
+# Object storage (issue #243, ADR-0005): AWS SDK v2 S3 client — the vendor-neutral
+# StorageProvider default (io.qnop.service.storage). Not BOM-managed → explicit version.
+aws-sdk-s3 = { module = "software.amazon.awssdk:s3", version.ref = "awsSdk" }
+
 # Test
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 # Spring Boot 4 split the web test slices into per-stack modules; @WebMvcTest now
@@ -110,6 +117,9 @@ spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-te
 # are managed transitively by the Spring Boot BOM (testcontainers-bom).
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter" }
+# MinIO container for the object-storage integration tests (issue #243). BOM-managed;
+# Testcontainers 2.x artifact ids carry the `testcontainers-` prefix.
+testcontainers-minio = { module = "org.testcontainers:testcontainers-minio" }
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -96,5 +96,9 @@ dependencies {
     testImplementation(libs.spring.boot.testcontainers)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.junit.jupiter)
+    // Object-storage integration tests run against a real MinIO (issue #243) and use the
+    // StorageProvider SPI types directly (qnop-core hides qnop-spi behind `implementation`).
+    testImplementation(libs.testcontainers.minio)
+    testImplementation(project(":qnop-spi"))
     testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -58,3 +58,18 @@ qnop:
       frontend-base-url: ${QNOP_AUTH_OIDC_FRONTEND_BASE_URL:}
   cors:
     allowed-origins: ${QNOP_CORS_ALLOWED_ORIGINS:http://localhost:5173}
+  # Object storage for binary documents (issue #243, ADR-0005). Defaults target the
+  # docker-compose MinIO; leave `endpoint` blank to target real AWS S3 (SaaS). The
+  # access/secret keys are storage credentials, not crypto secrets, so short local
+  # MinIO values are fine. `auto-create-bucket` is on for local dev / an empty MinIO;
+  # real S3 buckets are pre-provisioned, so set it false in production.
+  s3:
+    endpoint: ${QNOP_S3_ENDPOINT:}
+    region: ${QNOP_S3_REGION:us-east-1}
+    bucket: ${QNOP_S3_BUCKET:qnop-documents}
+    access-key: ${QNOP_S3_ACCESS_KEY:qnop}
+    secret-key: ${QNOP_S3_SECRET_KEY:qnop_secret}
+    path-style-access: ${QNOP_S3_PATH_STYLE_ACCESS:true}
+    auto-create-bucket: ${QNOP_S3_AUTO_CREATE_BUCKET:false}
+    reaper-grace-period: ${QNOP_S3_REAPER_GRACE_PERIOD:PT1H}
+    reaper-cron: ${QNOP_S3_REAPER_CRON:0 30 3 * * *}

--- a/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
@@ -24,17 +24,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MinIOContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Base for full-context integration tests: boots the application against a real PostgreSQL
- * (Testcontainers, ADR-0020) and supplies strong {@code QNOP_AUTH_*} secrets so the security
- * foundation's fail-fast validation (ADR-0022) is satisfied. Requires Docker.
+ * (Testcontainers, ADR-0020) and a real MinIO object store (ADR-0005, issue #243), and supplies
+ * strong {@code QNOP_AUTH_*} secrets so the security foundation's fail-fast validation (ADR-0022)
+ * is satisfied. Requires Docker.
  *
- * <p>The container is a JVM-lifetime singleton (started once in a static initializer, never
- * explicitly stopped — Ryuk reaps it). A per-class {@code @Testcontainers} lifecycle would stop and
- * restart it between test classes, handing the second class a new port while Spring reuses the
- * cached context built for the first — causing connection-refused failures.
+ * <p>Both containers are JVM-lifetime singletons (started once in a static initializer, never
+ * explicitly stopped — Ryuk reaps them). A per-class {@code @Testcontainers} lifecycle would stop
+ * and restart them between test classes, handing the second class a new port while Spring reuses
+ * the cached context built for the first — causing connection-refused failures.
  */
 @SpringBootTest(
     classes = QnopApplication.class,
@@ -45,8 +48,17 @@ public abstract class AbstractIntegrationTest {
   @ServiceConnection
   static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:18");
 
+  // MinIO for the object-storage adapter (ADR-0005). No @ServiceConnection: the qnop.s3.* props are
+  // wired manually below. Digest-pinned to match docker-compose.yml.
+  static final MinIOContainer minio =
+      new MinIOContainer(
+          DockerImageName.parse(
+                  "minio/minio:latest@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e")
+              .asCompatibleSubstituteFor("minio/minio"));
+
   static {
     postgres.start();
+    minio.start();
   }
 
   @DynamicPropertySource
@@ -60,5 +72,16 @@ public abstract class AbstractIntegrationTest {
     // race them (ADR-0033).
     registry.add("qnop.jobs.poll-interval-ms", () -> "3600000");
     registry.add("qnop.jobs.reaper-interval-ms", () -> "3600000");
+    // Object storage against the MinIO container (ADR-0005): auto-create the bucket, and disable
+    // the
+    // scheduled orphan reaper ("-") so StorageServiceIT can drive reapOrphans() deterministically.
+    registry.add("qnop.s3.endpoint", minio::getS3URL);
+    registry.add("qnop.s3.region", () -> "us-east-1");
+    registry.add("qnop.s3.bucket", () -> "qnop-test");
+    registry.add("qnop.s3.access-key", minio::getUserName);
+    registry.add("qnop.s3.secret-key", minio::getPassword);
+    registry.add("qnop.s3.path-style-access", () -> "true");
+    registry.add("qnop.s3.auto-create-bucket", () -> "true");
+    registry.add("qnop.s3.reaper-cron", () -> "-");
   }
 }

--- a/qnop-app/src/test/java/io/qnop/storage/StorageServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/storage/StorageServiceIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.storage;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.repository.StorageObjectRepository;
+import io.qnop.service.storage.StagedObject;
+import io.qnop.service.storage.StorageService;
+import io.qnop.spi.storage.StorageContent;
+import java.io.ByteArrayInputStream;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Object-storage acceptance against a real MinIO (issue #243, ADR-0005): put/get/delete round-trip,
+ * content hashing, and the orphan reaper. Not {@code @Transactional} — object-store writes are not
+ * rolled back, so each test uses unique content (content-addressed keys keep tests isolated) and
+ * cleans up after itself.
+ */
+class StorageServiceIT extends AbstractIntegrationTest {
+
+  @Autowired private StorageService storage;
+  @Autowired private StorageObjectRepository repository;
+  @Autowired private JdbcTemplate jdbc;
+
+  private static byte[] uniqueContent() {
+    return ("qnop-doc-" + UUID.randomUUID()).getBytes(UTF_8);
+  }
+
+  private StagedObject stage(byte[] content, String contentType) {
+    return storage.stage(new ByteArrayInputStream(content), contentType);
+  }
+
+  @Test
+  void putGetDeleteRoundTrip() throws Exception {
+    byte[] data = uniqueContent();
+
+    StagedObject staged = stage(data, "application/pdf");
+    assertThat(staged.key()).startsWith("sha256/");
+    assertThat(staged.sizeBytes()).isEqualTo(data.length);
+
+    try (StorageContent content = storage.get(staged.key()).orElseThrow()) {
+      assertThat(content.stream().readAllBytes()).isEqualTo(data);
+      assertThat(content.contentType()).isEqualTo("application/pdf");
+      assertThat(content.contentLength()).isEqualTo(data.length);
+    }
+
+    storage.delete(staged.key());
+    assertThat(storage.get(staged.key())).isEmpty();
+    assertThat(repository.findByObjectKey(staged.key())).isEmpty();
+  }
+
+  @Test
+  void keyIsContentAddressedBySha256() throws Exception {
+    byte[] data = uniqueContent();
+    String expected = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(data));
+
+    StagedObject staged = stage(data, "text/plain");
+
+    assertThat(staged.contentHash()).isEqualTo(expected);
+    assertThat(staged.key()).isEqualTo("sha256/" + expected.substring(0, 2) + "/" + expected);
+    storage.delete(staged.key());
+  }
+
+  @Test
+  void identicalContentDeduplicates() {
+    byte[] data = uniqueContent();
+
+    StagedObject first = stage(data, "application/pdf");
+    StagedObject second = stage(data, "application/pdf");
+
+    assertThat(second.key()).isEqualTo(first.key());
+    assertThat(repository.findByObjectKey(first.key())).isPresent();
+    storage.delete(first.key());
+  }
+
+  @Test
+  void deleteIsIdempotent() {
+    StagedObject staged = stage(uniqueContent(), "application/pdf");
+
+    storage.delete(staged.key());
+    storage.delete(staged.key()); // second delete must not fail
+
+    assertThat(storage.get(staged.key())).isEmpty();
+  }
+
+  @Test
+  void getMissingKeyReturnsEmpty() {
+    assertThat(storage.get("sha256/zz/" + UUID.randomUUID())).isEmpty();
+  }
+
+  @Test
+  void reaperDeletesUncommittedOrphanButKeepsCommitted() {
+    StagedObject orphan = stage(uniqueContent(), "application/pdf");
+    StagedObject committed = stage(uniqueContent(), "application/pdf");
+    storage.commit(committed.key());
+
+    // Backdate both rows beyond the reaper grace period (default 1h).
+    jdbc.update(
+        "UPDATE storage_object SET created_at = created_at - interval '2 hours' "
+            + "WHERE object_key IN (?, ?)",
+        orphan.key(),
+        committed.key());
+
+    storage.reapOrphans();
+
+    assertThat(repository.findByObjectKey(orphan.key())).isEmpty();
+    assertThat(storage.get(orphan.key())).isEmpty();
+    assertThat(repository.findByObjectKey(committed.key())).isPresent();
+    assertThat(storage.get(committed.key())).isPresent();
+
+    storage.delete(committed.key());
+  }
+
+  @Test
+  void recentUncommittedObjectSurvivesTheReaper() {
+    StagedObject fresh = stage(uniqueContent(), "application/pdf");
+
+    storage.reapOrphans(); // within the grace period → not reaped
+
+    assertThat(repository.findByObjectKey(fresh.key())).isPresent();
+    assertThat(storage.get(fresh.key())).isPresent();
+    storage.delete(fresh.key());
+  }
+}

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -53,6 +53,11 @@ dependencies {
     // that makes the lock real is wired in qnop-app.
     implementation(libs.shedlock.spring)
 
+    // Object storage (issue #243, ADR-0005): the AWS SDK v2 S3 client backs the
+    // StorageProvider default (io.qnop.service.storage) via endpointOverride +
+    // path-style, so MinIO / S3 / GCS is a deploy-time config switch.
+    implementation(libs.aws.sdk.s3)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/qnop-core/src/main/java/io/qnop/entity/StorageObject.java
+++ b/qnop-core/src/main/java/io/qnop/entity/StorageObject.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * Staging registry row for an object in storage (issue #243, ADR-0005/0036). Every upload records
+ * one row: {@code PENDING} until the domain row that references its {@code objectKey} is committed,
+ * then {@code COMMITTED}. The orphan reaper deletes {@code PENDING} rows (and their objects) older
+ * than the grace period, closing the upload-then-commit window.
+ *
+ * <p>Keys are content-addressed (sha-256), so {@code objectKey} is unique and identical content
+ * deduplicates to one row/object. JPA runs {@code ddl-auto=none}; this mapping matches migration
+ * 0012 exactly.
+ */
+@Entity
+@Table(name = "storage_object")
+public class StorageObject {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "object_key", nullable = false, updatable = false, length = 512)
+  private String objectKey;
+
+  @Column(name = "content_hash", nullable = false, updatable = false, length = 128)
+  private String contentHash;
+
+  @Column(name = "content_type", nullable = false, updatable = false, length = 128)
+  private String contentType;
+
+  @Column(name = "size_bytes", nullable = false, updatable = false)
+  private long sizeBytes;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 16)
+  private StorageObjectStatus status;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "committed_at")
+  private Instant committedAt;
+
+  @Version
+  @Column(name = "version", nullable = false)
+  private long version;
+
+  protected StorageObject() {
+    // for JPA
+  }
+
+  private StorageObject(String objectKey, String contentHash, String contentType, long sizeBytes) {
+    this.objectKey = objectKey;
+    this.contentHash = contentHash;
+    this.contentType = contentType;
+    this.sizeBytes = sizeBytes;
+    this.status = StorageObjectStatus.PENDING;
+  }
+
+  /** A freshly uploaded, not-yet-committed object. */
+  public static StorageObject pending(
+      String objectKey, String contentHash, String contentType, long sizeBytes) {
+    return new StorageObject(objectKey, contentHash, contentType, sizeBytes);
+  }
+
+  /** Marks this object committed (referenced by a durable domain row); idempotent. */
+  public void markCommitted(Instant at) {
+    this.status = StorageObjectStatus.COMMITTED;
+    this.committedAt = at;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getObjectKey() {
+    return objectKey;
+  }
+
+  public String getContentHash() {
+    return contentHash;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public long getSizeBytes() {
+    return sizeBytes;
+  }
+
+  public StorageObjectStatus getStatus() {
+    return status;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getCommittedAt() {
+    return committedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof StorageObject other && id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/StorageObjectStatus.java
+++ b/qnop-core/src/main/java/io/qnop/entity/StorageObjectStatus.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+/**
+ * Lifecycle of a {@link StorageObject} (ADR-0036). {@code PENDING} objects have been uploaded but
+ * are not yet referenced by a committed domain row; the orphan reaper deletes stale ones. {@code
+ * COMMITTED} objects are referenced and must be kept.
+ */
+public enum StorageObjectStatus {
+  PENDING,
+  COMMITTED
+}

--- a/qnop-core/src/main/java/io/qnop/repository/StorageObjectRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/StorageObjectRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.StorageObject;
+import io.qnop.entity.StorageObjectStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Data access for the object-storage staging registry (issue #243, ADR-0036). */
+public interface StorageObjectRepository extends JpaRepository<StorageObject, UUID> {
+
+  /** The registry row for a content-addressed key, if any (dedup + commit lookups). */
+  Optional<StorageObject> findByObjectKey(String objectKey);
+
+  /** Orphan-reaper query: rows in a given lifecycle state older than the cutoff. */
+  List<StorageObject> findByStatusAndCreatedAtBefore(StorageObjectStatus status, Instant cutoff);
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3BucketInitializer.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3BucketInitializer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+
+/**
+ * Ensures the configured bucket exists on startup when {@code qnop.s3.auto-create-bucket} is on
+ * (local dev / tests against an empty MinIO). Real S3 buckets are pre-provisioned, so the default
+ * is off and this is a no-op — the app never tries to create a bucket it may lack permission for.
+ */
+@Component
+public class S3BucketInitializer implements ApplicationRunner {
+
+  private static final Logger log = LoggerFactory.getLogger(S3BucketInitializer.class);
+
+  private final S3Client s3;
+  private final S3Properties properties;
+
+  public S3BucketInitializer(S3Client s3, S3Properties properties) {
+    this.s3 = s3;
+    this.properties = properties;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    if (!properties.autoCreateBucket()) {
+      return;
+    }
+    String bucket = properties.bucket();
+    try {
+      s3.headBucket(HeadBucketRequest.builder().bucket(bucket).build());
+      log.info("Object-storage bucket '{}' is present.", bucket);
+    } catch (NoSuchBucketException e) {
+      s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+      log.info("Created object-storage bucket '{}'.", bucket);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3Configuration.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3Configuration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import io.qnop.spi.storage.StorageProvider;
+import java.net.URI;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Wires the object-storage stack (issue #243, ADR-0005): an AWS SDK v2 {@link S3Client} built from
+ * {@link S3Properties} (endpoint override + path-style for MinIO) and the Community {@link
+ * StorageProvider} default. The provider is {@link ConditionalOnMissingBean} so a commercial add-on
+ * (or a test) can substitute its own implementation (ADR-0002/0003).
+ */
+@Configuration
+@EnableConfigurationProperties(S3Properties.class)
+public class S3Configuration {
+
+  @Bean
+  S3Client s3Client(S3Properties properties) {
+    var builder =
+        S3Client.builder()
+            .region(Region.of(properties.region()))
+            .forcePathStyle(properties.pathStyleAccess())
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())));
+    if (properties.endpoint() != null) {
+      builder.endpointOverride(URI.create(properties.endpoint()));
+    }
+    return builder.build();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(StorageProvider.class)
+  StorageProvider storageProvider(S3Client s3Client, S3Properties properties) {
+    return new S3StorageProvider(s3Client, properties.bucket());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3Properties.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3Properties.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Object-storage configuration (issue #243, ADR-0005), bound from the {@code qnop.s3.*} namespace.
+ * With {@code endpoint} set and {@code pathStyleAccess} on, the AWS SDK v2 client talks to a MinIO
+ * (On-Prem) endpoint; leaving {@code endpoint} blank targets real AWS S3 (SaaS). The access/secret
+ * keys are storage credentials (not crypto secrets), so they are only {@code @NotBlank} — MinIO's
+ * local-dev keys are short by design.
+ *
+ * @param endpoint S3 endpoint override (e.g. {@code http://localhost:9000}); blank → real AWS S3
+ * @param region the AWS region name (default {@code us-east-1}; MinIO ignores it but the SDK
+ *     requires one)
+ * @param bucket the bucket that holds all objects
+ * @param accessKey S3 access key id
+ * @param secretKey S3 secret access key
+ * @param pathStyleAccess force path-style addressing (default true; required by MinIO)
+ * @param autoCreateBucket create the bucket on startup if absent (default false; enable for local
+ *     dev / tests against an empty MinIO — real S3 buckets are pre-provisioned)
+ * @param reaperGracePeriod how long an uploaded-but-uncommitted object is kept before the orphan
+ *     reaper deletes it (default 1h)
+ */
+@ConfigurationProperties(prefix = "qnop.s3")
+@Validated
+public record S3Properties(
+    String endpoint,
+    String region,
+    @NotBlank String bucket,
+    @NotBlank String accessKey,
+    @NotBlank String secretKey,
+    Boolean pathStyleAccess,
+    Boolean autoCreateBucket,
+    Duration reaperGracePeriod) {
+
+  public S3Properties {
+    endpoint = (endpoint == null || endpoint.isBlank()) ? null : endpoint.trim();
+    region = (region == null || region.isBlank()) ? "us-east-1" : region;
+    pathStyleAccess = pathStyleAccess == null ? Boolean.TRUE : pathStyleAccess;
+    autoCreateBucket = autoCreateBucket == null ? Boolean.FALSE : autoCreateBucket;
+    reaperGracePeriod = reaperGracePeriod == null ? Duration.ofHours(1) : reaperGracePeriod;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3StorageProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3StorageProvider.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import io.qnop.spi.storage.StorageContent;
+import io.qnop.spi.storage.StorageException;
+import io.qnop.spi.storage.StorageProvider;
+import java.io.InputStream;
+import java.util.Optional;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * Community {@link StorageProvider} default (ADR-0005): an S3-compatible adapter over the AWS SDK
+ * v2. Configured with {@code endpointOverride} + path-style, it speaks to MinIO (On-Prem) or S3/GCS
+ * (SaaS) identically — the S3 API is the abstraction, so there is no multi-cloud layer.
+ */
+public class S3StorageProvider implements StorageProvider {
+
+  private final S3Client s3;
+  private final String bucket;
+
+  public S3StorageProvider(S3Client s3, String bucket) {
+    this.s3 = s3;
+    this.bucket = bucket;
+  }
+
+  @Override
+  public void put(String key, InputStream content, long contentLength, String contentType) {
+    try {
+      s3.putObject(
+          PutObjectRequest.builder().bucket(bucket).key(key).contentType(contentType).build(),
+          RequestBody.fromInputStream(content, contentLength));
+    } catch (S3Exception e) {
+      throw new StorageException("Failed to store object " + key, e);
+    }
+  }
+
+  @Override
+  public Optional<StorageContent> get(String key) {
+    try {
+      ResponseInputStream<GetObjectResponse> stream =
+          s3.getObject(GetObjectRequest.builder().bucket(bucket).key(key).build());
+      GetObjectResponse response = stream.response();
+      return Optional.of(
+          new StorageContent(stream, response.contentLength(), response.contentType()));
+    } catch (NoSuchKeyException e) {
+      return Optional.empty();
+    } catch (S3Exception e) {
+      throw new StorageException("Failed to read object " + key, e);
+    }
+  }
+
+  @Override
+  public boolean exists(String key) {
+    try {
+      s3.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+      return true;
+    } catch (NoSuchKeyException e) {
+      return false;
+    } catch (S3Exception e) {
+      // headObject reports a missing key as a 404 without a typed exception on some backends.
+      if (e.statusCode() == 404) {
+        return false;
+      }
+      throw new StorageException("Failed to probe object " + key, e);
+    }
+  }
+
+  @Override
+  public boolean delete(String key) {
+    if (!exists(key)) {
+      return false;
+    }
+    try {
+      s3.deleteObject(b -> b.bucket(bucket).key(key));
+      return true;
+    } catch (S3Exception e) {
+      throw new StorageException("Failed to delete object " + key, e);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/StagedObject.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StagedObject.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+/**
+ * The result of staging content into storage (issue #243): the content-addressed {@code key} to
+ * persist on the referencing domain row, plus the computed {@code contentHash} (sha-256 hex) and
+ * {@code sizeBytes}. Once the domain row is committed, call {@code StorageService.commit(key)}.
+ */
+public record StagedObject(String key, String contentHash, long sizeBytes) {}

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import io.qnop.entity.StorageObject;
+import io.qnop.entity.StorageObjectStatus;
+import io.qnop.repository.StorageObjectRepository;
+import io.qnop.spi.storage.StorageContent;
+import io.qnop.spi.storage.StorageException;
+import io.qnop.spi.storage.StorageProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The upload-then-commit consistency layer over the {@link StorageProvider} (issue #243,
+ * ADR-0005/0036).
+ *
+ * <p>{@link #stage} durably records a {@code PENDING} registry row <em>before</em> the object is
+ * put to storage, so a crash between the two never leaves an object the reaper cannot find. The
+ * caller persists its domain row (referencing the returned key) and then calls {@link #commit}; the
+ * {@link #reapOrphans() reaper} deletes objects left {@code PENDING} past the grace period. Keys
+ * are content-addressed (sha-256), so identical content deduplicates to one object and row.
+ */
+@Service
+public class StorageService {
+
+  private static final Logger log = LoggerFactory.getLogger(StorageService.class);
+
+  private final StorageProvider provider;
+  private final StorageObjectRepository repository;
+  private final S3Properties properties;
+
+  public StorageService(
+      StorageProvider provider, StorageObjectRepository repository, S3Properties properties) {
+    this.provider = provider;
+    this.repository = repository;
+    this.properties = properties;
+  }
+
+  /**
+   * Buffers the content (to compute its hash and length), uploads it under a content-addressed key,
+   * and records a {@code PENDING} registry row. Idempotent for identical content: an already-known
+   * key is returned without re-uploading (dedup).
+   */
+  public StagedObject stage(InputStream content, String contentType) {
+    Path buffer = bufferToTempFile(content);
+    try {
+      String hash = sha256(buffer);
+      long size = sizeOf(buffer);
+      String key = keyFor(hash);
+
+      if (repository.findByObjectKey(key).isPresent()) {
+        return new StagedObject(key, hash, size); // dedup: content already stored
+      }
+      // Persist the PENDING row (in Spring Data's own transaction) BEFORE the upload, so a crash
+      // between the two always leaves a row the reaper can reclaim. A concurrent stage of identical
+      // content may win the unique-key race first — treat that as dedup.
+      try {
+        repository.save(StorageObject.pending(key, hash, contentType, size));
+      } catch (DataIntegrityViolationException e) {
+        return new StagedObject(key, hash, size);
+      }
+      try (InputStream in = Files.newInputStream(buffer)) {
+        provider.put(key, in, size, contentType);
+      } catch (IOException e) {
+        throw new StorageException("Failed to read buffered upload for " + key, e);
+      }
+      return new StagedObject(key, hash, size);
+    } finally {
+      deleteQuietly(buffer);
+    }
+  }
+
+  /** Marks the object committed (its domain row is now durable). Idempotent; no-op if unknown. */
+  @Transactional
+  public void commit(String key) {
+    repository.findByObjectKey(key).ifPresent(object -> object.markCommitted(Instant.now()));
+  }
+
+  /** Opens the object for reading, or empty if absent. The caller closes the returned content. */
+  public Optional<StorageContent> get(String key) {
+    return provider.get(key);
+  }
+
+  /** Removes the object and its registry row. Idempotent. */
+  @Transactional
+  public void delete(String key) {
+    provider.delete(key);
+    repository.findByObjectKey(key).ifPresent(repository::delete);
+  }
+
+  /**
+   * Deletes objects left uploaded-but-uncommitted past the grace period (ADR-0036). Runs off-peak,
+   * single-instance via ShedLock (ADR-0029); tests invoke it directly. The object is removed before
+   * its row, so a crash mid-sweep simply retries next run (delete is idempotent).
+   */
+  @Scheduled(cron = "${qnop.s3.reaper-cron:0 30 3 * * *}")
+  @SchedulerLock(name = "storageOrphanReaper", lockAtMostFor = "PT10M")
+  @Transactional
+  public void reapOrphans() {
+    Instant cutoff = Instant.now().minus(properties.reaperGracePeriod());
+    List<StorageObject> orphans =
+        repository.findByStatusAndCreatedAtBefore(StorageObjectStatus.PENDING, cutoff);
+    for (StorageObject orphan : orphans) {
+      provider.delete(orphan.getObjectKey());
+      repository.delete(orphan);
+    }
+    if (!orphans.isEmpty()) {
+      log.info("Storage orphan reaper deleted {} uncommitted object(s).", orphans.size());
+    }
+  }
+
+  /**
+   * Content-addressed key: {@code sha256/<first-2-hex>/<full-hex>} (sharded to avoid a flat set).
+   */
+  private static String keyFor(String hash) {
+    return "sha256/" + hash.substring(0, 2) + "/" + hash;
+  }
+
+  private static Path bufferToTempFile(InputStream content) {
+    try {
+      Path temp = Files.createTempFile("qnop-storage-", ".tmp");
+      Files.copy(content, temp, StandardCopyOption.REPLACE_EXISTING);
+      return temp;
+    } catch (IOException e) {
+      throw new StorageException("Failed to buffer upload", e);
+    }
+  }
+
+  private static String sha256(Path path) {
+    try (InputStream in = Files.newInputStream(path)) {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] buffer = new byte[8192];
+      int read;
+      while ((read = in.read(buffer)) != -1) {
+        digest.update(buffer, 0, read);
+      }
+      return HexFormat.of().formatHex(digest.digest());
+    } catch (IOException | NoSuchAlgorithmException e) {
+      throw new StorageException("Failed to hash upload", e);
+    }
+  }
+
+  private static long sizeOf(Path path) {
+    try {
+      return Files.size(path);
+    } catch (IOException e) {
+      throw new StorageException("Failed to size upload", e);
+    }
+  }
+
+  private static void deleteQuietly(Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException e) {
+      log.warn("Could not delete temp upload buffer {}: {}", path, e.getMessage());
+    }
+  }
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -44,3 +44,6 @@ databaseChangeLog:
   - include:
       file: migrations/0011-document-review-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0012-storage-object-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0012-storage-object-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0012-storage-object-schema.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Object-storage staging registry (issue #243, ADR-0005 / ADR-0036). Every blob
+# upload records a row here: PENDING until the domain row that references its
+# object_key (e.g. document_version.storage_key) is committed, then COMMITTED.
+# The orphan reaper deletes PENDING rows (and their objects) older than the grace
+# period, closing the upload-then-commit window. Keys are content-addressed
+# (sha-256), so object_key is unique and identical content deduplicates. JPA runs
+# ddl-auto=none, so the entity mapping (io.qnop.entity.StorageObject) must match
+# these definitions exactly.
+databaseChangeLog:
+  - changeSet:
+      id: 0012-storage-object
+      author: qnop
+      comment: Object-storage staging registry + orphan-reaper index (ADR-0005/0036).
+      changes:
+        - createTable:
+            tableName: storage_object
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: object_key
+                  type: VARCHAR(512)
+                  constraints: { nullable: false }
+              - column:
+                  name: content_hash
+                  type: VARCHAR(128)
+                  constraints: { nullable: false }
+              - column:
+                  name: content_type
+                  type: VARCHAR(128)
+                  constraints: { nullable: false }
+              - column:
+                  name: size_bytes
+                  type: BIGINT
+                  constraints: { nullable: false }
+              - column:
+                  name: status
+                  type: VARCHAR(16)
+                  constraints: { nullable: false }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column: { name: committed_at, type: TIMESTAMP WITH TIME ZONE }
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints: { nullable: false }
+        - addUniqueConstraint:
+            tableName: storage_object
+            columnNames: object_key
+            constraintName: ux_storage_object_key
+        - sql:
+            comment: |
+              Status is a closed set. A partial index serves the orphan reaper's
+              hot path: scanning old PENDING rows.
+            sql: |
+              ALTER TABLE storage_object ADD CONSTRAINT ck_storage_object_status
+                CHECK (status IN ('PENDING', 'COMMITTED'));
+              CREATE INDEX ix_storage_object_pending_created_at
+                ON storage_object (created_at) WHERE status = 'PENDING';

--- a/qnop-spi/src/main/java/io/qnop/spi/storage/StorageContent.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/storage/StorageContent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.spi.storage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+/**
+ * A readable handle to a stored object: its byte {@code stream} plus the serving metadata. Owns the
+ * stream — use it in a try-with-resources block (it is {@link AutoCloseable}) so the underlying
+ * connection is released.
+ *
+ * @param stream the object's bytes; closed by {@link #close()}
+ * @param contentLength the object size in bytes
+ * @param contentType the stored MIME type
+ */
+public record StorageContent(InputStream stream, long contentLength, String contentType)
+    implements AutoCloseable {
+
+  @Override
+  public void close() {
+    try {
+      stream.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/qnop-spi/src/main/java/io/qnop/spi/storage/StorageException.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/storage/StorageException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.spi.storage;
+
+/** Unchecked failure from a {@link StorageProvider} operation (I/O, backend, or protocol error). */
+public class StorageException extends RuntimeException {
+
+  public StorageException(String message) {
+    super(message);
+  }
+
+  public StorageException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/qnop-spi/src/main/java/io/qnop/spi/storage/StorageProvider.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/storage/StorageProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.spi.storage;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+/**
+ * The object-storage extension point (ADR-0005): store, retrieve, probe and delete binary content
+ * by opaque key. The Community default is an S3/MinIO adapter; the S3 API is the abstraction (no
+ * multi-cloud layer — ADR-0005), so keys are plain strings and content streams both ways.
+ *
+ * <p>Implementations must be safe for concurrent use. All failures surface as {@link
+ * StorageException}.
+ */
+public interface StorageProvider {
+
+  /**
+   * Stores {@code content} under {@code key}, overwriting any existing object with that key.
+   *
+   * @param key the object key
+   * @param content the bytes to store; the caller retains ownership and closes it
+   * @param contentLength the exact number of bytes in {@code content}
+   * @param contentType the MIME type to record with the object
+   */
+  void put(String key, InputStream content, long contentLength, String contentType);
+
+  /**
+   * Opens the object at {@code key} for reading, or {@link Optional#empty()} if none exists. The
+   * caller must close the returned {@link StorageContent} (it owns the underlying stream).
+   */
+  Optional<StorageContent> get(String key);
+
+  /** Whether an object exists at {@code key}. */
+  boolean exists(String key);
+
+  /**
+   * Deletes the object at {@code key}. Idempotent.
+   *
+   * @return {@code true} if an object existed and was deleted, {@code false} if there was none
+   */
+  boolean delete(String key);
+}

--- a/qnop-spi/src/main/java/io/qnop/spi/storage/package-info.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/storage/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Object-storage extension point (ADR-0005). A {@link io.qnop.spi.storage.StorageProvider} stores,
+ * retrieves and deletes binary content by opaque key; the Community default is an S3/MinIO adapter
+ * in {@code io.qnop.service.storage}, but an add-on may supply its own. Pure contract: no Spring,
+ * no persistence, no internal-module types — only the JDK.
+ */
+package io.qnop.spi.storage;

--- a/qnop-spi/src/main/java/io/qnop/spi/storage/package-info.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/storage/package-info.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 /**
  * Object-storage extension point (ADR-0005). A {@link io.qnop.spi.storage.StorageProvider} stores,
  * retrieves and deletes binary content by opaque key; the Community default is an S3/MinIO adapter


### PR DESCRIPTION
## Summary

The object-storage seam for binary documents (ADR-0005), with an S3/MinIO default — foundation for the document-review slice (part of #241; consumed by ingest/serving in #245). No endpoints yet.

### What's added

- **`qnop-spi`** — the first published SPI contract: `StorageProvider` (`put`/`get`/`exists`/`delete`) + `StorageContent` (AutoCloseable stream + metadata) + `StorageException`. Pure (JDK only); passes `pluginContractStaysPure`.
- **`qnop-core` (`io.qnop.service.storage`, per ADR-0005)** — `S3StorageProvider` over **AWS SDK v2** (`endpointOverride` + `forcePathStyle`, `@ConditionalOnMissingBean` so add-ons/tests can swap it), `S3Properties` (`qnop.s3.*`), `S3Configuration`, and `S3BucketInitializer` (auto-creates the bucket for MinIO/dev; off for pre-provisioned S3).
- **Upload-then-commit + reaper (ADR-0036, new)** — a `storage_object` staging registry (migration 0012) with **content-addressed keys** (sha-256 ⇒ dedup). `StorageService.stage()` durably records a `PENDING` row *before* the upload; `commit(key)` marks it `COMMITTED`; a ShedLock'd `@Scheduled` reaper deletes objects left `PENDING` past the grace period (`qnop.s3.reaper-grace-period`, default 1h).
- **Wiring & docs** — `application.yml` `qnop.s3.*` (MinIO now consumed) + `.env.example`; CLAUDE.md updated; **ADR-0036** records the lifecycle decision.
- **Tests** — `AbstractIntegrationTest` starts a MinIO Testcontainer (JVM singleton); `StorageServiceIT` covers put/get/delete round-trip, sha-256 content-addressing, dedup, delete idempotency, missing-key, and the reaper (deletes an uncommitted orphan, keeps a committed / fresh object).

### Acceptance (from #243)

- [x] put/get/delete against MinIO (Testcontainers)
- [x] endpoint config-switchable (`qnop.s3.endpoint` + path-style)
- [x] orphan reaper covered

## Test plan

- [x] `spotlessApply`, compile, ArchUnit (`ArchitectureRulesTest`), `:qnop-spi:build`, `:qnop-core:build`, `:qnop-app:spotlessCheck` green locally.
- [ ] CI: Backend (ITs incl. `StorageServiceIT` against MinIO) + OWASP dep audit (new AWS SDK) + smoke green (Docker unavailable locally).

Part of #241. Closes #243.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code