### PR TITLE
feat(core): inter-version diff (ADR-0034, #249)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,10 @@ jmustache = "1.16"
 # endpointOverride + path-style so MinIO (On-Prem) and S3/GCS (SaaS) are a
 # deploy-time config switch. Not in the Spring Boot BOM → explicit version.
 awsSdk = "2.31.6"
+# Inter-version diff (issue #249, ADR-0034): actively-maintained Myers diff over
+# token lists (word granularity), Apache-2.0. Chosen over the unmaintained
+# java port of diff-match-patch. Not in the Spring Boot BOM → explicit version.
+javaDiffUtils = "4.15"
 
 # --- Pinned for later phases (NOT yet applied) -------------------------
 pdfbox = "3.0.5"            # PDF text extraction with glyph positions
@@ -111,6 +115,10 @@ jmustache = { module = "com.samskivert:jmustache", version.ref = "jmustache" }
 # Object storage (issue #243, ADR-0005): AWS SDK v2 S3 client — the vendor-neutral
 # StorageProvider default (io.qnop.service.storage). Not BOM-managed → explicit version.
 aws-sdk-s3 = { module = "software.amazon.awssdk:s3", version.ref = "awsSdk" }
+
+# Inter-version diff (issue #249, ADR-0034): Myers diff at word granularity over the
+# extracted text layers. Not BOM-managed → explicit version.
+java-diff-utils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "javaDiffUtils" }
 
 # Test
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1949,6 +1949,65 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /documents/{documentId}/diff:
+    get:
+      tags:
+        - Documents
+      summary: What changed between two versions
+      description: |
+        A word-granularity text diff over the two versions' extracted text layers
+        (ADR-0034), with every change mapped back to the normalized boxes of the
+        text runs it covers — so the change can be highlighted on the rendered
+        original. Any pair is diffable (not only adjacent versions). Versions are
+        immutable, so the result is computed on first request and served from a
+        permanent cache afterwards. A version without a text layer (an image)
+        contributes no changes; the client falls back to side-by-side.
+      operationId: getVersionDiff
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/DocumentIdParam'
+        - name: from
+          in: query
+          required: true
+          description: The 1-based number of the older (baseline) version.
+          schema:
+            type: integer
+            minimum: 1
+        - name: to
+          in: query
+          required: true
+          description: The 1-based number of the newer version to compare against.
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: The located changes from `from` to `to`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionDiffResponse'
+        '400':
+          description: Invalid version pair (e.g. `from` equals `to`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown document/version, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: >-
+            Extraction has not completed for one of the versions
+            (`EXTRACTION_PENDING`) or failed permanently (`EXTRACTION_FAILED`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -3620,3 +3679,73 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CommentView'
+    DiffChangeType:
+      type: string
+      description: The kind of a change, in the `from → to` direction (ADR-0034).
+      enum:
+        - INSERTED
+        - DELETED
+        - CHANGED
+    DiffLocation:
+      type: object
+      description: One highlighted rectangle of a change — a text run's box on a surface.
+      required:
+        - surfaceIndex
+        - box
+      properties:
+        surfaceIndex:
+          type: integer
+          minimum: 0
+          description: Zero-based surface (page) index.
+        box:
+          $ref: '#/components/schemas/NormalizedBox'
+    DiffChange:
+      type: object
+      description: |
+        One contiguous change. `fromText`/`fromLocations` describe the affected
+        content of the baseline version (empty for INSERTED); `toText`/
+        `toLocations` the newer version's (empty for DELETED).
+      required:
+        - type
+        - fromText
+        - fromLocations
+        - toText
+        - toLocations
+      properties:
+        type:
+          $ref: '#/components/schemas/DiffChangeType'
+        fromText:
+          type: string
+          description: The affected text in the baseline version ('' for INSERTED).
+        fromLocations:
+          type: array
+          description: Boxes of the affected text runs in the baseline version.
+          items:
+            $ref: '#/components/schemas/DiffLocation'
+        toText:
+          type: string
+          description: The affected text in the newer version ('' for DELETED).
+        toLocations:
+          type: array
+          description: Boxes of the affected text runs in the newer version.
+          items:
+            $ref: '#/components/schemas/DiffLocation'
+    VersionDiffResponse:
+      type: object
+      description: The located changes between two immutable versions (ADR-0034).
+      required:
+        - fromVersion
+        - toVersion
+        - changes
+      properties:
+        fromVersion:
+          type: integer
+          description: The 1-based baseline version number.
+        toVersion:
+          type: integer
+          description: The 1-based newer version number.
+        changes:
+          type: array
+          description: All changes in document order; empty when the texts are identical.
+          items:
+            $ref: '#/components/schemas/DiffChange'

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -21,11 +21,17 @@
 package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.DocumentsApi;
+import io.qnop.api.v1.model.DiffChange;
+import io.qnop.api.v1.model.DiffChangeType;
+import io.qnop.api.v1.model.DiffLocation;
 import io.qnop.api.v1.model.DocumentResponse;
 import io.qnop.api.v1.model.DocumentVersionListResponse;
 import io.qnop.api.v1.model.DocumentVersionSummary;
 import io.qnop.api.v1.model.ExtractionStatus;
+import io.qnop.api.v1.model.NormalizedBox;
 import io.qnop.api.v1.model.RenderedDocumentResponse;
+import io.qnop.api.v1.model.VersionDiffResponse;
+import io.qnop.service.diff.VersionDiffService;
 import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.document.DocumentAccessService.DocumentVersionView;
 import io.qnop.service.document.DocumentAccessService.DocumentView;
@@ -35,19 +41,54 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Document metadata, versions, and the canonical rendered representation (issue #245, ADR-0032),
- * implementing the generated {@link DocumentsApi} contract. Authorization (owner / participant /
- * admin, otherwise 404) lives in {@link DocumentAccessService}; this layer only maps views to the
- * published models. The multipart upload and the original-binary download are plain controllers
- * (ADR-0028): {@code DocumentUploadController} / {@code DocumentContentController}.
+ * Document metadata, versions, the canonical rendered representation (issue #245, ADR-0032), and
+ * the inter-version diff (issue #249, ADR-0034), implementing the generated {@link DocumentsApi}
+ * contract. Authorization (owner / participant / admin, otherwise 404) lives in the services; this
+ * layer only maps views to the published models. The multipart upload and the original-binary
+ * download are plain controllers (ADR-0028): {@code DocumentUploadController} / {@code
+ * DocumentContentController}.
  */
 @RestController
 public class DocumentsController implements DocumentsApi {
 
   private final DocumentAccessService documents;
+  private final VersionDiffService diffs;
 
-  public DocumentsController(DocumentAccessService documents) {
+  public DocumentsController(DocumentAccessService documents, VersionDiffService diffs) {
     this.documents = documents;
+    this.diffs = diffs;
+  }
+
+  @Override
+  public ResponseEntity<VersionDiffResponse> getVersionDiff(
+      UUID documentId, Integer from, Integer to) {
+    VersionDiffService.DiffView view =
+        diffs.diff(documentId, from, to, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.ok(
+        new VersionDiffResponse()
+            .fromVersion(view.fromVersion())
+            .toVersion(view.toVersion())
+            .changes(view.changes().stream().map(DocumentsController::toDto).toList()));
+  }
+
+  private static DiffChange toDto(VersionDiffService.ChangeView change) {
+    return new DiffChange()
+        .type(DiffChangeType.fromValue(change.type()))
+        .fromText(change.fromText())
+        .fromLocations(change.fromLocations().stream().map(DocumentsController::toDto).toList())
+        .toText(change.toText())
+        .toLocations(change.toLocations().stream().map(DocumentsController::toDto).toList());
+  }
+
+  private static DiffLocation toDto(VersionDiffService.LocationView location) {
+    return new DiffLocation()
+        .surfaceIndex(location.surfaceIndex())
+        .box(
+            new NormalizedBox()
+                .x(location.x())
+                .y(location.y())
+                .width(location.width())
+                .height(location.height()));
   }
 
   @Override

--- a/qnop-app/src/test/java/io/qnop/review/VersionDiffIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/VersionDiffIT.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.repository.VersionDiffRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Inter-version diff acceptance (issue #249, ADR-0034): located changes between two versions, the
+ * permanent cache, the extraction gate, and participant-only visibility. Owner {@code MEMBER_ID},
+ * reviewer {@code AUDITOR_ID}; {@code EXTERNAL_ID} is a non-participant (404, anti-enumeration).
+ */
+class VersionDiffIT extends SeededIntegrationTest {
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+  @Autowired private VersionDiffRepository diffCache;
+
+  /** The jsonb of a one-surface rendered document whose spans are the given lines (ADR-0032). */
+  private static String rendered(String... lines) {
+    StringBuilder spans = new StringBuilder();
+    int offset = 0;
+    double y = 0.1;
+    for (String line : lines) {
+      if (!spans.isEmpty()) {
+        spans.append(',');
+      }
+      spans.append(
+          "{\"text\":\"%s\",\"startOffset\":%d,\"endOffset\":%d,\"box\":{\"x\":0.1,\"y\":%s,\"width\":0.8,\"height\":0.05}}"
+              .formatted(line, offset, offset + line.length(), y));
+      offset += line.length() + 1;
+      y += 0.1;
+    }
+    return "{\"surfaces\":[{\"index\":0,\"width\":612.0,\"height\":792.0,\"textSpans\":["
+        + spans
+        + "]}]}";
+  }
+
+  private UUID seedDocument() {
+    Document document = documents.save(new Document(MEMBER_ID, "Contract"));
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    return document.getId();
+  }
+
+  private DocumentVersion seedVersion(UUID documentId, int number, String renderedJson) {
+    DocumentVersion version =
+        new DocumentVersion(
+            documentId,
+            number,
+            "sha256/aa/v" + number,
+            "hash-v" + number,
+            "application/pdf",
+            100L,
+            MEMBER_ID);
+    if (renderedJson != null) {
+      version.attachRenderedDocument(renderedJson);
+    }
+    return versions.save(version);
+  }
+
+  private MockHttpServletRequestBuilder diffRequest(UUID documentId, int from, int to, UUID user) {
+    return get("/api/v1/documents/" + documentId + "/diff")
+        .param("from", String.valueOf(from))
+        .param("to", String.valueOf(to))
+        .header("Authorization", "Bearer " + token(user));
+  }
+
+  @Test
+  void returnsLocatedChangesBetweenTwoVersions() throws Exception {
+    UUID documentId = seedDocument();
+    seedVersion(documentId, 1, rendered("the quick brown fox", "second line stays"));
+    seedVersion(documentId, 2, rendered("the quick red fox", "second line stays"));
+
+    mockMvc
+        .perform(diffRequest(documentId, 1, 2, AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.fromVersion").value(1))
+        .andExpect(jsonPath("$.toVersion").value(2))
+        .andExpect(jsonPath("$.changes.length()").value(1))
+        .andExpect(jsonPath("$.changes[0].type").value("CHANGED"))
+        .andExpect(jsonPath("$.changes[0].fromText").value("brown"))
+        .andExpect(jsonPath("$.changes[0].toText").value("red"))
+        .andExpect(jsonPath("$.changes[0].fromLocations[0].surfaceIndex").value(0))
+        .andExpect(jsonPath("$.changes[0].fromLocations[0].box.y").value(0.1))
+        .andExpect(jsonPath("$.changes[0].toLocations[0].box.width").value(0.8));
+  }
+
+  @Test
+  void secondRequestIsServedFromThePermanentCache() throws Exception {
+    UUID documentId = seedDocument();
+    DocumentVersion v1 = seedVersion(documentId, 1, rendered("alpha"));
+    DocumentVersion v2 = seedVersion(documentId, 2, rendered("alpha beta"));
+
+    mockMvc.perform(diffRequest(documentId, 1, 2, MEMBER_ID)).andExpect(status().isOk());
+    assertThat(diffCache.findByFromVersionIdAndToVersionId(v1.getId(), v2.getId())).isPresent();
+
+    // The cached second call returns the identical payload.
+    mockMvc
+        .perform(diffRequest(documentId, 1, 2, MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.changes.length()").value(1))
+        .andExpect(jsonPath("$.changes[0].type").value("INSERTED"))
+        .andExpect(jsonPath("$.changes[0].toText").value("beta"));
+    assertThat(diffCache.count()).isEqualTo(1);
+  }
+
+  @Test
+  void identicalVersionsYieldAnEmptyChangeList() throws Exception {
+    UUID documentId = seedDocument();
+    seedVersion(documentId, 1, rendered("same text"));
+    seedVersion(documentId, 2, rendered("same text"));
+
+    mockMvc
+        .perform(diffRequest(documentId, 1, 2, MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.changes.length()").value(0));
+  }
+
+  @Test
+  void nonParticipantSees404() throws Exception {
+    UUID documentId = seedDocument();
+    seedVersion(documentId, 1, rendered("alpha"));
+    seedVersion(documentId, 2, rendered("beta"));
+
+    mockMvc.perform(diffRequest(documentId, 1, 2, EXTERNAL_ID)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void pendingExtractionIsConflict() throws Exception {
+    UUID documentId = seedDocument();
+    seedVersion(documentId, 1, rendered("alpha"));
+    seedVersion(documentId, 2, null); // extraction still PENDING
+
+    mockMvc
+        .perform(diffRequest(documentId, 1, 2, MEMBER_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("EXTRACTION_PENDING"));
+  }
+
+  @Test
+  void equalFromAndToIsRejected() throws Exception {
+    UUID documentId = seedDocument();
+    seedVersion(documentId, 1, rendered("alpha"));
+
+    mockMvc
+        .perform(diffRequest(documentId, 1, 1, MEMBER_ID))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  void unknownVersionIsNotFound() throws Exception {
+    UUID documentId = seedDocument();
+    seedVersion(documentId, 1, rendered("alpha"));
+
+    mockMvc.perform(diffRequest(documentId, 1, 9, MEMBER_ID)).andExpect(status().isNotFound());
+  }
+}

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -64,6 +64,10 @@ dependencies {
     implementation(libs.pdfbox)
     implementation(libs.jackson3.databind)
 
+    // Inter-version diff (issue #249, ADR-0034): Myers diff at word granularity
+    // over the two versions' extracted text layers.
+    implementation(libs.java.diff.utils)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/qnop-core/src/main/java/io/qnop/entity/VersionDiff.java
+++ b/qnop-core/src/main/java/io/qnop/entity/VersionDiff.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * One permanently cached inter-version diff (issue #249, ADR-0034). Versions are immutable, so the
+ * diff between a {@code (fromVersion, toVersion)} pair is stable forever: computed lazily on first
+ * request, cached here indefinitely, never invalidated (unique on the pair; migration 0013). The
+ * {@code payload} is the serialized list of located changes.
+ */
+@Entity
+@Table(name = "version_diff")
+public class VersionDiff {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "document_id", nullable = false, updatable = false)
+  private UUID documentId;
+
+  @Column(name = "from_version_id", nullable = false, updatable = false)
+  private UUID fromVersionId;
+
+  @Column(name = "to_version_id", nullable = false, updatable = false)
+  private UUID toVersionId;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "payload", nullable = false, updatable = false)
+  private String payload;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  protected VersionDiff() {
+    // for JPA
+  }
+
+  public VersionDiff(UUID documentId, UUID fromVersionId, UUID toVersionId, String payload) {
+    this.documentId = documentId;
+    this.fromVersionId = fromVersionId;
+    this.toVersionId = toVersionId;
+    this.payload = payload;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getDocumentId() {
+    return documentId;
+  }
+
+  public UUID getFromVersionId() {
+    return fromVersionId;
+  }
+
+  public UUID getToVersionId() {
+    return toVersionId;
+  }
+
+  public String getPayload() {
+    return payload;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o instanceof VersionDiff other && id != null && id.equals(other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/VersionDiffRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/VersionDiffRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.VersionDiff;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Data access for the permanent inter-version diff cache (issue #249, ADR-0034). */
+public interface VersionDiffRepository extends JpaRepository<VersionDiff, UUID> {
+
+  /** The cached diff for a version pair, if it has been computed before. */
+  Optional<VersionDiff> findByFromVersionIdAndToVersionId(UUID fromVersionId, UUID toVersionId);
+}

--- a/qnop-core/src/main/java/io/qnop/service/diff/VersionDiffEngine.java
+++ b/qnop-core/src/main/java/io/qnop/service/diff/VersionDiffEngine.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.diff;
+
+import com.github.difflib.DiffUtils;
+import com.github.difflib.patch.AbstractDelta;
+import com.github.difflib.patch.Chunk;
+import io.qnop.spi.extract.NormalizedBox;
+import io.qnop.spi.extract.RenderedDocument;
+import io.qnop.spi.extract.Surface;
+import io.qnop.spi.extract.TextSpan;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The inter-version diff core (issue #249, ADR-0034): a Myers diff at word granularity over the two
+ * versions' extracted text layers, with every changed span mapped back to the normalized boxes of
+ * the text runs it covers — so the frontend can highlight the change on the rendered original.
+ *
+ * <p>The diff runs over the <em>document-wide</em> canonical text (each surface's canonical text —
+ * spans joined by {@code \n}, ADR-0032 — concatenated with {@code \n} between surfaces), so content
+ * reflowing across a page boundary is matched, not reported as delete + insert. Deliberately plain,
+ * DB-free logic (ADR-0004 guardrail): the service around it owns authz, gates, and the cache.
+ *
+ * <p>Documents without a text layer (images) yield an empty change list — the honest Community
+ * answer per ADR-0034 (the frontend falls back to side-by-side).
+ */
+public final class VersionDiffEngine {
+
+  private VersionDiffEngine() {}
+
+  /** The kind of a change, from the perspective of the {@code from → to} direction. */
+  public enum ChangeType {
+    INSERTED,
+    DELETED,
+    CHANGED
+  }
+
+  /** Where a changed span sits on a version: one surface and one normalized text-run box. */
+  public record Location(int surfaceIndex, NormalizedBox box) {}
+
+  /**
+   * One contiguous change. {@code fromText}/{@code fromLocations} describe the affected content of
+   * the from-version (empty for {@link ChangeType#INSERTED}); {@code toText}/{@code toLocations}
+   * the to-version's (empty for {@link ChangeType#DELETED}).
+   */
+  public record Change(
+      ChangeType type,
+      String fromText,
+      List<Location> fromLocations,
+      String toText,
+      List<Location> toLocations) {}
+
+  /** Diffs two rendered documents; the result is stable for the (immutable) input pair. */
+  public static List<Change> diff(RenderedDocument from, RenderedDocument to) {
+    TokenizedDocument left = TokenizedDocument.of(from);
+    TokenizedDocument right = TokenizedDocument.of(to);
+
+    List<Change> changes = new ArrayList<>();
+    for (AbstractDelta<String> delta : DiffUtils.diff(left.words(), right.words()).getDeltas()) {
+      switch (delta.getType()) {
+        case DELETE ->
+            changes.add(
+                new Change(
+                    ChangeType.DELETED,
+                    left.textOf(delta.getSource()),
+                    left.locate(delta.getSource()),
+                    "",
+                    List.of()));
+        case INSERT ->
+            changes.add(
+                new Change(
+                    ChangeType.INSERTED,
+                    "",
+                    List.of(),
+                    right.textOf(delta.getTarget()),
+                    right.locate(delta.getTarget())));
+        case CHANGE ->
+            changes.add(
+                new Change(
+                    ChangeType.CHANGED,
+                    left.textOf(delta.getSource()),
+                    left.locate(delta.getSource()),
+                    right.textOf(delta.getTarget()),
+                    right.locate(delta.getTarget())));
+        case EQUAL -> {
+          // not emitted by DiffUtils.diff, present only for exhaustiveness
+        }
+      }
+    }
+    return List.copyOf(changes);
+  }
+
+  /** A word token: its text and its inclusive start offset in the document-wide canonical text. */
+  private record Word(String text, int start) {}
+
+  /** A span's home: its surface index and its offset range in the document-wide canonical text. */
+  private record LocatedSpan(int surfaceIndex, int start, int end, NormalizedBox box) {}
+
+  /**
+   * One side of the comparison, indexed for the diff: the word tokens of the document-wide
+   * canonical text plus the global offset range of every text run (for the box mapping).
+   */
+  private record TokenizedDocument(
+      String canonicalText, List<Word> tokens, List<LocatedSpan> spans) {
+
+    static TokenizedDocument of(RenderedDocument document) {
+      StringBuilder canonical = new StringBuilder();
+      List<LocatedSpan> spans = new ArrayList<>();
+      for (Surface surface : document.surfaces()) {
+        if (!canonical.isEmpty()) {
+          canonical.append('\n');
+        }
+        int surfaceBase = canonical.length();
+        // Per ADR-0032 a surface's canonical text is its spans joined by a single '\n', and each
+        // span's offsets are relative to that text — so the global range is base + span offsets.
+        for (TextSpan span : surface.textSpans()) {
+          spans.add(
+              new LocatedSpan(
+                  surface.index(),
+                  surfaceBase + span.startOffset(),
+                  surfaceBase + span.endOffset(),
+                  span.box()));
+        }
+        canonical.append(canonicalTextOf(surface));
+      }
+      return new TokenizedDocument(canonical.toString(), tokenize(canonical), List.copyOf(spans));
+    }
+
+    private static String canonicalTextOf(Surface surface) {
+      StringBuilder text = new StringBuilder();
+      for (TextSpan span : surface.textSpans()) {
+        if (!text.isEmpty()) {
+          text.append('\n');
+        }
+        text.append(span.text());
+      }
+      return text.toString();
+    }
+
+    private static List<Word> tokenize(CharSequence text) {
+      List<Word> words = new ArrayList<>();
+      int i = 0;
+      while (i < text.length()) {
+        while (i < text.length() && Character.isWhitespace(text.charAt(i))) {
+          i++;
+        }
+        int start = i;
+        while (i < text.length() && !Character.isWhitespace(text.charAt(i))) {
+          i++;
+        }
+        if (i > start) {
+          words.add(new Word(text.subSequence(start, i).toString(), start));
+        }
+      }
+      return List.copyOf(words);
+    }
+
+    /** The word texts, the unit the Myers diff compares. */
+    List<String> words() {
+      return tokens.stream().map(Word::text).toList();
+    }
+
+    /** The verbatim canonical text covered by a delta chunk (first to last affected word). */
+    String textOf(Chunk<String> chunk) {
+      Range range = rangeOf(chunk);
+      return canonicalText.substring(range.start(), range.end());
+    }
+
+    /** The boxes of every text run overlapping a delta chunk, in document order. */
+    List<Location> locate(Chunk<String> chunk) {
+      Range range = rangeOf(chunk);
+      List<Location> locations = new ArrayList<>();
+      for (LocatedSpan span : spans) {
+        if (span.start() < range.end() && range.start() < span.end()) {
+          locations.add(new Location(span.surfaceIndex(), span.box()));
+        }
+      }
+      return List.copyOf(locations);
+    }
+
+    private Range rangeOf(Chunk<String> chunk) {
+      Word first = tokens.get(chunk.getPosition());
+      Word last = tokens.get(chunk.getPosition() + chunk.getLines().size() - 1);
+      return new Range(first.start(), last.start() + last.text().length());
+    }
+  }
+
+  private record Range(int start, int end) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/diff/VersionDiffService.java
+++ b/qnop-core/src/main/java/io/qnop/service/diff/VersionDiffService.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.diff;
+
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ExtractionStatus;
+import io.qnop.entity.VersionDiff;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.VersionDiffRepository;
+import io.qnop.service.diff.VersionDiffEngine.Change;
+import io.qnop.service.diff.VersionDiffEngine.Location;
+import io.qnop.service.document.DocumentAccessService;
+import io.qnop.service.document.DocumentValidationException;
+import io.qnop.spi.extract.RenderedDocument;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * "What changed since the last version?" (issue #249, ADR-0034): the on-demand inter-version diff
+ * with its permanent cache. Versions are immutable, so a computed diff is stable forever — the
+ * first request computes and caches it ({@code version_diff}, unique on the pair), every later
+ * request reads the cache. Arbitrary pairs are diffable, not only adjacent ones. Visibility is the
+ * document's (participants/admin, otherwise 404 — anti-enumeration); both sides must have a READY
+ * extraction (the same 409 gates as the rendered representation).
+ */
+@Service
+public class VersionDiffService {
+
+  // Jackson 3 (tools.jackson) — the same stack the extraction pipeline stores jsonb with, so the
+  // cached payload and the SPI records share one (de)serialization line.
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  private final DocumentVersionRepository versions;
+  private final VersionDiffRepository diffs;
+  private final DocumentAccessService documentAccess;
+
+  public VersionDiffService(
+      DocumentVersionRepository versions,
+      VersionDiffRepository diffs,
+      DocumentAccessService documentAccess) {
+    this.versions = versions;
+    this.diffs = diffs;
+    this.documentAccess = documentAccess;
+  }
+
+  /**
+   * The located changes of {@code from → to}. Status and box values cross the layer boundary as
+   * plain strings/doubles so the web layer maps them without entity/SPI types (ADR-0004).
+   */
+  public record DiffView(int fromVersion, int toVersion, List<ChangeView> changes) {}
+
+  /** One contiguous change; {@code type} is a {@link VersionDiffEngine.ChangeType} name. */
+  public record ChangeView(
+      String type,
+      String fromText,
+      List<LocationView> fromLocations,
+      String toText,
+      List<LocationView> toLocations) {}
+
+  /** One highlighted rectangle: a surface index and a 0..1-normalized box. */
+  public record LocationView(int surfaceIndex, double x, double y, double width, double height) {}
+
+  /** The (cached) diff between two versions of a visible document. */
+  @Transactional
+  public DiffView diff(UUID documentId, int fromNumber, int toNumber, UUID actor, boolean admin) {
+    if (!documentAccess.isVisible(documentId, actor, admin)) {
+      throw DocumentValidationException.notFound("no such document: " + documentId);
+    }
+    if (fromNumber == toNumber) {
+      throw DocumentValidationException.invalidRequest("from and to must be different versions");
+    }
+    DocumentVersion from = requireReadyVersion(documentId, fromNumber);
+    DocumentVersion to = requireReadyVersion(documentId, toNumber);
+
+    List<ChangeView> changes =
+        diffs
+            .findByFromVersionIdAndToVersionId(from.getId(), to.getId())
+            .map(cached -> readPayload(cached.getPayload()))
+            .orElseGet(() -> computeAndCache(documentId, from, to));
+    return new DiffView(fromNumber, toNumber, changes);
+  }
+
+  private List<ChangeView> computeAndCache(
+      UUID documentId, DocumentVersion from, DocumentVersion to) {
+    RenderedDocument left = readRendered(from);
+    RenderedDocument right = readRendered(to);
+    List<ChangeView> changes =
+        VersionDiffEngine.diff(left, right).stream().map(VersionDiffService::toView).toList();
+    try {
+      diffs.save(
+          new VersionDiff(
+              documentId, from.getId(), to.getId(), MAPPER.writeValueAsString(changes)));
+    } catch (DataIntegrityViolationException e) {
+      // A concurrent first request won the unique-pair race — its result is identical (immutable
+      // versions), so ours is just as valid to return.
+    }
+    return changes;
+  }
+
+  /** The version, gated exactly like the rendered representation (ADR-0032). */
+  private DocumentVersion requireReadyVersion(UUID documentId, int versionNumber) {
+    DocumentVersion version =
+        versions
+            .findByDocumentIdAndVersionNumber(documentId, versionNumber)
+            .orElseThrow(
+                () -> DocumentValidationException.notFound("no such version: " + versionNumber));
+    if (version.getExtractionStatus() == ExtractionStatus.FAILED) {
+      throw DocumentValidationException.renderingUnavailable(
+          "EXTRACTION_FAILED",
+          "extraction failed for version " + versionNumber + "; upload a new version");
+    }
+    if (version.getExtractionStatus() != ExtractionStatus.READY
+        || version.getRenderedDocument() == null) {
+      throw DocumentValidationException.renderingUnavailable(
+          "EXTRACTION_PENDING", "extraction has not completed yet for version " + versionNumber);
+    }
+    return version;
+  }
+
+  private static RenderedDocument readRendered(DocumentVersion version) {
+    return MAPPER.readValue(version.getRenderedDocument(), RenderedDocument.class);
+  }
+
+  private static List<ChangeView> readPayload(String payload) {
+    return List.of(MAPPER.readValue(payload, ChangeView[].class));
+  }
+
+  private static ChangeView toView(Change change) {
+    return new ChangeView(
+        change.type().name(),
+        change.fromText(),
+        change.fromLocations().stream().map(VersionDiffService::toView).toList(),
+        change.toText(),
+        change.toLocations().stream().map(VersionDiffService::toView).toList());
+  }
+
+  private static LocationView toView(Location location) {
+    return new LocationView(
+        location.surfaceIndex(),
+        location.box().x(),
+        location.box().y(),
+        location.box().width(),
+        location.box().height());
+  }
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -47,3 +47,6 @@ databaseChangeLog:
   - include:
       file: migrations/0012-storage-object-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0013-version-diff-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0013-version-diff-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0013-version-diff-schema.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Permanent inter-version diff cache (issue #249, ADR-0034). Document versions
+# are immutable, so a computed diff between any two versions is stable forever:
+# computed lazily on first request, cached here indefinitely, never invalidated.
+# The payload is the serialized list of located changes (jsonb). Rows die with
+# their versions (FK CASCADE). JPA runs ddl-auto=none, so the entity mapping
+# (io.qnop.entity.VersionDiff) must match these definitions exactly.
+databaseChangeLog:
+  - changeSet:
+      id: 0013-version-diff
+      author: qnop
+      comment: Permanent inter-version diff cache (ADR-0034) — keyed by the version pair.
+      changes:
+        - createTable:
+            tableName: version_diff
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: document_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: from_version_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: to_version_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: payload
+                  type: JSONB
+                  constraints: { nullable: false }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+        - addForeignKeyConstraint:
+            baseTableName: version_diff
+            baseColumnNames: document_id
+            referencedTableName: document
+            referencedColumnNames: id
+            constraintName: fk_version_diff_document
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: version_diff
+            baseColumnNames: from_version_id
+            referencedTableName: document_version
+            referencedColumnNames: id
+            constraintName: fk_version_diff_from_version
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: version_diff
+            baseColumnNames: to_version_id
+            referencedTableName: document_version
+            referencedColumnNames: id
+            constraintName: fk_version_diff_to_version
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: version_diff
+            columnNames: from_version_id, to_version_id
+            constraintName: ux_version_diff_pair

--- a/qnop-core/src/test/java/io/qnop/service/diff/VersionDiffEngineTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/diff/VersionDiffEngineTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.service.diff.VersionDiffEngine.Change;
+import io.qnop.service.diff.VersionDiffEngine.ChangeType;
+import io.qnop.spi.extract.NormalizedBox;
+import io.qnop.spi.extract.RenderedDocument;
+import io.qnop.spi.extract.Surface;
+import io.qnop.spi.extract.TextSpan;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The DB-free diff core (issue #249, ADR-0034): word-granularity change detection over the
+ * document-wide canonical text, and the mapping of changed spans back to the boxes of the text runs
+ * they cover.
+ */
+class VersionDiffEngineTest {
+
+  /** Builds one surface whose spans are the given lines, with offsets per the ADR-0032 contract. */
+  private static Surface surface(int index, double y0, String... lines) {
+    List<TextSpan> spans = new ArrayList<>();
+    int offset = 0;
+    double y = y0;
+    for (String line : lines) {
+      spans.add(
+          new TextSpan(line, offset, offset + line.length(), new NormalizedBox(0.1, y, 0.8, 0.05)));
+      offset += line.length() + 1; // the '\n' joiner
+      y += 0.1;
+    }
+    return new Surface(index, 612, 792, spans);
+  }
+
+  private static RenderedDocument doc(Surface... surfaces) {
+    return new RenderedDocument(List.of(surfaces));
+  }
+
+  @Test
+  @DisplayName("identical documents produce no changes")
+  void identicalDocumentsProduceNoChanges() {
+    RenderedDocument a = doc(surface(0, 0.1, "the quick brown fox", "jumps over the dog"));
+    RenderedDocument b = doc(surface(0, 0.1, "the quick brown fox", "jumps over the dog"));
+
+    assertThat(VersionDiffEngine.diff(a, b)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a replaced word is a CHANGED change carrying both texts and both locations")
+  void replacedWordIsChanged() {
+    RenderedDocument from = doc(surface(0, 0.1, "the quick brown fox"));
+    RenderedDocument to = doc(surface(0, 0.1, "the quick red fox"));
+
+    List<Change> changes = VersionDiffEngine.diff(from, to);
+
+    assertThat(changes).hasSize(1);
+    Change change = changes.get(0);
+    assertThat(change.type()).isEqualTo(ChangeType.CHANGED);
+    assertThat(change.fromText()).isEqualTo("brown");
+    assertThat(change.toText()).isEqualTo("red");
+    assertThat(change.fromLocations()).hasSize(1);
+    assertThat(change.fromLocations().get(0).surfaceIndex()).isZero();
+    assertThat(change.toLocations()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("appended text is INSERTED, located only in the to-version")
+  void appendedTextIsInserted() {
+    RenderedDocument from = doc(surface(0, 0.1, "clause one"));
+    RenderedDocument to = doc(surface(0, 0.1, "clause one", "clause two added"));
+
+    List<Change> changes = VersionDiffEngine.diff(from, to);
+
+    assertThat(changes).hasSize(1);
+    Change change = changes.get(0);
+    assertThat(change.type()).isEqualTo(ChangeType.INSERTED);
+    assertThat(change.fromText()).isEmpty();
+    assertThat(change.fromLocations()).isEmpty();
+    assertThat(change.toText()).isEqualTo("clause two added");
+    assertThat(change.toLocations()).hasSize(1);
+    assertThat(change.toLocations().get(0).box().y()).isEqualTo(0.2);
+  }
+
+  @Test
+  @DisplayName("removed text is DELETED, located only in the from-version")
+  void removedTextIsDeleted() {
+    RenderedDocument from = doc(surface(0, 0.1, "keep this", "drop that entirely"));
+    RenderedDocument to = doc(surface(0, 0.1, "keep this"));
+
+    List<Change> changes = VersionDiffEngine.diff(from, to);
+
+    assertThat(changes).hasSize(1);
+    Change change = changes.get(0);
+    assertThat(change.type()).isEqualTo(ChangeType.DELETED);
+    assertThat(change.fromText()).isEqualTo("drop that entirely");
+    assertThat(change.fromLocations()).hasSize(1);
+    assertThat(change.toText()).isEmpty();
+    assertThat(change.toLocations()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a change spanning two text runs yields one location per run")
+  void changeSpanningTwoRunsYieldsBothBoxes() {
+    RenderedDocument from = doc(surface(0, 0.1, "alpha beta", "gamma delta"));
+    RenderedDocument to = doc(surface(0, 0.1, "alpha X", "Y delta"));
+
+    List<Change> changes = VersionDiffEngine.diff(from, to);
+
+    // "beta gamma" → "X Y": one CHANGED covering the end of run 1 and the start of run 2.
+    assertThat(changes).hasSize(1);
+    Change change = changes.get(0);
+    assertThat(change.type()).isEqualTo(ChangeType.CHANGED);
+    assertThat(change.fromLocations()).hasSize(2);
+    assertThat(change.fromLocations().get(0).box().y()).isEqualTo(0.1);
+    assertThat(change.fromLocations().get(1).box().y()).isEqualTo(0.2);
+  }
+
+  @Test
+  @DisplayName("content moving across a surface boundary matches (document-wide diff)")
+  void reflowAcrossSurfacesIsNotAChange() {
+    // The same words, but the second line reflowed onto the next page.
+    RenderedDocument from = doc(surface(0, 0.1, "shared intro text", "tail sentence"));
+    RenderedDocument to =
+        doc(surface(0, 0.1, "shared intro text"), surface(1, 0.1, "tail sentence"));
+
+    assertThat(VersionDiffEngine.diff(from, to)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("an insertion on a later surface is attributed to that surface")
+  void insertionOnLaterSurfaceCarriesItsIndex() {
+    RenderedDocument from = doc(surface(0, 0.1, "page one"), surface(1, 0.1, "page two"));
+    RenderedDocument to =
+        doc(surface(0, 0.1, "page one"), surface(1, 0.1, "page two", "with brand new content"));
+
+    List<Change> changes = VersionDiffEngine.diff(from, to);
+
+    assertThat(changes).hasSize(1);
+    assertThat(changes.get(0).type()).isEqualTo(ChangeType.INSERTED);
+    assertThat(changes.get(0).toLocations()).hasSize(1);
+    assertThat(changes.get(0).toLocations().get(0).surfaceIndex()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("image-only documents (no text layer) yield an empty change list")
+  void imageOnlyDocumentsYieldNoChanges() {
+    RenderedDocument a = doc(new Surface(0, 800, 600, List.of()));
+    RenderedDocument b = doc(new Surface(0, 1024, 768, List.of()));
+
+    assertThat(VersionDiffEngine.diff(a, b)).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

"What changed since the last version?" (part of #241) — the Community-core **inter-version diff** per ADR-0034: a word-granularity text diff over the two versions' extracted text layers (ADR-0032), with every change mapped back to its normalized boxes so the frontend highlights it **on the rendered original**.

### What's added

- **`VersionDiffEngine`** (DB-free plain logic, ADR-0004 guardrail) — Myers diff at **word granularity** via `java-diff-utils` (Apache-2.0; chosen over the unmaintained Java port of diff-match-patch, both explicitly allowed by ADR-0034). Diffs the **document-wide** canonical text (surfaces concatenated), so content reflowing across a page boundary matches instead of appearing as delete+insert. Each `INSERTED`/`DELETED`/`CHANGED` span carries `{surfaceIndex, box}` locations for both sides.
- **Permanent cache** — versions are immutable ⇒ a computed diff is stable forever: `version_diff` (migration 0013, unique on the `(from,to)` pair, FK CASCADE), computed lazily on first request, never invalidated. A concurrent first request losing the unique race returns its (identical) result. Arbitrary pairs are diffable, not only adjacent ones.
- **REST** — `GET /documents/{documentId}/diff?from={n}&to={m}` (`Documents` tag), returning `VersionDiffResponse{fromVersion, toVersion, changes[]}`. Gated like the rendered representation: participants-only (404, anti-enumeration), `EXTRACTION_PENDING`/`EXTRACTION_FAILED` → 409, `from == to` → 400.
- **Layering** — views cross service→web as strings/doubles (no entity/SPI types in the web layer, ArchUnit-clean); images (no text layer) yield an empty change list — the honest fallback per ADR-0034 (FE shows side-by-side).

### Deliberate non-goal (documented)

The ADR's optional **job-queue offload** for large diffs is not wired: extracted text layers are small (KBs) and the permanent cache makes repeats free. It can be added later without contract changes.

## Acceptance (#249)

- [x] diff v_{n-1}→v_n returns located changes (`VersionDiffIT.returnsLocatedChangesBetweenTwoVersions`)
- [x] cached (`secondRequestIsServedFromThePermanentCache` — one `version_diff` row, identical response)
- [x] IT (+ 8 DB-free engine unit tests: tokenizer offsets, box mapping, multi-run spans, cross-surface reflow & attribution, image fallback)

## Test plan

- [x] `spotlessApply`, compile, ArchUnit, `VersionDiffEngineTest` (8/8), `:qnop-core:build` green locally
- [ ] CI: Backend (ITs incl. `VersionDiffIT` via Testcontainers) + OWASP (new dependency) + smoke green (Docker unavailable locally)

Part of #241. Closes #249.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code