### PR TITLE
feat(core): annotations, comments & placements API (ADR-0009/0011, #247)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -82,6 +82,13 @@ tags:
       the review core (issue #245, ADR-0032). Visible only to the owner, the
       review participants, and admins. The multipart upload and the
       original-binary download are deliberately outside this contract (ADR-0028).
+  - name: Annotations
+    description: |
+      Annotations, their comment threads, and per-version placements (issue #247,
+      ADR-0009/0011). A participant creates an anchored annotation on a version;
+      the document owner or the annotation's author accepts or rejects it, feeding
+      the review workflow. Visible only to the document's participants and admins —
+      a non-participant sees 404, as for documents (anti-enumeration).
 paths:
   /config:
     get:
@@ -1752,6 +1759,196 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /documents/{documentId}/annotations:
+    parameters:
+      - $ref: '#/components/parameters/DocumentIdParam'
+    get:
+      tags: [Annotations]
+      summary: List a document's annotations
+      description: |
+        Every annotation on the document. When `version` is given, each item also
+        carries its placement (anchor + status) on that version, or nulls when it
+        has none there.
+      operationId: listAnnotations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: version
+          in: query
+          required: false
+          description: A 1-based version number to resolve each annotation's placement against.
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: The annotations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationListResponse'
+        '404':
+          description: Unknown document, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags: [Annotations]
+      summary: Create an annotation on a version
+      description: |
+        Anchors a new annotation to a region (and, on a text surface, the quoted
+        text) of the given version. The placement on that version is `PLACED`
+        immediately — a human drew it; re-anchoring onto later versions is async
+        (#248). An optional `comment` seeds the discussion thread.
+      operationId: createAnnotation
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnnotationCreateRequest'
+      responses:
+        '201':
+          description: The created annotation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationView'
+        '400':
+          description: Validation failed (e.g. the region anchor is missing or out of 0..1)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown document/version, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /annotations/{annotationId}:
+    parameters:
+      - $ref: '#/components/parameters/AnnotationIdParam'
+    get:
+      tags: [Annotations]
+      summary: Get an annotation
+      operationId: getAnnotation
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The annotation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationView'
+        '404':
+          description: Unknown annotation, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /annotations/{annotationId}/decision:
+    parameters:
+      - $ref: '#/components/parameters/AnnotationIdParam'
+    post:
+      tags: [Annotations]
+      summary: Accept or reject an annotation (owner or author)
+      description: |
+        Applies the `OPEN → ACCEPTED | REJECTED` decision (ADR-0011). Allowed for
+        the document owner or the annotation's author. Accepting drives the review
+        workflow (`IN_REVIEW → CHANGES_REQUESTED`) through the state-machine
+        choke-point. Rejected with `409` if the annotation is already decided.
+      operationId: decideAnnotation
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnnotationDecisionRequest'
+      responses:
+        '200':
+          description: The updated annotation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationView'
+        '403':
+          description: The caller is neither the document owner nor the annotation's author
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown annotation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The annotation has already been decided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /annotations/{annotationId}/comments:
+    parameters:
+      - $ref: '#/components/parameters/AnnotationIdParam'
+    get:
+      tags: [Annotations]
+      summary: List an annotation's comment thread
+      operationId: listComments
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The thread, oldest first
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommentListResponse'
+        '404':
+          description: Unknown annotation, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags: [Annotations]
+      summary: Add a comment to an annotation
+      operationId: addComment
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommentCreateRequest'
+      responses:
+        '201':
+          description: The created comment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommentView'
+        '400':
+          description: Validation failed (e.g. an empty body)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown annotation, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -1808,6 +2005,14 @@ components:
       in: path
       required: true
       description: The team's id.
+      schema:
+        type: string
+        format: uuid
+    AnnotationIdParam:
+      name: annotationId
+      in: path
+      required: true
+      description: The annotation's id.
       schema:
         type: string
         format: uuid
@@ -3210,3 +3415,208 @@ components:
         - y
         - width
         - height
+    RegionAnchor:
+      type: object
+      description: |
+        The universal geometric layer of an anchor (ADR-0009): a normalized
+        rectangle on one surface. Always present — for an image it is the only
+        layer.
+      required:
+        - surfaceIndex
+        - box
+      properties:
+        surfaceIndex:
+          type: integer
+          minimum: 0
+          description: Zero-based surface (page) index.
+        box:
+          $ref: '#/components/schemas/NormalizedBox'
+    TextQuoteAnchor:
+      type: object
+      description: |
+        The text-quote layer (ADR-0009), present when the surface has a text
+        layer: the exact quoted text plus a little surrounding context, robust to
+        reflow across versions.
+      required:
+        - quote
+      properties:
+        quote:
+          type: string
+          minLength: 1
+          description: The exact quoted text.
+        prefix:
+          type: string
+          description: A short slice of text immediately before the quote.
+        suffix:
+          type: string
+          description: A short slice of text immediately after the quote.
+    TextPositionAnchor:
+      type: object
+      description: |
+        The text-position layer (ADR-0009): character offsets into the surface's
+        canonical text. Fast but brittle — a tiebreaker only.
+      required:
+        - start
+        - end
+      properties:
+        start:
+          type: integer
+          minimum: 0
+          description: Inclusive start offset.
+        end:
+          type: integer
+          minimum: 0
+          description: Exclusive end offset.
+    Anchor:
+      type: object
+      description: |
+        A multi-layer annotation anchor (ADR-0009). `region` is always present;
+        `textQuote` and `textPosition` are added when the surface has a text layer.
+      required:
+        - region
+      properties:
+        region:
+          $ref: '#/components/schemas/RegionAnchor'
+        textQuote:
+          $ref: '#/components/schemas/TextQuoteAnchor'
+        textPosition:
+          $ref: '#/components/schemas/TextPositionAnchor'
+    AnnotationStatus:
+      type: string
+      description: The owner-decided lifecycle of an annotation (ADR-0011).
+      enum:
+        - OPEN
+        - ACCEPTED
+        - REJECTED
+    PlacementStatus:
+      type: string
+      description: |
+        Where an annotation sits on a specific version (ADR-0009): PLACED when a
+        human drew it or re-anchoring resolved it uniquely; MOVED when re-anchored
+        with a change to review; ORPHANED when no confident match exists; PENDING
+        while the async re-anchoring job runs; FAILED on an internal error.
+      enum:
+        - PENDING
+        - PLACED
+        - MOVED
+        - ORPHANED
+        - FAILED
+    AnnotationCreateRequest:
+      type: object
+      description: Create an annotation anchored to a region of a version.
+      required:
+        - versionNumber
+        - anchor
+      properties:
+        versionNumber:
+          type: integer
+          minimum: 1
+          description: The 1-based version the annotation is drawn on.
+        anchor:
+          $ref: '#/components/schemas/Anchor'
+        comment:
+          type: string
+          minLength: 1
+          maxLength: 20000
+          description: An optional first comment seeding the discussion thread.
+    AnnotationView:
+      type: object
+      description: |
+        An annotation with, when a version was requested, its placement on that
+        version and the size of its comment thread.
+      required:
+        - id
+        - documentId
+        - authorId
+        - status
+        - commentCount
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        documentId:
+          type: string
+          format: uuid
+        authorId:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/AnnotationStatus'
+        anchor:
+          $ref: '#/components/schemas/Anchor'
+        placementStatus:
+          $ref: '#/components/schemas/PlacementStatus'
+        commentCount:
+          type: integer
+          description: Number of comments in the thread.
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    AnnotationListResponse:
+      type: object
+      required:
+        - annotations
+      properties:
+        annotations:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnnotationView'
+    AnnotationDecision:
+      type: string
+      description: An owner/author decision on an annotation (ADR-0011).
+      enum:
+        - ACCEPTED
+        - REJECTED
+    AnnotationDecisionRequest:
+      type: object
+      required:
+        - decision
+      properties:
+        decision:
+          $ref: '#/components/schemas/AnnotationDecision'
+    CommentCreateRequest:
+      type: object
+      required:
+        - body
+      properties:
+        body:
+          type: string
+          minLength: 1
+          maxLength: 20000
+    CommentView:
+      type: object
+      required:
+        - id
+        - annotationId
+        - authorId
+        - body
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        annotationId:
+          type: string
+          format: uuid
+        authorId:
+          type: string
+          format: uuid
+        body:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    CommentListResponse:
+      type: object
+      required:
+        - comments
+      properties:
+        comments:
+          type: array
+          items:
+            $ref: '#/components/schemas/CommentView'

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AnnotationsApi;
+import io.qnop.api.v1.model.Anchor;
+import io.qnop.api.v1.model.AnnotationCreateRequest;
+import io.qnop.api.v1.model.AnnotationDecision;
+import io.qnop.api.v1.model.AnnotationDecisionRequest;
+import io.qnop.api.v1.model.AnnotationListResponse;
+import io.qnop.api.v1.model.AnnotationStatus;
+import io.qnop.api.v1.model.AnnotationView;
+import io.qnop.api.v1.model.CommentCreateRequest;
+import io.qnop.api.v1.model.CommentListResponse;
+import io.qnop.api.v1.model.CommentView;
+import io.qnop.api.v1.model.PlacementStatus;
+import io.qnop.service.review.AnnotationService;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Annotations, comment threads and per-version placements (issue #247, ADR-0009/0011), implementing
+ * the generated {@link AnnotationsApi} contract. Participant visibility and the owner/author
+ * decision rule live in {@link AnnotationService} — this layer maps views to the published models
+ * and (de)serializes the jsonb anchor. Domain exceptions are mapped globally by {@link
+ * DocumentExceptionHandler}.
+ */
+@RestController
+public class AnnotationController implements AnnotationsApi {
+
+  // Jackson 3 (tools.jackson), matching the stack the document pipeline (de)serializes jsonb with.
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  private final AnnotationService annotations;
+
+  public AnnotationController(AnnotationService annotations) {
+    this.annotations = annotations;
+  }
+
+  @Override
+  public ResponseEntity<AnnotationView> createAnnotation(
+      UUID documentId, AnnotationCreateRequest request) {
+    AnnotationService.AnnotationView view =
+        annotations.create(
+            documentId,
+            request.getVersionNumber(),
+            CurrentUser.requireUserId(),
+            CurrentUser.isAdmin(),
+            MAPPER.writeValueAsString(request.getAnchor()),
+            request.getComment());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toDto(view));
+  }
+
+  @Override
+  public ResponseEntity<AnnotationListResponse> listAnnotations(UUID documentId, Integer version) {
+    var views =
+        annotations.list(documentId, version, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.ok(
+        new AnnotationListResponse().annotations(views.stream().map(this::toDto).toList()));
+  }
+
+  @Override
+  public ResponseEntity<AnnotationView> getAnnotation(UUID annotationId) {
+    return ResponseEntity.ok(
+        toDto(annotations.get(annotationId, CurrentUser.requireUserId(), CurrentUser.isAdmin())));
+  }
+
+  @Override
+  public ResponseEntity<AnnotationView> decideAnnotation(
+      UUID annotationId, AnnotationDecisionRequest request) {
+    boolean accept = request.getDecision() == AnnotationDecision.ACCEPTED;
+    return ResponseEntity.ok(
+        toDto(annotations.decide(annotationId, accept, CurrentUser.requireUserId())));
+  }
+
+  @Override
+  public ResponseEntity<CommentView> addComment(UUID annotationId, CommentCreateRequest request) {
+    AnnotationService.CommentView view =
+        annotations.addComment(
+            annotationId, CurrentUser.requireUserId(), CurrentUser.isAdmin(), request.getBody());
+    return ResponseEntity.status(HttpStatus.CREATED).body(toDto(view));
+  }
+
+  @Override
+  public ResponseEntity<CommentListResponse> listComments(UUID annotationId) {
+    var views =
+        annotations.listComments(annotationId, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.ok(
+        new CommentListResponse().comments(views.stream().map(this::toDto).toList()));
+  }
+
+  private AnnotationView toDto(AnnotationService.AnnotationView view) {
+    return new AnnotationView()
+        .id(view.id())
+        .documentId(view.documentId())
+        .authorId(view.authorId())
+        .status(AnnotationStatus.fromValue(view.status()))
+        .anchor(
+            view.anchorJson() == null ? null : MAPPER.readValue(view.anchorJson(), Anchor.class))
+        .placementStatus(
+            view.placementStatus() == null
+                ? null
+                : PlacementStatus.fromValue(view.placementStatus()))
+        .commentCount(view.commentCount())
+        .createdAt(view.createdAt().atOffset(ZoneOffset.UTC))
+        .updatedAt(view.updatedAt().atOffset(ZoneOffset.UTC));
+  }
+
+  private CommentView toDto(AnnotationService.CommentView view) {
+    return new CommentView()
+        .id(view.id())
+        .annotationId(view.annotationId())
+        .authorId(view.authorId())
+        .body(view.body())
+        .createdAt(view.createdAt().atOffset(ZoneOffset.UTC));
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
@@ -22,27 +22,59 @@ package io.qnop.web;
 
 import io.qnop.api.v1.model.ErrorResponse;
 import io.qnop.service.document.DocumentValidationException;
+import io.qnop.service.review.AnnotationDecisionForbiddenException;
+import io.qnop.service.review.AnnotationNotFoundException;
+import io.qnop.service.review.DocumentNotFoundException;
+import io.qnop.service.review.NotDocumentOwnerException;
+import io.qnop.service.review.WorkflowTransitionException;
 import java.time.OffsetDateTime;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /**
- * Maps {@link DocumentValidationException} onto the uniform {@code ErrorResponse} envelope (issue
- * #245/#45). A controller advice — rather than per-controller handlers — because the document
- * pipeline spans three controllers (metadata/rendered, multipart upload, binary download) that all
- * raise the same exception.
+ * Maps the review-domain exceptions onto the uniform {@code ErrorResponse} envelope (issues
+ * #245/#246/#247, #45). A controller advice — rather than per-controller handlers — because the
+ * document/review pipeline spans several controllers (metadata/rendered, upload, download,
+ * workflow, annotations) that raise the same exceptions.
  */
 @RestControllerAdvice
 public class DocumentExceptionHandler {
 
   @ExceptionHandler(DocumentValidationException.class)
   public ResponseEntity<ErrorResponse> onDocumentError(DocumentValidationException ex) {
-    return ResponseEntity.status(ex.getStatus())
-        .body(
-            new ErrorResponse()
-                .code(ex.getCode())
-                .message(ex.getMessage())
-                .timestamp(OffsetDateTime.now()));
+    return error(ex.getStatus(), ex.getCode(), ex.getMessage());
+  }
+
+  @ExceptionHandler(DocumentNotFoundException.class)
+  public ResponseEntity<ErrorResponse> onDocumentNotFound(DocumentNotFoundException ex) {
+    return error(HttpStatus.NOT_FOUND.value(), "DOCUMENT_NOT_FOUND", ex.getMessage());
+  }
+
+  @ExceptionHandler(AnnotationNotFoundException.class)
+  public ResponseEntity<ErrorResponse> onAnnotationNotFound(AnnotationNotFoundException ex) {
+    return error(HttpStatus.NOT_FOUND.value(), "ANNOTATION_NOT_FOUND", ex.getMessage());
+  }
+
+  @ExceptionHandler(NotDocumentOwnerException.class)
+  public ResponseEntity<ErrorResponse> onNotOwner(NotDocumentOwnerException ex) {
+    return error(HttpStatus.FORBIDDEN.value(), "NOT_DOCUMENT_OWNER", ex.getMessage());
+  }
+
+  @ExceptionHandler(AnnotationDecisionForbiddenException.class)
+  public ResponseEntity<ErrorResponse> onDecisionForbidden(
+      AnnotationDecisionForbiddenException ex) {
+    return error(HttpStatus.FORBIDDEN.value(), "ANNOTATION_DECISION_FORBIDDEN", ex.getMessage());
+  }
+
+  @ExceptionHandler(WorkflowTransitionException.class)
+  public ResponseEntity<ErrorResponse> onTransitionRefused(WorkflowTransitionException ex) {
+    return error(HttpStatus.CONFLICT.value(), ex.getCode(), ex.getMessage());
+  }
+
+  private static ResponseEntity<ErrorResponse> error(int status, String code, String message) {
+    return ResponseEntity.status(status)
+        .body(new ErrorResponse().code(code).message(message).timestamp(OffsetDateTime.now()));
   }
 }

--- a/qnop-app/src/main/java/io/qnop/web/ReviewWorkflowController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ReviewWorkflowController.java
@@ -21,27 +21,19 @@
 package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.ReviewWorkflowApi;
-import io.qnop.api.v1.model.ErrorResponse;
 import io.qnop.api.v1.model.WorkflowStatus;
 import io.qnop.api.v1.model.WorkflowTransitionRequest;
 import io.qnop.entity.WorkflowState;
-import io.qnop.service.review.DocumentNotFoundException;
-import io.qnop.service.review.NotDocumentOwnerException;
 import io.qnop.service.review.ReviewWorkflowService;
-import io.qnop.service.review.WorkflowTransitionException;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.UUID;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Workflow transition endpoints (issue #246, ADR-0011): reading a document's workflow status and
  * requesting a transition through the state-machine choke-point. State changes are owner-only; the
  * service enforces that and the domain guards — this controller only maps to the published
- * contract.
+ * contract. Domain exceptions are mapped globally by {@link DocumentExceptionHandler}.
  */
 @RestController
 public class ReviewWorkflowController implements ReviewWorkflowApi {
@@ -69,30 +61,5 @@ public class ReviewWorkflowController implements ReviewWorkflowApi {
     return new WorkflowStatus()
         .state(status.state())
         .allowedTransitions(status.allowedTransitions().stream().map(WorkflowState::name).toList());
-  }
-
-  @ExceptionHandler(DocumentNotFoundException.class)
-  ResponseEntity<ErrorResponse> documentNotFound(DocumentNotFoundException ex) {
-    return error(HttpStatus.NOT_FOUND, "DOCUMENT_NOT_FOUND", ex.getMessage());
-  }
-
-  @ExceptionHandler(NotDocumentOwnerException.class)
-  ResponseEntity<ErrorResponse> notOwner(NotDocumentOwnerException ex) {
-    return error(HttpStatus.FORBIDDEN, "NOT_DOCUMENT_OWNER", ex.getMessage());
-  }
-
-  @ExceptionHandler(WorkflowTransitionException.class)
-  ResponseEntity<ErrorResponse> transitionRefused(WorkflowTransitionException ex) {
-    return error(HttpStatus.CONFLICT, ex.getCode(), ex.getMessage());
-  }
-
-  private static ResponseEntity<ErrorResponse> error(
-      HttpStatus status, String code, String message) {
-    return ResponseEntity.status(status)
-        .body(
-            new ErrorResponse()
-                .code(code)
-                .message(message)
-                .timestamp(OffsetDateTime.now(ZoneOffset.UTC)));
   }
 }

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Annotations, comments & placements API acceptance (issue #247, ADR-0009/0011). Owner {@code
+ * MEMBER_ID}; reviewers {@code AUDITOR_ID} (also the annotation author) and {@code MEMBER2_ID};
+ * {@code EXTERNAL_ID} is a non-participant and must see 404 everywhere (anti-enumeration).
+ */
+class AnnotationApiIT extends SeededIntegrationTest {
+
+  private static final String ANCHOR =
+      "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.1}},"
+          + "\"textQuote\":{\"quote\":\"the clause\"}}";
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+
+  /** A DRAFT document owned by MEMBER with AUDITOR + MEMBER2 as reviewers and one version. */
+  private UUID seedDocumentWithVersion() {
+    Document document = documents.save(new Document(MEMBER_ID, "Master services agreement"));
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
+    versions.save(
+        new DocumentVersion(
+            document.getId(),
+            1,
+            "sha256/aa/deadbeef",
+            "deadbeef",
+            "application/pdf",
+            1234L,
+            MEMBER_ID));
+    return document.getId();
+  }
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  private String createAnnotation(UUID documentId, UUID actor) throws Exception {
+    String body = "{\"versionNumber\":1,\"anchor\":" + ANCHOR + ",\"comment\":\"please clarify\"}";
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return JsonPath.read(json, "$.id");
+  }
+
+  @Test
+  void participantCreatesAnAnnotationPlacedOnTheVersion() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+
+    String body = "{\"versionNumber\":1,\"anchor\":" + ANCHOR + ",\"comment\":\"please clarify\"}";
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.status").value("OPEN"))
+        .andExpect(jsonPath("$.authorId").value(AUDITOR_ID.toString()))
+        .andExpect(jsonPath("$.placementStatus").value("PLACED"))
+        .andExpect(jsonPath("$.anchor.region.surfaceIndex").value(0))
+        .andExpect(jsonPath("$.anchor.textQuote.quote").value("the clause"))
+        .andExpect(jsonPath("$.commentCount").value(1));
+  }
+
+  @Test
+  void listsAnnotationsWithTheirPlacementForAVersion() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    createAnnotation(documentId, AUDITOR_ID);
+
+    mockMvc
+        .perform(
+            as(
+                get("/api/v1/documents/" + documentId + "/annotations").param("version", "1"),
+                MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations.length()").value(1))
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("PLACED"))
+        .andExpect(jsonPath("$.annotations[0].anchor.region.box.width").value(0.3));
+  }
+
+  @Test
+  void nonParticipantSees404() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/annotations"), EXTERNAL_ID))
+        .andExpect(status().isNotFound());
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), EXTERNAL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"versionNumber\":1,\"anchor\":" + ANCHOR + "}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void ownerDecidesAccept() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/decision"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"decision\":\"ACCEPTED\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("ACCEPTED"));
+  }
+
+  @Test
+  void authorDecidesTheirOwnAnnotation() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/decision"), AUDITOR_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"decision\":\"REJECTED\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("REJECTED"));
+  }
+
+  @Test
+  void anotherReviewerCannotDecide() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    // MEMBER2 is a participant (so the annotation is visible) but neither owner nor author.
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/decision"), MEMBER2_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"decision\":\"ACCEPTED\"}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void decidingAnAlreadyDecidedAnnotationIsConflict() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+    decide(annotationId, "ACCEPTED", MEMBER_ID).andExpect(status().isOk());
+
+    decide(annotationId, "REJECTED", MEMBER_ID).andExpect(status().isConflict());
+  }
+
+  @Test
+  void addsAndListsComments() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/comments"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"agreed, please revise\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.body").value("agreed, please revise"));
+
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId + "/comments"), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.comments.length()").value(greaterThanOrEqualTo(2)));
+  }
+
+  @Test
+  void rejectsAnAnchorWithoutARegion() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"versionNumber\":1,\"anchor\":{}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  void unknownAnnotationIsNotFound() throws Exception {
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + UUID.randomUUID()), MEMBER_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  private org.springframework.test.web.servlet.ResultActions decide(
+      String annotationId, String decision, UUID actor) throws Exception {
+    return mockMvc.perform(
+        as(post("/api/v1/annotations/" + annotationId + "/decision"), actor)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"decision\":\"" + decision + "\"}"));
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationDecisionForbiddenException.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationDecisionForbiddenException.java
@@ -18,19 +18,15 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-package io.qnop.repository;
+package io.qnop.service.review;
 
-import io.qnop.entity.Comment;
-import java.util.List;
-import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
+/**
+ * The acting user may not decide this annotation (issue #247, ADR-0011): accept/reject is limited
+ * to the document owner or the annotation's author. Mapped to HTTP 403.
+ */
+public class AnnotationDecisionForbiddenException extends RuntimeException {
 
-/** Data access for annotation comment threads (issue #244, ADR-0011). */
-public interface CommentRepository extends JpaRepository<Comment, UUID> {
-
-  /** The discussion thread of an annotation, oldest message first. */
-  List<Comment> findByAnnotationIdOrderByCreatedAtAsc(UUID annotationId);
-
-  /** The size of an annotation's thread (issue #247). */
-  long countByAnnotationId(UUID annotationId);
+  public AnnotationDecisionForbiddenException() {
+    super("Only the document owner or the annotation's author may decide this annotation");
+  }
 }

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.AnnotationStatus;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.Comment;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.document.DocumentAccessService;
+import io.qnop.service.document.DocumentValidationException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Annotations, their comment threads, and per-version placements (issue #247, ADR-0009/0011).
+ *
+ * <p>A participant creates an anchored annotation on a version they are viewing; the placement on
+ * that version is {@code PLACED} immediately (a human drew it — re-anchoring onto later versions is
+ * the async job of #248). The owner/author decision (accept/reject) is the workflow's concern and
+ * lives in {@link ReviewWorkflowService}. Visibility is delegated to {@link DocumentAccessService},
+ * so a non-participant sees the same 404 as for the document itself (anti-enumeration).
+ */
+@Service
+public class AnnotationService {
+
+  static final String AUDIT_ANNOTATION_CREATED = "annotation.created";
+
+  private final AnnotationRepository annotations;
+  private final AnnotationPlacementRepository placements;
+  private final CommentRepository comments;
+  private final DocumentVersionRepository versions;
+  private final AuditEventRepository auditEvents;
+  private final DocumentAccessService documentAccess;
+  private final ReviewWorkflowService workflow;
+
+  public AnnotationService(
+      AnnotationRepository annotations,
+      AnnotationPlacementRepository placements,
+      CommentRepository comments,
+      DocumentVersionRepository versions,
+      AuditEventRepository auditEvents,
+      DocumentAccessService documentAccess,
+      ReviewWorkflowService workflow) {
+    this.annotations = annotations;
+    this.placements = placements;
+    this.comments = comments;
+    this.versions = versions;
+    this.auditEvents = auditEvents;
+    this.documentAccess = documentAccess;
+    this.workflow = workflow;
+  }
+
+  /**
+   * An annotation with (when a version was requested) its placement there and its thread size.
+   * {@code status} / {@code placementStatus} are the enum names (kept as strings so the web layer
+   * maps them without depending on the entity enums, ADR-0004).
+   */
+  public record AnnotationView(
+      UUID id,
+      UUID documentId,
+      UUID authorId,
+      String status,
+      String anchorJson,
+      String placementStatus,
+      int commentCount,
+      Instant createdAt,
+      Instant updatedAt) {}
+
+  /** One message in an annotation's thread. */
+  public record CommentView(
+      UUID id, UUID annotationId, UUID authorId, String body, Instant createdAt) {}
+
+  /**
+   * Creates an annotation on {@code versionNumber}, placed immediately, with an optional comment.
+   */
+  @Transactional
+  public AnnotationView create(
+      UUID documentId,
+      int versionNumber,
+      UUID author,
+      boolean admin,
+      String anchorJson,
+      String firstComment) {
+    documentAccess.getDocument(documentId, author, admin); // visibility → 404 if not a participant
+    DocumentVersion version =
+        versions
+            .findByDocumentIdAndVersionNumber(documentId, versionNumber)
+            .orElseThrow(
+                () -> DocumentValidationException.notFound("no such version: " + versionNumber));
+
+    Annotation annotation = annotations.save(new Annotation(documentId, author));
+    AnnotationPlacement placement =
+        new AnnotationPlacement(annotation.getId(), version.getId(), anchorJson);
+    placement.markPlaced(anchorJson);
+    placements.save(placement);
+
+    int commentCount = 0;
+    if (firstComment != null && !firstComment.isBlank()) {
+      comments.save(new Comment(annotation.getId(), author, firstComment));
+      commentCount = 1;
+    }
+    auditEvents.save(
+        new AuditEvent(
+            documentId,
+            AUDIT_ANNOTATION_CREATED,
+            author,
+            "{\"annotationId\":\"" + annotation.getId() + "\"}"));
+    return view(annotation, placement, commentCount);
+  }
+
+  /**
+   * All of a document's annotations; each with its placement on {@code versionNumber} when given.
+   */
+  @Transactional(readOnly = true)
+  public List<AnnotationView> list(
+      UUID documentId, Integer versionNumber, UUID actor, boolean admin) {
+    documentAccess.getDocument(documentId, actor, admin); // visibility → 404 if not a participant
+    UUID versionId =
+        versionNumber == null
+            ? null
+            : versions
+                .findByDocumentIdAndVersionNumber(documentId, versionNumber)
+                .map(DocumentVersion::getId)
+                .orElse(null);
+    return annotations.findByDocumentId(documentId).stream()
+        .map(
+            annotation -> {
+              AnnotationPlacement placement =
+                  versionId == null
+                      ? null
+                      : placements
+                          .findByAnnotationIdAndDocumentVersionId(annotation.getId(), versionId)
+                          .orElse(null);
+              return view(annotation, placement, threadSize(annotation.getId()));
+            })
+        .toList();
+  }
+
+  /** A single annotation (no version context, so no placement), visible to participants. */
+  @Transactional(readOnly = true)
+  public AnnotationView get(UUID annotationId, UUID actor, boolean admin) {
+    Annotation annotation = requireAnnotation(annotationId);
+    documentAccess.getDocument(annotation.getDocumentId(), actor, admin);
+    return view(annotation, null, threadSize(annotationId));
+  }
+
+  /**
+   * Applies the owner/author decision (ADR-0011) via the workflow choke-point (which enforces the
+   * authorization and drives the document state), and returns the updated annotation's view.
+   */
+  @Transactional
+  public AnnotationView decide(UUID annotationId, boolean accept, UUID actor) {
+    AnnotationStatus decision = accept ? AnnotationStatus.ACCEPTED : AnnotationStatus.REJECTED;
+    Annotation updated = workflow.decideAnnotation(annotationId, decision, actor);
+    return view(updated, null, threadSize(updated.getId()));
+  }
+
+  /** Appends a comment to an annotation's thread; visible participants only. */
+  @Transactional
+  public CommentView addComment(UUID annotationId, UUID author, boolean admin, String body) {
+    Annotation annotation = requireAnnotation(annotationId);
+    documentAccess.getDocument(annotation.getDocumentId(), author, admin);
+    return commentView(comments.save(new Comment(annotationId, author, body)));
+  }
+
+  /** An annotation's comment thread, oldest first; visible participants only. */
+  @Transactional(readOnly = true)
+  public List<CommentView> listComments(UUID annotationId, UUID actor, boolean admin) {
+    Annotation annotation = requireAnnotation(annotationId);
+    documentAccess.getDocument(annotation.getDocumentId(), actor, admin);
+    return comments.findByAnnotationIdOrderByCreatedAtAsc(annotationId).stream()
+        .map(AnnotationService::commentView)
+        .toList();
+  }
+
+  private Annotation requireAnnotation(UUID annotationId) {
+    return annotations
+        .findById(annotationId)
+        .orElseThrow(() -> new AnnotationNotFoundException(annotationId));
+  }
+
+  private int threadSize(UUID annotationId) {
+    return (int) comments.countByAnnotationId(annotationId);
+  }
+
+  private static AnnotationView view(
+      Annotation annotation, AnnotationPlacement placement, int commentCount) {
+    return new AnnotationView(
+        annotation.getId(),
+        annotation.getDocumentId(),
+        annotation.getAuthorId(),
+        annotation.getStatus().name(),
+        placement == null ? null : placement.getAnchor(),
+        placement == null ? null : placement.getStatus().name(),
+        commentCount,
+        annotation.getCreatedAt(),
+        annotation.getUpdatedAt());
+  }
+
+  private static CommentView commentView(Comment comment) {
+    return new CommentView(
+        comment.getId(),
+        comment.getAnnotationId(),
+        comment.getAuthorId(),
+        comment.getBody(),
+        comment.getCreatedAt());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -190,7 +190,8 @@ public class AnnotationService {
   public CommentView addComment(UUID annotationId, UUID author, boolean admin, String body) {
     Annotation annotation = requireAnnotation(annotationId);
     documentAccess.getDocument(annotation.getDocumentId(), author, admin);
-    return commentView(comments.save(new Comment(annotationId, author, body)));
+    // saveAndFlush so @CreationTimestamp is populated on the returned comment before the view.
+    return commentView(comments.saveAndFlush(new Comment(annotationId, author, body)));
   }
 
   /** An annotation's comment thread, oldest first; visible participants only. */

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -116,7 +116,9 @@ public class AnnotationService {
             .orElseThrow(
                 () -> DocumentValidationException.notFound("no such version: " + versionNumber));
 
-    Annotation annotation = annotations.save(new Annotation(documentId, author));
+    // saveAndFlush so the @CreationTimestamp / @UpdateTimestamp are populated on the returned
+    // entity (they are only set when the INSERT is flushed) before the view is built.
+    Annotation annotation = annotations.saveAndFlush(new Annotation(documentId, author));
     AnnotationPlacement placement =
         new AnnotationPlacement(annotation.getId(), version.getId(), anchorJson);
     placement.markPlaced(anchorJson);

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -102,10 +102,10 @@ public class ReviewWorkflowService {
   }
 
   /**
-   * Applies the owner's decision on an annotation — the {@code OPEN → ACCEPTED | REJECTED}
-   * sub-machine (ADR-0011). Accepting while the document is {@code IN_REVIEW} drives the workflow
-   * to {@code CHANGES_REQUESTED} through the same choke-point (with its own audit event). The REST
-   * surface for this lands with the annotations API (#247); the domain rule lives here.
+   * Applies a decision on an annotation — the {@code OPEN → ACCEPTED | REJECTED} sub-machine
+   * (ADR-0011), permitted for the document owner or the annotation's author (issue #247). Accepting
+   * while the document is {@code IN_REVIEW} drives the workflow to {@code CHANGES_REQUESTED}
+   * through the same choke-point (with its own audit event).
    */
   @Transactional
   public Annotation decideAnnotation(UUID annotationId, AnnotationStatus decision, UUID actorId) {
@@ -117,7 +117,9 @@ public class ReviewWorkflowService {
             .findById(annotationId)
             .orElseThrow(() -> new AnnotationNotFoundException(annotationId));
     Document document = load(annotation.getDocumentId());
-    requireOwner(document, actorId);
+    if (!document.getOwnerId().equals(actorId) && !annotation.getAuthorId().equals(actorId)) {
+      throw new AnnotationDecisionForbiddenException();
+    }
     if (!ReviewWorkflowMachine.canDecide(annotation.getStatus())) {
       throw new WorkflowTransitionException(
           WorkflowTransitionException.ANNOTATION_ALREADY_DECIDED,


### PR DESCRIPTION
## Summary

The annotations / comment-threads / per-version placements API (part of #241), built over the #244 domain model and reusing #245's participant authz (`DocumentAccessService`) and #246's workflow rule (`ReviewWorkflowService.decideAnnotation`).

### What's added

- **OpenAPI** — an `Annotations` tag with **typed multi-layer anchors** (`region` always present; `textQuote` + `textPosition` optional, per ADR-0009, reusing the existing `NormalizedBox`), and the paths: create/list annotations on a document, get one, `POST /annotations/{id}/decision`, and comment thread create/list.
- **`AnnotationService`** — creates an annotation `PLACED` on the version it's drawn on (optional first comment + `annotation.created` audit event), lists annotations with their per-version placement (anchor + status), get, add/list comments. Visibility is delegated to `DocumentAccessService`, so a **non-participant sees 404** (anti-enumeration, consistent with #245).
- **Decide (accept/reject)** — the guard in `ReviewWorkflowService.decideAnnotation` is relaxed from owner-only to **document owner OR the annotation's author** (per the chosen model); it still drives `IN_REVIEW → CHANGES_REQUESTED` through the state-machine choke-point + audit.
- **`AnnotationController`** — maps views↔models and (de)serializes the jsonb anchor with tools.jackson; status/placement cross the boundary as **strings** so the web layer never depends on the entity enums (ArchUnit-clean).
- **Exception handling** — consolidated the review-domain exceptions (`DocumentNotFound`, `AnnotationNotFound`, `NotDocumentOwner`, `AnnotationDecisionForbidden`, `WorkflowTransition`) into the global `DocumentExceptionHandler` (404/403/409) and removed the now-duplicated local handlers from `ReviewWorkflowController`.

### Scope / non-goals

Re-anchoring across versions is **#248** (this stores the human-placed anchor as `PLACED`). Comments are append-only per the schema (create + list; no edit/delete). Frontend viewer is #250.

## Acceptance (#247)

- [x] create / list / decide annotations + comment threads
- [x] participant-only authz enforced (non-participant → 404; decide → owner/author only, else 403; already-decided → 409)
- [x] IT (`AnnotationApiIT`)

## Test plan

- [x] `spotlessApply`, compile, **ArchUnit** (`ArchitectureRulesTest`), `:qnop-core:build`, spotless checks green locally; OpenAPI regenerates + compiles.
- [ ] CI: Backend (ITs incl. `AnnotationApiIT` against Testcontainers) + OWASP + smoke green (Docker unavailable locally).

Part of #241. Closes #247.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code