### PR TITLE
feat(ui): document viewer + annotation layer (ADR-0032/0009)

### DIFF
--- a/qnop-ui/package.json
+++ b/qnop-ui/package.json
@@ -32,6 +32,7 @@
     "@uiw/react-codemirror": "4.25.10",
     "axios": "1.18.1",
     "lucide-react": "1.22.0",
+    "pdfjs-dist": "^6.1.200",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-easy-crop": "6.0.2",

--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       lucide-react:
         specifier: 1.22.0
         version: 1.22.0(react@19.2.7)
+      pdfjs-dist:
+        specifier: ^6.1.200
+        version: 6.1.200
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -570,6 +573,81 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.2':
+    resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -2134,6 +2212,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdfjs-dist@6.1.200:
+    resolution: {integrity: sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3336,6 +3418,54 @@ snapshots:
       react-is: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas@1.0.2':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-x64': 1.0.2
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.2
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.2
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-musl': 1.0.2
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.2
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -5001,6 +5131,10 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pdfjs-dist@6.1.200:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.2
 
   picocolors@1.1.1: {}
 

--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -26,9 +26,11 @@ import {
   AdminSettingsApi,
   AdminTeamsApi,
   AdminUsersApi,
+  AnnotationsApi,
   AuthApi,
   AuthPasswordResetApi,
   AuthRegistrationApi,
+  DocumentsApi,
   ServerConfigApi,
   UsersApi,
 } from './generated';
@@ -92,3 +94,5 @@ export const adminTeamsApi = new AdminTeamsApi(undefined, undefined, axiosInstan
 export const adminSettingsApi = new AdminSettingsApi(undefined, undefined, axiosInstance);
 export const adminOidcProvidersApi = new AdminOidcProvidersApi(undefined, undefined, axiosInstance);
 export const adminEmailApi = new AdminEmailApi(undefined, undefined, axiosInstance);
+export const documentsApi = new DocumentsApi(undefined, undefined, axiosInstance);
+export const annotationsApi = new AnnotationsApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useAnnotations.test.tsx
+++ b/qnop-ui/src/api/hooks/useAnnotations.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { AnnotationListResponse } from '../generated';
+import { annotationKeys, useAnnotations, useCreateAnnotation } from './useAnnotations';
+import { annotationsApi } from '../config';
+
+vi.mock('../config', () => ({
+  annotationsApi: {
+    listAnnotations: vi.fn(),
+    createAnnotation: vi.fn(),
+  },
+}));
+
+const DOC_ID = '3f6f6f6f-0000-0000-0000-000000000001';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('annotationKeys', () => {
+  it('namespaces the list per document and version', () => {
+    expect(annotationKeys.list(DOC_ID, 3)).toEqual(['annotations', 'list', DOC_ID, 3]);
+  });
+});
+
+describe('useAnnotations', () => {
+  it('fetches annotations resolved against the given version', async () => {
+    const empty: AnnotationListResponse = { annotations: [] };
+    vi.mocked(annotationsApi.listAnnotations).mockResolvedValue({
+      data: empty,
+    } as Awaited<ReturnType<typeof annotationsApi.listAnnotations>>);
+
+    const { result } = renderHook(() => useAnnotations(DOC_ID, 2), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(annotationsApi.listAnnotations).toHaveBeenCalledWith({ documentId: DOC_ID, version: 2 });
+  });
+
+  it('stays idle until the version is known', () => {
+    const { result } = renderHook(() => useAnnotations(DOC_ID, undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(annotationsApi.listAnnotations).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCreateAnnotation', () => {
+  it('posts the anchor and drawn version', async () => {
+    vi.mocked(annotationsApi.createAnnotation).mockResolvedValue({ data: { id: 'a1' } } as Awaited<
+      ReturnType<typeof annotationsApi.createAnnotation>
+    >);
+
+    const { result } = renderHook(() => useCreateAnnotation(DOC_ID), { wrapper });
+    const request = {
+      versionNumber: 1,
+      anchor: { region: { surfaceIndex: 0, box: { x: 0.1, y: 0.2, width: 0.3, height: 0.05 } } },
+      comment: 'Please fix',
+    };
+    await result.current.mutateAsync(request);
+
+    expect(annotationsApi.createAnnotation).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+      annotationCreateRequest: request,
+    });
+  });
+});

--- a/qnop-ui/src/api/hooks/useAnnotations.ts
+++ b/qnop-ui/src/api/hooks/useAnnotations.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { AnnotationCreateRequest, AnnotationListResponse } from '../generated';
+import { annotationsApi } from '../config';
+
+export const annotationKeys = {
+  all: ['annotations'] as const,
+  list: (documentId: string, version?: number) =>
+    [...annotationKeys.all, 'list', documentId, version] as const,
+};
+
+/**
+ * The document's annotations with each placement (anchor + placement status)
+ * resolved against the given 1-based version (ADR-0009: identity is
+ * version-independent, physical location is per version).
+ */
+export function useAnnotations(documentId: string, version: number | undefined) {
+  return useQuery<AnnotationListResponse>({
+    queryKey: annotationKeys.list(documentId, version),
+    queryFn: async () => {
+      const response = await annotationsApi.listAnnotations({ documentId, version });
+      return response.data;
+    },
+    enabled: version !== undefined && version >= 1,
+  });
+}
+
+/** Creates an annotation on the drawn version; the placement is PLACED immediately. */
+export function useCreateAnnotation(documentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request: AnnotationCreateRequest) => {
+      const response = await annotationsApi.createAnnotation({
+        documentId,
+        annotationCreateRequest: request,
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: annotationKeys.all }),
+  });
+}

--- a/qnop-ui/src/api/hooks/useComments.test.tsx
+++ b/qnop-ui/src/api/hooks/useComments.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { CommentListResponse } from '../generated';
+import { commentKeys, useAddComment, useComments } from './useComments';
+import { annotationsApi } from '../config';
+
+vi.mock('../config', () => ({
+  annotationsApi: {
+    listComments: vi.fn(),
+    addComment: vi.fn(),
+  },
+}));
+
+const ANNOTATION_ID = 'aaaa1111-0000-0000-0000-000000000001';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('commentKeys', () => {
+  it('namespaces the thread per annotation', () => {
+    expect(commentKeys.list(ANNOTATION_ID)).toEqual(['comments', 'list', ANNOTATION_ID]);
+  });
+});
+
+describe('useComments', () => {
+  it('fetches the thread oldest first', async () => {
+    const empty: CommentListResponse = { comments: [] };
+    vi.mocked(annotationsApi.listComments).mockResolvedValue({
+      data: empty,
+    } as Awaited<ReturnType<typeof annotationsApi.listComments>>);
+
+    const { result } = renderHook(() => useComments(ANNOTATION_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(annotationsApi.listComments).toHaveBeenCalledWith({ annotationId: ANNOTATION_ID });
+  });
+
+  it('stays idle when disabled', () => {
+    const { result } = renderHook(() => useComments(ANNOTATION_ID, false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(annotationsApi.listComments).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAddComment', () => {
+  it('wraps the body into the request', async () => {
+    vi.mocked(annotationsApi.addComment).mockResolvedValue({ data: { id: 'c1' } } as Awaited<
+      ReturnType<typeof annotationsApi.addComment>
+    >);
+
+    const { result } = renderHook(() => useAddComment(ANNOTATION_ID), { wrapper });
+    await result.current.mutateAsync('Looks good to me');
+
+    expect(annotationsApi.addComment).toHaveBeenCalledWith({
+      annotationId: ANNOTATION_ID,
+      commentCreateRequest: { body: 'Looks good to me' },
+    });
+  });
+});

--- a/qnop-ui/src/api/hooks/useComments.ts
+++ b/qnop-ui/src/api/hooks/useComments.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CommentListResponse } from '../generated';
+import { annotationsApi } from '../config';
+import { annotationKeys } from './useAnnotations';
+
+export const commentKeys = {
+  all: ['comments'] as const,
+  list: (annotationId: string) => [...commentKeys.all, 'list', annotationId] as const,
+};
+
+/** An annotation's comment thread, oldest first (flat, single level). */
+export function useComments(annotationId: string, enabled = true) {
+  return useQuery<CommentListResponse>({
+    queryKey: commentKeys.list(annotationId),
+    queryFn: async () => {
+      const response = await annotationsApi.listComments({ annotationId });
+      return response.data;
+    },
+    enabled,
+  });
+}
+
+/**
+ * Appends a comment to the annotation's thread. Also invalidates the annotation
+ * lists because their `commentCount` changes with the new comment.
+ */
+export function useAddComment(annotationId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: string) => {
+      const response = await annotationsApi.addComment({
+        annotationId,
+        commentCreateRequest: { body },
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(annotationId) });
+      queryClient.invalidateQueries({ queryKey: annotationKeys.all });
+    },
+  });
+}

--- a/qnop-ui/src/api/hooks/useDocuments.test.tsx
+++ b/qnop-ui/src/api/hooks/useDocuments.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { RenderedDocumentResponse } from '../generated';
+import { ExtractionStatus } from '../generated';
+import {
+  documentKeys,
+  useDocument,
+  useDocumentVersions,
+  useOriginalPdf,
+  useRenderedDocument,
+} from './useDocuments';
+import { axiosInstance, documentsApi } from '../config';
+
+vi.mock('../config', () => ({
+  documentsApi: {
+    getDocument: vi.fn(),
+    listDocumentVersions: vi.fn(),
+    getRenderedDocument: vi.fn(),
+  },
+  axiosInstance: {
+    get: vi.fn(),
+  },
+}));
+
+const DOC_ID = '3f6f6f6f-0000-0000-0000-000000000001';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('documentKeys', () => {
+  it('namespaces per document and version', () => {
+    expect(documentKeys.detail(DOC_ID)).toEqual(['documents', 'detail', DOC_ID]);
+    expect(documentKeys.rendered(DOC_ID, 2)).toEqual(['documents', 'rendered', DOC_ID, 2]);
+    expect(documentKeys.original(DOC_ID, 2)).toEqual(['documents', 'original', DOC_ID, 2]);
+  });
+});
+
+describe('useDocument', () => {
+  it('fetches the document metadata', async () => {
+    vi.mocked(documentsApi.getDocument).mockResolvedValue({
+      data: { id: DOC_ID, title: 'Contract', latestVersionNumber: 1 },
+    } as Awaited<ReturnType<typeof documentsApi.getDocument>>);
+
+    const { result } = renderHook(() => useDocument(DOC_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(documentsApi.getDocument).toHaveBeenCalledWith({ documentId: DOC_ID });
+    expect(result.current.data?.title).toBe('Contract');
+  });
+});
+
+describe('useDocumentVersions', () => {
+  it('fetches the version list', async () => {
+    vi.mocked(documentsApi.listDocumentVersions).mockResolvedValue({
+      data: { versions: [{ versionNumber: 1, extractionStatus: ExtractionStatus.Ready }] },
+    } as Awaited<ReturnType<typeof documentsApi.listDocumentVersions>>);
+
+    const { result } = renderHook(() => useDocumentVersions(DOC_ID, 1), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(documentsApi.listDocumentVersions).toHaveBeenCalledWith({ documentId: DOC_ID });
+    expect(result.current.data?.versions).toHaveLength(1);
+  });
+});
+
+describe('useRenderedDocument', () => {
+  it('fetches the rendered representation when enabled', async () => {
+    const empty: RenderedDocumentResponse = { surfaces: [] };
+    vi.mocked(documentsApi.getRenderedDocument).mockResolvedValue({
+      data: empty,
+    } as Awaited<ReturnType<typeof documentsApi.getRenderedDocument>>);
+
+    const { result } = renderHook(() => useRenderedDocument(DOC_ID, 1, true), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(documentsApi.getRenderedDocument).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+      versionNumber: 1,
+    });
+  });
+
+  it('stays idle while extraction is not READY', () => {
+    const { result } = renderHook(() => useRenderedDocument(DOC_ID, 1, false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(documentsApi.getRenderedDocument).not.toHaveBeenCalled();
+  });
+});
+
+describe('useOriginalPdf', () => {
+  it('downloads the original bytes outside the generated contract', async () => {
+    const bytes = new ArrayBuffer(8);
+    vi.mocked(axiosInstance.get).mockResolvedValue({ data: bytes });
+
+    const { result } = renderHook(() => useOriginalPdf(DOC_ID, 2), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(axiosInstance.get).toHaveBeenCalledWith(`/documents/${DOC_ID}/versions/2/original`, {
+      responseType: 'arraybuffer',
+    });
+    expect(result.current.data).toBe(bytes);
+  });
+
+  it('stays idle until the version number is known', () => {
+    const { result } = renderHook(() => useOriginalPdf(DOC_ID, undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(axiosInstance.get).not.toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/api/hooks/useDocuments.ts
+++ b/qnop-ui/src/api/hooks/useDocuments.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import type {
+  DocumentResponse,
+  DocumentVersionListResponse,
+  RenderedDocumentResponse,
+} from '../generated';
+import { ExtractionStatus } from '../generated';
+import { axiosInstance, documentsApi } from '../config';
+
+/** How often to re-poll the version list while extraction is still running. */
+const EXTRACTION_POLL_MS = 2500;
+
+export const documentKeys = {
+  all: ['documents'] as const,
+  detail: (documentId: string) => [...documentKeys.all, 'detail', documentId] as const,
+  versions: (documentId: string) => [...documentKeys.all, 'versions', documentId] as const,
+  rendered: (documentId: string, versionNumber: number) =>
+    [...documentKeys.all, 'rendered', documentId, versionNumber] as const,
+  original: (documentId: string, versionNumber: number) =>
+    [...documentKeys.all, 'original', documentId, versionNumber] as const,
+};
+
+/** A review document's metadata (title, owner, workflow state, latest version). */
+export function useDocument(documentId: string) {
+  return useQuery<DocumentResponse>({
+    queryKey: documentKeys.detail(documentId),
+    queryFn: async () => {
+      const response = await documentsApi.getDocument({ documentId });
+      return response.data;
+    },
+  });
+}
+
+/**
+ * The document's version list, oldest first. While the given version's server-side
+ * extraction (ADR-0032) is still PENDING the list is re-polled, so the viewer
+ * flips to annotatable as soon as the rendered representation is READY.
+ */
+export function useDocumentVersions(documentId: string, watchVersion?: number) {
+  return useQuery<DocumentVersionListResponse>({
+    queryKey: documentKeys.versions(documentId),
+    queryFn: async () => {
+      const response = await documentsApi.listDocumentVersions({ documentId });
+      return response.data;
+    },
+    refetchInterval: (query) => {
+      if (!watchVersion) return false;
+      const watched = query.state.data?.versions.find((v) => v.versionNumber === watchVersion);
+      return watched?.extractionStatus === ExtractionStatus.Pending ? EXTRACTION_POLL_MS : false;
+    },
+  });
+}
+
+/**
+ * The server-authoritative rendered representation (surfaces + text spans with
+ * normalized boxes, ADR-0032). The endpoint answers 409 until extraction is
+ * READY, so callers gate with `enabled` on the version's extraction status.
+ */
+export function useRenderedDocument(documentId: string, versionNumber: number, enabled: boolean) {
+  return useQuery<RenderedDocumentResponse>({
+    queryKey: documentKeys.rendered(documentId, versionNumber),
+    queryFn: async () => {
+      const response = await documentsApi.getRenderedDocument({ documentId, versionNumber });
+      return response.data;
+    },
+    enabled: enabled && versionNumber >= 1,
+    // The rendered representation of a version is immutable once READY.
+    staleTime: Infinity,
+  });
+}
+
+/**
+ * The original binary of a version, served through the server with per-request
+ * authorization (ADR-0032 §5). The endpoint is deliberately outside the
+ * generated OpenAPI contract, hence the plain axios call; the bearer token is
+ * attached by the shared instance's interceptor. Versions are immutable, so the
+ * bytes never go stale.
+ */
+export function useOriginalPdf(documentId: string, versionNumber: number | undefined) {
+  return useQuery<ArrayBuffer>({
+    queryKey: documentKeys.original(documentId, versionNumber ?? 0),
+    queryFn: async () => {
+      const response = await axiosInstance.get<ArrayBuffer>(
+        `/documents/${documentId}/versions/${versionNumber}/original`,
+        { responseType: 'arraybuffer' },
+      );
+      return response.data;
+    },
+    enabled: versionNumber !== undefined && versionNumber >= 1,
+    staleTime: Infinity,
+  });
+}

--- a/qnop-ui/src/components/reviews/PanelResizer.test.tsx
+++ b/qnop-ui/src/components/reviews/PanelResizer.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { PANEL_MAX_WIDTH, PANEL_MIN_WIDTH, PanelResizer } from './PanelResizer';
+
+function renderResizer(width = 400, onWidthChange = vi.fn()) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <PanelResizer width={width} defaultWidth={PANEL_MIN_WIDTH} onWidthChange={onWidthChange} />
+    </ThemeProvider>,
+  );
+  return onWidthChange;
+}
+
+describe('PanelResizer', () => {
+  it('exposes separator semantics with value bounds', () => {
+    renderResizer(400);
+    const separator = screen.getByRole('separator', { name: 'Resize annotations panel' });
+    expect(separator).toHaveAttribute('aria-valuenow', '400');
+    expect(separator).toHaveAttribute('aria-valuemin', String(PANEL_MIN_WIDTH));
+    expect(separator).toHaveAttribute('aria-valuemax', String(PANEL_MAX_WIDTH));
+  });
+
+  it('resizes with the keyboard, clamped to the bounds', () => {
+    const onWidthChange = renderResizer(PANEL_MIN_WIDTH);
+    const separator = screen.getByRole('separator');
+
+    fireEvent.keyDown(separator, { key: 'ArrowLeft' });
+    expect(onWidthChange).toHaveBeenLastCalledWith(PANEL_MIN_WIDTH + 16);
+
+    // Shrinking below the minimum clamps.
+    fireEvent.keyDown(separator, { key: 'ArrowRight' });
+    expect(onWidthChange).toHaveBeenLastCalledWith(PANEL_MIN_WIDTH);
+
+    fireEvent.keyDown(separator, { key: 'Home' });
+    expect(onWidthChange).toHaveBeenLastCalledWith(PANEL_MAX_WIDTH);
+
+    fireEvent.keyDown(separator, { key: 'End' });
+    expect(onWidthChange).toHaveBeenLastCalledWith(PANEL_MIN_WIDTH);
+  });
+
+  it('resets to the default width on double-click', () => {
+    const onWidthChange = renderResizer(600);
+    fireEvent.doubleClick(screen.getByRole('separator'));
+    expect(onWidthChange).toHaveBeenCalledWith(PANEL_MIN_WIDTH);
+  });
+});

--- a/qnop-ui/src/components/reviews/PanelResizer.tsx
+++ b/qnop-ui/src/components/reviews/PanelResizer.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState } from 'react';
+import type { KeyboardEvent, PointerEvent } from 'react';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+
+export const PANEL_MIN_WIDTH = 360;
+export const PANEL_MAX_WIDTH = 720;
+const KEYBOARD_STEP = 16;
+
+interface PanelResizerProps {
+  /** Current width of the panel to the RIGHT of the divider. */
+  width: number;
+  defaultWidth: number;
+  onWidthChange: (width: number) => void;
+}
+
+function clamp(width: number): number {
+  return Math.min(PANEL_MAX_WIDTH, Math.max(PANEL_MIN_WIDTH, width));
+}
+
+/**
+ * The draggable divider between the document pane and the annotation panel:
+ * dragging left widens the panel (down to its current default as the
+ * minimum), double-click resets, and arrow keys resize from the keyboard —
+ * a real `separator` with value semantics for assistive tech. The visible
+ * hairline thickens and tints on hover/drag; the hit area stays comfortably
+ * wide.
+ */
+export function PanelResizer({ width, defaultWidth, onWidthChange }: PanelResizerProps) {
+  const theme = useTheme();
+  // Drag state lives in a ref so pointermove handlers never read a stale
+  // closure (moves can arrive before React re-renders); the state mirror only
+  // drives the visual dragging style.
+  const draggingRef = useRef(false);
+  const [dragging, setDragging] = useState(false);
+  const start = useRef({ x: 0, width });
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    start.current = { x: event.clientX, width };
+    draggingRef.current = true;
+    setDragging(true);
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Synthetic pointer events (tests) have no active pointer to capture.
+    }
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!draggingRef.current) return;
+    // Dragging left grows the right-hand panel.
+    onWidthChange(clamp(start.current.width + (start.current.x - event.clientX)));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const next =
+      event.key === 'ArrowLeft'
+        ? width + KEYBOARD_STEP
+        : event.key === 'ArrowRight'
+          ? width - KEYBOARD_STEP
+          : event.key === 'Home'
+            ? PANEL_MAX_WIDTH
+            : event.key === 'End'
+              ? PANEL_MIN_WIDTH
+              : null;
+    if (next === null) return;
+    event.preventDefault();
+    onWidthChange(clamp(next));
+  };
+
+  return (
+    <Box
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize annotations panel"
+      aria-valuemin={PANEL_MIN_WIDTH}
+      aria-valuemax={PANEL_MAX_WIDTH}
+      aria-valuenow={width}
+      tabIndex={0}
+      data-dragging={dragging}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={() => {
+        draggingRef.current = false;
+        setDragging(false);
+      }}
+      onPointerCancel={() => {
+        draggingRef.current = false;
+        setDragging(false);
+      }}
+      onDoubleClick={() => onWidthChange(defaultWidth)}
+      onKeyDown={handleKeyDown}
+      sx={{
+        width: 16,
+        flexShrink: 0,
+        alignSelf: 'stretch',
+        display: { xs: 'none', md: 'flex' },
+        alignItems: 'stretch',
+        justifyContent: 'center',
+        cursor: 'col-resize',
+        touchAction: 'none',
+        userSelect: 'none',
+        borderRadius: 1,
+        '&::before': {
+          content: '""',
+          width: '2px',
+          borderRadius: 1,
+          bgcolor: theme.palette.divider,
+          transition: 'background-color 120ms ease, width 120ms ease',
+        },
+        '&:hover::before, &[data-dragging="true"]::before': {
+          width: '3px',
+          bgcolor: theme.qnop.brand.blue,
+        },
+        '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
+        '@media (prefers-reduced-motion: reduce)': { '&::before': { transition: 'none' } },
+      }}
+    />
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -22,13 +22,19 @@
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha, keyframes, useTheme } from '@mui/material/styles';
-import { MessageSquare } from 'lucide-react';
+import type { Theme } from '@mui/material/styles';
+import { CircleCheck, CircleDot, CircleX, MessageSquare } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
+import { useComments } from '../../../api/hooks/useComments';
+import { useAuthStore } from '../../../stores/authStore';
 import type { BadgeTone } from '../../admin/ToneBadge';
 import { ToneBadge } from '../../admin/ToneBadge';
+import { UserAvatar } from '../../shell/UserAvatar';
 import { highlightColorFor } from '../viewer/markerColors';
 import { PlacementStatusChip } from './PlacementStatusChip';
 
@@ -38,11 +44,71 @@ const railGlow = keyframes`
   50% { box-shadow: 0 0 10px 2px var(--rail-glow); }
 `;
 
-const STATUS_CUES: Record<AnnotationStatus, { tone: BadgeTone; label: string }> = {
-  [AnnotationStatus.Open]: { tone: 'blue', label: 'Open' },
-  [AnnotationStatus.Accepted]: { tone: 'green', label: 'Accepted' },
-  [AnnotationStatus.Rejected]: { tone: 'neutral', label: 'Rejected' },
+const STATUS_CUES: Record<
+  AnnotationStatus,
+  { tone: BadgeTone; label: string; icon: LucideIcon; color: (theme: Theme) => string }
+> = {
+  [AnnotationStatus.Open]: {
+    tone: 'blue',
+    label: 'Open',
+    icon: CircleDot,
+    color: (theme) => theme.qnop.brand.blue,
+  },
+  [AnnotationStatus.Accepted]: {
+    tone: 'green',
+    label: 'Accepted',
+    icon: CircleCheck,
+    color: (theme) => theme.palette.success.main,
+  },
+  [AnnotationStatus.Rejected]: {
+    tone: 'neutral',
+    label: 'Rejected',
+    icon: CircleX,
+    color: (theme) => theme.palette.text.disabled,
+  },
 };
+
+/** Up to this many participant avatars stack in the collapsed row. */
+const MAX_AVATARS = 3;
+
+/** Overlapping avatar stack of everyone involved in the discussion. */
+function ParticipantAvatars({ ids }: { ids: string[] }) {
+  const userId = useAuthStore((state) => state.userId);
+  const displayName = useAuthStore((state) => state.displayName);
+  const avatarUrl = useAuthStore((state) => state.avatarUrl);
+  const shown = ids.slice(0, MAX_AVATARS);
+  return (
+    <Stack direction="row" sx={{ alignItems: 'center', flexShrink: 0 }}>
+      {shown.map((id, index) => {
+        const own = id === userId;
+        return (
+          <Box
+            key={id}
+            sx={{
+              borderRadius: '50%',
+              border: '2px solid',
+              borderColor: 'background.paper',
+              ml: index === 0 ? 0 : -0.75,
+              display: 'flex',
+              zIndex: shown.length - index,
+            }}
+          >
+            <UserAvatar
+              name={own ? (displayName ?? 'You') : 'Participant'}
+              size={20}
+              imageUrl={own ? avatarUrl : null}
+            />
+          </Box>
+        );
+      })}
+      {ids.length > MAX_AVATARS && (
+        <Typography variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+          +{ids.length - MAX_AVATARS}
+        </Typography>
+      )}
+    </Stack>
+  );
+}
 
 interface AnnotationListItemProps {
   annotation: AnnotationView;
@@ -54,11 +120,13 @@ interface AnnotationListItemProps {
 }
 
 /**
- * One annotation in the panel: its lifecycle status (owner's decision,
- * ADR-0011), the placement cue for the viewed version (ADR-0009), and the mark
- * itself — the quoted text, or the page for a pure region annotation. The left
- * rail carries the same colour the mark paints with on the page, and hovering
- * either side of the card↔mark pair lights up the other (prototype linking).
+ * One annotation in the panel. Collapsed it is a single dense row — status
+ * icon, the quoted passage, thread size, page and the participants' avatar
+ * stack — so a long review stays scannable. The active (clicked) annotation
+ * grows into the detailed card with badges, placement cue and full quote; the
+ * comment timeline follows below. The left rail always carries the colour the
+ * mark paints with on the page, and hovering either side of the card↔mark
+ * pair lights up the other.
  */
 export function AnnotationListItem({
   annotation,
@@ -71,9 +139,20 @@ export function AnnotationListItem({
   const quote = annotation.anchor?.textQuote?.quote;
   const region = annotation.anchor?.region;
   const statusCue = STATUS_CUES[annotation.status];
+  const StatusIcon = statusCue.icon;
   const railColor = annotation.anchor
     ? highlightColorFor(annotation, theme.palette)
     : theme.palette.divider;
+
+  // Participants: the annotation author plus every commenter already known to
+  // the cache (enabled: false never fetches — rows stay cheap; the stack
+  // enriches once a thread has been opened or hover-prefetched).
+  const cachedComments = useComments(annotation.id, false).data?.comments ?? [];
+  const participantIds = [
+    ...new Set([annotation.authorId, ...cachedComments.map((comment) => comment.authorId)]),
+  ];
+
+  const fallbackLabel = region ? 'Region annotation' : 'No placement on this version';
 
   return (
     <ButtonBase
@@ -98,8 +177,8 @@ export function AnnotationListItem({
             ? alpha(railColor, 0.08)
             : 'transparent',
         pl: 2,
-        pr: 1.5,
-        py: 1.25,
+        pr: 1.25,
+        py: active ? 1.25 : 0.75,
         transition:
           'border-color 120ms ease, background-color 120ms ease, transform 160ms ease, box-shadow 160ms ease',
         '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
@@ -146,44 +225,86 @@ export function AnnotationListItem({
           '@media (prefers-reduced-motion: reduce)': { animation: 'none', transition: 'none' },
         }}
       />
-      <Stack spacing={0.75}>
-        <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
-          <ToneBadge tone={statusCue.tone} label={statusCue.label} />
-          <PlacementStatusChip status={annotation.placementStatus} />
-          <Stack
-            direction="row"
-            spacing={1}
-            sx={{ alignItems: 'center', ml: 'auto', color: 'text.secondary' }}
-          >
-            {region && <Typography variant="caption">Page {region.surfaceIndex + 1}</Typography>}
-            <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-              <MessageSquare size={13} aria-hidden />
-              <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
-                {annotation.commentCount}
-              </Typography>
+      {active ? (
+        <Stack spacing={0.75}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+            <ToneBadge tone={statusCue.tone} label={statusCue.label} />
+            <PlacementStatusChip status={annotation.placementStatus} />
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ alignItems: 'center', ml: 'auto', color: 'text.secondary' }}
+            >
+              {region && <Typography variant="caption">Page {region.surfaceIndex + 1}</Typography>}
+              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                <MessageSquare size={13} aria-hidden />
+                <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
+                  {annotation.commentCount}
+                </Typography>
+              </Stack>
             </Stack>
           </Stack>
+          {quote ? (
+            <Typography
+              variant="body2"
+              sx={{
+                fontStyle: 'italic',
+                color: 'text.secondary',
+                display: '-webkit-box',
+                WebkitLineClamp: 4,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              “{quote}”
+            </Typography>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              {fallbackLabel}
+            </Typography>
+          )}
         </Stack>
-        {quote ? (
+      ) : (
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+          <Tooltip title={statusCue.label}>
+            <Box sx={{ display: 'flex', color: statusCue.color(theme), flexShrink: 0 }}>
+              <StatusIcon size={15} aria-label={statusCue.label} />
+            </Box>
+          </Tooltip>
           <Typography
             variant="body2"
+            noWrap
             sx={{
-              fontStyle: 'italic',
+              flex: 1,
+              minWidth: 0,
               color: 'text.secondary',
-              display: '-webkit-box',
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: 'vertical',
-              overflow: 'hidden',
+              fontStyle: quote ? 'italic' : 'normal',
             }}
           >
-            “{quote}”
+            {quote ? `“${quote}”` : fallbackLabel}
           </Typography>
-        ) : (
-          <Typography variant="body2" color="text.secondary">
-            {region ? 'Region annotation' : 'No placement on this version'}
-          </Typography>
-        )}
-      </Stack>
+          <Stack
+            direction="row"
+            spacing={0.5}
+            sx={{ alignItems: 'center', color: 'text.secondary', flexShrink: 0 }}
+          >
+            <MessageSquare size={13} aria-hidden />
+            <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
+              {annotation.commentCount}
+            </Typography>
+          </Stack>
+          {region && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}
+            >
+              p. {region.surfaceIndex + 1}
+            </Typography>
+          )}
+          <ParticipantAvatars ids={participantIds} />
+        </Stack>
+      )}
     </ButtonBase>
   );
 }

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -23,7 +23,7 @@ import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { alpha, useTheme } from '@mui/material/styles';
+import { alpha, keyframes, useTheme } from '@mui/material/styles';
 import { MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
@@ -31,6 +31,12 @@ import type { BadgeTone } from '../../admin/ToneBadge';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { highlightColorFor } from '../viewer/markerColors';
 import { PlacementStatusChip } from './PlacementStatusChip';
+
+/** Gentle glow on the status rail while the card is linked to its hovered mark. */
+const railGlow = keyframes`
+  0%, 100% { box-shadow: 0 0 0 0 transparent; }
+  50% { box-shadow: 0 0 10px 2px var(--rail-glow); }
+`;
 
 const STATUS_CUES: Record<AnnotationStatus, { tone: BadgeTone; label: string }> = {
   [AnnotationStatus.Open]: { tone: 'blue', label: 'Open' },
@@ -98,13 +104,30 @@ export function AnnotationListItem({
           'border-color 120ms ease, background-color 120ms ease, transform 160ms ease, box-shadow 160ms ease',
         '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
         ...(linked && {
-          transform: 'translateX(-2px)',
-          boxShadow: `0 6px 18px -8px ${alpha(railColor, 0.7)}`,
+          transform: 'translateX(-3px)',
+          boxShadow: `0 8px 22px -10px ${alpha(railColor, 0.8)}`,
         }),
         '&:hover': { borderColor: railColor },
         '&:focus-visible': { boxShadow: theme.qnop.focusRing },
       }}
     >
+      {/* Link arrow pointing at the document while the pair is hot (prototype). */}
+      {linked && (
+        <Box
+          aria-hidden
+          sx={{
+            position: 'absolute',
+            left: -7,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            width: 0,
+            height: 0,
+            borderTop: '6px solid transparent',
+            borderBottom: '6px solid transparent',
+            borderRight: `7px solid ${railColor}`,
+          }}
+        />
+      )}
       {/* Status rail — the same colour the mark paints with on the page. */}
       <Box
         aria-hidden
@@ -118,6 +141,9 @@ export function AnnotationListItem({
           bgcolor: railColor,
           opacity: linked || active ? 1 : 0.55,
           transition: 'opacity 120ms ease',
+          '--rail-glow': alpha(railColor, 0.55),
+          ...(linked && { animation: `${railGlow} 1.1s ease-in-out infinite` }),
+          '@media (prefers-reduced-motion: reduce)': { animation: 'none', transition: 'none' },
         }}
       />
       <Stack spacing={0.75}>

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -28,6 +29,7 @@ import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import type { BadgeTone } from '../../admin/ToneBadge';
 import { ToneBadge } from '../../admin/ToneBadge';
+import { highlightColorFor } from '../viewer/markerColors';
 import { PlacementStatusChip } from './PlacementStatusChip';
 
 const STATUS_CUES: Record<AnnotationStatus, { tone: BadgeTone; label: string }> = {
@@ -39,40 +41,85 @@ const STATUS_CUES: Record<AnnotationStatus, { tone: BadgeTone; label: string }> 
 interface AnnotationListItemProps {
   annotation: AnnotationView;
   active: boolean;
+  /** True while the mark on the page is hovered — mirrors the link visually. */
+  linked?: boolean;
   onClick: () => void;
+  onHover?: (annotationId: string | null) => void;
 }
 
 /**
  * One annotation in the panel: its lifecycle status (owner's decision,
  * ADR-0011), the placement cue for the viewed version (ADR-0009), and the mark
- * itself — the quoted text, or the page for a pure region annotation.
+ * itself — the quoted text, or the page for a pure region annotation. The left
+ * rail carries the same colour the mark paints with on the page, and hovering
+ * either side of the card↔mark pair lights up the other (prototype linking).
  */
-export function AnnotationListItem({ annotation, active, onClick }: AnnotationListItemProps) {
+export function AnnotationListItem({
+  annotation,
+  active,
+  linked = false,
+  onClick,
+  onHover,
+}: AnnotationListItemProps) {
   const theme = useTheme();
   const quote = annotation.anchor?.textQuote?.quote;
   const region = annotation.anchor?.region;
   const statusCue = STATUS_CUES[annotation.status];
+  const railColor = annotation.anchor
+    ? highlightColorFor(annotation, theme.palette)
+    : theme.palette.divider;
 
   return (
     <ButtonBase
       onClick={onClick}
+      onMouseEnter={() => onHover?.(annotation.id)}
+      onMouseLeave={() => onHover?.(null)}
+      onFocus={() => onHover?.(annotation.id)}
+      onBlur={() => onHover?.(null)}
       aria-expanded={active}
       data-testid={`annotation-item-${annotation.id}`}
       sx={{
         display: 'block',
         width: '100%',
         textAlign: 'left',
+        position: 'relative',
         borderRadius: 1.5,
         border: '1px solid',
-        borderColor: active ? theme.qnop.brand.blue : theme.palette.divider,
-        bgcolor: active ? alpha(theme.qnop.brand.blue, 0.06) : 'transparent',
-        px: 1.5,
+        borderColor: active ? theme.qnop.brand.blue : linked ? railColor : theme.palette.divider,
+        bgcolor: active
+          ? alpha(theme.qnop.brand.blue, 0.06)
+          : linked
+            ? alpha(railColor, 0.08)
+            : 'transparent',
+        pl: 2,
+        pr: 1.5,
         py: 1.25,
-        transition: 'border-color 120ms ease, background-color 120ms ease',
-        '&:hover': { borderColor: theme.qnop.brand.blue },
+        transition:
+          'border-color 120ms ease, background-color 120ms ease, transform 160ms ease, box-shadow 160ms ease',
+        '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+        ...(linked && {
+          transform: 'translateX(-2px)',
+          boxShadow: `0 6px 18px -8px ${alpha(railColor, 0.7)}`,
+        }),
+        '&:hover': { borderColor: railColor },
         '&:focus-visible': { boxShadow: theme.qnop.focusRing },
       }}
     >
+      {/* Status rail — the same colour the mark paints with on the page. */}
+      <Box
+        aria-hidden
+        sx={{
+          position: 'absolute',
+          left: 0,
+          top: 8,
+          bottom: 8,
+          width: 3,
+          borderRadius: '0 3px 3px 0',
+          bgcolor: railColor,
+          opacity: linked || active ? 1 : 0.55,
+          transition: 'opacity 120ms ease',
+        }}
+      />
       <Stack spacing={0.75}>
         <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
           <ToneBadge tone={statusCue.tone} label={statusCue.label} />

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import ButtonBase from '@mui/material/ButtonBase';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { MessageSquare } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus } from '../../../api/generated';
+import type { BadgeTone } from '../../admin/ToneBadge';
+import { ToneBadge } from '../../admin/ToneBadge';
+import { PlacementStatusChip } from './PlacementStatusChip';
+
+const STATUS_CUES: Record<AnnotationStatus, { tone: BadgeTone; label: string }> = {
+  [AnnotationStatus.Open]: { tone: 'blue', label: 'Open' },
+  [AnnotationStatus.Accepted]: { tone: 'green', label: 'Accepted' },
+  [AnnotationStatus.Rejected]: { tone: 'neutral', label: 'Rejected' },
+};
+
+interface AnnotationListItemProps {
+  annotation: AnnotationView;
+  active: boolean;
+  onClick: () => void;
+}
+
+/**
+ * One annotation in the panel: its lifecycle status (owner's decision,
+ * ADR-0011), the placement cue for the viewed version (ADR-0009), and the mark
+ * itself — the quoted text, or the page for a pure region annotation.
+ */
+export function AnnotationListItem({ annotation, active, onClick }: AnnotationListItemProps) {
+  const theme = useTheme();
+  const quote = annotation.anchor?.textQuote?.quote;
+  const region = annotation.anchor?.region;
+  const statusCue = STATUS_CUES[annotation.status];
+
+  return (
+    <ButtonBase
+      onClick={onClick}
+      aria-expanded={active}
+      data-testid={`annotation-item-${annotation.id}`}
+      sx={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'left',
+        borderRadius: 1.5,
+        border: '1px solid',
+        borderColor: active ? theme.qnop.brand.blue : theme.palette.divider,
+        bgcolor: active ? alpha(theme.qnop.brand.blue, 0.06) : 'transparent',
+        px: 1.5,
+        py: 1.25,
+        transition: 'border-color 120ms ease, background-color 120ms ease',
+        '&:hover': { borderColor: theme.qnop.brand.blue },
+        '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+      }}
+    >
+      <Stack spacing={0.75}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+          <ToneBadge tone={statusCue.tone} label={statusCue.label} />
+          <PlacementStatusChip status={annotation.placementStatus} />
+          <Stack
+            direction="row"
+            spacing={0.5}
+            sx={{ alignItems: 'center', ml: 'auto', color: 'text.secondary' }}
+          >
+            <MessageSquare size={13} aria-hidden />
+            <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
+              {annotation.commentCount}
+            </Typography>
+          </Stack>
+        </Stack>
+        {quote ? (
+          <Typography
+            variant="body2"
+            sx={{
+              fontStyle: 'italic',
+              color: 'text.secondary',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            “{quote}”
+          </Typography>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            {region ? `Region on page ${region.surfaceIndex + 1}` : 'No placement on this version'}
+          </Typography>
+        )}
+      </Stack>
+    </ButtonBase>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -168,7 +168,7 @@ export function AnnotationListItem({
         width: '100%',
         textAlign: 'left',
         position: 'relative',
-        borderRadius: 1.5,
+        borderRadius: 0.75,
         border: '1px solid',
         borderColor: active ? theme.qnop.brand.blue : linked ? railColor : theme.palette.divider,
         bgcolor: active

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -79,13 +79,16 @@ export function AnnotationListItem({ annotation, active, onClick }: AnnotationLi
           <PlacementStatusChip status={annotation.placementStatus} />
           <Stack
             direction="row"
-            spacing={0.5}
+            spacing={1}
             sx={{ alignItems: 'center', ml: 'auto', color: 'text.secondary' }}
           >
-            <MessageSquare size={13} aria-hidden />
-            <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
-              {annotation.commentCount}
-            </Typography>
+            {region && <Typography variant="caption">Page {region.surfaceIndex + 1}</Typography>}
+            <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+              <MessageSquare size={13} aria-hidden />
+              <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
+                {annotation.commentCount}
+              </Typography>
+            </Stack>
           </Stack>
         </Stack>
         {quote ? (
@@ -104,7 +107,7 @@ export function AnnotationListItem({ annotation, active, onClick }: AnnotationLi
           </Typography>
         ) : (
           <Typography variant="body2" color="text.secondary">
-            {region ? `Region on page ${region.surfaceIndex + 1}` : 'No placement on this version'}
+            {region ? 'Region annotation' : 'No placement on this version'}
           </Typography>
         )}
       </Stack>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -105,6 +105,34 @@ describe('AnnotationPanel', () => {
     expect(props.onSelect).toHaveBeenCalledWith(null);
   });
 
+  it('filters annotations by status', () => {
+    renderPanel({
+      annotations: [
+        annotation('open-1'),
+        annotation('accepted-1', { status: AnnotationStatus.Accepted }),
+      ],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByTestId('annotation-item-open-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('annotation-item-accepted-1')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Decided' }));
+    expect(screen.queryByTestId('annotation-item-open-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('annotation-item-accepted-1')).toBeInTheDocument();
+  });
+
+  it('collapses a section on click', () => {
+    renderPanel({ annotations: [annotation('a1')] });
+
+    const header = screen.getByRole('button', { name: /On this version/ });
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('annotation-item-a1')).toBeVisible();
+
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('opens the composer for a pending anchor and creates with the comment', () => {
     const props = renderPanel({
       pendingAnchor: {

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -159,4 +159,26 @@ describe('AnnotationPanel', () => {
     fireEvent.click(composer.getByRole('button', { name: 'Cancel' }));
     expect(props.onCancelPending).toHaveBeenCalled();
   });
+
+  it('creates via the submit shortcut and shows the hint', () => {
+    const props = renderPanel({
+      pendingAnchor: {
+        region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.1 } },
+      },
+    });
+
+    const composer = within(screen.getByTestId('annotation-composer'));
+    expect(composer.getByText('to create')).toBeInTheDocument();
+
+    const field = composer.getByLabelText('Annotation comment');
+    fireEvent.change(field, { target: { value: 'Shortcut comment' } });
+    fireEvent.keyDown(field, { key: 'Enter', metaKey: true });
+    expect(props.onCreate).toHaveBeenCalledWith('Shortcut comment');
+
+    // Plain Enter stays a newline, Alt+Enter submits too.
+    fireEvent.keyDown(field, { key: 'Enter' });
+    expect(props.onCreate).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(field, { key: 'Enter', altKey: true });
+    expect(props.onCreate).toHaveBeenCalledTimes(2);
+  });
 });

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { AnnotationPanel } from './AnnotationPanel';
+
+vi.mock('./CommentThread', () => ({
+  CommentThread: ({ annotationId }: { annotationId: string }) => (
+    <div data-testid={`thread-${annotationId}`} />
+  ),
+}));
+
+const annotation = (id: string, overrides: Partial<AnnotationView> = {}): AnnotationView => ({
+  id,
+  documentId: 'd1',
+  authorId: 'u1',
+  status: AnnotationStatus.Open,
+  placementStatus: PlacementStatus.Placed,
+  anchor: {
+    region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 } },
+    textQuote: { quote: 'quoted text' },
+  },
+  commentCount: 2,
+  createdAt: '2026-07-01T10:00:00Z',
+  updatedAt: '2026-07-01T10:00:00Z',
+  ...overrides,
+});
+
+function renderPanel(props: Partial<Parameters<typeof AnnotationPanel>[0]> = {}) {
+  const defaults: Parameters<typeof AnnotationPanel>[0] = {
+    annotations: [],
+    activeAnnotationId: null,
+    onSelect: vi.fn(),
+    pendingAnchor: null,
+    creating: false,
+    onCreate: vi.fn(),
+    onCancelPending: vi.fn(),
+    canAnnotate: true,
+    notify: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <AnnotationPanel {...merged} />
+    </ThemeProvider>,
+  );
+  return merged;
+}
+
+describe('AnnotationPanel', () => {
+  it('shows the empty state with the how-to hint when annotating is possible', () => {
+    renderPanel();
+    expect(
+      screen.getByText(/No annotations yet\. Select text or draw a region/),
+    ).toBeInTheDocument();
+  });
+
+  it('lists placed annotations and separates unplaced ones', () => {
+    renderPanel({
+      annotations: [
+        annotation('placed-1'),
+        annotation('orphaned-1', {
+          anchor: undefined,
+          placementStatus: PlacementStatus.Orphaned,
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Annotations (2)')).toBeInTheDocument();
+    expect(screen.getByText('Not placed on this version')).toBeInTheDocument();
+    expect(screen.getByText('Orphaned')).toBeInTheDocument();
+    expect(screen.getByText('“quoted text”')).toBeInTheDocument();
+  });
+
+  it('toggles the active annotation and reveals its thread', () => {
+    const props = renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });
+
+    expect(screen.getByTestId('thread-a1')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('annotation-item-a1'));
+    expect(props.onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('opens the composer for a pending anchor and creates with the comment', () => {
+    const props = renderPanel({
+      pendingAnchor: {
+        region: { surfaceIndex: 1, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.1 } },
+      },
+    });
+
+    const composer = within(screen.getByTestId('annotation-composer'));
+    expect(composer.getByText('Region on page 2')).toBeInTheDocument();
+
+    fireEvent.change(composer.getByLabelText('Annotation comment'), {
+      target: { value: 'Wrong figure' },
+    });
+    fireEvent.click(composer.getByRole('button', { name: 'Create annotation' }));
+    expect(props.onCreate).toHaveBeenCalledWith('Wrong figure');
+
+    fireEvent.click(composer.getByRole('button', { name: 'Cancel' }));
+    expect(props.onCancelPending).toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -153,7 +153,7 @@ describe('AnnotationPanel', () => {
     fireEvent.change(composer.getByLabelText('Annotation comment'), {
       target: { value: 'Wrong figure' },
     });
-    fireEvent.click(composer.getByRole('button', { name: 'Create annotation' }));
+    fireEvent.click(composer.getByRole('button', { name: /Create annotation/ }));
     expect(props.onCreate).toHaveBeenCalledWith('Wrong figure');
 
     fireEvent.click(composer.getByRole('button', { name: 'Cancel' }));
@@ -168,7 +168,7 @@ describe('AnnotationPanel', () => {
     });
 
     const composer = within(screen.getByTestId('annotation-composer'));
-    expect(composer.getByText('to create')).toBeInTheDocument();
+    expect(composer.getByRole('button', { name: /Create annotation \(.+\)/ })).toBeInTheDocument();
 
     const field = composer.getByLabelText('Annotation comment');
     fireEvent.change(field, { target: { value: 'Shortcut comment' } });

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -93,6 +93,8 @@ describe('AnnotationPanel', () => {
     expect(screen.getByText('Not placed on this version')).toBeInTheDocument();
     expect(screen.getByText('Orphaned')).toBeInTheDocument();
     expect(screen.getByText('“quoted text”')).toBeInTheDocument();
+    // The placed annotation shows its page; the unplaced one has none.
+    expect(screen.getByText('Page 1')).toBeInTheDocument();
   });
 
   it('toggles the active annotation and reveals its thread', () => {

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -33,6 +33,10 @@ vi.mock('./CommentThread', () => ({
   ),
 }));
 
+vi.mock('../../../api/hooks/useComments', () => ({
+  useComments: vi.fn().mockReturnValue({ isPending: false, isError: false, data: undefined }),
+}));
+
 const annotation = (id: string, overrides: Partial<AnnotationView> = {}): AnnotationView => ({
   id,
   documentId: 'd1',
@@ -87,14 +91,17 @@ describe('AnnotationPanel', () => {
           placementStatus: PlacementStatus.Orphaned,
         }),
       ],
+      // The unplaced annotation is expanded: placement cues are
+      // expanded-state details; collapsed rows stay a single dense line.
+      activeAnnotationId: 'orphaned-1',
     });
 
     expect(screen.getByText('Annotations (2)')).toBeInTheDocument();
     expect(screen.getByText('Not placed on this version')).toBeInTheDocument();
-    expect(screen.getByText('Orphaned')).toBeInTheDocument();
     expect(screen.getByText('“quoted text”')).toBeInTheDocument();
-    // The placed annotation shows its page; the unplaced one has none.
-    expect(screen.getByText('Page 1')).toBeInTheDocument();
+    // The collapsed placed row shows the page as a compact caption.
+    expect(screen.getByText('p. 1')).toBeInTheDocument();
+    expect(screen.getByText('Orphaned')).toBeInTheDocument();
   });
 
   it('toggles the active annotation and reveals its thread', () => {

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -43,28 +43,6 @@ import { CommentThread } from './CommentThread';
 
 type StatusFilter = 'all' | 'open' | 'decided';
 
-/** A keyboard-key chip for inline shortcut hints. */
-function Kbd({ children }: { children: ReactNode }) {
-  return (
-    <Box
-      component="kbd"
-      sx={(theme) => ({
-        px: 0.5,
-        py: 0.1,
-        borderRadius: '4px',
-        border: `1px solid ${theme.palette.divider}`,
-        bgcolor: theme.qnop.surface2,
-        fontFamily: '"JetBrains Mono", monospace',
-        fontSize: 11,
-        lineHeight: 1.4,
-        color: theme.palette.text.secondary,
-      })}
-    >
-      {children}
-    </Box>
-  );
-}
-
 const FILTERS: { value: StatusFilter; label: string }[] = [
   { value: 'all', label: 'All' },
   { value: 'open', label: 'Open' },
@@ -132,24 +110,17 @@ function Composer({
           }}
           slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Annotation comment' } }}
         />
-        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ mr: 'auto', display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
-          >
-            <Kbd>{submitShortcutLabel()}</Kbd> to create
-          </Typography>
-          <Button size="small" onClick={onCancel} disabled={creating}>
-            Cancel
-          </Button>
+        <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
           <Button
             size="small"
             variant="contained"
             onClick={() => onCreate(comment)}
             disabled={creating}
           >
-            Create annotation
+            Create annotation ({submitShortcutLabel()})
+          </Button>
+          <Button size="small" onClick={onCancel} disabled={creating}>
+            Cancel
           </Button>
         </Stack>
       </Stack>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -34,6 +34,7 @@ import { useTheme } from '@mui/material/styles';
 import { ChevronRight, Link2, NotebookPen, Unlink } from 'lucide-react';
 import type { Anchor, AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
+import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
 import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
 import { compareAnnotationsByPosition } from '../viewer/anchoring';
@@ -41,6 +42,28 @@ import { AnnotationListItem } from './AnnotationListItem';
 import { CommentThread } from './CommentThread';
 
 type StatusFilter = 'all' | 'open' | 'decided';
+
+/** A keyboard-key chip for inline shortcut hints. */
+function Kbd({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      component="kbd"
+      sx={(theme) => ({
+        px: 0.5,
+        py: 0.1,
+        borderRadius: '4px',
+        border: `1px solid ${theme.palette.divider}`,
+        bgcolor: theme.qnop.surface2,
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: 11,
+        lineHeight: 1.4,
+        color: theme.palette.text.secondary,
+      })}
+    >
+      {children}
+    </Box>
+  );
+}
 
 const FILTERS: { value: StatusFilter; label: string }[] = [
   { value: 'all', label: 'All' },
@@ -101,9 +124,22 @@ function Composer({
           placeholder="Add a comment (optional)"
           value={comment}
           onChange={(event) => setComment(event.target.value)}
+          onKeyDown={(event) => {
+            if (isSubmitShortcut(event) && !creating) {
+              event.preventDefault();
+              onCreate(comment);
+            }
+          }}
           slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Annotation comment' } }}
         />
-        <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ mr: 'auto', display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+          >
+            <Kbd>{submitShortcutLabel()}</Kbd> to create
+          </Typography>
           <Button size="small" onClick={onCancel} disabled={creating}>
             Cancel
           </Button>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Collapse from '@mui/material/Collapse';
+import Divider from '@mui/material/Divider';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { NotebookPen } from 'lucide-react';
+import type { Anchor, AnnotationView } from '../../../api/generated';
+import type { Notify } from '../../admin/layout/useToast';
+import { SectionCard } from '../../admin/layout/SectionCard';
+import { compareAnnotationsByPosition } from '../viewer/anchoring';
+import { AnnotationListItem } from './AnnotationListItem';
+import { CommentThread } from './CommentThread';
+
+interface AnnotationPanelProps {
+  annotations: AnnotationView[];
+  activeAnnotationId: string | null;
+  onSelect: (annotationId: string | null) => void;
+  /** The drawn-but-not-yet-created anchor; non-null opens the composer. */
+  pendingAnchor: Anchor | null;
+  creating: boolean;
+  onCreate: (comment: string) => void;
+  onCancelPending: () => void;
+  canAnnotate: boolean;
+  notify: Notify;
+}
+
+/** The composer for a freshly drawn anchor: optional first comment, then create. */
+function Composer({
+  pendingAnchor,
+  creating,
+  onCreate,
+  onCancel,
+}: {
+  pendingAnchor: Anchor;
+  creating: boolean;
+  onCreate: (comment: string) => void;
+  onCancel: () => void;
+}) {
+  const [comment, setComment] = useState('');
+  const quote = pendingAnchor.textQuote?.quote;
+  return (
+    <Paper variant="outlined" sx={{ p: 1.5 }} data-testid="annotation-composer">
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">New annotation</Typography>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{
+            fontStyle: quote ? 'italic' : 'normal',
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {quote ? `“${quote}”` : `Region on page ${pendingAnchor.region.surfaceIndex + 1}`}
+        </Typography>
+        <TextField
+          multiline
+          minRows={2}
+          size="small"
+          placeholder="Add a comment (optional)"
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Annotation comment' } }}
+        />
+        <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
+          <Button size="small" onClick={onCancel} disabled={creating}>
+            Cancel
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => onCreate(comment)}
+            disabled={creating}
+          >
+            Create annotation
+          </Button>
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+}
+
+/**
+ * The right-hand review panel: the composer for a pending mark, then all
+ * annotations of the viewed version ordered by document position; annotations
+ * without a placement on this version (orphaned/failed, ADR-0009) are listed
+ * separately at the end. The active annotation expands into its comment thread.
+ */
+export function AnnotationPanel({
+  annotations,
+  activeAnnotationId,
+  onSelect,
+  pendingAnchor,
+  creating,
+  onCreate,
+  onCancelPending,
+  canAnnotate,
+  notify,
+}: AnnotationPanelProps) {
+  const sorted = [...annotations].sort(compareAnnotationsByPosition);
+  const placed = sorted.filter((annotation) => annotation.anchor);
+  const unplaced = sorted.filter((annotation) => !annotation.anchor);
+
+  const renderItem = (annotation: AnnotationView) => {
+    const active = annotation.id === activeAnnotationId;
+    return (
+      <Stack key={annotation.id} spacing={0}>
+        <AnnotationListItem
+          annotation={annotation}
+          active={active}
+          onClick={() => onSelect(active ? null : annotation.id)}
+        />
+        <Collapse in={active} unmountOnExit>
+          <CommentThread annotationId={annotation.id} notify={notify} />
+        </Collapse>
+      </Stack>
+    );
+  };
+
+  return (
+    <SectionCard
+      icon={NotebookPen}
+      title={`Annotations (${annotations.length})`}
+      description="Marks and their discussion on this version."
+    >
+      <Stack spacing={1.5}>
+        {pendingAnchor && (
+          <Composer
+            pendingAnchor={pendingAnchor}
+            creating={creating}
+            onCreate={onCreate}
+            onCancel={onCancelPending}
+          />
+        )}
+        {annotations.length === 0 && !pendingAnchor && (
+          <Typography variant="body2" color="text.secondary">
+            No annotations yet.
+            {canAnnotate && ' Select text or draw a region on the document to add one.'}
+          </Typography>
+        )}
+        {placed.map(renderItem)}
+        {unplaced.length > 0 && (
+          <>
+            <Divider>
+              <Typography variant="caption" color="text.secondary">
+                Not placed on this version
+              </Typography>
+            </Divider>
+            {unplaced.map(renderItem)}
+          </>
+        )}
+      </Stack>
+    </SectionCard>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -20,25 +20,40 @@
  */
 
 import { useState } from 'react';
+import type { ReactNode } from 'react';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
+import Chip from '@mui/material/Chip';
 import Collapse from '@mui/material/Collapse';
-import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { NotebookPen } from 'lucide-react';
+import { useTheme } from '@mui/material/styles';
+import { ChevronRight, Link2, NotebookPen, Unlink } from 'lucide-react';
 import type { Anchor, AnnotationView } from '../../../api/generated';
+import { AnnotationStatus } from '../../../api/generated';
 import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
 import { compareAnnotationsByPosition } from '../viewer/anchoring';
 import { AnnotationListItem } from './AnnotationListItem';
 import { CommentThread } from './CommentThread';
 
+type StatusFilter = 'all' | 'open' | 'decided';
+
+const FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'open', label: 'Open' },
+  { value: 'decided', label: 'Decided' },
+];
+
 interface AnnotationPanelProps {
   annotations: AnnotationView[];
   activeAnnotationId: string | null;
+  hoverAnnotationId?: string | null;
   onSelect: (annotationId: string | null) => void;
+  onHover?: (annotationId: string | null) => void;
   /** The drawn-but-not-yet-created anchor; non-null opens the composer. */
   pendingAnchor: Anchor | null;
   creating: boolean;
@@ -106,16 +121,113 @@ function Composer({
   );
 }
 
+/** A collapsible, counted group of annotation cards (prototype sidebar section). */
+function PanelSection({
+  title,
+  subtitle,
+  icon,
+  count,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  icon: ReactNode;
+  count: number;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const theme = useTheme();
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <Box>
+      <ButtonBase
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        sx={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          textAlign: 'left',
+          borderRadius: 1,
+          px: 0.5,
+          py: 0.75,
+          '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+        }}
+      >
+        <ChevronRight
+          size={14}
+          aria-hidden
+          style={{
+            color: theme.palette.text.secondary,
+            flexShrink: 0,
+            transform: open ? 'rotate(90deg)' : 'none',
+            transition: 'transform 150ms ease',
+          }}
+        />
+        <Box
+          aria-hidden
+          sx={{
+            width: 24,
+            height: 24,
+            borderRadius: 1,
+            display: 'grid',
+            placeItems: 'center',
+            bgcolor: theme.qnop.badge.blue.bg,
+            color: theme.qnop.brand.blue,
+            flexShrink: 0,
+          }}
+        >
+          {icon}
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography variant="subtitle2" sx={{ lineHeight: 1.25 }}>
+            {title}
+          </Typography>
+          {subtitle && (
+            <Typography variant="caption" color="text.secondary">
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+        <Typography
+          variant="caption"
+          sx={{
+            color: 'text.secondary',
+            bgcolor: theme.qnop.surface2,
+            borderRadius: 99,
+            px: 0.75,
+            fontVariantNumeric: 'tabular-nums',
+            flexShrink: 0,
+          }}
+        >
+          {count}
+        </Typography>
+      </ButtonBase>
+      <Collapse in={open} unmountOnExit>
+        <Stack spacing={1.5} sx={{ pt: 1 }}>
+          {children}
+        </Stack>
+      </Collapse>
+    </Box>
+  );
+}
+
 /**
- * The right-hand review panel: the composer for a pending mark, then all
- * annotations of the viewed version ordered by document position; annotations
- * without a placement on this version (orphaned/failed, ADR-0009) are listed
- * separately at the end. The active annotation expands into its comment thread.
+ * The right-hand review panel: the composer for a pending mark, a status
+ * filter, and the annotations of the viewed version grouped into collapsible
+ * sections — placed marks ordered by document position, then annotations
+ * without a placement on this version (orphaned/failed, ADR-0009). The active
+ * annotation expands into its comment thread; hovering a card lights up its
+ * mark on the page (and vice versa).
  */
 export function AnnotationPanel({
   annotations,
   activeAnnotationId,
+  hoverAnnotationId,
   onSelect,
+  onHover,
   pendingAnchor,
   creating,
   onCreate,
@@ -123,9 +235,18 @@ export function AnnotationPanel({
   canAnnotate,
   notify,
 }: AnnotationPanelProps) {
+  const [filter, setFilter] = useState<StatusFilter>('all');
+
+  const matchesFilter = (annotation: AnnotationView) =>
+    filter === 'all' ||
+    (filter === 'open'
+      ? annotation.status === AnnotationStatus.Open
+      : annotation.status !== AnnotationStatus.Open);
+
   const sorted = [...annotations].sort(compareAnnotationsByPosition);
-  const placed = sorted.filter((annotation) => annotation.anchor);
-  const unplaced = sorted.filter((annotation) => !annotation.anchor);
+  const placed = sorted.filter((annotation) => annotation.anchor && matchesFilter(annotation));
+  const unplaced = sorted.filter((annotation) => !annotation.anchor && matchesFilter(annotation));
+  const hiddenByFilter = annotations.length > 0 && placed.length + unplaced.length === 0;
 
   const renderItem = (annotation: AnnotationView) => {
     const active = annotation.id === activeAnnotationId;
@@ -134,7 +255,9 @@ export function AnnotationPanel({
         <AnnotationListItem
           annotation={annotation}
           active={active}
+          linked={annotation.id === hoverAnnotationId}
           onClick={() => onSelect(active ? null : annotation.id)}
+          onHover={onHover}
         />
         <Collapse in={active} unmountOnExit>
           <CommentThread annotationId={annotation.id} notify={notify} />
@@ -150,6 +273,21 @@ export function AnnotationPanel({
       description="Marks and their discussion on this version."
     >
       <Stack spacing={1.5}>
+        {annotations.length > 0 && (
+          <Stack direction="row" spacing={0.5} role="group" aria-label="Filter annotations">
+            {FILTERS.map(({ value, label }) => (
+              <Chip
+                key={value}
+                label={label}
+                size="small"
+                variant={filter === value ? 'filled' : 'outlined'}
+                color={filter === value ? 'primary' : 'default'}
+                onClick={() => setFilter(value)}
+                aria-pressed={filter === value}
+              />
+            ))}
+          </Stack>
+        )}
         {pendingAnchor && (
           <Composer
             pendingAnchor={pendingAnchor}
@@ -164,16 +302,30 @@ export function AnnotationPanel({
             {canAnnotate && ' Select text or draw a region on the document to add one.'}
           </Typography>
         )}
-        {placed.map(renderItem)}
+        {hiddenByFilter && (
+          <Typography variant="body2" color="text.secondary">
+            No annotations match this filter.
+          </Typography>
+        )}
+        {placed.length > 0 && (
+          <PanelSection
+            title="On this version"
+            subtitle="Anchored to the document"
+            icon={<Link2 size={13} aria-hidden />}
+            count={placed.length}
+          >
+            {placed.map(renderItem)}
+          </PanelSection>
+        )}
         {unplaced.length > 0 && (
-          <>
-            <Divider>
-              <Typography variant="caption" color="text.secondary">
-                Not placed on this version
-              </Typography>
-            </Divider>
+          <PanelSection
+            title="Not placed on this version"
+            subtitle="Anchor lost — needs manual handling"
+            icon={<Unlink size={13} aria-hidden />}
+            count={unplaced.length}
+          >
             {unplaced.map(renderItem)}
-          </>
+          </PanelSection>
         )}
       </Stack>
     </SectionCard>

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -93,7 +93,7 @@ describe('CommentThread', () => {
 
     renderThread();
 
-    expect(screen.getByText('No comments yet.')).toBeInTheDocument();
+    expect(screen.getByText(/No comments yet/)).toBeInTheDocument();
   });
 
   it('submits a trimmed comment and blocks empty drafts', () => {

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import { useAuthStore } from '../../../stores/authStore';
+import { CommentThread } from './CommentThread';
+import { useAddComment, useComments } from '../../../api/hooks/useComments';
+
+vi.mock('../../../api/hooks/useComments', () => ({
+  useComments: vi.fn(),
+  useAddComment: vi.fn(),
+}));
+
+const addMutate = vi.fn();
+
+function renderThread() {
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <CommentThread annotationId="a1" notify={vi.fn()} />
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({ userId: 'me' });
+  vi.mocked(useAddComment).mockReturnValue({
+    mutate: addMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof useAddComment>);
+});
+
+describe('CommentThread', () => {
+  it('renders the thread with authorship relative to the signed-in user', () => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        comments: [
+          {
+            id: 'c1',
+            annotationId: 'a1',
+            authorId: 'me',
+            body: 'Mine',
+            createdAt: '2026-07-01T10:00:00Z',
+          },
+          {
+            id: 'c2',
+            annotationId: 'a1',
+            authorId: 'other',
+            body: 'Theirs',
+            createdAt: '2026-07-01T11:00:00Z',
+          },
+        ],
+      },
+    } as unknown as ReturnType<typeof useComments>);
+
+    renderThread();
+
+    expect(screen.getByText('You')).toBeInTheDocument();
+    expect(screen.getByText('Participant')).toBeInTheDocument();
+    expect(screen.getByText('Mine')).toBeInTheDocument();
+    expect(screen.getByText('Theirs')).toBeInTheDocument();
+  });
+
+  it('shows the empty state', () => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: { comments: [] },
+    } as unknown as ReturnType<typeof useComments>);
+
+    renderThread();
+
+    expect(screen.getByText('No comments yet.')).toBeInTheDocument();
+  });
+
+  it('submits a trimmed comment and blocks empty drafts', () => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: { comments: [] },
+    } as unknown as ReturnType<typeof useComments>);
+
+    renderThread();
+
+    const button = screen.getByRole('button', { name: 'Comment' });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Add a comment'), {
+      target: { value: '  Needs a stronger clause  ' },
+    });
+    fireEvent.click(button);
+
+    expect(addMutate).toHaveBeenCalledWith('Needs a stronger clause', expect.anything());
+  });
+});

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -25,10 +25,12 @@ import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import { SendHorizontal } from 'lucide-react';
 import { useAddComment, useComments } from '../../../api/hooks/useComments';
+import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { UserAvatar } from '../../shell/UserAvatar';
@@ -155,21 +157,30 @@ export function CommentThread({ annotationId, notify }: CommentThreadProps) {
             placeholder="Add a comment"
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (isSubmitShortcut(event)) {
+                event.preventDefault();
+                submit();
+              }
+            }}
             slotProps={{
               htmlInput: { maxLength: 20000, 'aria-label': 'Add a comment' },
               input: {
                 sx: { borderRadius: 1, bgcolor: 'background.paper' },
                 endAdornment: (
-                  <IconButton
-                    size="small"
-                    aria-label="Comment"
-                    color="primary"
-                    onClick={submit}
-                    disabled={!draft.trim() || addComment.isPending}
-                    sx={{ alignSelf: 'flex-end' }}
-                  >
-                    <SendHorizontal size={16} />
-                  </IconButton>
+                  <Tooltip title={`Send (${submitShortcutLabel()})`}>
+                    <span style={{ alignSelf: 'flex-end' }}>
+                      <IconButton
+                        size="small"
+                        aria-label="Comment"
+                        color="primary"
+                        onClick={submit}
+                        disabled={!draft.trim() || addComment.isPending}
+                      >
+                        <SendHorizontal size={16} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
                 ),
               },
             }}

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -20,14 +20,22 @@
  */
 
 import { useState } from 'react';
-import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { SendHorizontal } from 'lucide-react';
 import { useAddComment, useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
+import { UserAvatar } from '../../shell/UserAvatar';
+
+const AVATAR_SIZE = 26;
+/** Centre of the avatar column — where the thread line runs. */
+const LINE_LEFT = AVATAR_SIZE / 2 - 1;
 
 interface CommentThreadProps {
   annotationId: string;
@@ -40,13 +48,18 @@ const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
 });
 
 /**
- * The annotation's discussion: a flat thread, oldest first (ADR-0011 — the
- * annotation owns the thread; accept/reject decisions live on the annotation,
- * not on comments). Participant names are not part of the annotation API yet,
- * so authorship is shown relative to the signed-in user.
+ * The annotation's discussion as a social-style thread (ADR-0011 — the
+ * annotation owns the thread): every comment is an avatar on a shared
+ * timeline rail with a speech bubble, the composer continues the same rail —
+ * the annotation card above is the root post. Participant names are not part
+ * of the annotation API yet, so authorship is shown relative to the signed-in
+ * user.
  */
 export function CommentThread({ annotationId, notify }: CommentThreadProps) {
+  const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
+  const displayName = useAuthStore((state) => state.displayName);
+  const avatarUrl = useAuthStore((state) => state.avatarUrl);
   const commentsQuery = useComments(annotationId);
   const addComment = useAddComment(annotationId);
   const [draft, setDraft] = useState('');
@@ -60,58 +73,109 @@ export function CommentThread({ annotationId, notify }: CommentThreadProps) {
     });
   };
 
+  const comments = commentsQuery.data?.comments ?? [];
+
   return (
-    <Stack spacing={1.5} sx={{ pt: 1 }}>
-      {commentsQuery.isPending && (
-        <Stack sx={{ alignItems: 'center', py: 1 }}>
-          <CircularProgress size={18} />
-        </Stack>
-      )}
-      {commentsQuery.isError && (
-        <Typography variant="body2" color="error">
-          Could not load the comments.
-        </Typography>
-      )}
-      {commentsQuery.data?.comments.map((comment) => (
-        <Stack key={comment.id} spacing={0.25}>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'baseline' }}>
-            <Typography variant="body2" sx={{ fontWeight: 600 }}>
-              {comment.authorId === userId ? 'You' : 'Participant'}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              {TIME_FORMAT.format(new Date(comment.createdAt))}
-            </Typography>
+    <Box sx={{ position: 'relative', mt: 0.5, ml: 1.5, pl: 0 }}>
+      {/* The timeline rail connecting the annotation card to its thread. */}
+      <Box
+        aria-hidden
+        sx={{
+          position: 'absolute',
+          left: LINE_LEFT,
+          top: -6,
+          bottom: 18,
+          width: 2,
+          borderRadius: 1,
+          bgcolor: theme.palette.divider,
+        }}
+      />
+      <Stack spacing={1.25} sx={{ pt: 1 }}>
+        {commentsQuery.isPending && (
+          <Stack sx={{ alignItems: 'center', py: 1 }}>
+            <CircularProgress size={18} aria-label="Loading comments" />
           </Stack>
-          <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>
-            {comment.body}
+        )}
+        {commentsQuery.isError && (
+          <Typography variant="body2" color="error" sx={{ pl: 4.5 }}>
+            Could not load the comments.
           </Typography>
+        )}
+        {comments.map((comment) => {
+          const own = comment.authorId === userId;
+          const name = own ? (displayName ?? 'You') : 'Participant';
+          return (
+            <Stack key={comment.id} direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+              <Box sx={{ position: 'relative', zIndex: 1, pt: 0.25 }}>
+                <UserAvatar name={name} size={AVATAR_SIZE} imageUrl={own ? avatarUrl : null} />
+              </Box>
+              <Box
+                sx={{
+                  flex: 1,
+                  minWidth: 0,
+                  bgcolor: theme.qnop.surface2,
+                  borderRadius: '4px 12px 12px 12px',
+                  px: 1.25,
+                  py: 0.75,
+                }}
+              >
+                <Stack direction="row" spacing={1} sx={{ alignItems: 'baseline' }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {own ? 'You' : name}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {TIME_FORMAT.format(new Date(comment.createdAt))}
+                  </Typography>
+                </Stack>
+                <Typography
+                  variant="body2"
+                  sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', mt: 0.25 }}
+                >
+                  {comment.body}
+                </Typography>
+              </Box>
+            </Stack>
+          );
+        })}
+        {!commentsQuery.isPending && !commentsQuery.isError && comments.length === 0 && (
+          <Typography variant="body2" color="text.secondary" sx={{ pl: 4.5 }}>
+            No comments yet. Start the discussion.
+          </Typography>
+        )}
+        {/* Composer continues the thread rail with the signed-in user's avatar. */}
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+          <Box sx={{ position: 'relative', zIndex: 1, pt: 0.5 }}>
+            <UserAvatar name={displayName ?? 'You'} size={AVATAR_SIZE} imageUrl={avatarUrl} />
+          </Box>
+          <TextField
+            multiline
+            minRows={1}
+            size="small"
+            fullWidth
+            placeholder="Add a comment"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            slotProps={{
+              htmlInput: { maxLength: 20000, 'aria-label': 'Add a comment' },
+              input: {
+                sx: { borderRadius: 3, bgcolor: 'background.paper' },
+                endAdornment: (
+                  <IconButton
+                    size="small"
+                    aria-label="Comment"
+                    color="primary"
+                    onClick={submit}
+                    disabled={!draft.trim() || addComment.isPending}
+                    sx={{ alignSelf: 'flex-end' }}
+                  >
+                    <SendHorizontal size={16} />
+                  </IconButton>
+                ),
+              },
+            }}
+          />
         </Stack>
-      ))}
-      {commentsQuery.data?.comments.length === 0 && (
-        <Typography variant="body2" color="text.secondary">
-          No comments yet.
-        </Typography>
-      )}
-      <Stack spacing={1}>
-        <TextField
-          multiline
-          minRows={2}
-          size="small"
-          placeholder="Add a comment"
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Add a comment' } }}
-        />
-        <Button
-          variant="contained"
-          size="small"
-          onClick={submit}
-          disabled={!draft.trim() || addComment.isPending}
-          sx={{ alignSelf: 'flex-end' }}
-        >
-          Comment
-        </Button>
       </Stack>
-    </Stack>
+    </Box>
   );
 }

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useAddComment, useComments } from '../../../api/hooks/useComments';
+import { useAuthStore } from '../../../stores/authStore';
+import type { Notify } from '../../admin/layout/useToast';
+
+interface CommentThreadProps {
+  annotationId: string;
+  notify: Notify;
+}
+
+const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+/**
+ * The annotation's discussion: a flat thread, oldest first (ADR-0011 — the
+ * annotation owns the thread; accept/reject decisions live on the annotation,
+ * not on comments). Participant names are not part of the annotation API yet,
+ * so authorship is shown relative to the signed-in user.
+ */
+export function CommentThread({ annotationId, notify }: CommentThreadProps) {
+  const userId = useAuthStore((state) => state.userId);
+  const commentsQuery = useComments(annotationId);
+  const addComment = useAddComment(annotationId);
+  const [draft, setDraft] = useState('');
+
+  const submit = () => {
+    const body = draft.trim();
+    if (!body) return;
+    addComment.mutate(body, {
+      onSuccess: () => setDraft(''),
+      onError: () => notify('Could not add the comment.', 'error'),
+    });
+  };
+
+  return (
+    <Stack spacing={1.5} sx={{ pt: 1 }}>
+      {commentsQuery.isPending && (
+        <Stack sx={{ alignItems: 'center', py: 1 }}>
+          <CircularProgress size={18} />
+        </Stack>
+      )}
+      {commentsQuery.isError && (
+        <Typography variant="body2" color="error">
+          Could not load the comments.
+        </Typography>
+      )}
+      {commentsQuery.data?.comments.map((comment) => (
+        <Stack key={comment.id} spacing={0.25}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'baseline' }}>
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {comment.authorId === userId ? 'You' : 'Participant'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {TIME_FORMAT.format(new Date(comment.createdAt))}
+            </Typography>
+          </Stack>
+          <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>
+            {comment.body}
+          </Typography>
+        </Stack>
+      ))}
+      {commentsQuery.data?.comments.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          No comments yet.
+        </Typography>
+      )}
+      <Stack spacing={1}>
+        <TextField
+          multiline
+          minRows={2}
+          size="small"
+          placeholder="Add a comment"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Add a comment' } }}
+        />
+        <Button
+          variant="contained"
+          size="small"
+          onClick={submit}
+          disabled={!draft.trim() || addComment.isPending}
+          sx={{ alignSelf: 'flex-end' }}
+        >
+          Comment
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -114,7 +114,7 @@ export function CommentThread({ annotationId, notify }: CommentThreadProps) {
                   flex: 1,
                   minWidth: 0,
                   bgcolor: theme.qnop.surface2,
-                  borderRadius: '4px 12px 12px 12px',
+                  borderRadius: '3px 8px 8px 8px',
                   px: 1.25,
                   py: 0.75,
                 }}
@@ -158,7 +158,7 @@ export function CommentThread({ annotationId, notify }: CommentThreadProps) {
             slotProps={{
               htmlInput: { maxLength: 20000, 'aria-label': 'Add a comment' },
               input: {
-                sx: { borderRadius: 3, bgcolor: 'background.paper' },
+                sx: { borderRadius: 1, bgcolor: 'background.paper' },
                 endAdornment: (
                   <IconButton
                     size="small"

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -149,7 +149,7 @@ export function CommentThread({ annotationId, notify }: CommentThreadProps) {
           </Box>
           <TextField
             multiline
-            minRows={1}
+            minRows={3}
             size="small"
             fullWidth
             placeholder="Add a comment"

--- a/qnop-ui/src/components/reviews/panel/PlacementStatusChip.tsx
+++ b/qnop-ui/src/components/reviews/panel/PlacementStatusChip.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Tooltip from '@mui/material/Tooltip';
+import { PlacementStatus } from '../../../api/generated';
+import type { BadgeTone } from '../../admin/ToneBadge';
+import { ToneBadge } from '../../admin/ToneBadge';
+
+/**
+ * The placement-status cue (ADR-0009): how the annotation's anchor resolved
+ * on the version being viewed. PLACED renders nothing — it is the expected
+ * state and needs no badge.
+ */
+const CUES: Partial<Record<PlacementStatus, { tone: BadgeTone; label: string; hint: string }>> = {
+  [PlacementStatus.Pending]: {
+    tone: 'neutral',
+    label: 'Re-anchoring…',
+    hint: 'The new version is still being matched against this annotation.',
+  },
+  [PlacementStatus.Moved]: {
+    tone: 'amber',
+    label: 'Moved',
+    hint: 'The anchored text changed with the new version — please verify the highlight.',
+  },
+  [PlacementStatus.Orphaned]: {
+    tone: 'red',
+    label: 'Orphaned',
+    hint: 'No confident match on this version — the annotation needs manual handling.',
+  },
+  [PlacementStatus.Failed]: {
+    tone: 'red',
+    label: 'Failed',
+    hint: 'Re-anchoring failed for this annotation.',
+  },
+};
+
+export function PlacementStatusChip({ status }: { status?: PlacementStatus }) {
+  if (!status) return null;
+  const cue = CUES[status];
+  if (!cue) return null;
+  return (
+    <Tooltip title={cue.hint}>
+      <span>
+        <ToneBadge tone={cue.tone} label={cue.label} />
+      </span>
+    </Tooltip>
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.test.tsx
@@ -50,11 +50,9 @@ const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => 
 });
 
 function renderCard(view: AnnotationView) {
-  const anchorEl = document.createElement('div');
-  document.body.appendChild(anchorEl);
   render(
     <ThemeProvider theme={buildTheme('light')}>
-      <AnnotationHoverCard annotation={view} anchorEl={anchorEl} />
+      <AnnotationHoverCard annotation={view} getAnchorPosition={() => ({ left: 120, top: 240 })} />
     </ThemeProvider>,
   );
 }

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { useAuthStore } from '../../../stores/authStore';
+import { AnnotationHoverCard } from './AnnotationHoverCard';
+import { useComments } from '../../../api/hooks/useComments';
+
+vi.mock('../../../api/hooks/useComments', () => ({
+  useComments: vi.fn(),
+}));
+
+const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => ({
+  id: 'a1',
+  documentId: 'd1',
+  authorId: 'other',
+  status: AnnotationStatus.Open,
+  placementStatus: PlacementStatus.Moved,
+  anchor: {
+    region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 } },
+    textQuote: { quote: 'quoted text' },
+  },
+  commentCount: 3,
+  createdAt: '2026-07-01T10:00:00Z',
+  updatedAt: '2026-07-01T10:00:00Z',
+  ...overrides,
+});
+
+function renderCard(view: AnnotationView) {
+  const anchorEl = document.createElement('div');
+  document.body.appendChild(anchorEl);
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <AnnotationHoverCard annotation={view} anchorEl={anchorEl} />
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({ userId: 'me', displayName: 'Martin', avatarUrl: null });
+});
+
+describe('AnnotationHoverCard', () => {
+  it('previews author, first comment, status, placement cue and thread size', async () => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        comments: [
+          {
+            id: 'c1',
+            annotationId: 'a1',
+            authorId: 'other',
+            body: 'Please tighten this clause.',
+            createdAt: '2026-07-01T11:00:00Z',
+          },
+        ],
+      },
+    } as unknown as ReturnType<typeof useComments>);
+
+    renderCard(annotation());
+
+    await waitFor(() =>
+      expect(screen.getByText('Please tighten this clause.')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Participant')).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Moved')).toBeInTheDocument();
+    expect(screen.getByText('3 comments')).toBeInTheDocument();
+    expect(useComments).toHaveBeenCalledWith('a1', true);
+  });
+
+  it('shows the empty state without fetching when there are no comments', async () => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: undefined,
+    } as unknown as ReturnType<typeof useComments>);
+
+    renderCard(annotation({ commentCount: 0, placementStatus: PlacementStatus.Placed }));
+
+    await waitFor(() => expect(screen.getByText('No comments yet.')).toBeInTheDocument());
+    expect(useComments).toHaveBeenCalledWith('a1', false);
+    expect(screen.getByText('0 comments')).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useState } from 'react';
+import Box from '@mui/material/Box';
+import Popover from '@mui/material/Popover';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { MessageSquare } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus } from '../../../api/generated';
+import { useComments } from '../../../api/hooks/useComments';
+import { useAuthStore } from '../../../stores/authStore';
+import type { BadgeTone } from '../../admin/ToneBadge';
+import { ToneBadge } from '../../admin/ToneBadge';
+import { UserAvatar } from '../../shell/UserAvatar';
+import { PlacementStatusChip } from '../panel/PlacementStatusChip';
+import { highlightColorFor } from './markerColors';
+
+/** Hover intent: the preview appears only after the pointer settles on a mark. */
+const SHOW_DELAY_MS = 320;
+
+const STATUS_CUES: Record<AnnotationStatus, { tone: BadgeTone; label: string }> = {
+  [AnnotationStatus.Open]: { tone: 'blue', label: 'Open' },
+  [AnnotationStatus.Accepted]: { tone: 'green', label: 'Accepted' },
+  [AnnotationStatus.Rejected]: { tone: 'neutral', label: 'Rejected' },
+};
+
+const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+interface AnnotationHoverCardProps {
+  annotation: AnnotationView;
+  anchorEl: HTMLElement;
+}
+
+/**
+ * The mark's hover preview: who opened the discussion and where it stands,
+ * without leaving the document. Shows the first comment with its author's
+ * avatar, the annotation status, the placement cue and the thread size.
+ * Hovering also warms the comments cache, so opening the thread afterwards is
+ * instant. Pointer events pass through — the card never traps the mouse.
+ */
+export function AnnotationHoverCard({ annotation, anchorEl }: AnnotationHoverCardProps) {
+  const theme = useTheme();
+  const userId = useAuthStore((state) => state.userId);
+  const displayName = useAuthStore((state) => state.displayName);
+  const avatarUrl = useAuthStore((state) => state.avatarUrl);
+  const commentsQuery = useComments(annotation.id, annotation.commentCount > 0);
+
+  // Hide instantly when the hovered mark changes (adjust-state-during-render
+  // pattern), then re-show after the hover-intent delay.
+  const [visible, setVisible] = useState(false);
+  const [lastId, setLastId] = useState(annotation.id);
+  if (annotation.id !== lastId) {
+    setLastId(annotation.id);
+    setVisible(false);
+  }
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), SHOW_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [annotation.id]);
+
+  const firstComment = commentsQuery.data?.comments[0];
+  const authorId = firstComment?.authorId ?? annotation.authorId;
+  const own = authorId === userId;
+  const authorName = own ? (displayName ?? 'You') : 'Participant';
+  const statusCue = STATUS_CUES[annotation.status];
+  const railColor = highlightColorFor(annotation, theme.palette);
+  const commentLabel =
+    annotation.commentCount === 1 ? '1 comment' : `${annotation.commentCount} comments`;
+
+  return (
+    <Popover
+      open={visible}
+      anchorEl={anchorEl}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      disableAutoFocus
+      disableEnforceFocus
+      disableRestoreFocus
+      // Pure preview: it must never catch the pointer or steal focus.
+      sx={{ pointerEvents: 'none' }}
+      slotProps={{
+        paper: {
+          sx: {
+            mt: 0.75,
+            width: 320,
+            borderRadius: 2.5,
+            border: `1px solid ${theme.palette.divider}`,
+            boxShadow: '0 12px 32px -8px rgba(1, 32, 66, 0.25)',
+            overflow: 'hidden',
+          },
+        },
+      }}
+    >
+      <Box sx={{ position: 'relative', pl: 2, pr: 1.75, py: 1.5 }}>
+        {/* The rail binds the card to its mark: same colour as the highlight. */}
+        <Box
+          aria-hidden
+          sx={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: 4, bgcolor: railColor }}
+        />
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+            <UserAvatar name={authorName} size={28} imageUrl={own ? avatarUrl : null} />
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.2 }} noWrap>
+                {own ? 'You' : authorName}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {TIME_FORMAT.format(new Date(firstComment?.createdAt ?? annotation.createdAt))}
+              </Typography>
+            </Box>
+            <ToneBadge tone={statusCue.tone} label={statusCue.label} />
+          </Stack>
+
+          {annotation.commentCount > 0 ? (
+            commentsQuery.isPending ? (
+              <Stack spacing={0.5}>
+                <Skeleton variant="text" width="90%" />
+                <Skeleton variant="text" width="65%" />
+              </Stack>
+            ) : (
+              <Typography
+                variant="body2"
+                sx={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: 3,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  overflowWrap: 'anywhere',
+                }}
+              >
+                {firstComment?.body ?? ''}
+              </Typography>
+            )
+          ) : (
+            <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+              No comments yet.
+            </Typography>
+          )}
+
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{ alignItems: 'center', color: 'text.secondary' }}
+            >
+              <MessageSquare size={13} aria-hidden />
+              <Typography variant="caption">{commentLabel}</Typography>
+            </Stack>
+            <PlacementStatusChip status={annotation.placementStatus} />
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
+              Click to open the thread
+            </Typography>
+          </Stack>
+        </Stack>
+      </Box>
+    </Popover>
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
@@ -118,7 +118,7 @@ export function AnnotationHoverCard({ annotation, getAnchorPosition }: Annotatio
           sx: {
             mt: 0.75,
             width: 320,
-            borderRadius: 2.5,
+            borderRadius: 0.75,
             border: `1px solid ${theme.palette.divider}`,
             boxShadow: '0 12px 32px -8px rgba(1, 32, 66, 0.25)',
             overflow: 'hidden',

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
@@ -28,6 +28,7 @@ import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import { MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
+import type { ScreenPosition } from './anchoring';
 import { AnnotationStatus } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
@@ -51,9 +52,13 @@ const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
   timeStyle: 'short',
 });
 
+/** Vertical offset so the card sits just below the pointer, not under it. */
+const POINTER_OFFSET_PX = 14;
+
 interface AnnotationHoverCardProps {
   annotation: AnnotationView;
-  anchorEl: HTMLElement;
+  /** The current pointer position — read once when the card becomes visible. */
+  getAnchorPosition: () => ScreenPosition | null;
 }
 
 /**
@@ -63,7 +68,7 @@ interface AnnotationHoverCardProps {
  * Hovering also warms the comments cache, so opening the thread afterwards is
  * instant. Pointer events pass through — the card never traps the mouse.
  */
-export function AnnotationHoverCard({ annotation, anchorEl }: AnnotationHoverCardProps) {
+export function AnnotationHoverCard({ annotation, getAnchorPosition }: AnnotationHoverCardProps) {
   const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
   const displayName = useAuthStore((state) => state.displayName);
@@ -71,16 +76,19 @@ export function AnnotationHoverCard({ annotation, anchorEl }: AnnotationHoverCar
   const commentsQuery = useComments(annotation.id, annotation.commentCount > 0);
 
   // Hide instantly when the hovered mark changes (adjust-state-during-render
-  // pattern), then re-show after the hover-intent delay.
-  const [visible, setVisible] = useState(false);
+  // pattern), then re-show after the hover-intent delay — frozen at wherever
+  // the pointer settled, so the card does not chase the mouse.
+  const [position, setPosition] = useState<ScreenPosition | null>(null);
   const [lastId, setLastId] = useState(annotation.id);
   if (annotation.id !== lastId) {
     setLastId(annotation.id);
-    setVisible(false);
+    setPosition(null);
   }
   useEffect(() => {
-    const timer = setTimeout(() => setVisible(true), SHOW_DELAY_MS);
+    const timer = setTimeout(() => setPosition(getAnchorPosition()), SHOW_DELAY_MS);
     return () => clearTimeout(timer);
+    // getAnchorPosition is a stable ref reader from the viewer.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [annotation.id]);
 
   const firstComment = commentsQuery.data?.comments[0];
@@ -94,9 +102,11 @@ export function AnnotationHoverCard({ annotation, anchorEl }: AnnotationHoverCar
 
   return (
     <Popover
-      open={visible}
-      anchorEl={anchorEl}
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      open={Boolean(position)}
+      anchorReference="anchorPosition"
+      anchorPosition={
+        position ? { left: position.left, top: position.top + POINTER_OFFSET_PX } : undefined
+      }
       transformOrigin={{ vertical: 'top', horizontal: 'left' }}
       disableAutoFocus
       disableEnforceFocus

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -113,9 +113,7 @@ export function DocumentViewer({
                 onSelectAnnotation={onSelectAnnotation}
                 tool={tool}
                 canAnnotate={canAnnotate}
-                pendingAnchorBox={
-                  pendingAnchor?.region.surfaceIndex === pageIndex ? pendingAnchor.region.box : null
-                }
+                pendingAnchor={pendingAnchor}
                 onTextSelected={onTextSelected}
                 onRegionSelected={onRegionSelected}
               />

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -29,7 +29,7 @@ import type {
   NormalizedBox,
   RenderedSurface,
 } from '../../../api/generated';
-import type { TextSelectionOffsets } from './anchoring';
+import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
 import { SurfacePage } from './SurfacePage';
 import type { ViewerTool } from './ViewerToolbar';
 
@@ -47,8 +47,8 @@ interface DocumentViewerProps {
   tool: ViewerTool;
   canAnnotate: boolean;
   pendingAnchor: Anchor | null;
-  onTextSelected: (selection: TextSelectionOffsets) => void;
-  onRegionSelected: (surfaceIndex: number, box: NormalizedBox) => void;
+  onTextSelected: (selection: TextSelectionOffsets, at: ScreenPosition) => void;
+  onRegionSelected: (surfaceIndex: number, box: NormalizedBox, at: ScreenPosition) => void;
 }
 
 /**

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -19,7 +19,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useImperativeHandle, useRef, useState } from 'react';
+import type { Ref } from 'react';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
@@ -36,14 +37,24 @@ import type { ViewerTool } from './ViewerToolbar';
 /** Keep hairline page borders visible inside the scroll area. */
 const PAGE_GUTTER_PX = 2;
 
+/** Imperative surface for the toolbar's page navigation. */
+export interface DocumentViewerHandle {
+  scrollToPage: (pageIndex: number) => void;
+}
+
 interface DocumentViewerProps {
+  ref?: Ref<DocumentViewerHandle>;
   pdf: PDFDocumentProxy;
   /** Server surfaces; undefined while extraction is running (pixels only then). */
   surfaces?: RenderedSurface[];
   zoom: number;
   annotations: AnnotationView[];
   activeAnnotationId: string | null;
+  hoverAnnotationId?: string | null;
   onSelectAnnotation: (annotationId: string) => void;
+  onHoverAnnotation?: (annotationId: string | null) => void;
+  /** Reports the page currently crossing the upper third of the viewport. */
+  onVisiblePageChange?: (pageIndex: number) => void;
   tool: ViewerTool;
   canAnnotate: boolean;
   pendingAnchor: Anchor | null;
@@ -52,17 +63,24 @@ interface DocumentViewerProps {
 }
 
 /**
- * The scrollable page stack. Fit-width at zoom 1: the page width tracks the
- * container via ResizeObserver; larger zooms overflow horizontally inside the
- * viewer, never the app shell.
+ * The scrollable page stack — its own scroll pane inside the review
+ * workspace. Fit-width at zoom 1: the page width tracks the container via
+ * ResizeObserver; larger zooms overflow horizontally inside the viewer, never
+ * the app shell. A scroll spy reports the current page to the toolbar, and a
+ * hovered annotation (from the panel) is scrolled into view when off-screen —
+ * the prototype's card↔mark linking.
  */
 export function DocumentViewer({
+  ref,
   pdf,
   surfaces,
   zoom,
   annotations,
   activeAnnotationId,
+  hoverAnnotationId,
   onSelectAnnotation,
+  onHoverAnnotation,
+  onVisiblePageChange,
   tool,
   canAnnotate,
   pendingAnchor,
@@ -70,6 +88,7 @@ export function DocumentViewer({
   onRegionSelected,
 }: DocumentViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const pageRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [containerWidth, setContainerWidth] = useState(0);
 
   useEffect(() => {
@@ -84,6 +103,39 @@ export function DocumentViewer({
     return () => observer.disconnect();
   }, []);
 
+  useImperativeHandle(ref, () => ({
+    scrollToPage: (pageIndex: number) => {
+      pageRefs.current[pageIndex]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    },
+  }));
+
+  // Scroll spy: report the page whose top has crossed the upper third of the
+  // viewport. rAF-throttled — scroll fires far more often than the answer
+  // changes.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !onVisiblePageChange) return undefined;
+    let frame = 0;
+    const report = () => {
+      frame = 0;
+      const probe = container.getBoundingClientRect().top + container.clientHeight / 3;
+      let current = 0;
+      pageRefs.current.forEach((page, index) => {
+        if (page && page.getBoundingClientRect().top <= probe) current = index;
+      });
+      onVisiblePageChange(current);
+    };
+    const handleScroll = () => {
+      if (!frame) frame = requestAnimationFrame(report);
+    };
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    report();
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [onVisiblePageChange]);
+
   // A panel click scrolls the (possibly off-screen) highlight into view.
   useEffect(() => {
     if (!activeAnnotationId) return;
@@ -92,31 +144,63 @@ export function DocumentViewer({
       ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, [activeAnnotationId]);
 
+  // Hovering a panel card brings its mark into view — but only when it is
+  // off-screen, so hovering an already-visible mark never causes scroll jumps.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!hoverAnnotationId || !container) return;
+    const mark = document.getElementById(`annotation-highlight-${hoverAnnotationId}`);
+    if (!mark) return;
+    const markRect = mark.getBoundingClientRect();
+    const viewRect = container.getBoundingClientRect();
+    if (markRect.top < viewRect.top + 24 || markRect.bottom > viewRect.bottom - 8) {
+      mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [hoverAnnotationId]);
+
   const pageWidth = Math.max(0, (containerWidth - 2 * PAGE_GUTTER_PX) * zoom);
   const pageCount = surfaces?.length ?? pdf.numPages;
 
   return (
-    <Box ref={containerRef} sx={{ overflowX: 'auto', p: `${PAGE_GUTTER_PX}px` }}>
+    <Box
+      ref={containerRef}
+      component="section"
+      aria-label="Document pages"
+      sx={{
+        overflow: 'auto',
+        height: '100%',
+        p: `${PAGE_GUTTER_PX}px`,
+        '@media (prefers-reduced-motion: reduce)': { scrollBehavior: 'auto' },
+      }}
+    >
       {pageWidth > 0 && (
-        <Stack spacing={2} sx={{ width: 'max-content', minWidth: '100%', alignItems: 'center' }}>
+        <Stack spacing={2.5} sx={{ width: 'max-content', minWidth: '100%', alignItems: 'center' }}>
           {Array.from({ length: pageCount }, (_, pageIndex) => {
             const surface = surfaces?.find((s) => s.index === pageIndex);
             return (
-              <SurfacePage
+              <div
                 key={pageIndex}
-                pdf={pdf}
-                pageIndex={pageIndex}
-                surface={surface}
-                width={pageWidth}
-                annotations={annotations}
-                activeAnnotationId={activeAnnotationId}
-                onSelectAnnotation={onSelectAnnotation}
-                tool={tool}
-                canAnnotate={canAnnotate}
-                pendingAnchor={pendingAnchor}
-                onTextSelected={onTextSelected}
-                onRegionSelected={onRegionSelected}
-              />
+                ref={(el) => {
+                  pageRefs.current[pageIndex] = el;
+                }}
+              >
+                <SurfacePage
+                  pdf={pdf}
+                  pageIndex={pageIndex}
+                  surface={surface}
+                  width={pageWidth}
+                  annotations={annotations}
+                  activeAnnotationId={activeAnnotationId}
+                  hoverAnnotationId={hoverAnnotationId}
+                  onSelectAnnotation={onSelectAnnotation}
+                  onHoverAnnotation={onHoverAnnotation}
+                  tool={tool}
+                  canAnnotate={canAnnotate}
+                  pendingAnchor={pendingAnchor}
+                  onTextSelected={onTextSelected}
+                  onRegionSelected={onRegionSelected}
+                />
+              </div>
             );
           })}
         </Stack>

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+import type {
+  Anchor,
+  AnnotationView,
+  NormalizedBox,
+  RenderedSurface,
+} from '../../../api/generated';
+import type { TextSelectionOffsets } from './anchoring';
+import { SurfacePage } from './SurfacePage';
+import type { ViewerTool } from './ViewerToolbar';
+
+/** Keep hairline page borders visible inside the scroll area. */
+const PAGE_GUTTER_PX = 2;
+
+interface DocumentViewerProps {
+  pdf: PDFDocumentProxy;
+  /** Server surfaces; undefined while extraction is running (pixels only then). */
+  surfaces?: RenderedSurface[];
+  zoom: number;
+  annotations: AnnotationView[];
+  activeAnnotationId: string | null;
+  onSelectAnnotation: (annotationId: string) => void;
+  tool: ViewerTool;
+  canAnnotate: boolean;
+  pendingAnchor: Anchor | null;
+  onTextSelected: (selection: TextSelectionOffsets) => void;
+  onRegionSelected: (surfaceIndex: number, box: NormalizedBox) => void;
+}
+
+/**
+ * The scrollable page stack. Fit-width at zoom 1: the page width tracks the
+ * container via ResizeObserver; larger zooms overflow horizontally inside the
+ * viewer, never the app shell.
+ */
+export function DocumentViewer({
+  pdf,
+  surfaces,
+  zoom,
+  annotations,
+  activeAnnotationId,
+  onSelectAnnotation,
+  tool,
+  canAnnotate,
+  pendingAnchor,
+  onTextSelected,
+  onRegionSelected,
+}: DocumentViewerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return undefined;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) setContainerWidth(width);
+    });
+    observer.observe(element);
+    setContainerWidth(element.clientWidth);
+    return () => observer.disconnect();
+  }, []);
+
+  // A panel click scrolls the (possibly off-screen) highlight into view.
+  useEffect(() => {
+    if (!activeAnnotationId) return;
+    document
+      .getElementById(`annotation-highlight-${activeAnnotationId}`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [activeAnnotationId]);
+
+  const pageWidth = Math.max(0, (containerWidth - 2 * PAGE_GUTTER_PX) * zoom);
+  const pageCount = surfaces?.length ?? pdf.numPages;
+
+  return (
+    <Box ref={containerRef} sx={{ overflowX: 'auto', p: `${PAGE_GUTTER_PX}px` }}>
+      {pageWidth > 0 && (
+        <Stack spacing={2} sx={{ width: 'max-content', minWidth: '100%', alignItems: 'center' }}>
+          {Array.from({ length: pageCount }, (_, pageIndex) => {
+            const surface = surfaces?.find((s) => s.index === pageIndex);
+            return (
+              <SurfacePage
+                key={pageIndex}
+                pdf={pdf}
+                pageIndex={pageIndex}
+                surface={surface}
+                width={pageWidth}
+                annotations={annotations}
+                activeAnnotationId={activeAnnotationId}
+                onSelectAnnotation={onSelectAnnotation}
+                tool={tool}
+                canAnnotate={canAnnotate}
+                pendingAnchorBox={
+                  pendingAnchor?.region.surfaceIndex === pageIndex ? pendingAnchor.region.box : null
+                }
+                onTextSelected={onTextSelected}
+                onRegionSelected={onRegionSelected}
+              />
+            );
+          })}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -31,6 +31,7 @@ import type {
   RenderedSurface,
 } from '../../../api/generated';
 import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
+import { AnnotationHoverCard } from './AnnotationHoverCard';
 import { SurfacePage } from './SurfacePage';
 import type { ViewerTool } from './ViewerToolbar';
 
@@ -90,6 +91,14 @@ export function DocumentViewer({
   const containerRef = useRef<HTMLDivElement>(null);
   const pageRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [containerWidth, setContainerWidth] = useState(0);
+  // Preview card for marks only: hovering a PANEL card links the mark but must
+  // not stack a second card over the document.
+  const [previewId, setPreviewId] = useState<string | null>(null);
+
+  const handleMarkHover = (annotationId: string | null) => {
+    setPreviewId(annotationId);
+    onHoverAnnotation?.(annotationId);
+  };
 
   useEffect(() => {
     const element = containerRef.current;
@@ -192,8 +201,11 @@ export function DocumentViewer({
                   annotations={annotations}
                   activeAnnotationId={activeAnnotationId}
                   hoverAnnotationId={hoverAnnotationId}
-                  onSelectAnnotation={onSelectAnnotation}
-                  onHoverAnnotation={onHoverAnnotation}
+                  onSelectAnnotation={(id) => {
+                    setPreviewId(null);
+                    onSelectAnnotation(id);
+                  }}
+                  onHoverAnnotation={handleMarkHover}
                   tool={tool}
                   canAnnotate={canAnnotate}
                   pendingAnchor={pendingAnchor}
@@ -205,6 +217,15 @@ export function DocumentViewer({
           })}
         </Stack>
       )}
+      {(() => {
+        const preview = previewId ? annotations.find((a) => a.id === previewId) : undefined;
+        const anchor = previewId
+          ? document.getElementById(`annotation-highlight-${previewId}`)
+          : null;
+        return preview && anchor ? (
+          <AnnotationHoverCard annotation={preview} anchorEl={anchor} />
+        ) : null;
+      })()}
     </Box>
   );
 }

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -171,6 +171,9 @@ export function DocumentViewer({
 
   const pageWidth = Math.max(0, (containerWidth - 2 * PAGE_GUTTER_PX) * zoom);
   const pageCount = surfaces?.length ?? pdf.numPages;
+  // Only a PANEL-card hover stages the mark's spotlight treatment; hovering
+  // the mark directly keeps the gentle CSS :hover (earlier feedback: no ring).
+  const linkHoverId = hoverAnnotationId === previewId ? null : (hoverAnnotationId ?? null);
 
   return (
     <Box
@@ -205,7 +208,7 @@ export function DocumentViewer({
                   width={pageWidth}
                   annotations={annotations}
                   activeAnnotationId={activeAnnotationId}
-                  hoverAnnotationId={hoverAnnotationId}
+                  hoverAnnotationId={linkHoverId}
                   onSelectAnnotation={(id) => {
                     setPreviewId(null);
                     onSelectAnnotation(id);

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -92,8 +92,10 @@ export function DocumentViewer({
   const pageRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [containerWidth, setContainerWidth] = useState(0);
   // Preview card for marks only: hovering a PANEL card links the mark but must
-  // not stack a second card over the document.
+  // not stack a second card over the document. The pointer position is kept in
+  // a ref (no re-renders) and read once when the card shows.
   const [previewId, setPreviewId] = useState<string | null>(null);
+  const pointerRef = useRef<ScreenPosition | null>(null);
 
   const handleMarkHover = (annotationId: string | null) => {
     setPreviewId(annotationId);
@@ -175,6 +177,9 @@ export function DocumentViewer({
       ref={containerRef}
       component="section"
       aria-label="Document pages"
+      onMouseMove={(event) => {
+        pointerRef.current = { left: event.clientX, top: event.clientY };
+      }}
       sx={{
         overflow: 'auto',
         height: '100%',
@@ -219,11 +224,8 @@ export function DocumentViewer({
       )}
       {(() => {
         const preview = previewId ? annotations.find((a) => a.id === previewId) : undefined;
-        const anchor = previewId
-          ? document.getElementById(`annotation-highlight-${previewId}`)
-          : null;
-        return preview && anchor ? (
-          <AnnotationHoverCard annotation={preview} anchorEl={anchor} />
+        return preview ? (
+          <AnnotationHoverCard annotation={preview} getAnchorPosition={() => pointerRef.current} />
         ) : null;
       })()}
     </Box>

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.test.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { HighlightLayer } from './HighlightLayer';
+
+function wrap(children: ReactNode) {
+  return <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>;
+}
+
+const annotation = (
+  id: string,
+  surfaceIndex: number,
+  placementStatus: PlacementStatus = PlacementStatus.Placed,
+  status: AnnotationStatus = AnnotationStatus.Open,
+): AnnotationView => ({
+  id,
+  documentId: 'd1',
+  authorId: 'u1',
+  status,
+  placementStatus,
+  anchor: {
+    region: { surfaceIndex, box: { x: 0.25, y: 0.5, width: 0.4, height: 0.05 } },
+    textQuote: { quote: 'the quoted passage' },
+  },
+  commentCount: 1,
+  createdAt: '2026-07-01T10:00:00Z',
+  updatedAt: '2026-07-01T10:00:00Z',
+});
+
+describe('HighlightLayer', () => {
+  it('draws only the annotations placed on its surface, at the stored box', () => {
+    render(
+      wrap(
+        <HighlightLayer
+          annotations={[annotation('on-surface', 0), annotation('other-surface', 1)]}
+          surfaceIndex={0}
+          activeAnnotationId={null}
+          onSelect={() => {}}
+        />,
+      ),
+    );
+
+    const highlight = screen.getByTestId('highlight-on-surface');
+    expect(highlight).toHaveStyle({ left: '25%', top: '50%', width: '40%', height: '5%' });
+    expect(screen.queryByTestId('highlight-other-surface')).not.toBeInTheDocument();
+  });
+
+  it('selects the annotation on click and on keyboard activation', () => {
+    const onSelect = vi.fn();
+    render(
+      wrap(
+        <HighlightLayer
+          annotations={[annotation('a1', 0)]}
+          surfaceIndex={0}
+          activeAnnotationId={null}
+          onSelect={onSelect}
+        />,
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId('highlight-a1'));
+    fireEvent.keyDown(screen.getByTestId('highlight-a1'), { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledTimes(2);
+    expect(onSelect).toHaveBeenCalledWith('a1');
+  });
+
+  it('exposes the quote in the accessible name', () => {
+    render(
+      wrap(
+        <HighlightLayer
+          annotations={[annotation('a1', 0)]}
+          surfaceIndex={0}
+          activeAnnotationId={null}
+          onSelect={() => {}}
+        />,
+      ),
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Annotation: the quoted passage/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the pending preview box without pointer interaction', () => {
+    render(
+      wrap(
+        <HighlightLayer
+          annotations={[]}
+          surfaceIndex={0}
+          activeAnnotationId={null}
+          onSelect={() => {}}
+          pendingBox={{ x: 0.1, y: 0.2, width: 0.3, height: 0.1 }}
+        />,
+      ),
+    );
+
+    const pending = screen.getByTestId('pending-highlight');
+    expect(pending).toHaveStyle({ left: '10%', top: '20%' });
+    expect(pending).toHaveStyle({ 'pointer-events': 'none' });
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.test.tsx
@@ -114,10 +114,11 @@ describe('HighlightLayer', () => {
     );
     // Two lines → two marker bands: the primary (focusable) one plus one aria-hidden band.
     expect(rects).toHaveLength(2);
-    // First line: "world" trimmed proportionally, expanded by the 1.3 overshoot.
+    // First line: "world" trimmed proportionally, grown to the fixture pitch
+    // (0.05) with a quarter of the extra height above the box.
     const computed = getComputedStyle(primary);
-    expect(parseFloat(computed.top)).toBeCloseTo((0.1 - 0.02 * 0.15) * 100);
-    expect(parseFloat(computed.height)).toBeCloseTo(0.02 * 1.3 * 100);
+    expect(parseFloat(computed.top)).toBeCloseTo((0.1 - 0.03 * 0.25) * 100);
+    expect(parseFloat(computed.height)).toBeCloseTo(5);
     // Marker bands have no border — the highlighter look.
     expect(computed.borderStyle).toBe('none');
   });
@@ -200,9 +201,10 @@ describe('HighlightLayer', () => {
     );
 
     const pending = screen.getByTestId('pending-highlight');
-    // Line-wise: the preview follows the first line's box, not the union box.
+    // Line-wise: the preview follows the first line's pitch-tall marker band,
+    // not the union box.
     const computed = getComputedStyle(pending);
-    expect(parseFloat(computed.top)).toBeCloseTo((0.1 - 0.02 * 0.15) * 100);
-    expect(parseFloat(computed.height)).toBeCloseTo(0.02 * 1.3 * 100);
+    expect(parseFloat(computed.top)).toBeCloseTo((0.1 - 0.03 * 0.25) * 100);
+    expect(parseFloat(computed.height)).toBeCloseTo(5);
   });
 });

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.test.tsx
@@ -23,7 +23,7 @@ import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
-import type { AnnotationView } from '../../../api/generated';
+import type { Anchor, AnnotationView, RenderedTextSpan } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';
 import { HighlightLayer } from './HighlightLayer';
@@ -32,18 +32,35 @@ function wrap(children: ReactNode) {
   return <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>;
 }
 
+/** Two lines: "Hello world" (0..11) + "Second line" (12..23). */
+const SPANS: RenderedTextSpan[] = [
+  {
+    text: 'Hello world',
+    startOffset: 0,
+    endOffset: 11,
+    box: { x: 0.1, y: 0.1, width: 0.5, height: 0.02 },
+  },
+  {
+    text: 'Second line',
+    startOffset: 12,
+    endOffset: 23,
+    box: { x: 0.1, y: 0.15, width: 0.4, height: 0.02 },
+  },
+];
+
 const annotation = (
   id: string,
   surfaceIndex: number,
   placementStatus: PlacementStatus = PlacementStatus.Placed,
   status: AnnotationStatus = AnnotationStatus.Open,
+  anchorOverride?: Anchor,
 ): AnnotationView => ({
   id,
   documentId: 'd1',
   authorId: 'u1',
   status,
   placementStatus,
-  anchor: {
+  anchor: anchorOverride ?? {
     region: { surfaceIndex, box: { x: 0.25, y: 0.5, width: 0.4, height: 0.05 } },
     textQuote: { quote: 'the quoted passage' },
   },
@@ -59,6 +76,7 @@ describe('HighlightLayer', () => {
         <HighlightLayer
           annotations={[annotation('on-surface', 0), annotation('other-surface', 1)]}
           surfaceIndex={0}
+          spans={SPANS}
           activeAnnotationId={null}
           onSelect={() => {}}
         />,
@@ -70,6 +88,40 @@ describe('HighlightLayer', () => {
     expect(screen.queryByTestId('highlight-other-surface')).not.toBeInTheDocument();
   });
 
+  it('paints a text anchor as one marker band per line', () => {
+    const textAnchor: Anchor = {
+      region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.5, height: 0.07 } },
+      textQuote: { quote: 'world\nSecond' },
+      textPosition: { start: 6, end: 18 },
+    };
+    render(
+      wrap(
+        <HighlightLayer
+          annotations={[
+            annotation('text-1', 0, PlacementStatus.Placed, AnnotationStatus.Open, textAnchor),
+          ]}
+          surfaceIndex={0}
+          spans={SPANS}
+          activeAnnotationId={null}
+          onSelect={() => {}}
+        />,
+      ),
+    );
+
+    const primary = screen.getByTestId('highlight-text-1');
+    const rects = primary.parentElement!.querySelectorAll(
+      '[id^=annotation-highlight-], [aria-hidden=true]',
+    );
+    // Two lines → two marker bands: the primary (focusable) one plus one aria-hidden band.
+    expect(rects).toHaveLength(2);
+    // First line: "world" trimmed proportionally, expanded by the 1.3 overshoot.
+    const computed = getComputedStyle(primary);
+    expect(parseFloat(computed.top)).toBeCloseTo((0.1 - 0.02 * 0.15) * 100);
+    expect(parseFloat(computed.height)).toBeCloseTo(0.02 * 1.3 * 100);
+    // Marker bands have no border — the highlighter look.
+    expect(computed.borderStyle).toBe('none');
+  });
+
   it('selects the annotation on click and on keyboard activation', () => {
     const onSelect = vi.fn();
     render(
@@ -77,6 +129,7 @@ describe('HighlightLayer', () => {
         <HighlightLayer
           annotations={[annotation('a1', 0)]}
           surfaceIndex={0}
+          spans={SPANS}
           activeAnnotationId={null}
           onSelect={onSelect}
         />,
@@ -95,6 +148,7 @@ describe('HighlightLayer', () => {
         <HighlightLayer
           annotations={[annotation('a1', 0)]}
           surfaceIndex={0}
+          spans={SPANS}
           activeAnnotationId={null}
           onSelect={() => {}}
         />,
@@ -106,15 +160,18 @@ describe('HighlightLayer', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the pending preview box without pointer interaction', () => {
+  it('previews a pending region anchor as a dashed box without pointer interaction', () => {
     render(
       wrap(
         <HighlightLayer
           annotations={[]}
           surfaceIndex={0}
+          spans={SPANS}
           activeAnnotationId={null}
           onSelect={() => {}}
-          pendingBox={{ x: 0.1, y: 0.2, width: 0.3, height: 0.1 }}
+          pendingAnchor={{
+            region: { surfaceIndex: 0, box: { x: 0.1, y: 0.2, width: 0.3, height: 0.1 } },
+          }}
         />,
       ),
     );
@@ -122,5 +179,30 @@ describe('HighlightLayer', () => {
     const pending = screen.getByTestId('pending-highlight');
     expect(pending).toHaveStyle({ left: '10%', top: '20%' });
     expect(pending).toHaveStyle({ 'pointer-events': 'none' });
+  });
+
+  it('previews a pending text anchor as per-line marker bands', () => {
+    render(
+      wrap(
+        <HighlightLayer
+          annotations={[]}
+          surfaceIndex={0}
+          spans={SPANS}
+          activeAnnotationId={null}
+          onSelect={() => {}}
+          pendingAnchor={{
+            region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.5, height: 0.07 } },
+            textQuote: { quote: 'world\nSecond' },
+            textPosition: { start: 6, end: 18 },
+          }}
+        />,
+      ),
+    );
+
+    const pending = screen.getByTestId('pending-highlight');
+    // Line-wise: the preview follows the first line's box, not the union box.
+    const computed = getComputedStyle(pending);
+    expect(parseFloat(computed.top)).toBeCloseTo((0.1 - 0.02 * 0.15) * 100);
+    expect(parseFloat(computed.height)).toBeCloseTo(0.02 * 1.3 * 100);
   });
 });

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -31,7 +31,7 @@ import type {
 } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { highlightBoxesForAnchor } from './anchoring';
-import { MARKER_YELLOW, MARKER_YELLOW_BORDER, SELECTION_MARKER_BG } from './markerColors';
+import { MARKER_YELLOW, SELECTION_MARKER_BG } from './markerColors';
 
 interface HighlightLayerProps {
   /** All annotations of the document — the layer picks the ones on this surface. */
@@ -83,40 +83,25 @@ export function HighlightLayer({
       : null;
 
   /**
-   * The mark's colour: open marks paint highlighter yellow — text as bands,
-   * regions as a filled box whose darker-yellow outline keeps the shape
-   * readable. Cue colours override the base — decided annotations turn
-   * green/grey, a MOVED placement turns amber, a still-pending placement
-   * renders dimmed.
+   * The mark's colour: open marks paint highlighter yellow — text as per-line
+   * bands, regions as one borderless filled box. Cue colours override the
+   * base — decided annotations turn green/grey, a MOVED placement turns
+   * amber, a still-pending placement renders dimmed.
    */
   const styleFor = (annotation: AnnotationView) => {
     if (annotation.status === AnnotationStatus.Accepted) {
-      const color = theme.palette.success.main;
-      return { color, border: color, borderStyle: 'solid', opacity: 1 };
+      return { color: theme.palette.success.main, opacity: 1 };
     }
     if (annotation.status === AnnotationStatus.Rejected) {
-      const color = theme.palette.text.disabled;
-      return { color, border: color, borderStyle: 'solid', opacity: 0.7 };
+      return { color: theme.palette.text.disabled, opacity: 0.7 };
     }
     switch (annotation.placementStatus) {
-      case PlacementStatus.Moved: {
-        const color = theme.palette.warning.main;
-        return { color, border: color, borderStyle: 'dashed', opacity: 1 };
-      }
+      case PlacementStatus.Moved:
+        return { color: theme.palette.warning.main, opacity: 1 };
       case PlacementStatus.Pending:
-        return {
-          color: MARKER_YELLOW,
-          border: MARKER_YELLOW_BORDER,
-          borderStyle: 'dotted',
-          opacity: 0.6,
-        };
+        return { color: MARKER_YELLOW, opacity: 0.6 };
       default:
-        return {
-          color: MARKER_YELLOW,
-          border: MARKER_YELLOW_BORDER,
-          borderStyle: 'solid',
-          opacity: 1,
-        };
+        return { color: MARKER_YELLOW, opacity: 1 };
     }
   };
 
@@ -168,16 +153,14 @@ export function HighlightLayer({
                     cursor: 'pointer',
                     opacity: style.opacity,
                     transition: 'background-color 120ms ease',
-                    // Highlighter look for both kinds: the fill multiplies over
-                    // the page pixels so printed glyphs stay crisp underneath.
-                    // A region keeps its outline so the drawn shape stays
-                    // readable; text bands are fill-only.
+                    // Highlighter look for both kinds: a borderless fill that
+                    // multiplies over the page pixels, so printed glyphs stay
+                    // crisp underneath.
                     bgcolor: alpha(
                       style.color,
                       marker ? (active ? 0.65 : 0.45) : active ? 0.5 : 0.35,
                     ),
                     mixBlendMode: 'multiply',
-                    border: marker ? 'none' : `1.5px ${style.borderStyle} ${style.border}`,
                     borderRadius: marker ? '1px' : '2px',
                     '&:hover': { bgcolor: alpha(style.color, marker ? 0.6 : 0.45) },
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
@@ -206,7 +189,6 @@ export function HighlightLayer({
                     borderRadius: '1px',
                   }
                 : {
-                    border: `2px dashed ${MARKER_YELLOW_BORDER}`,
                     bgcolor: SELECTION_MARKER_BG,
                     mixBlendMode: 'multiply',
                     borderRadius: '2px',

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -64,8 +64,8 @@ function positionSx(box: NormalizedBox) {
  * keyframe set serves every status colour.
  */
 const markPulse = keyframes`
-  0%, 100% { background-color: color-mix(in srgb, var(--hl) 48%, transparent); }
-  50% { background-color: color-mix(in srgb, var(--hl) 78%, transparent); }
+  0%, 100% { background-color: color-mix(in srgb, var(--hl) 55%, transparent); }
+  50% { background-color: color-mix(in srgb, var(--hl) 95%, transparent); }
 `;
 
 /**
@@ -167,18 +167,24 @@ export function HighlightLayer({
                     transition: 'background-color 120ms ease, box-shadow 120ms ease',
                     // Highlighter look for both kinds: a borderless fill that
                     // multiplies over the page pixels, so printed glyphs stay
-                    // crisp underneath. Text bands and region boxes share the
-                    // same intensity in every state; a hover on either side of
-                    // the card↔mark link paints the mark "hot".
-                    bgcolor: alpha(style.color, active || hot ? 0.65 : 0.45),
+                    // crisp underneath. At rest the marker is a pale wash;
+                    // hovering the mark itself deepens it gently (no ring —
+                    // earlier feedback), while hovering its PANEL CARD stages
+                    // the full spotlight: a deep colour pulse plus a glow ring
+                    // so the linked passage is unmissable.
+                    bgcolor: alpha(style.color, hot ? 0.85 : active ? 0.6 : 0.3),
                     mixBlendMode: 'multiply',
                     borderRadius: marker ? '1px' : '2px',
-                    '&:hover': { bgcolor: alpha(style.color, 0.6) },
+                    '&:hover': { bgcolor: alpha(style.color, 0.5) },
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
-                    // Hovering a region only pulses the fill — no ring; the
-                    // ring stays an active/keyboard-focus cue.
                     ...(primary && !marker && active && { boxShadow: theme.qnop.focusRing }),
-                    ...(hot && { animation: `${markPulse} 1.1s ease-in-out infinite` }),
+                    ...(hot && {
+                      animation: `${markPulse} 0.9s ease-in-out infinite`,
+                      boxShadow: marker
+                        ? `0 3px 16px -2px ${alpha(style.color, 0.9)}`
+                        : `0 0 0 2px ${theme.palette.background.paper}, 0 0 0 4px ${style.color}, 0 4px 14px -2px ${alpha(style.color, 0.8)}`,
+                      zIndex: 1,
+                    }),
                     '@media (prefers-reduced-motion: reduce)': {
                       transition: 'none',
                       animation: 'none',

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -180,9 +180,9 @@ export function HighlightLayer({
                     ...(primary && !marker && active && { boxShadow: theme.qnop.focusRing }),
                     ...(hot && {
                       animation: `${markPulse} 0.9s ease-in-out infinite`,
-                      boxShadow: marker
-                        ? `0 3px 16px -2px ${alpha(style.color, 0.9)}`
-                        : `0 0 0 2px ${theme.palette.background.paper}, 0 0 0 4px ${style.color}, 0 4px 14px -2px ${alpha(style.color, 0.8)}`,
+                      // One spotlight treatment for both kinds: white-gap ring
+                      // plus glow (prototype hl-hot).
+                      boxShadow: `0 0 0 2px ${theme.palette.background.paper}, 0 0 0 4px ${style.color}, 0 4px 14px -2px ${alpha(style.color, 0.8)}`,
                       zIndex: 1,
                     }),
                     '@media (prefers-reduced-motion: reduce)': {

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -150,7 +150,6 @@ export function HighlightLayer({
                   }
                   aria-hidden={primary ? undefined : true}
                   data-testid={primary ? `highlight-${annotation.id}` : undefined}
-                  title={quote ? `“${quote.slice(0, 120)}”` : 'Region annotation'}
                   onClick={() => onSelect(annotation.id)}
                   onMouseEnter={() => onHover?.(annotation.id)}
                   onMouseLeave={() => onHover?.(null)}

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -182,8 +182,9 @@ export function HighlightLayer({
                     mixBlendMode: 'multiply',
                     borderRadius: marker ? '1px' : '2px',
                     '&:hover': { bgcolor: alpha(style.color, 0.5) },
+                    // No ring on selection either — the deeper fill carries the
+                    // active state; the ring stays keyboard-focus only.
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
-                    ...(primary && !marker && active && { boxShadow: theme.qnop.focusRing }),
                     // Spotlight without any ring: the linked mark pulses to
                     // the full, brightness-deepened colour instead.
                     ...(hot && {

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -19,42 +19,68 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { Fragment } from 'react';
 import type { KeyboardEvent } from 'react';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
-import type { AnnotationView, NormalizedBox } from '../../../api/generated';
+import type {
+  Anchor,
+  AnnotationView,
+  NormalizedBox,
+  RenderedTextSpan,
+} from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+import { highlightBoxesForAnchor } from './anchoring';
+import { selectionMarkerColor } from './markerColors';
 
 interface HighlightLayerProps {
   /** All annotations of the document — the layer picks the ones on this surface. */
   annotations: AnnotationView[];
   surfaceIndex: number;
+  /** The surface's extracted text spans — text anchors repaint as per-line markers. */
+  spans: RenderedTextSpan[];
   activeAnnotationId: string | null;
   onSelect: (annotationId: string) => void;
-  /** Preview rectangle of a not-yet-created annotation. */
-  pendingBox?: NormalizedBox | null;
+  /** The drawn-but-not-yet-created anchor; painted as a preview. */
+  pendingAnchor?: Anchor | null;
+}
+
+function positionSx(box: NormalizedBox) {
+  return {
+    position: 'absolute',
+    left: `${box.x * 100}%`,
+    top: `${box.y * 100}%`,
+    width: `${box.width * 100}%`,
+    height: `${box.height * 100}%`,
+  } as const;
 }
 
 /**
- * The highlight overlay of one surface. Every rectangle is drawn from the
- * stored normalized box of the annotation's placement on the current version
- * (ADR-0032) — the client never computes highlight geometry itself. Colour
- * carries the cue: decided annotations turn green/grey, a placement the
- * re-anchoring engine changed turns amber and dashed, a still-pending
- * placement renders dimmed (ADR-0009).
+ * The highlight overlay of one surface. Geometry comes from the stored anchors
+ * (ADR-0032 — the client never computes highlight geometry from its own
+ * rendering): a text anchor paints as per-line marker bands, like a
+ * highlighter pen; a region anchor stays a bordered box. Colour carries the
+ * cue: decided annotations turn green/grey, a placement the re-anchoring
+ * engine changed turns amber, a still-pending placement renders dimmed
+ * (ADR-0009).
  */
 export function HighlightLayer({
   annotations,
   surfaceIndex,
+  spans,
   activeAnnotationId,
   onSelect,
-  pendingBox,
+  pendingAnchor,
 }: HighlightLayerProps) {
   const theme = useTheme();
 
   const visible = annotations.filter(
     (annotation) => annotation.anchor?.region.surfaceIndex === surfaceIndex,
   );
+  const pending =
+    pendingAnchor && pendingAnchor.region.surfaceIndex === surfaceIndex
+      ? highlightBoxesForAnchor(pendingAnchor, spans)
+      : null;
 
   const styleFor = (annotation: AnnotationView) => {
     const brand = theme.qnop.brand.blue;
@@ -84,57 +110,88 @@ export function HighlightLayer({
   return (
     <Box sx={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
       {visible.map((annotation) => {
-        const box = annotation.anchor!.region.box;
+        const anchor = annotation.anchor!;
+        const { kind, boxes } = highlightBoxesForAnchor(anchor, spans);
         const style = styleFor(annotation);
         const active = annotation.id === activeAnnotationId;
-        const quote = annotation.anchor?.textQuote?.quote;
+        const quote = anchor.textQuote?.quote;
         return (
-          <Box
-            key={annotation.id}
-            id={`annotation-highlight-${annotation.id}`}
-            role="button"
-            tabIndex={0}
-            aria-pressed={active}
-            aria-label={quote ? `Annotation: ${quote.slice(0, 60)}` : 'Region annotation'}
-            data-testid={`highlight-${annotation.id}`}
-            onClick={() => onSelect(annotation.id)}
-            onKeyDown={(event) => handleKeyDown(event, annotation.id)}
-            sx={{
-              position: 'absolute',
-              left: `${box.x * 100}%`,
-              top: `${box.y * 100}%`,
-              width: `${box.width * 100}%`,
-              height: `${box.height * 100}%`,
-              pointerEvents: 'auto',
-              cursor: 'pointer',
-              bgcolor: alpha(style.color, active ? 0.28 : 0.16),
-              border: `1.5px ${style.borderStyle} ${style.color}`,
-              borderRadius: '2px',
-              opacity: style.opacity,
-              transition: 'background-color 120ms ease',
-              '&:hover': { bgcolor: alpha(style.color, 0.26) },
-              '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
-              ...(active && { boxShadow: theme.qnop.focusRing }),
-            }}
-          />
+          <Fragment key={annotation.id}>
+            {boxes.map((box, index) => {
+              const primary = index === 0;
+              const marker = kind === 'marker';
+              return (
+                <Box
+                  key={index}
+                  id={primary ? `annotation-highlight-${annotation.id}` : undefined}
+                  role={primary ? 'button' : undefined}
+                  tabIndex={primary ? 0 : undefined}
+                  aria-pressed={primary ? active : undefined}
+                  aria-label={
+                    primary
+                      ? quote
+                        ? `Annotation: ${quote.slice(0, 60)}`
+                        : 'Region annotation'
+                      : undefined
+                  }
+                  aria-hidden={primary ? undefined : true}
+                  data-testid={primary ? `highlight-${annotation.id}` : undefined}
+                  onClick={() => onSelect(annotation.id)}
+                  onKeyDown={
+                    primary
+                      ? (event: KeyboardEvent) => handleKeyDown(event, annotation.id)
+                      : undefined
+                  }
+                  sx={{
+                    ...positionSx(box),
+                    pointerEvents: 'auto',
+                    cursor: 'pointer',
+                    opacity: style.opacity,
+                    transition: 'background-color 120ms ease',
+                    // Marker = highlighter look: fill only, multiplied over the
+                    // page pixels so the printed glyphs stay crisp underneath.
+                    // Box = the bordered region rectangle.
+                    bgcolor: alpha(
+                      style.color,
+                      marker ? (active ? 0.45 : 0.3) : active ? 0.28 : 0.16,
+                    ),
+                    mixBlendMode: marker ? 'multiply' : 'normal',
+                    border: marker ? 'none' : `1.5px ${style.borderStyle} ${style.color}`,
+                    borderRadius: marker ? '1px' : '2px',
+                    '&:hover': { bgcolor: alpha(style.color, marker ? 0.45 : 0.26) },
+                    '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
+                    ...(active && primary && !marker && { boxShadow: theme.qnop.focusRing }),
+                  }}
+                />
+              );
+            })}
+          </Fragment>
         );
       })}
-      {pendingBox && (
-        <Box
-          data-testid="pending-highlight"
-          sx={{
-            position: 'absolute',
-            left: `${pendingBox.x * 100}%`,
-            top: `${pendingBox.y * 100}%`,
-            width: `${pendingBox.width * 100}%`,
-            height: `${pendingBox.height * 100}%`,
-            border: `2px dashed ${theme.qnop.brand.blue}`,
-            bgcolor: alpha(theme.qnop.brand.blue, 0.08),
-            borderRadius: '2px',
-            pointerEvents: 'none',
-          }}
-        />
-      )}
+      {pending &&
+        pending.boxes.map((box, index) => (
+          <Box
+            key={index}
+            data-testid={index === 0 ? 'pending-highlight' : undefined}
+            sx={{
+              ...positionSx(box),
+              pointerEvents: 'none',
+              ...(pending.kind === 'marker'
+                ? {
+                    // Identical to the live selection, so releasing the mouse
+                    // does not visually change the mark.
+                    bgcolor: selectionMarkerColor(theme.palette.mode),
+                    mixBlendMode: 'multiply',
+                    borderRadius: '1px',
+                  }
+                : {
+                    border: `2px dashed ${theme.qnop.brand.blue}`,
+                    bgcolor: alpha(theme.qnop.brand.blue, 0.08),
+                    borderRadius: '2px',
+                  }),
+            }}
+          />
+        ))}
     </Box>
   );
 }

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -31,7 +31,7 @@ import type {
 } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { highlightBoxesForAnchor } from './anchoring';
-import { MARKER_YELLOW, SELECTION_MARKER_BG } from './markerColors';
+import { MARKER_YELLOW, MARKER_YELLOW_BORDER, SELECTION_MARKER_BG } from './markerColors';
 
 interface HighlightLayerProps {
   /** All annotations of the document — the layer picks the ones on this surface. */
@@ -83,26 +83,40 @@ export function HighlightLayer({
       : null;
 
   /**
-   * The mark's colour: open text markers paint highlighter yellow (like the
-   * selection they were drawn from); open region boxes stay brand blue. Cue
-   * colours override the base — decided annotations turn green/grey, a MOVED
-   * placement turns amber, a still-pending placement renders dimmed.
+   * The mark's colour: open marks paint highlighter yellow — text as bands,
+   * regions as a filled box whose darker-yellow outline keeps the shape
+   * readable. Cue colours override the base — decided annotations turn
+   * green/grey, a MOVED placement turns amber, a still-pending placement
+   * renders dimmed.
    */
-  const styleFor = (annotation: AnnotationView, marker: boolean) => {
-    const base = marker ? MARKER_YELLOW : theme.qnop.brand.blue;
+  const styleFor = (annotation: AnnotationView) => {
     if (annotation.status === AnnotationStatus.Accepted) {
-      return { color: theme.palette.success.main, borderStyle: 'solid', opacity: 1 };
+      const color = theme.palette.success.main;
+      return { color, border: color, borderStyle: 'solid', opacity: 1 };
     }
     if (annotation.status === AnnotationStatus.Rejected) {
-      return { color: theme.palette.text.disabled, borderStyle: 'solid', opacity: 0.7 };
+      const color = theme.palette.text.disabled;
+      return { color, border: color, borderStyle: 'solid', opacity: 0.7 };
     }
     switch (annotation.placementStatus) {
-      case PlacementStatus.Moved:
-        return { color: theme.palette.warning.main, borderStyle: 'dashed', opacity: 1 };
+      case PlacementStatus.Moved: {
+        const color = theme.palette.warning.main;
+        return { color, border: color, borderStyle: 'dashed', opacity: 1 };
+      }
       case PlacementStatus.Pending:
-        return { color: base, borderStyle: 'dotted', opacity: 0.6 };
+        return {
+          color: MARKER_YELLOW,
+          border: MARKER_YELLOW_BORDER,
+          borderStyle: 'dotted',
+          opacity: 0.6,
+        };
       default:
-        return { color: base, borderStyle: 'solid', opacity: 1 };
+        return {
+          color: MARKER_YELLOW,
+          border: MARKER_YELLOW_BORDER,
+          borderStyle: 'solid',
+          opacity: 1,
+        };
     }
   };
 
@@ -118,7 +132,7 @@ export function HighlightLayer({
       {visible.map((annotation) => {
         const anchor = annotation.anchor!;
         const { kind, boxes } = highlightBoxesForAnchor(anchor, spans);
-        const style = styleFor(annotation, kind === 'marker');
+        const style = styleFor(annotation);
         const active = annotation.id === activeAnnotationId;
         const quote = anchor.textQuote?.quote;
         return (
@@ -154,17 +168,18 @@ export function HighlightLayer({
                     cursor: 'pointer',
                     opacity: style.opacity,
                     transition: 'background-color 120ms ease',
-                    // Marker = highlighter look: fill only, multiplied over the
-                    // page pixels so the printed glyphs stay crisp underneath.
-                    // Box = the bordered region rectangle.
+                    // Highlighter look for both kinds: the fill multiplies over
+                    // the page pixels so printed glyphs stay crisp underneath.
+                    // A region keeps its outline so the drawn shape stays
+                    // readable; text bands are fill-only.
                     bgcolor: alpha(
                       style.color,
-                      marker ? (active ? 0.65 : 0.45) : active ? 0.28 : 0.16,
+                      marker ? (active ? 0.65 : 0.45) : active ? 0.5 : 0.35,
                     ),
-                    mixBlendMode: marker ? 'multiply' : 'normal',
-                    border: marker ? 'none' : `1.5px ${style.borderStyle} ${style.color}`,
+                    mixBlendMode: 'multiply',
+                    border: marker ? 'none' : `1.5px ${style.borderStyle} ${style.border}`,
                     borderRadius: marker ? '1px' : '2px',
-                    '&:hover': { bgcolor: alpha(style.color, marker ? 0.6 : 0.26) },
+                    '&:hover': { bgcolor: alpha(style.color, marker ? 0.6 : 0.45) },
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
                     ...(active && primary && !marker && { boxShadow: theme.qnop.focusRing }),
                   }}
@@ -191,8 +206,9 @@ export function HighlightLayer({
                     borderRadius: '1px',
                   }
                 : {
-                    border: `2px dashed ${theme.qnop.brand.blue}`,
-                    bgcolor: alpha(theme.qnop.brand.blue, 0.08),
+                    border: `2px dashed ${MARKER_YELLOW_BORDER}`,
+                    bgcolor: SELECTION_MARKER_BG,
+                    mixBlendMode: 'multiply',
                     borderRadius: '2px',
                   }),
             }}

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -155,14 +155,12 @@ export function HighlightLayer({
                     transition: 'background-color 120ms ease',
                     // Highlighter look for both kinds: a borderless fill that
                     // multiplies over the page pixels, so printed glyphs stay
-                    // crisp underneath.
-                    bgcolor: alpha(
-                      style.color,
-                      marker ? (active ? 0.65 : 0.45) : active ? 0.5 : 0.35,
-                    ),
+                    // crisp underneath. Text bands and region boxes share the
+                    // same intensity in every state.
+                    bgcolor: alpha(style.color, active ? 0.65 : 0.45),
                     mixBlendMode: 'multiply',
                     borderRadius: marker ? '1px' : '2px',
-                    '&:hover': { bgcolor: alpha(style.color, marker ? 0.6 : 0.45) },
+                    '&:hover': { bgcolor: alpha(style.color, 0.6) },
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
                     ...(active && primary && !marker && { boxShadow: theme.qnop.focusRing }),
                   }}

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { KeyboardEvent } from 'react';
+import Box from '@mui/material/Box';
+import { alpha, useTheme } from '@mui/material/styles';
+import type { AnnotationView, NormalizedBox } from '../../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+
+interface HighlightLayerProps {
+  /** All annotations of the document — the layer picks the ones on this surface. */
+  annotations: AnnotationView[];
+  surfaceIndex: number;
+  activeAnnotationId: string | null;
+  onSelect: (annotationId: string) => void;
+  /** Preview rectangle of a not-yet-created annotation. */
+  pendingBox?: NormalizedBox | null;
+}
+
+/**
+ * The highlight overlay of one surface. Every rectangle is drawn from the
+ * stored normalized box of the annotation's placement on the current version
+ * (ADR-0032) — the client never computes highlight geometry itself. Colour
+ * carries the cue: decided annotations turn green/grey, a placement the
+ * re-anchoring engine changed turns amber and dashed, a still-pending
+ * placement renders dimmed (ADR-0009).
+ */
+export function HighlightLayer({
+  annotations,
+  surfaceIndex,
+  activeAnnotationId,
+  onSelect,
+  pendingBox,
+}: HighlightLayerProps) {
+  const theme = useTheme();
+
+  const visible = annotations.filter(
+    (annotation) => annotation.anchor?.region.surfaceIndex === surfaceIndex,
+  );
+
+  const styleFor = (annotation: AnnotationView) => {
+    const brand = theme.qnop.brand.blue;
+    if (annotation.status === AnnotationStatus.Accepted) {
+      return { color: theme.palette.success.main, borderStyle: 'solid', opacity: 1 };
+    }
+    if (annotation.status === AnnotationStatus.Rejected) {
+      return { color: theme.palette.text.disabled, borderStyle: 'solid', opacity: 0.7 };
+    }
+    switch (annotation.placementStatus) {
+      case PlacementStatus.Moved:
+        return { color: theme.palette.warning.main, borderStyle: 'dashed', opacity: 1 };
+      case PlacementStatus.Pending:
+        return { color: brand, borderStyle: 'dotted', opacity: 0.6 };
+      default:
+        return { color: brand, borderStyle: 'solid', opacity: 1 };
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent, annotationId: string) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect(annotationId);
+    }
+  };
+
+  return (
+    <Box sx={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+      {visible.map((annotation) => {
+        const box = annotation.anchor!.region.box;
+        const style = styleFor(annotation);
+        const active = annotation.id === activeAnnotationId;
+        const quote = annotation.anchor?.textQuote?.quote;
+        return (
+          <Box
+            key={annotation.id}
+            id={`annotation-highlight-${annotation.id}`}
+            role="button"
+            tabIndex={0}
+            aria-pressed={active}
+            aria-label={quote ? `Annotation: ${quote.slice(0, 60)}` : 'Region annotation'}
+            data-testid={`highlight-${annotation.id}`}
+            onClick={() => onSelect(annotation.id)}
+            onKeyDown={(event) => handleKeyDown(event, annotation.id)}
+            sx={{
+              position: 'absolute',
+              left: `${box.x * 100}%`,
+              top: `${box.y * 100}%`,
+              width: `${box.width * 100}%`,
+              height: `${box.height * 100}%`,
+              pointerEvents: 'auto',
+              cursor: 'pointer',
+              bgcolor: alpha(style.color, active ? 0.28 : 0.16),
+              border: `1.5px ${style.borderStyle} ${style.color}`,
+              borderRadius: '2px',
+              opacity: style.opacity,
+              transition: 'background-color 120ms ease',
+              '&:hover': { bgcolor: alpha(style.color, 0.26) },
+              '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
+              ...(active && { boxShadow: theme.qnop.focusRing }),
+            }}
+          />
+        );
+      })}
+      {pendingBox && (
+        <Box
+          data-testid="pending-highlight"
+          sx={{
+            position: 'absolute',
+            left: `${pendingBox.x * 100}%`,
+            top: `${pendingBox.y * 100}%`,
+            width: `${pendingBox.width * 100}%`,
+            height: `${pendingBox.height * 100}%`,
+            border: `2px dashed ${theme.qnop.brand.blue}`,
+            bgcolor: alpha(theme.qnop.brand.blue, 0.08),
+            borderRadius: '2px',
+            pointerEvents: 'none',
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -31,7 +31,7 @@ import type {
 } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { highlightBoxesForAnchor } from './anchoring';
-import { MARKER_YELLOW, SELECTION_MARKER_BG } from './markerColors';
+import { SELECTION_MARKER_BG, highlightColorFor } from './markerColors';
 
 interface HighlightLayerProps {
   /** All annotations of the document — the layer picks the ones on this surface. */
@@ -40,7 +40,10 @@ interface HighlightLayerProps {
   /** The surface's extracted text spans — text anchors repaint as per-line markers. */
   spans: RenderedTextSpan[];
   activeAnnotationId: string | null;
+  /** The annotation hovered anywhere (page or panel) — paints "hot" for linking. */
+  hoverAnnotationId?: string | null;
   onSelect: (annotationId: string) => void;
+  onHover?: (annotationId: string | null) => void;
   /** The drawn-but-not-yet-created anchor; painted as a preview. */
   pendingAnchor?: Anchor | null;
 }
@@ -69,7 +72,9 @@ export function HighlightLayer({
   surfaceIndex,
   spans,
   activeAnnotationId,
+  hoverAnnotationId,
   onSelect,
+  onHover,
   pendingAnchor,
 }: HighlightLayerProps) {
   const theme = useTheme();
@@ -88,22 +93,15 @@ export function HighlightLayer({
    * base — decided annotations turn green/grey, a MOVED placement turns
    * amber, a still-pending placement renders dimmed.
    */
-  const styleFor = (annotation: AnnotationView) => {
-    if (annotation.status === AnnotationStatus.Accepted) {
-      return { color: theme.palette.success.main, opacity: 1 };
-    }
-    if (annotation.status === AnnotationStatus.Rejected) {
-      return { color: theme.palette.text.disabled, opacity: 0.7 };
-    }
-    switch (annotation.placementStatus) {
-      case PlacementStatus.Moved:
-        return { color: theme.palette.warning.main, opacity: 1 };
-      case PlacementStatus.Pending:
-        return { color: MARKER_YELLOW, opacity: 0.6 };
-      default:
-        return { color: MARKER_YELLOW, opacity: 1 };
-    }
-  };
+  const styleFor = (annotation: AnnotationView) => ({
+    color: highlightColorFor(annotation, theme.palette),
+    opacity:
+      annotation.status === AnnotationStatus.Rejected
+        ? 0.7
+        : annotation.placementStatus === PlacementStatus.Pending
+          ? 0.6
+          : 1,
+  });
 
   const handleKeyDown = (event: KeyboardEvent, annotationId: string) => {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -119,6 +117,7 @@ export function HighlightLayer({
         const { kind, boxes } = highlightBoxesForAnchor(anchor, spans);
         const style = styleFor(annotation);
         const active = annotation.id === activeAnnotationId;
+        const hot = annotation.id === hoverAnnotationId;
         const quote = anchor.textQuote?.quote;
         return (
           <Fragment key={annotation.id}>
@@ -141,7 +140,10 @@ export function HighlightLayer({
                   }
                   aria-hidden={primary ? undefined : true}
                   data-testid={primary ? `highlight-${annotation.id}` : undefined}
+                  title={quote ? `“${quote.slice(0, 120)}”` : 'Region annotation'}
                   onClick={() => onSelect(annotation.id)}
+                  onMouseEnter={() => onHover?.(annotation.id)}
+                  onMouseLeave={() => onHover?.(null)}
                   onKeyDown={
                     primary
                       ? (event: KeyboardEvent) => handleKeyDown(event, annotation.id)
@@ -152,17 +154,21 @@ export function HighlightLayer({
                     pointerEvents: 'auto',
                     cursor: 'pointer',
                     opacity: style.opacity,
-                    transition: 'background-color 120ms ease',
+                    transition: 'background-color 120ms ease, box-shadow 120ms ease',
+                    '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
                     // Highlighter look for both kinds: a borderless fill that
                     // multiplies over the page pixels, so printed glyphs stay
                     // crisp underneath. Text bands and region boxes share the
-                    // same intensity in every state.
-                    bgcolor: alpha(style.color, active ? 0.65 : 0.45),
+                    // same intensity in every state; a hover on either side of
+                    // the card↔mark link paints the mark "hot".
+                    bgcolor: alpha(style.color, active || hot ? 0.65 : 0.45),
                     mixBlendMode: 'multiply',
                     borderRadius: marker ? '1px' : '2px',
                     '&:hover': { bgcolor: alpha(style.color, 0.6) },
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
-                    ...(active && primary && !marker && { boxShadow: theme.qnop.focusRing }),
+                    ...(primary &&
+                      !marker &&
+                      (active || hot) && { boxShadow: theme.qnop.focusRing }),
                   }}
                 />
               );

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -31,7 +31,7 @@ import type {
 } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { highlightBoxesForAnchor } from './anchoring';
-import { selectionMarkerColor } from './markerColors';
+import { MARKER_YELLOW, SELECTION_MARKER_BG } from './markerColors';
 
 interface HighlightLayerProps {
   /** All annotations of the document — the layer picks the ones on this surface. */
@@ -82,8 +82,14 @@ export function HighlightLayer({
       ? highlightBoxesForAnchor(pendingAnchor, spans)
       : null;
 
-  const styleFor = (annotation: AnnotationView) => {
-    const brand = theme.qnop.brand.blue;
+  /**
+   * The mark's colour: open text markers paint highlighter yellow (like the
+   * selection they were drawn from); open region boxes stay brand blue. Cue
+   * colours override the base — decided annotations turn green/grey, a MOVED
+   * placement turns amber, a still-pending placement renders dimmed.
+   */
+  const styleFor = (annotation: AnnotationView, marker: boolean) => {
+    const base = marker ? MARKER_YELLOW : theme.qnop.brand.blue;
     if (annotation.status === AnnotationStatus.Accepted) {
       return { color: theme.palette.success.main, borderStyle: 'solid', opacity: 1 };
     }
@@ -94,9 +100,9 @@ export function HighlightLayer({
       case PlacementStatus.Moved:
         return { color: theme.palette.warning.main, borderStyle: 'dashed', opacity: 1 };
       case PlacementStatus.Pending:
-        return { color: brand, borderStyle: 'dotted', opacity: 0.6 };
+        return { color: base, borderStyle: 'dotted', opacity: 0.6 };
       default:
-        return { color: brand, borderStyle: 'solid', opacity: 1 };
+        return { color: base, borderStyle: 'solid', opacity: 1 };
     }
   };
 
@@ -112,7 +118,7 @@ export function HighlightLayer({
       {visible.map((annotation) => {
         const anchor = annotation.anchor!;
         const { kind, boxes } = highlightBoxesForAnchor(anchor, spans);
-        const style = styleFor(annotation);
+        const style = styleFor(annotation, kind === 'marker');
         const active = annotation.id === activeAnnotationId;
         const quote = anchor.textQuote?.quote;
         return (
@@ -153,12 +159,12 @@ export function HighlightLayer({
                     // Box = the bordered region rectangle.
                     bgcolor: alpha(
                       style.color,
-                      marker ? (active ? 0.45 : 0.3) : active ? 0.28 : 0.16,
+                      marker ? (active ? 0.65 : 0.45) : active ? 0.28 : 0.16,
                     ),
                     mixBlendMode: marker ? 'multiply' : 'normal',
                     border: marker ? 'none' : `1.5px ${style.borderStyle} ${style.color}`,
                     borderRadius: marker ? '1px' : '2px',
-                    '&:hover': { bgcolor: alpha(style.color, marker ? 0.45 : 0.26) },
+                    '&:hover': { bgcolor: alpha(style.color, marker ? 0.6 : 0.26) },
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
                     ...(active && primary && !marker && { boxShadow: theme.qnop.focusRing }),
                   }}
@@ -180,7 +186,7 @@ export function HighlightLayer({
                 ? {
                     // Identical to the live selection, so releasing the mouse
                     // does not visually change the mark.
-                    bgcolor: selectionMarkerColor(theme.palette.mode),
+                    bgcolor: SELECTION_MARKER_BG,
                     mixBlendMode: 'multiply',
                     borderRadius: '1px',
                   }

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -64,8 +64,14 @@ function positionSx(box: NormalizedBox) {
  * keyframe set serves every status colour.
  */
 const markPulse = keyframes`
-  0%, 100% { background-color: color-mix(in srgb, var(--hl) 55%, transparent); }
-  50% { background-color: color-mix(in srgb, var(--hl) 95%, transparent); }
+  0%, 100% {
+    background-color: color-mix(in srgb, var(--hl) 60%, transparent);
+    filter: none;
+  }
+  50% {
+    background-color: var(--hl);
+    filter: brightness(0.88) saturate(1.35);
+  }
 `;
 
 /**
@@ -172,17 +178,16 @@ export function HighlightLayer({
                     // earlier feedback), while hovering its PANEL CARD stages
                     // the full spotlight: a deep colour pulse plus a glow ring
                     // so the linked passage is unmissable.
-                    bgcolor: alpha(style.color, hot ? 0.85 : active ? 0.6 : 0.3),
+                    bgcolor: alpha(style.color, hot ? 0.9 : active ? 0.6 : 0.3),
                     mixBlendMode: 'multiply',
                     borderRadius: marker ? '1px' : '2px',
                     '&:hover': { bgcolor: alpha(style.color, 0.5) },
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
                     ...(primary && !marker && active && { boxShadow: theme.qnop.focusRing }),
+                    // Spotlight without any ring: the linked mark pulses to
+                    // the full, brightness-deepened colour instead.
                     ...(hot && {
                       animation: `${markPulse} 0.9s ease-in-out infinite`,
-                      // One spotlight treatment for both kinds: white-gap ring
-                      // plus glow (prototype hl-hot).
-                      boxShadow: `0 0 0 2px ${theme.palette.background.paper}, 0 0 0 4px ${style.color}, 0 4px 14px -2px ${alpha(style.color, 0.8)}`,
                       zIndex: 1,
                     }),
                     '@media (prefers-reduced-motion: reduce)': {

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -22,7 +22,7 @@
 import { Fragment } from 'react';
 import type { KeyboardEvent } from 'react';
 import Box from '@mui/material/Box';
-import { alpha, useTheme } from '@mui/material/styles';
+import { alpha, keyframes, useTheme } from '@mui/material/styles';
 import type {
   Anchor,
   AnnotationView,
@@ -57,6 +57,16 @@ function positionSx(box: NormalizedBox) {
     height: `${box.height * 100}%`,
   } as const;
 }
+
+/**
+ * The card↔mark link cue (prototype `hlHotPulse`): the hovered mark breathes
+ * between its rest and hot intensity. Driven by a CSS variable so one
+ * keyframe set serves every status colour.
+ */
+const markPulse = keyframes`
+  0%, 100% { background-color: color-mix(in srgb, var(--hl) 48%, transparent); }
+  50% { background-color: color-mix(in srgb, var(--hl) 78%, transparent); }
+`;
 
 /**
  * The highlight overlay of one surface. Geometry comes from the stored anchors
@@ -151,11 +161,11 @@ export function HighlightLayer({
                   }
                   sx={{
                     ...positionSx(box),
+                    '--hl': style.color,
                     pointerEvents: 'auto',
                     cursor: 'pointer',
                     opacity: style.opacity,
                     transition: 'background-color 120ms ease, box-shadow 120ms ease',
-                    '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
                     // Highlighter look for both kinds: a borderless fill that
                     // multiplies over the page pixels, so printed glyphs stay
                     // crisp underneath. Text bands and region boxes share the
@@ -169,6 +179,11 @@ export function HighlightLayer({
                     ...(primary &&
                       !marker &&
                       (active || hot) && { boxShadow: theme.qnop.focusRing }),
+                    ...(hot && { animation: `${markPulse} 1.1s ease-in-out infinite` }),
+                    '@media (prefers-reduced-motion: reduce)': {
+                      transition: 'none',
+                      animation: 'none',
+                    },
                   }}
                 />
               );

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -176,9 +176,9 @@ export function HighlightLayer({
                     borderRadius: marker ? '1px' : '2px',
                     '&:hover': { bgcolor: alpha(style.color, 0.6) },
                     '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
-                    ...(primary &&
-                      !marker &&
-                      (active || hot) && { boxShadow: theme.qnop.focusRing }),
+                    // Hovering a region only pulses the fill — no ring; the
+                    // ring stays an active/keyboard-focus cue.
+                    ...(primary && !marker && active && { boxShadow: theme.qnop.focusRing }),
                     ...(hot && { animation: `${markPulse} 1.1s ease-in-out infinite` }),
                     '@media (prefers-reduced-motion: reduce)': {
                       transition: 'none',

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState } from 'react';
+import type { PointerEvent } from 'react';
+import Box from '@mui/material/Box';
+import { alpha, useTheme } from '@mui/material/styles';
+import type { NormalizedBox } from '../../../api/generated';
+
+interface RegionSelectLayerProps {
+  surfaceIndex: number;
+  enabled: boolean;
+  onRegionSelected: (surfaceIndex: number, box: NormalizedBox) => void;
+}
+
+interface DraftRect {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+function clampUnit(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Rubber-band region selection: drag a rectangle anywhere on the surface —
+ * the universal anchor layer that works with or without a text layer
+ * (ADR-0009). Coordinates are normalized against the page box, so the drawn
+ * region is zoom- and DPI-independent (ADR-0032).
+ */
+export function RegionSelectLayer({
+  surfaceIndex,
+  enabled,
+  onRegionSelected,
+}: RegionSelectLayerProps) {
+  const theme = useTheme();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [draft, setDraft] = useState<DraftRect | null>(null);
+
+  const toNormalized = (event: PointerEvent) => {
+    const rect = rootRef.current!.getBoundingClientRect();
+    return {
+      x: clampUnit((event.clientX - rect.left) / rect.width),
+      y: clampUnit((event.clientY - rect.top) / rect.height),
+    };
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (!enabled || event.button !== 0) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const point = toNormalized(event);
+    setDraft({ x1: point.x, y1: point.y, x2: point.x, y2: point.y });
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!draft) return;
+    const point = toNormalized(event);
+    setDraft({ ...draft, x2: point.x, y2: point.y });
+  };
+
+  const handlePointerUp = () => {
+    if (!draft) return;
+    setDraft(null);
+    onRegionSelected(surfaceIndex, {
+      x: draft.x1,
+      y: draft.y1,
+      width: draft.x2 - draft.x1,
+      height: draft.y2 - draft.y1,
+    });
+  };
+
+  const preview: NormalizedBox | null = draft && {
+    x: Math.min(draft.x1, draft.x2),
+    y: Math.min(draft.y1, draft.y2),
+    width: Math.abs(draft.x2 - draft.x1),
+    height: Math.abs(draft.y2 - draft.y1),
+  };
+
+  return (
+    <Box
+      ref={rootRef}
+      data-testid={`region-layer-${surfaceIndex}`}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        cursor: 'crosshair',
+        pointerEvents: enabled ? 'auto' : 'none',
+        touchAction: 'none',
+      }}
+    >
+      {preview && (
+        <Box
+          sx={{
+            position: 'absolute',
+            left: `${preview.x * 100}%`,
+            top: `${preview.y * 100}%`,
+            width: `${preview.width * 100}%`,
+            height: `${preview.height * 100}%`,
+            border: `2px dashed ${theme.qnop.brand.blue}`,
+            bgcolor: alpha(theme.qnop.brand.blue, 0.08),
+            pointerEvents: 'none',
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
@@ -22,9 +22,9 @@
 import { useRef, useState } from 'react';
 import type { PointerEvent } from 'react';
 import Box from '@mui/material/Box';
-import { alpha, useTheme } from '@mui/material/styles';
 import type { NormalizedBox } from '../../../api/generated';
 import type { ScreenPosition } from './anchoring';
+import { MARKER_YELLOW_BORDER, SELECTION_MARKER_BG } from './markerColors';
 
 interface RegionSelectLayerProps {
   surfaceIndex: number;
@@ -54,7 +54,6 @@ export function RegionSelectLayer({
   enabled,
   onRegionSelected,
 }: RegionSelectLayerProps) {
-  const theme = useTheme();
   const rootRef = useRef<HTMLDivElement>(null);
   const [draft, setDraft] = useState<DraftRect | null>(null);
 
@@ -119,8 +118,9 @@ export function RegionSelectLayer({
             top: `${preview.y * 100}%`,
             width: `${preview.width * 100}%`,
             height: `${preview.height * 100}%`,
-            border: `2px dashed ${theme.qnop.brand.blue}`,
-            bgcolor: alpha(theme.qnop.brand.blue, 0.08),
+            border: `2px dashed ${MARKER_YELLOW_BORDER}`,
+            bgcolor: SELECTION_MARKER_BG,
+            mixBlendMode: 'multiply',
             pointerEvents: 'none',
           }}
         />

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
@@ -24,11 +24,12 @@ import type { PointerEvent } from 'react';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
 import type { NormalizedBox } from '../../../api/generated';
+import type { ScreenPosition } from './anchoring';
 
 interface RegionSelectLayerProps {
   surfaceIndex: number;
   enabled: boolean;
-  onRegionSelected: (surfaceIndex: number, box: NormalizedBox) => void;
+  onRegionSelected: (surfaceIndex: number, box: NormalizedBox, at: ScreenPosition) => void;
 }
 
 interface DraftRect {
@@ -78,15 +79,14 @@ export function RegionSelectLayer({
     setDraft({ ...draft, x2: point.x, y2: point.y });
   };
 
-  const handlePointerUp = () => {
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
     if (!draft) return;
     setDraft(null);
-    onRegionSelected(surfaceIndex, {
-      x: draft.x1,
-      y: draft.y1,
-      width: draft.x2 - draft.x1,
-      height: draft.y2 - draft.y1,
-    });
+    onRegionSelected(
+      surfaceIndex,
+      { x: draft.x1, y: draft.y1, width: draft.x2 - draft.x1, height: draft.y2 - draft.y1 },
+      { left: event.clientX, top: event.clientY },
+    );
   };
 
   const preview: NormalizedBox | null = draft && {

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -28,7 +28,7 @@ import type {
   NormalizedBox,
   RenderedSurface,
 } from '../../../api/generated';
-import type { TextSelectionOffsets } from './anchoring';
+import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
 import { HighlightLayer } from './HighlightLayer';
 import { RegionSelectLayer } from './RegionSelectLayer';
 import { TextSpanLayer } from './TextSpanLayer';
@@ -53,8 +53,8 @@ interface SurfacePageProps {
   /** False disables both selection layers (extraction pending, or read-only). */
   canAnnotate: boolean;
   pendingAnchor: Anchor | null;
-  onTextSelected: (selection: TextSelectionOffsets) => void;
-  onRegionSelected: (surfaceIndex: number, box: NormalizedBox) => void;
+  onTextSelected: (selection: TextSelectionOffsets, at: ScreenPosition) => void;
+  onRegionSelected: (surfaceIndex: number, box: NormalizedBox, at: ScreenPosition) => void;
 }
 
 /**

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import Paper from '@mui/material/Paper';
+import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
+import type { AnnotationView, NormalizedBox, RenderedSurface } from '../../../api/generated';
+import type { TextSelectionOffsets } from './anchoring';
+import { HighlightLayer } from './HighlightLayer';
+import { RegionSelectLayer } from './RegionSelectLayer';
+import { TextSpanLayer } from './TextSpanLayer';
+import type { ViewerTool } from './ViewerToolbar';
+
+interface SurfacePageProps {
+  pdf: PDFDocumentProxy;
+  /** Zero-based page index (== surface index, one surface per PDF page). */
+  pageIndex: number;
+  /**
+   * The server-extracted surface. Absent while extraction is still running —
+   * the page then renders pixels only, without annotation layers (ADR-0033:
+   * the version is visible immediately).
+   */
+  surface?: RenderedSurface;
+  /** Display width in CSS pixels. */
+  width: number;
+  annotations: AnnotationView[];
+  activeAnnotationId: string | null;
+  onSelectAnnotation: (annotationId: string) => void;
+  tool: ViewerTool;
+  /** False disables both selection layers (extraction pending, or read-only). */
+  canAnnotate: boolean;
+  pendingAnchorBox: NormalizedBox | null;
+  onTextSelected: (selection: TextSelectionOffsets) => void;
+  onRegionSelected: (surfaceIndex: number, box: NormalizedBox) => void;
+}
+
+/**
+ * One document page: the pdf.js pixel canvas plus the overlay stack —
+ * highlights from stored boxes, the selectable server text layer, and the
+ * region rubber-band. The page box uses the server surface's aspect ratio
+ * (falling back to the pdf.js viewport before extraction), and every overlay
+ * is positioned in percent, so all layers stay aligned at any zoom.
+ */
+export function SurfacePage({
+  pdf,
+  pageIndex,
+  surface,
+  width,
+  annotations,
+  activeAnnotationId,
+  onSelectAnnotation,
+  tool,
+  canAnnotate,
+  pendingAnchorBox,
+  onTextSelected,
+  onRegionSelected,
+}: SurfacePageProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [visible, setVisible] = useState(false);
+  const [fallbackAspect, setFallbackAspect] = useState<number | null>(null);
+
+  // Render lazily: pages far outside the viewport keep an empty canvas.
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setVisible(true);
+      },
+      { rootMargin: '100% 0px' },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return undefined;
+    let cancelled = false;
+    let renderTask: RenderTask | undefined;
+    void pdf.getPage(pageIndex + 1).then((page) => {
+      if (cancelled) return;
+      const base = page.getViewport({ scale: 1 });
+      if (!surface) setFallbackAspect(base.width / base.height);
+      const dpr = window.devicePixelRatio || 1;
+      const viewport = page.getViewport({ scale: (width / base.width) * dpr });
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      canvas.width = Math.floor(viewport.width);
+      canvas.height = Math.floor(viewport.height);
+      renderTask = page.render({ canvas, viewport });
+      // Re-renders cancel the previous pass; swallow the cancellation rejection.
+      renderTask.promise.catch(() => {});
+    });
+    return () => {
+      cancelled = true;
+      renderTask?.cancel();
+    };
+  }, [pdf, pageIndex, surface, width, visible]);
+
+  const aspect = surface ? surface.width / surface.height : (fallbackAspect ?? Math.SQRT1_2);
+  const pageHeight = width / aspect;
+
+  return (
+    <Paper
+      ref={containerRef}
+      variant="outlined"
+      square
+      data-testid={`surface-page-${pageIndex}`}
+      sx={{
+        position: 'relative',
+        width,
+        aspectRatio: `${aspect}`,
+        bgcolor: '#fff',
+        overflow: 'hidden',
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        aria-label={`Page ${pageIndex + 1}`}
+        style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+      />
+      {surface && (
+        <>
+          <TextSpanLayer
+            spans={surface.textSpans}
+            surfaceIndex={surface.index}
+            pageHeight={pageHeight}
+            enabled={canAnnotate && tool === 'text' && surface.textSpans.length > 0}
+            onTextSelected={onTextSelected}
+          />
+          <HighlightLayer
+            annotations={annotations}
+            surfaceIndex={surface.index}
+            activeAnnotationId={activeAnnotationId}
+            onSelect={onSelectAnnotation}
+            pendingBox={pendingAnchorBox}
+          />
+          <RegionSelectLayer
+            surfaceIndex={surface.index}
+            enabled={canAnnotate && tool === 'region'}
+            onRegionSelected={onRegionSelected}
+          />
+        </>
+      )}
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -162,6 +162,15 @@ export function SurfacePage({
             enabled={canAnnotate && tool === 'text' && surface.textSpans.length > 0}
             onTextSelected={onTextSelected}
           />
+          {/* The rubber-band sits BELOW the highlights: existing marks stay
+              hoverable/clickable in region mode exactly as in text mode, and
+              pointer capture keeps an already-started drag alive across them
+              — only starting a drag on a mark belongs to the mark. */}
+          <RegionSelectLayer
+            surfaceIndex={surface.index}
+            enabled={canAnnotate && tool === 'region'}
+            onRegionSelected={onRegionSelected}
+          />
           <HighlightLayer
             annotations={annotations}
             surfaceIndex={surface.index}
@@ -171,11 +180,6 @@ export function SurfacePage({
             onSelect={onSelectAnnotation}
             onHover={onHoverAnnotation}
             pendingAnchor={pendingAnchor}
-          />
-          <RegionSelectLayer
-            surfaceIndex={surface.index}
-            enabled={canAnnotate && tool === 'region'}
-            onRegionSelected={onRegionSelected}
           />
         </>
       )}

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -143,6 +143,7 @@ export function SurfacePage({
           <TextSpanLayer
             spans={surface.textSpans}
             surfaceIndex={surface.index}
+            pageWidth={width}
             pageHeight={pageHeight}
             enabled={canAnnotate && tool === 'text' && surface.textSpans.length > 0}
             onTextSelected={onTextSelected}

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -48,7 +48,9 @@ interface SurfacePageProps {
   width: number;
   annotations: AnnotationView[];
   activeAnnotationId: string | null;
+  hoverAnnotationId?: string | null;
   onSelectAnnotation: (annotationId: string) => void;
+  onHoverAnnotation?: (annotationId: string | null) => void;
   tool: ViewerTool;
   /** False disables both selection layers (extraction pending, or read-only). */
   canAnnotate: boolean;
@@ -71,7 +73,9 @@ export function SurfacePage({
   width,
   annotations,
   activeAnnotationId,
+  hoverAnnotationId,
   onSelectAnnotation,
+  onHoverAnnotation,
   tool,
   canAnnotate,
   pendingAnchor,
@@ -127,16 +131,21 @@ export function SurfacePage({
   return (
     <Paper
       ref={containerRef}
-      variant="outlined"
+      elevation={0}
       square
       data-testid={`surface-page-${pageIndex}`}
-      sx={{
+      sx={(theme) => ({
         position: 'relative',
         width,
         aspectRatio: `${aspect}`,
         bgcolor: '#fff',
         overflow: 'hidden',
-      }}
+        borderRadius: '3px',
+        // "Document on a desk": a soft ambient shadow in light mode; dark mode
+        // keeps a hairline edge instead (shadows vanish on dark surfaces).
+        boxShadow: theme.palette.mode === 'light' ? '0 4px 24px rgba(1, 32, 66, 0.10)' : 'none',
+        border: theme.palette.mode === 'dark' ? `1px solid ${theme.palette.divider}` : 'none',
+      })}
     >
       <canvas
         ref={canvasRef}
@@ -158,7 +167,9 @@ export function SurfacePage({
             surfaceIndex={surface.index}
             spans={surface.textSpans}
             activeAnnotationId={activeAnnotationId}
+            hoverAnnotationId={hoverAnnotationId}
             onSelect={onSelectAnnotation}
+            onHover={onHoverAnnotation}
             pendingAnchor={pendingAnchor}
           />
           <RegionSelectLayer

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -22,7 +22,12 @@
 import { useEffect, useRef, useState } from 'react';
 import Paper from '@mui/material/Paper';
 import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
-import type { AnnotationView, NormalizedBox, RenderedSurface } from '../../../api/generated';
+import type {
+  Anchor,
+  AnnotationView,
+  NormalizedBox,
+  RenderedSurface,
+} from '../../../api/generated';
 import type { TextSelectionOffsets } from './anchoring';
 import { HighlightLayer } from './HighlightLayer';
 import { RegionSelectLayer } from './RegionSelectLayer';
@@ -47,7 +52,7 @@ interface SurfacePageProps {
   tool: ViewerTool;
   /** False disables both selection layers (extraction pending, or read-only). */
   canAnnotate: boolean;
-  pendingAnchorBox: NormalizedBox | null;
+  pendingAnchor: Anchor | null;
   onTextSelected: (selection: TextSelectionOffsets) => void;
   onRegionSelected: (surfaceIndex: number, box: NormalizedBox) => void;
 }
@@ -69,7 +74,7 @@ export function SurfacePage({
   onSelectAnnotation,
   tool,
   canAnnotate,
-  pendingAnchorBox,
+  pendingAnchor,
   onTextSelected,
   onRegionSelected,
 }: SurfacePageProps) {
@@ -151,9 +156,10 @@ export function SurfacePage({
           <HighlightLayer
             annotations={annotations}
             surfaceIndex={surface.index}
+            spans={surface.textSpans}
             activeAnnotationId={activeAnnotationId}
             onSelect={onSelectAnnotation}
-            pendingBox={pendingAnchorBox}
+            pendingAnchor={pendingAnchor}
           />
           <RegionSelectLayer
             surfaceIndex={surface.index}

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { RenderedTextSpan } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { TextSpanLayer } from './TextSpanLayer';
+
+const SPANS: RenderedTextSpan[] = [
+  {
+    text: 'Hello world',
+    startOffset: 0,
+    endOffset: 11,
+    box: { x: 0.1, y: 0.1, width: 0.5, height: 0.02 },
+  },
+  {
+    text: 'Second line',
+    startOffset: 12,
+    endOffset: 23,
+    box: { x: 0.1, y: 0.15, width: 0.4, height: 0.02 },
+  },
+];
+
+function renderLayer(onTextSelected = vi.fn()) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <TextSpanLayer
+        spans={SPANS}
+        surfaceIndex={0}
+        pageWidth={800}
+        pageHeight={1035}
+        enabled
+        onTextSelected={onTextSelected}
+      />
+    </ThemeProvider>,
+  );
+  return onTextSelected;
+}
+
+describe('TextSpanLayer', () => {
+  it('positions each span at its normalized box with transparent glyphs', () => {
+    renderLayer();
+
+    const span = screen.getByText('Hello world');
+    expect(span).toHaveAttribute('data-span-start', '0');
+    expect(span).toHaveAttribute('data-span-length', '11');
+    expect(span).toHaveStyle({ left: '10%', top: '10%', color: 'rgba(0, 0, 0, 0)' });
+  });
+
+  it('reports a cross-span selection as canonical-text offsets', () => {
+    const onTextSelected = renderLayer();
+
+    // Select "world" (6..11) through "Second" (12..18) via a real DOM range.
+    const first = screen.getByText('Hello world').firstChild!;
+    const second = screen.getByText('Second line').firstChild!;
+    const range = document.createRange();
+    range.setStart(first, 6);
+    range.setEnd(second, 6);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.pointerUp(screen.getByTestId('text-layer-0'));
+
+    expect(onTextSelected).toHaveBeenCalledWith({ surfaceIndex: 0, start: 6, end: 18 });
+  });
+
+  it('ignores a collapsed selection', () => {
+    const onTextSelected = renderLayer();
+    window.getSelection()?.removeAllRanges();
+
+    fireEvent.pointerUp(screen.getByTestId('text-layer-0'));
+
+    expect(onTextSelected).not.toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -84,9 +84,12 @@ describe('TextSpanLayer', () => {
     selection.removeAllRanges();
     selection.addRange(range);
 
-    fireEvent.pointerUp(screen.getByTestId('text-layer-0'));
+    fireEvent.pointerUp(screen.getByTestId('text-layer-0'), { clientX: 120, clientY: 240 });
 
-    expect(onTextSelected).toHaveBeenCalledWith({ surfaceIndex: 0, start: 6, end: 18 });
+    expect(onTextSelected).toHaveBeenCalledWith(
+      { surfaceIndex: 0, start: 6, end: 18 },
+      { left: 120, top: 240 },
+    );
   });
 
   it('ignores a collapsed selection', () => {

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -64,11 +64,11 @@ describe('TextSpanLayer', () => {
     const span = screen.getByText('Hello world');
     expect(span).toHaveAttribute('data-span-start', '0');
     expect(span).toHaveAttribute('data-span-length', '11');
-    // Box y=0.1/h=0.02 with 1.3 overshoot → top 9.7%, height 2.6%: the marker
-    // paints taller than the printed glyphs, centred on the line.
+    // Fixture pitch 0.05 on 0.02-tall boxes → the marker line paints the full
+    // pitch (5%), with a quarter of the extra height above the box top.
     expect(span).toHaveStyle({ left: '10%', color: 'rgba(0, 0, 0, 0)' });
-    expect(parseFloat(span.style.top)).toBeCloseTo(9.7);
-    expect(parseFloat(span.style.height)).toBeCloseTo(2.6);
+    expect(parseFloat(span.style.top)).toBeCloseTo(9.25);
+    expect(parseFloat(span.style.height)).toBeCloseTo(5);
   });
 
   it('reports a cross-span selection as canonical-text offsets', () => {

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -58,13 +58,17 @@ function renderLayer(onTextSelected = vi.fn()) {
 }
 
 describe('TextSpanLayer', () => {
-  it('positions each span at its normalized box with transparent glyphs', () => {
+  it('positions each span centred on its box with marker overshoot and transparent glyphs', () => {
     renderLayer();
 
     const span = screen.getByText('Hello world');
     expect(span).toHaveAttribute('data-span-start', '0');
     expect(span).toHaveAttribute('data-span-length', '11');
-    expect(span).toHaveStyle({ left: '10%', top: '10%', color: 'rgba(0, 0, 0, 0)' });
+    // Box y=0.1/h=0.02 with 1.3 overshoot → top 9.7%, height 2.6%: the marker
+    // paints taller than the printed glyphs, centred on the line.
+    expect(span).toHaveStyle({ left: '10%', color: 'rgba(0, 0, 0, 0)' });
+    expect(parseFloat(span.style.top)).toBeCloseTo(9.7);
+    expect(parseFloat(span.style.height)).toBeCloseTo(2.6);
   });
 
   it('reports a cross-span selection as canonical-text offsets', () => {

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -100,4 +100,24 @@ describe('TextSpanLayer', () => {
 
     expect(onTextSelected).not.toHaveBeenCalled();
   });
+
+  it('mirrors the live selection as marker bands and clears them on collapse', () => {
+    renderLayer();
+
+    const first = screen.getByText('Hello world').firstChild!;
+    const range = document.createRange();
+    range.setStart(first, 0);
+    range.setEnd(first, 5);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    fireEvent(document, new Event('selectionchange'));
+
+    expect(screen.getByTestId('live-selection-0')).toBeInTheDocument();
+
+    selection.removeAllRanges();
+    fireEvent(document, new Event('selectionchange'));
+
+    expect(screen.queryByTestId('live-selection-0')).not.toBeInTheDocument();
+  });
 });

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -27,8 +27,15 @@ import type { TextSelectionOffsets } from './anchoring';
 import { markerLineBox, surfaceLinePitch } from './anchoring';
 import { selectionMarkerColor } from './markerColors';
 
-/** The font the invisible glyphs are measured and rendered with. */
-const LAYER_FONT_FAMILY = 'sans-serif';
+/**
+ * The font the invisible glyphs are measured and rendered with. Monospace is
+ * deliberate: with the run stretched to the span box (scaleX), every character
+ * then sits at i/len of the box — the same uniform-grid model boxesForRange
+ * uses for drawing. A proportional layer font would only match the box in
+ * total width, so dragging over the printed glyphs would hit neighbouring
+ * characters in the invisible run (selection offsets shifted by a few chars).
+ */
+const LAYER_FONT_FAMILY = 'monospace';
 
 interface TextSpanLayerProps {
   spans: RenderedTextSpan[];

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -21,11 +21,10 @@
 
 import { useRef } from 'react';
 import Box from '@mui/material/Box';
-import { useTheme } from '@mui/material/styles';
 import type { RenderedTextSpan } from '../../../api/generated';
 import type { TextSelectionOffsets } from './anchoring';
 import { markerLineBox, surfaceLinePitch } from './anchoring';
-import { selectionMarkerColor } from './markerColors';
+import { SELECTION_MARKER_BG } from './markerColors';
 
 /**
  * The font the invisible glyphs are measured and rendered with. Monospace is
@@ -88,7 +87,6 @@ export function TextSpanLayer({
   enabled,
   onTextSelected,
 }: TextSpanLayerProps) {
-  const theme = useTheme();
   const rootRef = useRef<HTMLDivElement>(null);
 
   const handlePointerUp = () => {
@@ -120,7 +118,6 @@ export function TextSpanLayer({
     onTextSelected({ surfaceIndex, start, end });
   };
 
-  const selectionBackground = selectionMarkerColor(theme.palette.mode);
   const pitch = surfaceLinePitch(spans);
 
   return (
@@ -140,7 +137,7 @@ export function TextSpanLayer({
         // without the color override the browser would repaint the selected
         // glyphs (in the layer's font, not the page's) as visible text.
         '& span::selection': {
-          backgroundColor: selectionBackground,
+          backgroundColor: SELECTION_MARKER_BG,
           color: 'transparent',
         },
       }}

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef } from 'react';
+import type { RenderedTextSpan } from '../../../api/generated';
+import type { TextSelectionOffsets } from './anchoring';
+
+interface TextSpanLayerProps {
+  spans: RenderedTextSpan[];
+  surfaceIndex: number;
+  /** Current display height of the page in CSS pixels — sizes the invisible glyphs. */
+  pageHeight: number;
+  enabled: boolean;
+  onTextSelected: (selection: TextSelectionOffsets) => void;
+}
+
+/** Finds the enclosing span element carrying canonical-text offsets. */
+function spanElementFor(node: Node | null): HTMLElement | null {
+  if (!node) return null;
+  const element = node instanceof HTMLElement ? node : node.parentElement;
+  return element?.closest<HTMLElement>('[data-span-start]') ?? null;
+}
+
+/**
+ * An invisible, selectable text layer built from the server-extracted spans
+ * (ADR-0032 — the client is not the authority on where text is; it only makes
+ * the server's text selectable). Each span is absolutely positioned at its
+ * normalized box, like pdf.js's own text layer, but the offsets attached to
+ * each span are the canonical-text offsets the anchor model needs (ADR-0009).
+ */
+export function TextSpanLayer({
+  spans,
+  surfaceIndex,
+  pageHeight,
+  enabled,
+  onTextSelected,
+}: TextSpanLayerProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const handlePointerUp = () => {
+    const selection = window.getSelection();
+    const root = rootRef.current;
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed || !root) return;
+    const range = selection.getRangeAt(0);
+    const startElement = spanElementFor(range.startContainer);
+    const endElement = spanElementFor(range.endContainer);
+    // Both ends must sit on this surface's spans; cross-surface selections are ignored.
+    if (
+      !startElement ||
+      !endElement ||
+      !root.contains(startElement) ||
+      !root.contains(endElement)
+    ) {
+      return;
+    }
+    const start =
+      Number(startElement.dataset.spanStart) +
+      (range.startContainer.nodeType === Node.TEXT_NODE ? range.startOffset : 0);
+    const end =
+      Number(endElement.dataset.spanStart) +
+      (range.endContainer.nodeType === Node.TEXT_NODE
+        ? range.endOffset
+        : Number(endElement.dataset.spanLength));
+    if (end <= start) return;
+    selection.removeAllRanges();
+    onTextSelected({ surfaceIndex, start, end });
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      data-testid={`text-layer-${surfaceIndex}`}
+      onPointerUp={handlePointerUp}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        overflow: 'hidden',
+        cursor: enabled ? 'text' : 'default',
+        pointerEvents: enabled ? 'auto' : 'none',
+        userSelect: enabled ? 'text' : 'none',
+      }}
+    >
+      {spans.map((span) => (
+        <span
+          key={span.startOffset}
+          data-span-start={span.startOffset}
+          data-span-length={span.text.length}
+          style={{
+            position: 'absolute',
+            left: `${span.box.x * 100}%`,
+            top: `${span.box.y * 100}%`,
+            width: `${span.box.width * 100}%`,
+            height: `${span.box.height * 100}%`,
+            color: 'transparent',
+            whiteSpace: 'pre',
+            overflow: 'hidden',
+            // Approximate glyph metrics: selection needs plausible hit targets,
+            // not typographic fidelity — the anchor is built from offsets.
+            fontSize: `${Math.max(span.box.height * pageHeight * 0.85, 6)}px`,
+            lineHeight: `${Math.max(span.box.height * pageHeight, 7)}px`,
+          }}
+        >
+          {span.text}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -20,12 +20,28 @@
  */
 
 import { useRef } from 'react';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
 import type { RenderedTextSpan } from '../../../api/generated';
 import type { TextSelectionOffsets } from './anchoring';
+
+/**
+ * Text-marker selection colours: translucent so the page's own glyphs stay
+ * readable underneath (the PDF pixels are white in both themes). Light mode is
+ * the classic highlighter yellow; dark mode uses the softer brand amber so the
+ * marker matches the muted dark UI.
+ */
+const SELECTION_BG_LIGHT = 'rgba(255, 224, 0, 0.45)';
+const SELECTION_BG_DARK = 'rgba(245, 184, 61, 0.5)';
+
+/** The font the invisible glyphs are measured and rendered with. */
+const LAYER_FONT_FAMILY = 'sans-serif';
 
 interface TextSpanLayerProps {
   spans: RenderedTextSpan[];
   surfaceIndex: number;
+  /** Current display width of the page in CSS pixels — scales glyph runs to their boxes. */
+  pageWidth: number;
   /** Current display height of the page in CSS pixels — sizes the invisible glyphs. */
   pageHeight: number;
   enabled: boolean;
@@ -39,20 +55,40 @@ function spanElementFor(node: Node | null): HTMLElement | null {
   return element?.closest<HTMLElement>('[data-span-start]') ?? null;
 }
 
+// One shared 2D context for glyph-run measurement (null in jsdom → scale 1).
+let sharedMeasureContext: CanvasRenderingContext2D | null | undefined;
+
+/** The width of a glyph run in the layer font, or null when measuring is unavailable. */
+function measureGlyphRun(text: string, fontSize: number): number | null {
+  if (sharedMeasureContext === undefined) {
+    sharedMeasureContext = document.createElement('canvas').getContext('2d');
+  }
+  if (!sharedMeasureContext) return null;
+  sharedMeasureContext.font = `${fontSize}px ${LAYER_FONT_FAMILY}`;
+  const width = sharedMeasureContext.measureText(text).width;
+  return width > 0 ? width : null;
+}
+
 /**
  * An invisible, selectable text layer built from the server-extracted spans
  * (ADR-0032 — the client is not the authority on where text is; it only makes
- * the server's text selectable). Each span is absolutely positioned at its
- * normalized box, like pdf.js's own text layer, but the offsets attached to
- * each span are the canonical-text offsets the anchor model needs (ADR-0009).
+ * the server's text selectable). Like pdf.js's own text layer, each span is
+ * absolutely positioned at its normalized box and its glyph run is stretched
+ * horizontally (scaleX from a canvas measurement) to cover the box, so the
+ * browser's selection rectangles trace the printed text. The glyphs themselves
+ * stay transparent — also while selected — and the selection paints as a
+ * translucent marker; the offsets attached to each span are the canonical-text
+ * offsets the anchor model needs (ADR-0009).
  */
 export function TextSpanLayer({
   spans,
   surfaceIndex,
+  pageWidth,
   pageHeight,
   enabled,
   onTextSelected,
 }: TextSpanLayerProps) {
+  const theme = useTheme();
   const rootRef = useRef<HTMLDivElement>(null);
 
   const handlePointerUp = () => {
@@ -84,43 +120,60 @@ export function TextSpanLayer({
     onTextSelected({ surfaceIndex, start, end });
   };
 
+  const selectionBackground =
+    theme.palette.mode === 'dark' ? SELECTION_BG_DARK : SELECTION_BG_LIGHT;
+
   return (
-    <div
+    <Box
       ref={rootRef}
       data-testid={`text-layer-${surfaceIndex}`}
       onPointerUp={handlePointerUp}
-      style={{
+      sx={{
         position: 'absolute',
         inset: 0,
         overflow: 'hidden',
         cursor: enabled ? 'text' : 'default',
         pointerEvents: enabled ? 'auto' : 'none',
         userSelect: enabled ? 'text' : 'none',
+        // The transparent-marker feel: the selection paints a translucent
+        // highlight while the layer's approximated glyphs stay invisible —
+        // without the color override the browser would repaint the selected
+        // glyphs (in the layer's font, not the page's) as visible text.
+        '& span::selection': {
+          backgroundColor: selectionBackground,
+          color: 'transparent',
+        },
       }}
     >
-      {spans.map((span) => (
-        <span
-          key={span.startOffset}
-          data-span-start={span.startOffset}
-          data-span-length={span.text.length}
-          style={{
-            position: 'absolute',
-            left: `${span.box.x * 100}%`,
-            top: `${span.box.y * 100}%`,
-            width: `${span.box.width * 100}%`,
-            height: `${span.box.height * 100}%`,
-            color: 'transparent',
-            whiteSpace: 'pre',
-            overflow: 'hidden',
-            // Approximate glyph metrics: selection needs plausible hit targets,
-            // not typographic fidelity — the anchor is built from offsets.
-            fontSize: `${Math.max(span.box.height * pageHeight * 0.85, 6)}px`,
-            lineHeight: `${Math.max(span.box.height * pageHeight, 7)}px`,
-          }}
-        >
-          {span.text}
-        </span>
-      ))}
-    </div>
+      {spans.map((span) => {
+        const fontSize = Math.max(span.box.height * pageHeight * 0.85, 6);
+        const measured = span.text.length > 0 ? measureGlyphRun(span.text, fontSize) : null;
+        const scaleX = measured ? (span.box.width * pageWidth) / measured : 1;
+        return (
+          <span
+            key={span.startOffset}
+            data-span-start={span.startOffset}
+            data-span-length={span.text.length}
+            style={{
+              position: 'absolute',
+              left: `${span.box.x * 100}%`,
+              top: `${span.box.y * 100}%`,
+              height: `${span.box.height * 100}%`,
+              color: 'transparent',
+              whiteSpace: 'pre',
+              fontFamily: LAYER_FONT_FAMILY,
+              fontSize: `${fontSize}px`,
+              lineHeight: `${Math.max(span.box.height * pageHeight, 7)}px`,
+              // Stretch the glyph run to the server box so the selection
+              // rectangles trace the printed text (same trick as pdf.js).
+              transform: `scaleX(${scaleX})`,
+              transformOrigin: '0 0',
+            }}
+          >
+            {span.text}
+          </span>
+        );
+      })}
+    </Box>
   );
 }

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -24,26 +24,11 @@ import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 import type { RenderedTextSpan } from '../../../api/generated';
 import type { TextSelectionOffsets } from './anchoring';
-
-/**
- * Text-marker selection colours: translucent so the page's own glyphs stay
- * readable underneath (the PDF pixels are white in both themes). Light mode is
- * the classic highlighter yellow; dark mode uses the softer brand amber so the
- * marker matches the muted dark UI.
- */
-const SELECTION_BG_LIGHT = 'rgba(255, 224, 0, 0.45)';
-const SELECTION_BG_DARK = 'rgba(245, 184, 61, 0.5)';
+import { MARKER_OVERSHOOT } from './anchoring';
+import { selectionMarkerColor } from './markerColors';
 
 /** The font the invisible glyphs are measured and rendered with. */
 const LAYER_FONT_FAMILY = 'sans-serif';
-
-/**
- * How much taller the selection marker paints than the extracted glyph box,
- * centred on the printed line. PDF viewers (macOS Preview, Acrobat) and Word
- * overshoot the glyphs the same way — ascenders/descenders stay covered and
- * multi-line selections merge into one continuous marker.
- */
-const MARKER_OVERSHOOT = 1.3;
 
 interface TextSpanLayerProps {
   spans: RenderedTextSpan[];
@@ -128,8 +113,7 @@ export function TextSpanLayer({
     onTextSelected({ surfaceIndex, start, end });
   };
 
-  const selectionBackground =
-    theme.palette.mode === 'dark' ? SELECTION_BG_DARK : SELECTION_BG_LIGHT;
+  const selectionBackground = selectionMarkerColor(theme.palette.mode);
 
   return (
     <Box

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -20,9 +20,10 @@
  */
 
 import { useRef } from 'react';
+import type { PointerEvent } from 'react';
 import Box from '@mui/material/Box';
 import type { RenderedTextSpan } from '../../../api/generated';
-import type { TextSelectionOffsets } from './anchoring';
+import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
 import { markerLineBox, surfaceLinePitch } from './anchoring';
 import { SELECTION_MARKER_BG } from './markerColors';
 
@@ -44,7 +45,7 @@ interface TextSpanLayerProps {
   /** Current display height of the page in CSS pixels — sizes the invisible glyphs. */
   pageHeight: number;
   enabled: boolean;
-  onTextSelected: (selection: TextSelectionOffsets) => void;
+  onTextSelected: (selection: TextSelectionOffsets, at: ScreenPosition) => void;
 }
 
 /** Finds the enclosing span element carrying canonical-text offsets. */
@@ -89,7 +90,7 @@ export function TextSpanLayer({
 }: TextSpanLayerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
 
-  const handlePointerUp = () => {
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
     const selection = window.getSelection();
     const root = rootRef.current;
     if (!selection || selection.rangeCount === 0 || selection.isCollapsed || !root) return;
@@ -115,7 +116,7 @@ export function TextSpanLayer({
         : Number(endElement.dataset.spanLength));
     if (end <= start) return;
     selection.removeAllRanges();
-    onTextSelected({ surfaceIndex, start, end });
+    onTextSelected({ surfaceIndex, start, end }, { left: event.clientX, top: event.clientY });
   };
 
   const pitch = surfaceLinePitch(spans);

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -37,6 +37,14 @@ const SELECTION_BG_DARK = 'rgba(245, 184, 61, 0.5)';
 /** The font the invisible glyphs are measured and rendered with. */
 const LAYER_FONT_FAMILY = 'sans-serif';
 
+/**
+ * How much taller the selection marker paints than the extracted glyph box,
+ * centred on the printed line. PDF viewers (macOS Preview, Acrobat) and Word
+ * overshoot the glyphs the same way — ascenders/descenders stay covered and
+ * multi-line selections merge into one continuous marker.
+ */
+const MARKER_OVERSHOOT = 1.3;
+
 interface TextSpanLayerProps {
   spans: RenderedTextSpan[];
   surfaceIndex: number;
@@ -149,6 +157,10 @@ export function TextSpanLayer({
         const fontSize = Math.max(span.box.height * pageHeight * 0.85, 6);
         const measured = span.text.length > 0 ? measureGlyphRun(span.text, fontSize) : null;
         const scaleX = measured ? (span.box.width * pageWidth) / measured : 1;
+        // The line box is taller than the glyph box and shifted up by half the
+        // overshoot, so the marker paints centred on the printed line.
+        const lineHeightPx = Math.max(span.box.height * pageHeight * MARKER_OVERSHOOT, 9);
+        const topFraction = span.box.y - (span.box.height * (MARKER_OVERSHOOT - 1)) / 2;
         return (
           <span
             key={span.startOffset}
@@ -157,13 +169,13 @@ export function TextSpanLayer({
             style={{
               position: 'absolute',
               left: `${span.box.x * 100}%`,
-              top: `${span.box.y * 100}%`,
-              height: `${span.box.height * 100}%`,
+              top: `${topFraction * 100}%`,
+              height: `${span.box.height * MARKER_OVERSHOOT * 100}%`,
               color: 'transparent',
               whiteSpace: 'pre',
               fontFamily: LAYER_FONT_FAMILY,
               fontSize: `${fontSize}px`,
-              lineHeight: `${Math.max(span.box.height * pageHeight, 7)}px`,
+              lineHeight: `${lineHeightPx}px`,
               // Stretch the glyph run to the server box so the selection
               // rectangles trace the printed text (same trick as pdf.js).
               transform: `scaleX(${scaleX})`,

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -24,7 +24,7 @@ import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 import type { RenderedTextSpan } from '../../../api/generated';
 import type { TextSelectionOffsets } from './anchoring';
-import { MARKER_OVERSHOOT } from './anchoring';
+import { markerLineBox, surfaceLinePitch } from './anchoring';
 import { selectionMarkerColor } from './markerColors';
 
 /** The font the invisible glyphs are measured and rendered with. */
@@ -114,6 +114,7 @@ export function TextSpanLayer({
   };
 
   const selectionBackground = selectionMarkerColor(theme.palette.mode);
+  const pitch = surfaceLinePitch(spans);
 
   return (
     <Box
@@ -141,10 +142,11 @@ export function TextSpanLayer({
         const fontSize = Math.max(span.box.height * pageHeight * 0.85, 6);
         const measured = span.text.length > 0 ? measureGlyphRun(span.text, fontSize) : null;
         const scaleX = measured ? (span.box.width * pageWidth) / measured : 1;
-        // The line box is taller than the glyph box and shifted up by half the
-        // overshoot, so the marker paints centred on the printed line.
-        const lineHeightPx = Math.max(span.box.height * pageHeight * MARKER_OVERSHOOT, 9);
-        const topFraction = span.box.y - (span.box.height * (MARKER_OVERSHOOT - 1)) / 2;
+        // The selection paints the line box: grown to the surface's line pitch
+        // and shifted like the persisted markers, so selecting and the created
+        // highlight cover the printed line identically (Word-style full line).
+        const line = markerLineBox(span.box, pitch);
+        const lineHeightPx = Math.max(line.height * pageHeight, 9);
         return (
           <span
             key={span.startOffset}
@@ -153,8 +155,8 @@ export function TextSpanLayer({
             style={{
               position: 'absolute',
               left: `${span.box.x * 100}%`,
-              top: `${topFraction * 100}%`,
-              height: `${span.box.height * MARKER_OVERSHOOT * 100}%`,
+              top: `${line.y * 100}%`,
+              height: `${line.height * 100}%`,
               color: 'transparent',
               whiteSpace: 'pre',
               fontFamily: LAYER_FONT_FAMILY,

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -19,12 +19,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { PointerEvent } from 'react';
 import Box from '@mui/material/Box';
 import type { RenderedTextSpan } from '../../../api/generated';
 import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
-import { markerLineBox, surfaceLinePitch } from './anchoring';
+import { boxesForRange, markerLineBox, surfaceLinePitch } from './anchoring';
 import { SELECTION_MARKER_BG } from './markerColors';
 
 /**
@@ -69,16 +69,42 @@ function measureGlyphRun(text: string, fontSize: number): number | null {
   return width > 0 ? width : null;
 }
 
+/** The current DOM selection as canonical-text offsets within this layer, or null. */
+function resolveSelectionOffsets(root: HTMLElement): { start: number; end: number } | null {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
+  const range = selection.getRangeAt(0);
+  const startElement = spanElementFor(range.startContainer);
+  const endElement = spanElementFor(range.endContainer);
+  // Both ends must sit on this surface's spans; cross-surface selections are ignored.
+  if (!startElement || !endElement || !root.contains(startElement) || !root.contains(endElement)) {
+    return null;
+  }
+  const start =
+    Number(startElement.dataset.spanStart) +
+    (range.startContainer.nodeType === Node.TEXT_NODE ? range.startOffset : 0);
+  const end =
+    Number(endElement.dataset.spanStart) +
+    (range.endContainer.nodeType === Node.TEXT_NODE
+      ? range.endOffset
+      : Number(endElement.dataset.spanLength));
+  return end > start ? { start, end } : null;
+}
+
 /**
  * An invisible, selectable text layer built from the server-extracted spans
  * (ADR-0032 — the client is not the authority on where text is; it only makes
  * the server's text selectable). Like pdf.js's own text layer, each span is
  * absolutely positioned at its normalized box and its glyph run is stretched
  * horizontally (scaleX from a canvas measurement) to cover the box, so the
- * browser's selection rectangles trace the printed text. The glyphs themselves
- * stay transparent — also while selected — and the selection paints as a
- * translucent marker; the offsets attached to each span are the canonical-text
- * offsets the anchor model needs (ADR-0009).
+ * browser's selection hit-testing traces the printed text.
+ *
+ * The native selection paint is fully suppressed (a translucent ::selection
+ * over the canvas would tint the printed glyphs); instead the layer follows
+ * `selectionchange` and draws its own marker bands with multiply blending —
+ * the page's text keeps its original colour, exactly like the pending preview
+ * and persisted highlights. The offsets attached to each span are the
+ * canonical-text offsets the anchor model needs (ADR-0009).
  */
 export function TextSpanLayer({
   spans,
@@ -89,37 +115,36 @@ export function TextSpanLayer({
   onTextSelected,
 }: TextSpanLayerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  const [liveRange, setLiveRange] = useState<{ start: number; end: number } | null>(null);
+
+  // Follow the native selection while it is being dragged and mirror it as
+  // marker bands; a collapsed or foreign selection clears the bands.
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const handleSelectionChange = () => {
+      const root = rootRef.current;
+      setLiveRange(root ? resolveSelectionOffsets(root) : null);
+    };
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () => document.removeEventListener('selectionchange', handleSelectionChange);
+  }, [enabled]);
 
   const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
-    const selection = window.getSelection();
     const root = rootRef.current;
-    if (!selection || selection.rangeCount === 0 || selection.isCollapsed || !root) return;
-    const range = selection.getRangeAt(0);
-    const startElement = spanElementFor(range.startContainer);
-    const endElement = spanElementFor(range.endContainer);
-    // Both ends must sit on this surface's spans; cross-surface selections are ignored.
-    if (
-      !startElement ||
-      !endElement ||
-      !root.contains(startElement) ||
-      !root.contains(endElement)
-    ) {
-      return;
-    }
-    const start =
-      Number(startElement.dataset.spanStart) +
-      (range.startContainer.nodeType === Node.TEXT_NODE ? range.startOffset : 0);
-    const end =
-      Number(endElement.dataset.spanStart) +
-      (range.endContainer.nodeType === Node.TEXT_NODE
-        ? range.endOffset
-        : Number(endElement.dataset.spanLength));
-    if (end <= start) return;
-    selection.removeAllRanges();
-    onTextSelected({ surfaceIndex, start, end }, { left: event.clientX, top: event.clientY });
+    if (!root) return;
+    const offsets = resolveSelectionOffsets(root);
+    if (!offsets) return;
+    window.getSelection()?.removeAllRanges();
+    setLiveRange(null);
+    onTextSelected({ surfaceIndex, ...offsets }, { left: event.clientX, top: event.clientY });
   };
 
   const pitch = surfaceLinePitch(spans);
+  // Guarded by `enabled` so a stale range never paints on a disabled layer.
+  const liveBoxes =
+    enabled && liveRange
+      ? boxesForRange(spans, liveRange.start, liveRange.end).map((box) => markerLineBox(box, pitch))
+      : [];
 
   return (
     <Box
@@ -133,16 +158,34 @@ export function TextSpanLayer({
         cursor: enabled ? 'text' : 'default',
         pointerEvents: enabled ? 'auto' : 'none',
         userSelect: enabled ? 'text' : 'none',
-        // The transparent-marker feel: the selection paints a translucent
-        // highlight while the layer's approximated glyphs stay invisible —
-        // without the color override the browser would repaint the selected
-        // glyphs (in the layer's font, not the page's) as visible text.
+        // Suppress the native selection paint entirely: a translucent
+        // ::selection sits ABOVE the canvas and would tint the printed glyphs
+        // (no blend modes on pseudo-selections). The visible marking comes
+        // from the layer's own multiply-blended bands below; the color
+        // override keeps the browser from repainting the invisible glyphs.
         '& span::selection': {
-          backgroundColor: SELECTION_MARKER_BG,
+          backgroundColor: 'transparent',
           color: 'transparent',
         },
       }}
     >
+      {liveBoxes.map((box, index) => (
+        <div
+          key={index}
+          data-testid={index === 0 ? `live-selection-${surfaceIndex}` : undefined}
+          style={{
+            position: 'absolute',
+            left: `${box.x * 100}%`,
+            top: `${box.y * 100}%`,
+            width: `${box.width * 100}%`,
+            height: `${box.height * 100}%`,
+            backgroundColor: SELECTION_MARKER_BG,
+            mixBlendMode: 'multiply',
+            borderRadius: '1px',
+            pointerEvents: 'none',
+          }}
+        />
+      ))}
       {spans.map((span) => {
         const fontSize = Math.max(span.box.height * pageHeight * 0.85, 6);
         const measured = span.text.length > 0 ? measureGlyphRun(span.text, fontSize) : null;

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -30,7 +30,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { BoxSelect, TextCursor, ZoomIn, ZoomOut } from 'lucide-react';
+import { BoxSelect, ChevronDown, ChevronUp, TextCursor, ZoomIn, ZoomOut } from 'lucide-react';
 import type { DocumentVersionSummary } from '../../../api/generated';
 import { ExtractionStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
@@ -46,6 +46,10 @@ interface ViewerToolbarProps {
   currentVersion: number;
   onVersionChange: (versionNumber: number) => void;
   extractionStatus?: ExtractionStatus;
+  /** Zero-based page from the viewer's scroll spy. */
+  currentPage: number;
+  pageCount: number;
+  onNavigateToPage: (pageIndex: number) => void;
   tool: ViewerTool;
   onToolChange: (tool: ViewerTool) => void;
   textToolAvailable: boolean;
@@ -55,15 +59,19 @@ interface ViewerToolbarProps {
 }
 
 /**
- * The viewer's control strip: version switcher, extraction cue, annotation
- * tool toggle (text quote vs. universal region, ADR-0009) and zoom. Sticky at
- * the top of the page column so the tools stay reachable while scrolling.
+ * The viewer's control strip: version switcher, page navigation (fed by the
+ * viewer's scroll spy), extraction cue, annotation tool toggle (text quote
+ * vs. universal region, ADR-0009) and zoom. Sits as its own row above the
+ * document pane, so the tools stay reachable while the pages scroll.
  */
 export function ViewerToolbar({
   versions,
   currentVersion,
   onVersionChange,
   extractionStatus,
+  currentPage,
+  pageCount,
+  onNavigateToPage,
   tool,
   onToolChange,
   textToolAvailable,
@@ -75,9 +83,6 @@ export function ViewerToolbar({
     <Paper
       variant="outlined"
       sx={{
-        position: 'sticky',
-        top: 0,
-        zIndex: 2,
         px: 1.5,
         py: 1,
         display: 'flex',
@@ -100,6 +105,33 @@ export function ViewerToolbar({
           </MenuItem>
         ))}
       </TextField>
+
+      <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center' }}>
+        <IconButton
+          size="small"
+          aria-label="Previous page"
+          disabled={currentPage <= 0}
+          onClick={() => onNavigateToPage(currentPage - 1)}
+        >
+          <ChevronUp size={16} />
+        </IconButton>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          aria-live="polite"
+          sx={{ fontVariantNumeric: 'tabular-nums', px: 0.5, whiteSpace: 'nowrap' }}
+        >
+          Page {Math.min(currentPage + 1, pageCount)} / {pageCount}
+        </Typography>
+        <IconButton
+          size="small"
+          aria-label="Next page"
+          disabled={currentPage >= pageCount - 1}
+          onClick={() => onNavigateToPage(currentPage + 1)}
+        >
+          <ChevronDown size={16} />
+        </IconButton>
+      </Stack>
 
       {extractionStatus === ExtractionStatus.Pending && (
         <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
@@ -144,13 +176,28 @@ export function ViewerToolbar({
         >
           <ZoomOut size={16} />
         </IconButton>
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ minWidth: 44, textAlign: 'center', fontVariantNumeric: 'tabular-nums' }}
-        >
-          {Math.round(zoom * 100)}%
-        </Typography>
+        <Tooltip title="Reset zoom to fit width">
+          <Typography
+            component="button"
+            variant="body2"
+            color="text.secondary"
+            aria-label="Reset zoom to fit width"
+            onClick={() => onZoomChange(1)}
+            sx={{
+              minWidth: 44,
+              textAlign: 'center',
+              fontVariantNumeric: 'tabular-nums',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              font: 'inherit',
+              borderRadius: 1,
+              '&:focus-visible': (theme) => ({ outline: 'none', boxShadow: theme.qnop.focusRing }),
+            }}
+          >
+            {Math.round(zoom * 100)}%
+          </Typography>
+        </Tooltip>
         <IconButton
           size="small"
           aria-label="Zoom in"

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { BoxSelect, TextCursor, ZoomIn, ZoomOut } from 'lucide-react';
+import type { DocumentVersionSummary } from '../../../api/generated';
+import { ExtractionStatus } from '../../../api/generated';
+import { ToneBadge } from '../../admin/ToneBadge';
+
+export type ViewerTool = 'text' | 'region';
+
+export const MIN_ZOOM = 0.5;
+export const MAX_ZOOM = 3;
+const ZOOM_STEP = 0.25;
+
+interface ViewerToolbarProps {
+  versions: DocumentVersionSummary[];
+  currentVersion: number;
+  onVersionChange: (versionNumber: number) => void;
+  extractionStatus?: ExtractionStatus;
+  tool: ViewerTool;
+  onToolChange: (tool: ViewerTool) => void;
+  textToolAvailable: boolean;
+  canAnnotate: boolean;
+  zoom: number;
+  onZoomChange: (zoom: number) => void;
+}
+
+/**
+ * The viewer's control strip: version switcher, extraction cue, annotation
+ * tool toggle (text quote vs. universal region, ADR-0009) and zoom. Sticky at
+ * the top of the page column so the tools stay reachable while scrolling.
+ */
+export function ViewerToolbar({
+  versions,
+  currentVersion,
+  onVersionChange,
+  extractionStatus,
+  tool,
+  onToolChange,
+  textToolAvailable,
+  canAnnotate,
+  zoom,
+  onZoomChange,
+}: ViewerToolbarProps) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 2,
+        px: 1.5,
+        py: 1,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        flexWrap: 'wrap',
+      }}
+    >
+      <TextField
+        select
+        size="small"
+        label="Version"
+        value={String(currentVersion)}
+        onChange={(event) => onVersionChange(Number(event.target.value))}
+        sx={{ minWidth: 110 }}
+      >
+        {versions.map((version) => (
+          <MenuItem key={version.versionNumber} value={String(version.versionNumber)}>
+            v{version.versionNumber}
+          </MenuItem>
+        ))}
+      </TextField>
+
+      {extractionStatus === ExtractionStatus.Pending && (
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          <CircularProgress size={14} />
+          <Typography variant="body2" color="text.secondary">
+            Processing document…
+          </Typography>
+        </Stack>
+      )}
+      {extractionStatus === ExtractionStatus.Failed && (
+        <ToneBadge tone="red" label="Extraction failed" />
+      )}
+
+      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', ml: 'auto' }}>
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={tool}
+          onChange={(_event, next: ViewerTool | null) => next && onToolChange(next)}
+          disabled={!canAnnotate}
+          aria-label="Annotation tool"
+        >
+          <ToggleButton value="text" disabled={!textToolAvailable} aria-label="Select text">
+            <Tooltip title="Select text to annotate a quote">
+              <TextCursor size={16} />
+            </Tooltip>
+          </ToggleButton>
+          <ToggleButton value="region" aria-label="Draw region">
+            <Tooltip title="Draw a rectangle to annotate a region">
+              <BoxSelect size={16} />
+            </Tooltip>
+          </ToggleButton>
+        </ToggleButtonGroup>
+
+        <Divider orientation="vertical" flexItem />
+
+        <IconButton
+          size="small"
+          aria-label="Zoom out"
+          disabled={zoom <= MIN_ZOOM}
+          onClick={() => onZoomChange(Math.max(MIN_ZOOM, zoom - ZOOM_STEP))}
+        >
+          <ZoomOut size={16} />
+        </IconButton>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ minWidth: 44, textAlign: 'center', fontVariantNumeric: 'tabular-nums' }}
+        >
+          {Math.round(zoom * 100)}%
+        </Typography>
+        <IconButton
+          size="small"
+          aria-label="Zoom in"
+          disabled={zoom >= MAX_ZOOM}
+          onClick={() => onZoomChange(Math.min(MAX_ZOOM, zoom + ZOOM_STEP))}
+        >
+          <ZoomIn size={16} />
+        </IconButton>
+      </Stack>
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
@@ -23,12 +23,14 @@ import { describe, expect, it } from 'vitest';
 import type { AnnotationView, RenderedTextSpan } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import {
+  MARKER_OVERSHOOT,
   QUOTE_CONTEXT_CHARS,
   boxesForRange,
   buildRegionAnchor,
   buildTextAnchor,
   clampBox,
   compareAnnotationsByPosition,
+  highlightBoxesForAnchor,
   surfaceText,
   unionBoxes,
 } from './anchoring';
@@ -164,6 +166,35 @@ describe('buildRegionAnchor', () => {
   it('rejects degenerate rectangles from stray clicks', () => {
     expect(buildRegionAnchor(0, { x: 0.5, y: 0.5, width: 0.001, height: 0.2 })).toBeNull();
     expect(buildRegionAnchor(0, { x: 0.5, y: 0.5, width: 0.2, height: 0 })).toBeNull();
+  });
+});
+
+describe('highlightBoxesForAnchor', () => {
+  it('paints a text anchor as one overshot marker box per line', () => {
+    const anchor = buildTextAnchor(0, SPANS, 6, 18)!;
+    const geometry = highlightBoxesForAnchor(anchor, SPANS);
+
+    expect(geometry.kind).toBe('marker');
+    expect(geometry.boxes).toHaveLength(2);
+    // First line box vertically expanded by the overshoot, centred on the glyphs.
+    expect(geometry.boxes[0].y).toBeCloseTo(0.1 - (0.02 * (MARKER_OVERSHOOT - 1)) / 2);
+    expect(geometry.boxes[0].height).toBeCloseTo(0.02 * MARKER_OVERSHOOT);
+  });
+
+  it('falls back to the stored region box for region-only anchors', () => {
+    const anchor = buildRegionAnchor(0, { x: 0.2, y: 0.3, width: 0.1, height: 0.1 })!;
+    const geometry = highlightBoxesForAnchor(anchor, SPANS);
+
+    expect(geometry.kind).toBe('box');
+    expect(geometry.boxes).toEqual([anchor.region.box]);
+  });
+
+  it('falls back to the region box when the surface has no spans or the offsets miss', () => {
+    const anchor = buildTextAnchor(0, SPANS, 6, 18)!;
+    expect(highlightBoxesForAnchor(anchor, []).kind).toBe('box');
+
+    const stale = { ...anchor, textPosition: { start: 500, end: 600 } };
+    expect(highlightBoxesForAnchor(stale, SPANS).kind).toBe('box');
   });
 });
 

--- a/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
@@ -23,7 +23,9 @@ import { describe, expect, it } from 'vitest';
 import type { AnnotationView, RenderedTextSpan } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import {
-  MARKER_OVERSHOOT,
+  MARKER_FALLBACK_FACTOR,
+  MARKER_MAX_FACTOR,
+  MARKER_MIN_FACTOR,
   QUOTE_CONTEXT_CHARS,
   boxesForRange,
   buildRegionAnchor,
@@ -31,6 +33,8 @@ import {
   clampBox,
   compareAnnotationsByPosition,
   highlightBoxesForAnchor,
+  markerLineBox,
+  surfaceLinePitch,
   surfaceText,
   unionBoxes,
 } from './anchoring';
@@ -169,16 +173,46 @@ describe('buildRegionAnchor', () => {
   });
 });
 
+describe('surfaceLinePitch', () => {
+  it('returns the median gap between line tops', () => {
+    expect(surfaceLinePitch(SPANS)).toBeCloseTo(0.05);
+  });
+
+  it('returns null for a single line or no text', () => {
+    expect(surfaceLinePitch([SPANS[0]])).toBeNull();
+    expect(surfaceLinePitch([])).toBeNull();
+  });
+});
+
+describe('markerLineBox', () => {
+  it('grows the line to the pitch, biased below the box (descenders hang there)', () => {
+    const box = { x: 0.1, y: 0.1, width: 0.5, height: 0.02 };
+    const marker = markerLineBox(box, 0.03); // pitch/height = 1.5
+    expect(marker.height).toBeCloseTo(0.03);
+    expect(marker.y).toBeCloseTo(0.1 - 0.01 * 0.25);
+    // Bottom extends further than the top: baseline + descender coverage.
+    expect(box.y - marker.y).toBeLessThan(marker.y + marker.height - (box.y + box.height));
+  });
+
+  it('bounds the factor and falls back without pitch info', () => {
+    const box = { x: 0, y: 0.5, width: 0.5, height: 0.02 };
+    expect(markerLineBox(box, 0.001).height).toBeCloseTo(0.02 * MARKER_MIN_FACTOR);
+    expect(markerLineBox(box, 0.5).height).toBeCloseTo(0.02 * MARKER_MAX_FACTOR);
+    expect(markerLineBox(box, null).height).toBeCloseTo(0.02 * MARKER_FALLBACK_FACTOR);
+  });
+});
+
 describe('highlightBoxesForAnchor', () => {
-  it('paints a text anchor as one overshot marker box per line', () => {
+  it('paints a text anchor as one pitch-tall marker box per line', () => {
     const anchor = buildTextAnchor(0, SPANS, 6, 18)!;
     const geometry = highlightBoxesForAnchor(anchor, SPANS);
 
     expect(geometry.kind).toBe('marker');
     expect(geometry.boxes).toHaveLength(2);
-    // First line box vertically expanded by the overshoot, centred on the glyphs.
-    expect(geometry.boxes[0].y).toBeCloseTo(0.1 - (0.02 * (MARKER_OVERSHOOT - 1)) / 2);
-    expect(geometry.boxes[0].height).toBeCloseTo(0.02 * MARKER_OVERSHOOT);
+    // Fixture pitch 0.05 on 0.02-tall boxes → factor 2.5, a quarter of the
+    // extra height above the box.
+    expect(geometry.boxes[0].height).toBeCloseTo(0.05);
+    expect(geometry.boxes[0].y).toBeCloseTo(0.1 - 0.03 * 0.25);
   });
 
   it('falls back to the stored region box for region-only anchors', () => {

--- a/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
@@ -111,6 +111,25 @@ describe('boxesForRange', () => {
     expect(boxesForRange(SPANS, 0, 5)).toHaveLength(1);
     expect(boxesForRange(SPANS, 11, 12)).toHaveLength(0);
   });
+
+  it('never paints trailing whitespace of a padded line', () => {
+    // "Short text" + 10 padding spaces: 20 chars across a 0.5-wide box.
+    const padded: RenderedTextSpan[] = [
+      {
+        text: 'Short text          ',
+        startOffset: 0,
+        endOffset: 20,
+        box: { x: 0.1, y: 0.1, width: 0.5, height: 0.02 },
+      },
+    ];
+    const boxes = boxesForRange(padded, 0, 20);
+    expect(boxes).toHaveLength(1);
+    // Clamped to the 10 visible characters: half the padded box width.
+    expect(boxes[0].width).toBeCloseTo(0.5 * (10 / 20));
+
+    // A range entirely inside the padding paints nothing.
+    expect(boxesForRange(padded, 12, 20)).toHaveLength(0);
+  });
 });
 
 describe('buildTextAnchor', () => {
@@ -144,6 +163,14 @@ describe('buildTextAnchor', () => {
     expect(buildTextAnchor(0, SPANS, 5, 5)).toBeNull();
     expect(buildTextAnchor(0, SPANS, 11, 12)).toBeNull();
     expect(buildTextAnchor(0, [], 0, 5)).toBeNull();
+  });
+
+  it('trims whitespace at the selection ends (Word/Acrobat semantics)', () => {
+    // " world\nSecond " selected — the mark starts and ends on printed chars.
+    const anchor = buildTextAnchor(0, SPANS, 5, 19);
+    expect(anchor?.textQuote?.quote).toBe('world\nSecond');
+    expect(anchor?.textPosition).toEqual({ start: 6, end: 18 });
+    expect(anchor?.textQuote?.prefix).toBe('Hello ');
   });
 });
 

--- a/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AnnotationView, RenderedTextSpan } from '../../../api/generated';
+import { AnnotationStatus } from '../../../api/generated';
+import {
+  QUOTE_CONTEXT_CHARS,
+  boxesForRange,
+  buildRegionAnchor,
+  buildTextAnchor,
+  clampBox,
+  compareAnnotationsByPosition,
+  surfaceText,
+  unionBoxes,
+} from './anchoring';
+
+/** Two lines: "Hello world" (0..11) + '\n' (11) + "Second line" (12..23). */
+const SPANS: RenderedTextSpan[] = [
+  {
+    text: 'Hello world',
+    startOffset: 0,
+    endOffset: 11,
+    box: { x: 0.1, y: 0.1, width: 0.5, height: 0.02 },
+  },
+  {
+    text: 'Second line',
+    startOffset: 12,
+    endOffset: 23,
+    box: { x: 0.1, y: 0.15, width: 0.4, height: 0.02 },
+  },
+];
+
+describe('surfaceText', () => {
+  it('joins spans with single newlines, matching the server offsets', () => {
+    const text = surfaceText(SPANS);
+    expect(text).toBe('Hello world\nSecond line');
+    expect(text.slice(SPANS[1].startOffset, SPANS[1].endOffset)).toBe('Second line');
+  });
+
+  it('returns an empty string for a surface without a text layer', () => {
+    expect(surfaceText([])).toBe('');
+  });
+});
+
+describe('clampBox', () => {
+  it('clamps coordinates and sizes into the unit square', () => {
+    expect(clampBox({ x: -0.2, y: 0.9, width: 2, height: 0.3 })).toEqual({
+      x: 0,
+      y: 0.9,
+      width: 1,
+      height: expect.closeTo(0.1),
+    });
+  });
+});
+
+describe('unionBoxes', () => {
+  it('returns null for an empty list', () => {
+    expect(unionBoxes([])).toBeNull();
+  });
+
+  it('returns the bounding box across boxes', () => {
+    const union = unionBoxes([
+      { x: 0.1, y: 0.1, width: 0.2, height: 0.02 },
+      { x: 0.3, y: 0.2, width: 0.3, height: 0.02 },
+    ]);
+    expect(union).toEqual({ x: 0.1, y: 0.1, width: 0.5, height: 0.12 });
+  });
+});
+
+describe('boxesForRange', () => {
+  it('trims a partially selected span proportionally by characters', () => {
+    // "world" = offsets 6..11 of an 11-char span 0.5 wide starting at x=0.1.
+    const boxes = boxesForRange(SPANS, 6, 11);
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].x).toBeCloseTo(0.1 + 0.5 * (6 / 11));
+    expect(boxes[0].width).toBeCloseTo(0.5 * (5 / 11));
+    expect(boxes[0].y).toBe(0.1);
+  });
+
+  it('covers every span the range touches', () => {
+    const boxes = boxesForRange(SPANS, 6, 18);
+    expect(boxes).toHaveLength(2);
+  });
+
+  it('skips spans outside the range', () => {
+    expect(boxesForRange(SPANS, 0, 5)).toHaveLength(1);
+    expect(boxesForRange(SPANS, 11, 12)).toHaveLength(0);
+  });
+});
+
+describe('buildTextAnchor', () => {
+  it('builds all three layers for a selection', () => {
+    const anchor = buildTextAnchor(0, SPANS, 6, 18);
+    expect(anchor).not.toBeNull();
+    expect(anchor?.textQuote?.quote).toBe('world\nSecond');
+    expect(anchor?.textQuote?.prefix).toBe('Hello ');
+    expect(anchor?.textQuote?.suffix).toBe(' line');
+    expect(anchor?.textPosition).toEqual({ start: 6, end: 18 });
+    expect(anchor?.region.surfaceIndex).toBe(0);
+    // Region spans both lines vertically.
+    expect(anchor?.region.box.y).toBeCloseTo(0.1);
+    expect(anchor?.region.box.height).toBeCloseTo(0.07);
+  });
+
+  it('swaps reversed offsets and clamps out-of-range offsets', () => {
+    const anchor = buildTextAnchor(0, SPANS, 999, 12);
+    expect(anchor?.textQuote?.quote).toBe('Second line');
+    expect(anchor?.textPosition).toEqual({ start: 12, end: 23 });
+  });
+
+  it('omits prefix at the very start of the surface', () => {
+    const anchor = buildTextAnchor(0, SPANS, 0, 5);
+    expect(anchor?.textQuote?.quote).toBe('Hello');
+    expect(anchor?.textQuote?.prefix).toBeUndefined();
+    expect(anchor?.textQuote?.suffix).toBe(` world\nSecond line`.slice(0, QUOTE_CONTEXT_CHARS));
+  });
+
+  it('rejects empty and whitespace-only selections', () => {
+    expect(buildTextAnchor(0, SPANS, 5, 5)).toBeNull();
+    expect(buildTextAnchor(0, SPANS, 11, 12)).toBeNull();
+    expect(buildTextAnchor(0, [], 0, 5)).toBeNull();
+  });
+});
+
+describe('buildRegionAnchor', () => {
+  it('normalizes a drag in any direction', () => {
+    const anchor = buildRegionAnchor(2, { x: 0.5, y: 0.6, width: -0.2, height: -0.1 });
+    expect(anchor?.region).toEqual({
+      surfaceIndex: 2,
+      box: { x: 0.3, y: 0.5, width: expect.closeTo(0.2), height: expect.closeTo(0.1) },
+    });
+    expect(anchor?.textQuote).toBeUndefined();
+  });
+
+  it('clamps to the surface', () => {
+    const anchor = buildRegionAnchor(0, { x: 0.9, y: 0.9, width: 0.5, height: 0.5 });
+    expect(anchor?.region.box).toEqual({
+      x: 0.9,
+      y: 0.9,
+      width: expect.closeTo(0.1),
+      height: expect.closeTo(0.1),
+    });
+  });
+
+  it('rejects degenerate rectangles from stray clicks', () => {
+    expect(buildRegionAnchor(0, { x: 0.5, y: 0.5, width: 0.001, height: 0.2 })).toBeNull();
+    expect(buildRegionAnchor(0, { x: 0.5, y: 0.5, width: 0.2, height: 0 })).toBeNull();
+  });
+});
+
+describe('compareAnnotationsByPosition', () => {
+  const annotation = (
+    id: string,
+    region: { surfaceIndex: number; y: number; x?: number } | null,
+    createdAt = '2026-07-01T10:00:00Z',
+  ): AnnotationView => ({
+    id,
+    documentId: 'd1',
+    authorId: 'u1',
+    status: AnnotationStatus.Open,
+    commentCount: 0,
+    createdAt,
+    updatedAt: createdAt,
+    ...(region && {
+      anchor: {
+        region: {
+          surfaceIndex: region.surfaceIndex,
+          box: { x: region.x ?? 0.1, y: region.y, width: 0.2, height: 0.02 },
+        },
+      },
+    }),
+  });
+
+  it('orders by surface, then top edge, and puts unplaced annotations last', () => {
+    const sorted = [
+      annotation('unplaced', null),
+      annotation('page2', { surfaceIndex: 1, y: 0.1 }),
+      annotation('page1-low', { surfaceIndex: 0, y: 0.8 }),
+      annotation('page1-top', { surfaceIndex: 0, y: 0.2 }),
+    ].sort(compareAnnotationsByPosition);
+    expect(sorted.map((a) => a.id)).toEqual(['page1-top', 'page1-low', 'page2', 'unplaced']);
+  });
+
+  it('orders unplaced annotations by creation time', () => {
+    const sorted = [
+      annotation('newer', null, '2026-07-02T10:00:00Z'),
+      annotation('older', null, '2026-07-01T10:00:00Z'),
+    ].sort(compareAnnotationsByPosition);
+    expect(sorted.map((a) => a.id)).toEqual(['older', 'newer']);
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/anchoring.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type {
+  Anchor,
+  AnnotationView,
+  NormalizedBox,
+  RenderedTextSpan,
+} from '../../../api/generated';
+
+/**
+ * Pure anchor-building logic for the viewer (ADR-0009). The client never
+ * derives geometry from its own PDF rendering — every coordinate here comes
+ * from the server-extracted text spans and their normalized 0..1 boxes
+ * (ADR-0032), so anchors agree with what re-anchoring will later see.
+ */
+
+/** Characters of surrounding context stored with a text-quote anchor. */
+export const QUOTE_CONTEXT_CHARS = 32;
+
+/** Smallest normalized edge a drawn region may have — guards against stray clicks. */
+export const MIN_REGION_EDGE = 0.004;
+
+/** A text selection expressed in canonical-text offsets of one surface. */
+export interface TextSelectionOffsets {
+  surfaceIndex: number;
+  /** Inclusive start offset into the surface's canonical text. */
+  start: number;
+  /** Exclusive end offset. */
+  end: number;
+}
+
+/** The canonical text of a surface: span texts joined by single newlines (API contract). */
+export function surfaceText(spans: RenderedTextSpan[]): string {
+  return spans.map((span) => span.text).join('\n');
+}
+
+function clampUnit(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Clamps a box into the normalized 0..1 space of its surface. */
+export function clampBox(box: NormalizedBox): NormalizedBox {
+  const x = clampUnit(box.x);
+  const y = clampUnit(box.y);
+  return {
+    x,
+    y,
+    width: clampUnit(Math.min(box.width, 1 - x)),
+    height: clampUnit(Math.min(box.height, 1 - y)),
+  };
+}
+
+/** The bounding box of the given boxes, or null for an empty list. */
+export function unionBoxes(boxes: NormalizedBox[]): NormalizedBox | null {
+  if (boxes.length === 0) return null;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const box of boxes) {
+    minX = Math.min(minX, box.x);
+    minY = Math.min(minY, box.y);
+    maxX = Math.max(maxX, box.x + box.width);
+    maxY = Math.max(maxY, box.y + box.height);
+  }
+  return clampBox({ x: minX, y: minY, width: maxX - minX, height: maxY - minY });
+}
+
+/**
+ * The highlight boxes covering the canonical-text range [start, end).
+ * Partially selected spans are trimmed proportionally by character count — an
+ * approximation (glyph widths vary), acceptable because the authoritative
+ * anchor is the text quote; the box only needs to visually cover the selection.
+ */
+export function boxesForRange(
+  spans: RenderedTextSpan[],
+  start: number,
+  end: number,
+): NormalizedBox[] {
+  const boxes: NormalizedBox[] = [];
+  for (const span of spans) {
+    const overlapStart = Math.max(start, span.startOffset);
+    const overlapEnd = Math.min(end, span.endOffset);
+    if (overlapEnd <= overlapStart || span.text.length === 0) continue;
+    const fromFraction = (overlapStart - span.startOffset) / span.text.length;
+    const widthFraction = (overlapEnd - overlapStart) / span.text.length;
+    boxes.push(
+      clampBox({
+        x: span.box.x + span.box.width * fromFraction,
+        y: span.box.y,
+        width: span.box.width * widthFraction,
+        height: span.box.height,
+      }),
+    );
+  }
+  return boxes;
+}
+
+/**
+ * Builds the multi-layer anchor (region + text-quote + text-position,
+ * ADR-0009) for a text selection. Returns null when the range is empty,
+ * whitespace-only, or covers no span.
+ */
+export function buildTextAnchor(
+  surfaceIndex: number,
+  spans: RenderedTextSpan[],
+  start: number,
+  end: number,
+): Anchor | null {
+  const text = surfaceText(spans);
+  const from = Math.max(0, Math.min(start, end));
+  const to = Math.min(text.length, Math.max(start, end));
+  if (to <= from) return null;
+  const quote = text.slice(from, to);
+  if (quote.trim().length === 0) return null;
+  const box = unionBoxes(boxesForRange(spans, from, to));
+  if (!box) return null;
+  const prefix = text.slice(Math.max(0, from - QUOTE_CONTEXT_CHARS), from);
+  const suffix = text.slice(to, Math.min(text.length, to + QUOTE_CONTEXT_CHARS));
+  return {
+    region: { surfaceIndex, box },
+    textQuote: {
+      quote,
+      ...(prefix.length > 0 && { prefix }),
+      ...(suffix.length > 0 && { suffix }),
+    },
+    textPosition: { start: from, end: to },
+  };
+}
+
+/**
+ * Builds a region-only anchor from a drawn rectangle. Accepts boxes with
+ * negative width/height (drag direction), clamps into 0..1 and rejects
+ * degenerate rectangles below {@link MIN_REGION_EDGE}.
+ */
+export function buildRegionAnchor(surfaceIndex: number, box: NormalizedBox): Anchor | null {
+  const x1 = clampUnit(Math.min(box.x, box.x + box.width));
+  const y1 = clampUnit(Math.min(box.y, box.y + box.height));
+  const x2 = clampUnit(Math.max(box.x, box.x + box.width));
+  const y2 = clampUnit(Math.max(box.y, box.y + box.height));
+  const rect: NormalizedBox = { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
+  if (rect.width < MIN_REGION_EDGE || rect.height < MIN_REGION_EDGE) return null;
+  return { region: { surfaceIndex, box: rect } };
+}
+
+/**
+ * Orders annotations by their resolved position on the current version:
+ * surface first, then top edge, then left edge. Annotations without a resolved
+ * anchor (orphaned/failed placements) sort last.
+ */
+export function compareAnnotationsByPosition(a: AnnotationView, b: AnnotationView): number {
+  const ra = a.anchor?.region;
+  const rb = b.anchor?.region;
+  if (!ra && !rb) return a.createdAt.localeCompare(b.createdAt);
+  if (!ra) return 1;
+  if (!rb) return -1;
+  return ra.surfaceIndex - rb.surfaceIndex || ra.box.y - rb.box.y || ra.box.x - rb.box.x;
+}

--- a/qnop-ui/src/components/reviews/viewer/anchoring.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.ts
@@ -40,13 +40,20 @@ export const QUOTE_CONTEXT_CHARS = 32;
 export const MIN_REGION_EDGE = 0.004;
 
 /**
- * How much taller a text marker paints than the extracted glyph box, centred
- * on the printed line. PDF viewers (macOS Preview, Acrobat) and Word overshoot
- * the glyphs the same way — ascenders/descenders stay covered and adjacent
- * lines merge into one continuous marker. Used by both the live selection
- * (TextSpanLayer) and persisted text highlights (HighlightLayer).
+ * Text-marker line metrics. Word and native PDF viewers paint a highlight over
+ * the FULL line box (baseline to baseline), so consecutive lines merge into
+ * one continuous marker. The extracted span box is only the ascent (its bottom
+ * edge is the baseline — descenders hang below it), so the marker height is
+ * derived from the surface's measured line pitch, bounded to stay sane on
+ * unusual layouts, and the extra height is distributed asymmetrically: most of
+ * it below the box, covering the descenders.
  */
-export const MARKER_OVERSHOOT = 1.3;
+export const MARKER_MIN_FACTOR = 1.35;
+export const MARKER_MAX_FACTOR = 2.6;
+/** Marker height relative to the span box when the surface has no pitch info. */
+export const MARKER_FALLBACK_FACTOR = 1.45;
+/** Share of the extra marker height that goes above the box top. */
+const MARKER_EXTRA_TOP_SHARE = 0.25;
 
 /** A text selection expressed in canonical-text offsets of one surface. */
 export interface TextSelectionOffsets {
@@ -177,21 +184,50 @@ export interface HighlightGeometry {
   boxes: NormalizedBox[];
 }
 
-function expandMarkerLine(box: NormalizedBox): NormalizedBox {
+/**
+ * The surface's typical line pitch: the median gap between distinct line tops.
+ * The median is robust against paragraph gaps and headings. Null when the
+ * surface has fewer than two text lines.
+ */
+export function surfaceLinePitch(spans: RenderedTextSpan[]): number | null {
+  const tops = [...new Set(spans.map((span) => span.box.y))].sort((a, b) => a - b);
+  const deltas: number[] = [];
+  for (let i = 1; i < tops.length; i++) {
+    const delta = tops[i] - tops[i - 1];
+    if (delta > 1e-6) deltas.push(delta);
+  }
+  if (deltas.length === 0) return null;
+  deltas.sort((a, b) => a - b);
+  return deltas[Math.floor(deltas.length / 2)];
+}
+
+/**
+ * The marker band for one text line: the span box grown to the line pitch
+ * (Word-style full-line highlight), with most of the extra height below the
+ * box — the box bottom is the baseline, so that is where descenders hang.
+ */
+export function markerLineBox(box: NormalizedBox, pitch: number | null): NormalizedBox {
+  const factor =
+    pitch && box.height > 0
+      ? Math.min(Math.max(pitch / box.height, MARKER_MIN_FACTOR), MARKER_MAX_FACTOR)
+      : MARKER_FALLBACK_FACTOR;
+  const height = box.height * factor;
+  const extra = height - box.height;
   return clampBox({
     x: box.x,
-    y: box.y - (box.height * (MARKER_OVERSHOOT - 1)) / 2,
+    y: box.y - extra * MARKER_EXTRA_TOP_SHARE,
     width: box.width,
-    height: box.height * MARKER_OVERSHOOT,
+    height,
   });
 }
 
 /**
  * The highlight geometry of an anchor on its surface: a text anchor paints as
  * per-line marker boxes (recomputed from the stored text-position offsets
- * against the surface's spans, each with {@link MARKER_OVERSHOOT}); a
- * region-only anchor — or a text anchor whose offsets no longer hit any span —
- * falls back to the stored region bounding box.
+ * against the surface's spans, each grown to the line pitch via
+ * {@link markerLineBox}); a region-only anchor — or a text anchor whose
+ * offsets no longer hit any span — falls back to the stored region bounding
+ * box.
  */
 export function highlightBoxesForAnchor(
   anchor: Anchor,
@@ -200,7 +236,8 @@ export function highlightBoxesForAnchor(
   if (anchor.textPosition && spans.length > 0) {
     const lines = boxesForRange(spans, anchor.textPosition.start, anchor.textPosition.end);
     if (lines.length > 0) {
-      return { kind: 'marker', boxes: lines.map(expandMarkerLine) };
+      const pitch = surfaceLinePitch(spans);
+      return { kind: 'marker', boxes: lines.map((line) => markerLineBox(line, pitch)) };
     }
   }
   return { kind: 'box', boxes: [anchor.region.box] };

--- a/qnop-ui/src/components/reviews/viewer/anchoring.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.ts
@@ -39,6 +39,15 @@ export const QUOTE_CONTEXT_CHARS = 32;
 /** Smallest normalized edge a drawn region may have — guards against stray clicks. */
 export const MIN_REGION_EDGE = 0.004;
 
+/**
+ * How much taller a text marker paints than the extracted glyph box, centred
+ * on the printed line. PDF viewers (macOS Preview, Acrobat) and Word overshoot
+ * the glyphs the same way — ascenders/descenders stay covered and adjacent
+ * lines merge into one continuous marker. Used by both the live selection
+ * (TextSpanLayer) and persisted text highlights (HighlightLayer).
+ */
+export const MARKER_OVERSHOOT = 1.3;
+
 /** A text selection expressed in canonical-text offsets of one surface. */
 export interface TextSelectionOffsets {
   surfaceIndex: number;
@@ -160,6 +169,41 @@ export function buildRegionAnchor(surfaceIndex: number, box: NormalizedBox): Anc
   const rect: NormalizedBox = { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
   if (rect.width < MIN_REGION_EDGE || rect.height < MIN_REGION_EDGE) return null;
   return { region: { surfaceIndex, box: rect } };
+}
+
+/** How an anchor paints on its surface: line-wise text marker, or a plain box. */
+export interface HighlightGeometry {
+  kind: 'marker' | 'box';
+  boxes: NormalizedBox[];
+}
+
+function expandMarkerLine(box: NormalizedBox): NormalizedBox {
+  return clampBox({
+    x: box.x,
+    y: box.y - (box.height * (MARKER_OVERSHOOT - 1)) / 2,
+    width: box.width,
+    height: box.height * MARKER_OVERSHOOT,
+  });
+}
+
+/**
+ * The highlight geometry of an anchor on its surface: a text anchor paints as
+ * per-line marker boxes (recomputed from the stored text-position offsets
+ * against the surface's spans, each with {@link MARKER_OVERSHOOT}); a
+ * region-only anchor — or a text anchor whose offsets no longer hit any span —
+ * falls back to the stored region bounding box.
+ */
+export function highlightBoxesForAnchor(
+  anchor: Anchor,
+  spans: RenderedTextSpan[],
+): HighlightGeometry {
+  if (anchor.textPosition && spans.length > 0) {
+    const lines = boxesForRange(spans, anchor.textPosition.start, anchor.textPosition.end);
+    if (lines.length > 0) {
+      return { kind: 'marker', boxes: lines.map(expandMarkerLine) };
+    }
+  }
+  return { kind: 'box', boxes: [anchor.region.box] };
 }
 
 /**

--- a/qnop-ui/src/components/reviews/viewer/anchoring.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.ts
@@ -64,6 +64,12 @@ export interface TextSelectionOffsets {
   end: number;
 }
 
+/** A viewport position (e.g. the pointer on release) for anchoring a popup. */
+export interface ScreenPosition {
+  left: number;
+  top: number;
+}
+
 /** The canonical text of a surface: span texts joined by single newlines (API contract). */
 export function surfaceText(spans: RenderedTextSpan[]): string {
   return spans.map((span) => span.text).join('\n');

--- a/qnop-ui/src/components/reviews/viewer/anchoring.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.ts
@@ -107,11 +107,21 @@ export function unionBoxes(boxes: NormalizedBox[]): NormalizedBox | null {
   return clampBox({ x: minX, y: minY, width: maxX - minX, height: maxY - minY });
 }
 
+/** The length of the text without its trailing whitespace. */
+function visibleLength(text: string): number {
+  let end = text.length;
+  while (end > 0 && /\s/.test(text[end - 1])) end--;
+  return end;
+}
+
 /**
  * The highlight boxes covering the canonical-text range [start, end).
  * Partially selected spans are trimmed proportionally by character count — an
  * approximation (glyph widths vary), acceptable because the authoritative
  * anchor is the text quote; the box only needs to visually cover the selection.
+ * Each line is clamped to its visible text: trailing whitespace (e.g. lines
+ * padded to a fixed width) never paints — matching Word/Acrobat, where a
+ * highlight ends at the last printed character.
  */
 export function boxesForRange(
   spans: RenderedTextSpan[],
@@ -120,8 +130,9 @@ export function boxesForRange(
 ): NormalizedBox[] {
   const boxes: NormalizedBox[] = [];
   for (const span of spans) {
+    const visibleEnd = span.startOffset + visibleLength(span.text);
     const overlapStart = Math.max(start, span.startOffset);
-    const overlapEnd = Math.min(end, span.endOffset);
+    const overlapEnd = Math.min(end, span.endOffset, visibleEnd);
     if (overlapEnd <= overlapStart || span.text.length === 0) continue;
     const fromFraction = (overlapStart - span.startOffset) / span.text.length;
     const widthFraction = (overlapEnd - overlapStart) / span.text.length;
@@ -139,8 +150,10 @@ export function boxesForRange(
 
 /**
  * Builds the multi-layer anchor (region + text-quote + text-position,
- * ADR-0009) for a text selection. Returns null when the range is empty,
- * whitespace-only, or covers no span.
+ * ADR-0009) for a text selection. Whitespace at either end of the range is
+ * trimmed away first (Word/Acrobat semantics: a mark starts and ends on a
+ * printed character — and the stored quote stays clean for re-anchoring).
+ * Returns null when the range is empty, whitespace-only, or covers no span.
  */
 export function buildTextAnchor(
   surfaceIndex: number,
@@ -149,11 +162,12 @@ export function buildTextAnchor(
   end: number,
 ): Anchor | null {
   const text = surfaceText(spans);
-  const from = Math.max(0, Math.min(start, end));
-  const to = Math.min(text.length, Math.max(start, end));
+  let from = Math.max(0, Math.min(start, end));
+  let to = Math.min(text.length, Math.max(start, end));
+  while (from < to && /\s/.test(text[from])) from++;
+  while (to > from && /\s/.test(text[to - 1])) to--;
   if (to <= from) return null;
   const quote = text.slice(from, to);
-  if (quote.trim().length === 0) return null;
   const box = unionBoxes(boxesForRange(spans, from, to));
   if (!box) return null;
   const prefix = text.slice(Math.max(0, from - QUOTE_CONTEXT_CHARS), from);

--- a/qnop-ui/src/components/reviews/viewer/markerColors.ts
+++ b/qnop-ui/src/components/reviews/viewer/markerColors.ts
@@ -40,7 +40,7 @@ export const MARKER_YELLOW_BORDER = '#D9AD00';
  * readable): identical everywhere a mark is being drawn, so releasing the
  * mouse and creating the annotation never changes the mark's colour.
  */
-export const SELECTION_MARKER_BG = 'rgba(255, 224, 0, 0.45)';
+export const SELECTION_MARKER_BG = 'rgba(255, 224, 0, 0.3)';
 
 /**
  * The colour a mark paints with on the page — shared with the panel so an

--- a/qnop-ui/src/components/reviews/viewer/markerColors.ts
+++ b/qnop-ui/src/components/reviews/viewer/markerColors.ts
@@ -26,8 +26,11 @@
  * MOVED placement cue (ADR-0009).
  */
 
-/** Solid highlighter yellow — the base of open text markers. */
+/** Solid highlighter yellow — the base of open marks (text and region). */
 export const MARKER_YELLOW = '#FFE000';
+
+/** Darker yellow for region-box outlines — pure yellow lacks edge contrast on white. */
+export const MARKER_YELLOW_BORDER = '#D9AD00';
 
 /**
  * The live-selection / pending-preview fill (translucent so the glyphs stay

--- a/qnop-ui/src/components/reviews/viewer/markerColors.ts
+++ b/qnop-ui/src/components/reviews/viewer/markerColors.ts
@@ -19,6 +19,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+
 /**
  * Text-marker colours. The classic highlighter yellow is used in BOTH themes —
  * markers paint on the page itself, and the PDF pixels are white regardless of
@@ -38,3 +41,22 @@ export const MARKER_YELLOW_BORDER = '#D9AD00';
  * mouse and creating the annotation never changes the mark's colour.
  */
 export const SELECTION_MARKER_BG = 'rgba(255, 224, 0, 0.45)';
+
+/**
+ * The colour a mark paints with on the page — shared with the panel so an
+ * annotation card's status rail matches its highlight. Open marks are
+ * highlighter yellow; cue colours override the base (ADR-0009).
+ */
+export function highlightColorFor(
+  annotation: AnnotationView,
+  palette: {
+    success: { main: string };
+    warning: { main: string };
+    text: { disabled: string };
+  },
+): string {
+  if (annotation.status === AnnotationStatus.Accepted) return palette.success.main;
+  if (annotation.status === AnnotationStatus.Rejected) return palette.text.disabled;
+  if (annotation.placementStatus === PlacementStatus.Moved) return palette.warning.main;
+  return MARKER_YELLOW;
+}

--- a/qnop-ui/src/components/reviews/viewer/markerColors.ts
+++ b/qnop-ui/src/components/reviews/viewer/markerColors.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { PaletteMode } from '@mui/material/styles';
+
+/**
+ * Text-marker colours shared by the live selection (TextSpanLayer) and the
+ * pending-anchor preview (HighlightLayer), so drawing a mark and its preview
+ * look identical. Translucent so the page's own glyphs stay readable — the
+ * PDF pixels are white in both themes. Light mode is the classic highlighter
+ * yellow; dark mode uses the softer brand amber to match the muted dark UI.
+ */
+const SELECTION_BG_LIGHT = 'rgba(255, 224, 0, 0.45)';
+const SELECTION_BG_DARK = 'rgba(245, 184, 61, 0.5)';
+
+export function selectionMarkerColor(mode: PaletteMode): string {
+  return mode === 'dark' ? SELECTION_BG_DARK : SELECTION_BG_LIGHT;
+}

--- a/qnop-ui/src/components/reviews/viewer/markerColors.ts
+++ b/qnop-ui/src/components/reviews/viewer/markerColors.ts
@@ -29,7 +29,7 @@
 /** Solid highlighter yellow — the base of open marks (text and region). */
 export const MARKER_YELLOW = '#FFE000';
 
-/** Darker yellow for region-box outlines — pure yellow lacks edge contrast on white. */
+/** Darker yellow for the rubber-band outline while a region is being drawn. */
 export const MARKER_YELLOW_BORDER = '#D9AD00';
 
 /**

--- a/qnop-ui/src/components/reviews/viewer/markerColors.ts
+++ b/qnop-ui/src/components/reviews/viewer/markerColors.ts
@@ -19,18 +19,19 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { PaletteMode } from '@mui/material/styles';
+/**
+ * Text-marker colours. The classic highlighter yellow is used in BOTH themes —
+ * markers paint on the page itself, and the PDF pixels are white regardless of
+ * the UI theme. Keeping the base yellow also leaves amber unambiguous as the
+ * MOVED placement cue (ADR-0009).
+ */
+
+/** Solid highlighter yellow — the base of open text markers. */
+export const MARKER_YELLOW = '#FFE000';
 
 /**
- * Text-marker colours shared by the live selection (TextSpanLayer) and the
- * pending-anchor preview (HighlightLayer), so drawing a mark and its preview
- * look identical. Translucent so the page's own glyphs stay readable — the
- * PDF pixels are white in both themes. Light mode is the classic highlighter
- * yellow; dark mode uses the softer brand amber to match the muted dark UI.
+ * The live-selection / pending-preview fill (translucent so the glyphs stay
+ * readable): identical everywhere a mark is being drawn, so releasing the
+ * mouse and creating the annotation never changes the mark's colour.
  */
-const SELECTION_BG_LIGHT = 'rgba(255, 224, 0, 0.45)';
-const SELECTION_BG_DARK = 'rgba(245, 184, 61, 0.5)';
-
-export function selectionMarkerColor(mode: PaletteMode): string {
-  return mode === 'dark' ? SELECTION_BG_DARK : SELECTION_BG_LIGHT;
-}
+export const SELECTION_MARKER_BG = 'rgba(255, 224, 0, 0.45)';

--- a/qnop-ui/src/components/reviews/viewer/usePdfDocument.ts
+++ b/qnop-ui/src/components/reviews/viewer/usePdfDocument.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useState } from 'react';
+import * as pdfjs from 'pdfjs-dist';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+
+// Vite resolves the worker to an emitted asset relative to the app's base, so
+// this also works when the SPA is served single-origin from the Spring app.
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString();
+
+export interface PdfDocumentState {
+  pdf: PDFDocumentProxy | null;
+  error: string | null;
+}
+
+/**
+ * Parses PDF bytes into a pdf.js document (pixels only — anchoring geometry
+ * comes from the server, ADR-0032). The loading task is destroyed on unmount,
+ * which also terminates the worker's document handle.
+ */
+export function usePdfDocument(data: ArrayBuffer | undefined): PdfDocumentState {
+  const [state, setState] = useState<PdfDocumentState>({ pdf: null, error: null });
+
+  useEffect(() => {
+    if (!data) return undefined;
+    let cancelled = false;
+    // pdf.js transfers the buffer to its worker; hand it a copy so the
+    // query-cached buffer stays usable when the viewer remounts.
+    const task = pdfjs.getDocument({ data: data.slice(0) });
+    task.promise.then(
+      (pdf) => {
+        if (!cancelled) setState({ pdf, error: null });
+      },
+      (error: unknown) => {
+        if (!cancelled) {
+          setState({
+            pdf: null,
+            error: error instanceof Error ? error.message : 'Failed to parse PDF',
+          });
+        }
+      },
+    );
+    return () => {
+      cancelled = true;
+      setState({ pdf: null, error: null });
+      void task.destroy();
+    };
+  }, [data]);
+
+  return state;
+}

--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -25,7 +25,7 @@ import Container from '@mui/material/Container';
 import Drawer from '@mui/material/Drawer';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useMatch } from 'react-router-dom';
 import { SidebarContent } from './SidebarContent';
 import { TopBar } from './TopBar';
 
@@ -42,6 +42,9 @@ const COLLAPSE_KEY = 'qnop-nav-collapsed';
 export function AppShell() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  // The document review workspace (#250) spans the full width; every other
+  // surface keeps the centred reading container.
+  const fullBleed = Boolean(useMatch('/reviews/:documentId'));
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
       return localStorage.getItem(COLLAPSE_KEY) === '1';
@@ -106,8 +109,25 @@ export function AppShell() {
       {/* Main column */}
       <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
         <TopBar isMobile={isMobile} onToggleSidebar={toggleSidebar} />
-        <Box component="main" sx={{ flex: 1, overflow: 'auto', bgcolor: 'background.default' }}>
-          <Container maxWidth="lg" sx={{ py: { xs: 3, md: 4 } }}>
+        <Box
+          component="main"
+          sx={{
+            flex: 1,
+            // The review workspace manages its own scrolling (document pane and
+            // annotation panel scroll independently) — the shell must not add a
+            // second scrollbar around it. On xs the workspace stacks and the
+            // page scroll returns.
+            overflow: fullBleed ? { xs: 'auto', md: 'hidden' } : 'auto',
+            bgcolor: 'background.default',
+          }}
+        >
+          <Container
+            maxWidth={fullBleed ? false : 'lg'}
+            sx={{
+              py: fullBleed ? 2 : { xs: 3, md: 4 },
+              height: fullBleed ? { md: '100%' } : undefined,
+            }}
+          >
             <Outlet />
           </Container>
         </Box>

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -184,7 +184,6 @@ describe('DocumentReviewPage', () => {
 
     expect(screen.getByRole('heading', { level: 1, name: 'Supply Contract' })).toBeInTheDocument();
     expect(screen.getByText('In review')).toBeInTheDocument();
-    expect(screen.getByText('Version 2 of 2')).toBeInTheDocument();
     expect(screen.getByTestId('document-viewer')).toHaveAttribute('data-annotation-count', '1');
     expect(screen.getByText('Annotations (1)')).toBeInTheDocument();
     expect(screen.getByText('“Hello”')).toBeInTheDocument();

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView, RenderedSurface } from '../../api/generated';
+import { AnnotationStatus, ExtractionStatus, PlacementStatus } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { DocumentReviewPage } from './DocumentReviewPage';
+import {
+  useDocument,
+  useDocumentVersions,
+  useOriginalPdf,
+  useRenderedDocument,
+} from '../../api/hooks/useDocuments';
+import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotations';
+import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
+
+vi.mock('../../api/hooks/useDocuments', () => ({
+  useDocument: vi.fn(),
+  useDocumentVersions: vi.fn(),
+  useRenderedDocument: vi.fn(),
+  useOriginalPdf: vi.fn(),
+}));
+vi.mock('../../api/hooks/useAnnotations', () => ({
+  useAnnotations: vi.fn(),
+  useCreateAnnotation: vi.fn(),
+}));
+vi.mock('../../api/hooks/useComments', () => ({
+  useComments: vi.fn().mockReturnValue({ isPending: true, isError: false, data: undefined }),
+  useAddComment: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('../../components/reviews/viewer/usePdfDocument', () => ({
+  usePdfDocument: vi.fn(),
+}));
+// The viewer needs a real pdf.js document and layout; the page test only
+// verifies the orchestration around it.
+vi.mock('../../components/reviews/viewer/DocumentViewer', () => ({
+  DocumentViewer: ({ annotations }: { annotations: AnnotationView[] }) => (
+    <div data-testid="document-viewer" data-annotation-count={annotations.length} />
+  ),
+}));
+
+const SURFACES: RenderedSurface[] = [
+  {
+    index: 0,
+    width: 612,
+    height: 792,
+    textSpans: [
+      {
+        text: 'Hello',
+        startOffset: 0,
+        endOffset: 5,
+        box: { x: 0.1, y: 0.1, width: 0.3, height: 0.02 },
+      },
+    ],
+  },
+];
+
+const ANNOTATIONS: AnnotationView[] = [
+  {
+    id: 'a1',
+    documentId: 'doc-1',
+    authorId: 'u1',
+    status: AnnotationStatus.Open,
+    placementStatus: PlacementStatus.Moved,
+    anchor: {
+      region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 } },
+      textQuote: { quote: 'Hello' },
+    },
+    commentCount: 0,
+    createdAt: '2026-07-01T10:00:00Z',
+    updatedAt: '2026-07-01T10:00:00Z',
+  },
+];
+
+type Queryish = { data?: unknown; isPending?: boolean; isError?: boolean };
+const asQuery = <T,>(value: Queryish) =>
+  ({ isPending: false, isError: false, ...value }) as unknown as T;
+
+function seedHappyPath(extractionStatus: ExtractionStatus = ExtractionStatus.Ready) {
+  vi.mocked(useDocument).mockReturnValue(
+    asQuery({
+      data: {
+        id: 'doc-1',
+        title: 'Supply Contract',
+        ownerId: 'u1',
+        workflowState: 'IN_REVIEW',
+        latestVersionNumber: 2,
+        createdAt: '2026-07-01T10:00:00Z',
+        updatedAt: '2026-07-01T10:00:00Z',
+      },
+    }),
+  );
+  vi.mocked(useDocumentVersions).mockReturnValue(
+    asQuery({
+      data: {
+        versions: [
+          { versionNumber: 1, extractionStatus: ExtractionStatus.Ready },
+          { versionNumber: 2, extractionStatus },
+        ],
+      },
+    }),
+  );
+  vi.mocked(useRenderedDocument).mockReturnValue(
+    asQuery({
+      data: extractionStatus === ExtractionStatus.Ready ? { surfaces: SURFACES } : undefined,
+    }),
+  );
+  vi.mocked(useOriginalPdf).mockReturnValue(asQuery({ data: new ArrayBuffer(4) }));
+  vi.mocked(usePdfDocument).mockReturnValue({
+    pdf: { numPages: 1 } as unknown as NonNullable<ReturnType<typeof usePdfDocument>['pdf']>,
+    error: null,
+  });
+  vi.mocked(useAnnotations).mockReturnValue(asQuery({ data: { annotations: ANNOTATIONS } }));
+  vi.mocked(useCreateAnnotation).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useCreateAnnotation>);
+}
+
+function renderPage() {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter initialEntries={['/reviews/doc-1']}>
+        <Routes>
+          <Route path="/reviews/:documentId" element={<DocumentReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DocumentReviewPage', () => {
+  it('renders title, workflow badge, version info, viewer and annotations', () => {
+    seedHappyPath();
+    renderPage();
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Supply Contract' })).toBeInTheDocument();
+    expect(screen.getByText('In review')).toBeInTheDocument();
+    expect(screen.getByText('Version 2 of 2')).toBeInTheDocument();
+    expect(screen.getByTestId('document-viewer')).toHaveAttribute('data-annotation-count', '1');
+    expect(screen.getByText('Annotations (1)')).toBeInTheDocument();
+    expect(screen.getByText('“Hello”')).toBeInTheDocument();
+    expect(screen.getByText('Moved')).toBeInTheDocument();
+  });
+
+  it('announces a still-processing version and keeps annotating disabled', () => {
+    seedHappyPath(ExtractionStatus.Pending);
+    renderPage();
+
+    expect(screen.getByText(/The document is being processed/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Draw region' })).toBeDisabled();
+  });
+
+  it('shows the anti-enumeration error state', () => {
+    vi.mocked(useDocument).mockReturnValue(asQuery({ isError: true }));
+    vi.mocked(useDocumentVersions).mockReturnValue(asQuery({}));
+    vi.mocked(useRenderedDocument).mockReturnValue(asQuery({}));
+    vi.mocked(useOriginalPdf).mockReturnValue(asQuery({}));
+    vi.mocked(usePdfDocument).mockReturnValue({ pdf: null, error: null });
+    vi.mocked(useAnnotations).mockReturnValue(asQuery({}));
+    vi.mocked(useCreateAnnotation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateAnnotation>);
+
+    renderPage();
+
+    expect(
+      screen.getByText('This document does not exist, or you are not a participant of its review.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -20,7 +20,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView, RenderedSurface } from '../../api/generated';
@@ -54,10 +54,32 @@ vi.mock('../../components/reviews/viewer/usePdfDocument', () => ({
   usePdfDocument: vi.fn(),
 }));
 // The viewer needs a real pdf.js document and layout; the page test only
-// verifies the orchestration around it.
+// verifies the orchestration around it. The stub exposes a button that
+// simulates a completed text selection.
 vi.mock('../../components/reviews/viewer/DocumentViewer', () => ({
-  DocumentViewer: ({ annotations }: { annotations: AnnotationView[] }) => (
-    <div data-testid="document-viewer" data-annotation-count={annotations.length} />
+  DocumentViewer: ({
+    annotations,
+    pendingAnchor,
+    onTextSelected,
+  }: {
+    annotations: AnnotationView[];
+    pendingAnchor: unknown;
+    onTextSelected: (sel: unknown, at: unknown) => void;
+  }) => (
+    <div
+      data-testid="document-viewer"
+      data-annotation-count={annotations.length}
+      data-has-pending={String(Boolean(pendingAnchor))}
+    >
+      <button
+        data-testid="fake-text-select"
+        onClick={() =>
+          onTextSelected({ surfaceIndex: 0, start: 0, end: 5 }, { left: 120, top: 240 })
+        }
+      >
+        select
+      </button>
+    </div>
   ),
 }));
 
@@ -175,6 +197,35 @@ describe('DocumentReviewPage', () => {
 
     expect(screen.getByText(/The document is being processed/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Draw region' })).toBeDisabled();
+  });
+
+  it('opens the composer only after choosing "Create annotation" from the popup', () => {
+    seedHappyPath();
+    renderPage();
+
+    // Selection complete → popup at the pointer, mark previewed, no composer yet.
+    fireEvent.click(screen.getByTestId('fake-text-select'));
+    expect(screen.getByRole('menuitem', { name: /Create annotation/ })).toBeInTheDocument();
+    expect(screen.getByTestId('document-viewer')).toHaveAttribute('data-has-pending', 'true');
+    expect(screen.queryByTestId('annotation-composer')).not.toBeInTheDocument();
+
+    // Explicitly choosing the item opens the composer; the mark stays.
+    fireEvent.click(screen.getByRole('menuitem', { name: /Create annotation/ }));
+    expect(screen.getByTestId('annotation-composer')).toBeInTheDocument();
+    expect(screen.getByTestId('document-viewer')).toHaveAttribute('data-has-pending', 'true');
+  });
+
+  it('discards popup and mark when the popup is dismissed', () => {
+    seedHappyPath();
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('fake-text-select'));
+    // Escape = click-away semantics: the menu closes and the mark is gone.
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+
+    expect(screen.queryByRole('menuitem', { name: /Create annotation/ })).not.toBeInTheDocument();
+    expect(screen.getByTestId('document-viewer')).toHaveAttribute('data-has-pending', 'false');
+    expect(screen.queryByTestId('annotation-composer')).not.toBeInTheDocument();
   });
 
   it('shows the anti-enumeration error state', () => {

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -187,6 +187,8 @@ describe('DocumentReviewPage', () => {
     expect(screen.getByTestId('document-viewer')).toHaveAttribute('data-annotation-count', '1');
     expect(screen.getByText('Annotations (1)')).toBeInTheDocument();
     expect(screen.getByText('“Hello”')).toBeInTheDocument();
+    // Placement cues are expanded-state details.
+    fireEvent.click(screen.getByTestId('annotation-item-a1'));
     expect(screen.getByText('Moved')).toBeInTheDocument();
   });
 

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMemo, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import type { Anchor, NormalizedBox } from '../../api/generated';
+import { ExtractionStatus } from '../../api/generated';
+import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotations';
+import {
+  useDocument,
+  useDocumentVersions,
+  useOriginalPdf,
+  useRenderedDocument,
+} from '../../api/hooks/useDocuments';
+import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { useToast } from '../../components/admin/layout/useToast';
+import type { BadgeTone } from '../../components/admin/ToneBadge';
+import { ToneBadge } from '../../components/admin/ToneBadge';
+import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
+import type { TextSelectionOffsets } from '../../components/reviews/viewer/anchoring';
+import { buildRegionAnchor, buildTextAnchor } from '../../components/reviews/viewer/anchoring';
+import { DocumentViewer } from '../../components/reviews/viewer/DocumentViewer';
+import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
+import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
+import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
+
+/** Community workflow states with a badge tone; unknown (enterprise) states render neutral. */
+const WORKFLOW_TONES: Record<string, BadgeTone> = {
+  DRAFT: 'neutral',
+  IN_REVIEW: 'blue',
+  CHANGES_REQUESTED: 'amber',
+  FINALIZED: 'green',
+  CANCELLED: 'red',
+};
+
+function workflowBadge(state: string) {
+  const label = state
+    .toLowerCase()
+    .replaceAll('_', ' ')
+    .replace(/^./, (c) => c.toUpperCase());
+  return <ToneBadge tone={WORKFLOW_TONES[state] ?? 'neutral'} label={label} />;
+}
+
+/**
+ * The review surface of one document (#250): pdf.js renders the original for
+ * fidelity, every annotation overlay is driven by the stored normalized boxes
+ * of the server's rendered representation (ADR-0032), and marks anchor via the
+ * multi-layer model (ADR-0009). The viewed version comes from the `version`
+ * search param, defaulting to the latest.
+ */
+export function DocumentReviewPage() {
+  const { documentId = '' } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { toast, notify, clear } = useToast();
+
+  const documentQuery = useDocument(documentId);
+  const latestVersion = documentQuery.data?.latestVersionNumber ?? 0;
+  const requestedVersion = Number(searchParams.get('version'));
+  const versionNumber =
+    requestedVersion >= 1 && requestedVersion <= latestVersion
+      ? requestedVersion
+      : latestVersion >= 1
+        ? latestVersion
+        : undefined;
+
+  const versionsQuery = useDocumentVersions(documentId, versionNumber);
+  const versionSummary = versionsQuery.data?.versions.find(
+    (version) => version.versionNumber === versionNumber,
+  );
+  const extractionStatus = versionSummary?.extractionStatus;
+  const extractionReady = extractionStatus === ExtractionStatus.Ready;
+
+  const renderedQuery = useRenderedDocument(documentId, versionNumber ?? 0, extractionReady);
+  const pdfQuery = useOriginalPdf(documentId, versionNumber);
+  const { pdf, error: pdfError } = usePdfDocument(pdfQuery.data);
+  const annotationsQuery = useAnnotations(documentId, versionNumber);
+  const createAnnotation = useCreateAnnotation(documentId);
+
+  const [tool, setTool] = useState<ViewerTool>('text');
+  const [zoom, setZoom] = useState(1);
+  const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
+  const [pendingAnchor, setPendingAnchor] = useState<Anchor | null>(null);
+
+  const surfaces = renderedQuery.data?.surfaces;
+  const annotations = useMemo(
+    () => annotationsQuery.data?.annotations ?? [],
+    [annotationsQuery.data],
+  );
+  const canAnnotate = extractionReady && surfaces !== undefined;
+  const textToolAvailable = (surfaces ?? []).some((surface) => surface.textSpans.length > 0);
+
+  const handleVersionChange = (version: number) => {
+    setSearchParams({ version: String(version) });
+    setActiveAnnotationId(null);
+    setPendingAnchor(null);
+  };
+
+  const handleTextSelected = ({ surfaceIndex, start, end }: TextSelectionOffsets) => {
+    const surface = surfaces?.find((s) => s.index === surfaceIndex);
+    if (!surface) return;
+    const anchor = buildTextAnchor(surfaceIndex, surface.textSpans, start, end);
+    if (anchor) {
+      setPendingAnchor(anchor);
+      setActiveAnnotationId(null);
+    }
+  };
+
+  const handleRegionSelected = (surfaceIndex: number, box: NormalizedBox) => {
+    const anchor = buildRegionAnchor(surfaceIndex, box);
+    if (anchor) {
+      setPendingAnchor(anchor);
+      setActiveAnnotationId(null);
+    }
+  };
+
+  const handleCreate = (comment: string) => {
+    if (!pendingAnchor || versionNumber === undefined) return;
+    createAnnotation.mutate(
+      { versionNumber, anchor: pendingAnchor, comment: comment.trim() || undefined },
+      {
+        onSuccess: (created) => {
+          setPendingAnchor(null);
+          setActiveAnnotationId(created.id);
+          notify('Annotation created.');
+        },
+        onError: () => notify('Could not create the annotation.', 'error'),
+      },
+    );
+  };
+
+  if (documentQuery.isPending) {
+    return (
+      <Stack sx={{ alignItems: 'center', py: 8 }}>
+        <CircularProgress />
+      </Stack>
+    );
+  }
+
+  if (documentQuery.isError || !documentQuery.data) {
+    return (
+      <Alert severity="error">
+        This document does not exist, or you are not a participant of its review.
+      </Alert>
+    );
+  }
+
+  const document = documentQuery.data;
+
+  return (
+    <Stack spacing={3}>
+      <PageHeader
+        title={document.title}
+        titleAdornment={workflowBadge(document.workflowState)}
+        description={
+          versionNumber !== undefined
+            ? `Version ${versionNumber} of ${latestVersion}`
+            : 'No version uploaded yet.'
+        }
+      />
+      {versionNumber === undefined ? (
+        <Alert severity="info">This review has no uploaded document version yet.</Alert>
+      ) : (
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={3}
+          sx={{ alignItems: 'flex-start' }}
+        >
+          <Box sx={{ flex: 1, minWidth: 0, alignSelf: 'stretch' }}>
+            <Stack spacing={2}>
+              <ViewerToolbar
+                versions={versionsQuery.data?.versions ?? []}
+                currentVersion={versionNumber}
+                onVersionChange={handleVersionChange}
+                extractionStatus={extractionStatus}
+                tool={tool}
+                onToolChange={setTool}
+                textToolAvailable={textToolAvailable}
+                canAnnotate={canAnnotate}
+                zoom={zoom}
+                onZoomChange={setZoom}
+              />
+              {extractionStatus === ExtractionStatus.Pending && (
+                <Alert severity="info">
+                  The document is being processed — annotating becomes available once the text layer
+                  is extracted.
+                </Alert>
+              )}
+              {extractionStatus === ExtractionStatus.Failed && (
+                <Alert severity="error">
+                  Extraction failed for this version, so it cannot be annotated. The original
+                  document is still shown below.
+                </Alert>
+              )}
+              {pdfError && (
+                <Alert severity="error">The PDF could not be displayed: {pdfError}</Alert>
+              )}
+              {pdfQuery.isError && (
+                <Alert severity="error">The original document could not be loaded.</Alert>
+              )}
+              {(pdfQuery.isPending || (!pdf && !pdfError && !pdfQuery.isError)) && (
+                <Stack sx={{ alignItems: 'center', py: 6 }}>
+                  <CircularProgress />
+                </Stack>
+              )}
+              {pdf && (
+                <DocumentViewer
+                  pdf={pdf}
+                  surfaces={surfaces}
+                  zoom={zoom}
+                  annotations={annotations}
+                  activeAnnotationId={activeAnnotationId}
+                  onSelectAnnotation={(id) => {
+                    setActiveAnnotationId(id);
+                    setPendingAnchor(null);
+                  }}
+                  tool={tool}
+                  canAnnotate={canAnnotate}
+                  pendingAnchor={pendingAnchor}
+                  onTextSelected={handleTextSelected}
+                  onRegionSelected={handleRegionSelected}
+                />
+              )}
+            </Stack>
+          </Box>
+          <Box
+            sx={{
+              width: { xs: '100%', md: 360 },
+              flexShrink: 0,
+              position: { md: 'sticky' },
+              top: { md: 0 },
+              maxHeight: { md: 'calc(100dvh - 140px)' },
+              overflowY: { md: 'auto' },
+            }}
+          >
+            <AnnotationPanel
+              annotations={annotations}
+              activeAnnotationId={activeAnnotationId}
+              onSelect={setActiveAnnotationId}
+              pendingAnchor={pendingAnchor}
+              creating={createAnnotation.isPending}
+              onCreate={handleCreate}
+              onCancelPending={() => setPendingAnchor(null)}
+              canAnnotate={canAnnotate}
+              notify={notify}
+            />
+          </Box>
+        </Stack>
+      )}
+      <AdminToast toast={toast} onClose={clear} />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -197,9 +197,9 @@ export function DocumentReviewPage() {
       spacing={2.5}
       sx={{
         // The review surface is a fixed workspace (prototype layout): the page
-        // header stays put while document and panel scroll independently.
-        // 100dvh minus the shell top bar and the container paddings.
-        height: { md: 'calc(100dvh - 112px)' },
+        // header stays put while document and panel scroll independently. The
+        // shell hands this route the full container height (AppShell fullBleed).
+        height: { md: '100%' },
         minHeight: { md: 480 },
       }}
     >

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -50,6 +50,7 @@ import type {
   TextSelectionOffsets,
 } from '../../components/reviews/viewer/anchoring';
 import { buildRegionAnchor, buildTextAnchor } from '../../components/reviews/viewer/anchoring';
+import type { DocumentViewerHandle } from '../../components/reviews/viewer/DocumentViewer';
 import { DocumentViewer } from '../../components/reviews/viewer/DocumentViewer';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
@@ -110,6 +111,10 @@ export function DocumentReviewPage() {
   const [tool, setTool] = useState<ViewerTool>('text');
   const [zoom, setZoom] = useState(1);
   const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
+  // Card↔mark linking (prototype): hovering either side lights up the other.
+  const [hoverAnnotationId, setHoverAnnotationId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const viewerRef = useRef<DocumentViewerHandle>(null);
   // A drawn-but-not-created mark. While `menuPosition` is set, the "Create
   // annotation" popup is open at the pointer; choosing the item clears the
   // position and opens the composer in the panel. Dismissing the popup
@@ -126,6 +131,7 @@ export function DocumentReviewPage() {
   );
   const canAnnotate = extractionReady && surfaces !== undefined;
   const textToolAvailable = (surfaces ?? []).some((surface) => surface.textSpans.length > 0);
+  const pageCount = surfaces?.length ?? pdf?.numPages ?? 0;
 
   const handleVersionChange = (version: number) => {
     setSearchParams({ version: String(version) });
@@ -187,7 +193,16 @@ export function DocumentReviewPage() {
   const document = documentQuery.data;
 
   return (
-    <Stack spacing={3}>
+    <Stack
+      spacing={2.5}
+      sx={{
+        // The review surface is a fixed workspace (prototype layout): the page
+        // header stays put while document and panel scroll independently.
+        // 100dvh minus the shell top bar and the container paddings.
+        height: { md: 'calc(100dvh - 112px)' },
+        minHeight: { md: 480 },
+      }}
+    >
       <PageHeader
         title={document.title}
         titleAdornment={workflowBadge(document.workflowState)}
@@ -202,80 +217,94 @@ export function DocumentReviewPage() {
       ) : (
         <Stack
           direction={{ xs: 'column', md: 'row' }}
-          spacing={3}
-          sx={{ alignItems: 'flex-start' }}
+          spacing={2.5}
+          sx={{ alignItems: { xs: 'stretch', md: 'stretch' }, flex: 1, minHeight: 0 }}
         >
-          <Box sx={{ flex: 1, minWidth: 0, alignSelf: 'stretch' }}>
-            <Stack spacing={2}>
-              <ViewerToolbar
-                versions={versionsQuery.data?.versions ?? []}
-                currentVersion={versionNumber}
-                onVersionChange={handleVersionChange}
-                extractionStatus={extractionStatus}
-                tool={tool}
-                onToolChange={setTool}
-                textToolAvailable={textToolAvailable}
-                canAnnotate={canAnnotate}
-                zoom={zoom}
-                onZoomChange={setZoom}
-              />
-              {extractionStatus === ExtractionStatus.Pending && (
-                <Alert severity="info">
-                  The document is being processed — annotating becomes available once the text layer
-                  is extracted.
-                </Alert>
-              )}
-              {extractionStatus === ExtractionStatus.Failed && (
-                <Alert severity="error">
-                  Extraction failed for this version, so it cannot be annotated. The original
-                  document is still shown below.
-                </Alert>
-              )}
-              {pdfError && (
-                <Alert severity="error">The PDF could not be displayed: {pdfError}</Alert>
-              )}
-              {pdfQuery.isError && (
-                <Alert severity="error">The original document could not be loaded.</Alert>
-              )}
-              {(pdfQuery.isPending || (!pdf && !pdfError && !pdfQuery.isError)) && (
-                <Stack sx={{ alignItems: 'center', py: 6 }}>
-                  <CircularProgress />
-                </Stack>
-              )}
-              {pdf && (
+          <Stack spacing={1.5} sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
+            <ViewerToolbar
+              versions={versionsQuery.data?.versions ?? []}
+              currentVersion={versionNumber}
+              onVersionChange={handleVersionChange}
+              extractionStatus={extractionStatus}
+              currentPage={currentPage}
+              pageCount={pageCount}
+              onNavigateToPage={(pageIndex) => viewerRef.current?.scrollToPage(pageIndex)}
+              tool={tool}
+              onToolChange={setTool}
+              textToolAvailable={textToolAvailable}
+              canAnnotate={canAnnotate}
+              zoom={zoom}
+              onZoomChange={setZoom}
+            />
+            {extractionStatus === ExtractionStatus.Pending && (
+              <Alert severity="info">
+                The document is being processed — annotating becomes available once the text layer
+                is extracted.
+              </Alert>
+            )}
+            {extractionStatus === ExtractionStatus.Failed && (
+              <Alert severity="error">
+                Extraction failed for this version, so it cannot be annotated. The original document
+                is still shown below.
+              </Alert>
+            )}
+            {pdfError && <Alert severity="error">The PDF could not be displayed: {pdfError}</Alert>}
+            {pdfQuery.isError && (
+              <Alert severity="error">The original document could not be loaded.</Alert>
+            )}
+            {(pdfQuery.isPending || (!pdf && !pdfError && !pdfQuery.isError)) && (
+              <Stack sx={{ alignItems: 'center', py: 6 }}>
+                <CircularProgress aria-label="Loading document" />
+              </Stack>
+            )}
+            {pdf && (
+              <Box
+                sx={{
+                  flex: 1,
+                  minHeight: { xs: 480, md: 0 },
+                  borderRadius: 1,
+                  bgcolor: (theme) => theme.qnop.surface2,
+                }}
+              >
                 <DocumentViewer
+                  ref={viewerRef}
                   pdf={pdf}
                   surfaces={surfaces}
                   zoom={zoom}
                   annotations={annotations}
                   activeAnnotationId={activeAnnotationId}
+                  hoverAnnotationId={hoverAnnotationId}
                   onSelectAnnotation={(id) => {
                     setActiveAnnotationId(id);
                     setPending(null);
                   }}
+                  onHoverAnnotation={setHoverAnnotationId}
+                  onVisiblePageChange={setCurrentPage}
                   tool={tool}
                   canAnnotate={canAnnotate}
                   pendingAnchor={pending?.anchor ?? null}
                   onTextSelected={handleTextSelected}
                   onRegionSelected={handleRegionSelected}
                 />
-              )}
-            </Stack>
-          </Box>
+              </Box>
+            )}
+          </Stack>
           <Box
+            component="aside"
+            aria-label="Annotations"
             sx={{
               width: { xs: '100%', md: 360 },
               flexShrink: 0,
-              position: { md: 'sticky' },
-              top: { md: 0 },
-              maxHeight: { md: 'calc(100dvh - 140px)' },
+              minHeight: 0,
               overflowY: { md: 'auto' },
             }}
           >
             <AnnotationPanel
               annotations={annotations}
               activeAnnotationId={activeAnnotationId}
+              hoverAnnotationId={hoverAnnotationId}
               onSelect={setActiveAnnotationId}
+              onHover={setHoverAnnotationId}
               pendingAnchor={pending && !pending.menuPosition ? pending.anchor : null}
               creating={createAnnotation.isPending}
               onCreate={handleCreate}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -45,6 +45,7 @@ import { useToast } from '../../components/admin/layout/useToast';
 import type { BadgeTone } from '../../components/admin/ToneBadge';
 import { ToneBadge } from '../../components/admin/ToneBadge';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
+import { PANEL_MIN_WIDTH, PanelResizer } from '../../components/reviews/PanelResizer';
 import type {
   ScreenPosition,
   TextSelectionOffsets,
@@ -55,6 +56,8 @@ import { DocumentViewer } from '../../components/reviews/viewer/DocumentViewer';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
 import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
+
+const PANEL_WIDTH_KEY = 'qnop-review-panel-width';
 
 /** Community workflow states with a badge tone; unknown (enterprise) states render neutral. */
 const WORKFLOW_TONES: Record<string, BadgeTone> = {
@@ -115,6 +118,23 @@ export function DocumentReviewPage() {
   const [hoverAnnotationId, setHoverAnnotationId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
   const viewerRef = useRef<DocumentViewerHandle>(null);
+  const [panelWidth, setPanelWidth] = useState<number>(() => {
+    try {
+      const stored = Number(localStorage.getItem(PANEL_WIDTH_KEY));
+      return stored >= PANEL_MIN_WIDTH ? stored : PANEL_MIN_WIDTH;
+    } catch {
+      return PANEL_MIN_WIDTH;
+    }
+  });
+
+  const handlePanelWidthChange = (width: number) => {
+    setPanelWidth(width);
+    try {
+      localStorage.setItem(PANEL_WIDTH_KEY, String(width));
+    } catch {
+      // best-effort persistence
+    }
+  };
   // A drawn-but-not-created mark. While `menuPosition` is set, the "Create
   // annotation" popup is open at the pointer; choosing the item clears the
   // position and opens the composer in the panel. Dismissing the popup
@@ -217,8 +237,9 @@ export function DocumentReviewPage() {
       ) : (
         <Stack
           direction={{ xs: 'column', md: 'row' }}
-          spacing={2.5}
-          sx={{ alignItems: { xs: 'stretch', md: 'stretch' }, flex: 1, minHeight: 0 }}
+          // On md+ the resizer provides the gap between the panes.
+          spacing={{ xs: 2.5, md: 0 }}
+          sx={{ alignItems: 'stretch', flex: 1, minHeight: 0 }}
         >
           <Stack spacing={1.5} sx={{ flex: 1, minWidth: 0, minHeight: 0 }}>
             <ViewerToolbar
@@ -289,11 +310,16 @@ export function DocumentReviewPage() {
               </Box>
             )}
           </Stack>
+          <PanelResizer
+            width={panelWidth}
+            defaultWidth={PANEL_MIN_WIDTH}
+            onWidthChange={handlePanelWidthChange}
+          />
           <Box
             component="aside"
             aria-label="Annotations"
             sx={{
-              width: { xs: '100%', md: 360 },
+              width: { xs: '100%', md: panelWidth },
               flexShrink: 0,
               minHeight: 0,
               overflowY: { md: 'auto' },

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -223,15 +223,9 @@ export function DocumentReviewPage() {
         minHeight: { md: 480 },
       }}
     >
-      <PageHeader
-        title={document.title}
-        titleAdornment={workflowBadge(document.workflowState)}
-        description={
-          versionNumber !== undefined
-            ? `Version ${versionNumber} of ${latestVersion}`
-            : 'No version uploaded yet.'
-        }
-      />
+      {/* No description line: the version lives in the toolbar dropdown, and
+          every saved pixel goes to the document and its annotations. */}
+      <PageHeader title={document.title} titleAdornment={workflowBadge(document.workflowState)} />
       {versionNumber === undefined ? (
         <Alert severity="info">This review has no uploaded document version yet.</Alert>
       ) : (

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -24,7 +24,12 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
+import { NotebookPen } from 'lucide-react';
 import type { Anchor, NormalizedBox } from '../../api/generated';
 import { ExtractionStatus } from '../../api/generated';
 import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotations';
@@ -40,7 +45,10 @@ import { useToast } from '../../components/admin/layout/useToast';
 import type { BadgeTone } from '../../components/admin/ToneBadge';
 import { ToneBadge } from '../../components/admin/ToneBadge';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
-import type { TextSelectionOffsets } from '../../components/reviews/viewer/anchoring';
+import type {
+  ScreenPosition,
+  TextSelectionOffsets,
+} from '../../components/reviews/viewer/anchoring';
 import { buildRegionAnchor, buildTextAnchor } from '../../components/reviews/viewer/anchoring';
 import { DocumentViewer } from '../../components/reviews/viewer/DocumentViewer';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
@@ -102,7 +110,14 @@ export function DocumentReviewPage() {
   const [tool, setTool] = useState<ViewerTool>('text');
   const [zoom, setZoom] = useState(1);
   const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
-  const [pendingAnchor, setPendingAnchor] = useState<Anchor | null>(null);
+  // A drawn-but-not-created mark. While `menuPosition` is set, the "Create
+  // annotation" popup is open at the pointer; choosing the item clears the
+  // position and opens the composer in the panel. Dismissing the popup
+  // discards the mark entirely.
+  const [pending, setPending] = useState<{
+    anchor: Anchor;
+    menuPosition: { left: number; top: number } | null;
+  } | null>(null);
 
   const surfaces = renderedQuery.data?.surfaces;
   const annotations = useMemo(
@@ -115,34 +130,36 @@ export function DocumentReviewPage() {
   const handleVersionChange = (version: number) => {
     setSearchParams({ version: String(version) });
     setActiveAnnotationId(null);
-    setPendingAnchor(null);
+    setPending(null);
   };
 
-  const handleTextSelected = ({ surfaceIndex, start, end }: TextSelectionOffsets) => {
+  const stagePending = (anchor: Anchor, at: ScreenPosition) => {
+    setPending({ anchor, menuPosition: at });
+    setActiveAnnotationId(null);
+  };
+
+  const handleTextSelected = (
+    { surfaceIndex, start, end }: TextSelectionOffsets,
+    at: ScreenPosition,
+  ) => {
     const surface = surfaces?.find((s) => s.index === surfaceIndex);
     if (!surface) return;
     const anchor = buildTextAnchor(surfaceIndex, surface.textSpans, start, end);
-    if (anchor) {
-      setPendingAnchor(anchor);
-      setActiveAnnotationId(null);
-    }
+    if (anchor) stagePending(anchor, at);
   };
 
-  const handleRegionSelected = (surfaceIndex: number, box: NormalizedBox) => {
+  const handleRegionSelected = (surfaceIndex: number, box: NormalizedBox, at: ScreenPosition) => {
     const anchor = buildRegionAnchor(surfaceIndex, box);
-    if (anchor) {
-      setPendingAnchor(anchor);
-      setActiveAnnotationId(null);
-    }
+    if (anchor) stagePending(anchor, at);
   };
 
   const handleCreate = (comment: string) => {
-    if (!pendingAnchor || versionNumber === undefined) return;
+    if (!pending || versionNumber === undefined) return;
     createAnnotation.mutate(
-      { versionNumber, anchor: pendingAnchor, comment: comment.trim() || undefined },
+      { versionNumber, anchor: pending.anchor, comment: comment.trim() || undefined },
       {
         onSuccess: (created) => {
-          setPendingAnchor(null);
+          setPending(null);
           setActiveAnnotationId(created.id);
           notify('Annotation created.');
         },
@@ -234,11 +251,11 @@ export function DocumentReviewPage() {
                   activeAnnotationId={activeAnnotationId}
                   onSelectAnnotation={(id) => {
                     setActiveAnnotationId(id);
-                    setPendingAnchor(null);
+                    setPending(null);
                   }}
                   tool={tool}
                   canAnnotate={canAnnotate}
-                  pendingAnchor={pendingAnchor}
+                  pendingAnchor={pending?.anchor ?? null}
                   onTextSelected={handleTextSelected}
                   onRegionSelected={handleRegionSelected}
                 />
@@ -259,16 +276,31 @@ export function DocumentReviewPage() {
               annotations={annotations}
               activeAnnotationId={activeAnnotationId}
               onSelect={setActiveAnnotationId}
-              pendingAnchor={pendingAnchor}
+              pendingAnchor={pending && !pending.menuPosition ? pending.anchor : null}
               creating={createAnnotation.isPending}
               onCreate={handleCreate}
-              onCancelPending={() => setPendingAnchor(null)}
+              onCancelPending={() => setPending(null)}
               canAnnotate={canAnnotate}
               notify={notify}
             />
           </Box>
         </Stack>
       )}
+      {/* The post-selection popup: only an explicit "Create annotation" opens
+          the composer; dismissing it (click-away, Escape) discards the mark. */}
+      <Menu
+        open={Boolean(pending?.menuPosition)}
+        onClose={() => setPending(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={pending?.menuPosition ?? undefined}
+      >
+        <MenuItem onClick={() => setPending((state) => state && { ...state, menuPosition: null })}>
+          <ListItemIcon>
+            <NotebookPen size={16} />
+          </ListItemIcon>
+          <ListItemText>Create annotation</ListItemText>
+        </MenuItem>
+      </Menu>
       <AdminToast toast={toast} onClose={clear} />
     </Stack>
   );

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -51,6 +51,15 @@ const MailTemplateEditPage = lazy(() =>
   import('../pages/admin/MailTemplateEditPage').then((m) => ({ default: m.MailTemplateEditPage })),
 );
 
+// The review surface pulls in pdf.js; load it lazily so the rest of the app stays light (#250).
+const DocumentReviewPage = lazy(() =>
+  import('../pages/reviews/DocumentReviewPage').then((m) => ({ default: m.DocumentReviewPage })),
+);
+
+const lazyFallback = (
+  <div style={{ padding: '8px 4px', fontSize: 14, color: '#5E6C7B' }}>Loading…</div>
+);
+
 /**
  * Central route table. Public routes (login, errors) sit outside the shell;
  * everything under the shell requires authentication. Surfaces whose screens
@@ -83,6 +92,14 @@ export const router = createBrowserRouter([
             description="Upload, review and approve documents — the review surface arrives in the PDF vertical slice."
             icon={FileText}
           />
+        ),
+      },
+      {
+        path: 'reviews/:documentId',
+        element: (
+          <Suspense fallback={lazyFallback}>
+            <DocumentReviewPage />
+          </Suspense>
         ),
       },
       {
@@ -157,11 +174,7 @@ export const router = createBrowserRouter([
         path: 'admin/mail-templates/:key',
         element: (
           <AdminRoute>
-            <Suspense
-              fallback={
-                <div style={{ padding: '8px 4px', fontSize: 14, color: '#5E6C7B' }}>Loading…</div>
-              }
-            >
+            <Suspense fallback={lazyFallback}>
               <MailTemplateEditPage />
             </Suspense>
           </AdminRoute>

--- a/qnop-ui/src/test/setup.ts
+++ b/qnop-ui/src/test/setup.ts
@@ -49,3 +49,19 @@ if (!window.ResizeObserver) {
     disconnect() {}
   };
 }
+
+// jsdom does not implement IntersectionObserver; the document viewer uses it
+// to render pages lazily. The stub never fires, so canvases stay blank in tests.
+if (!window.IntersectionObserver) {
+  window.IntersectionObserver = class {
+    root = null;
+    rootMargin = '';
+    thresholds = [];
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  } as unknown as typeof IntersectionObserver;
+}

--- a/qnop-ui/src/utils/platform.test.ts
+++ b/qnop-ui/src/utils/platform.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { isApplePlatform, isSubmitShortcut, submitShortcutLabel } from './platform';
+
+const originalPlatform = navigator.platform;
+
+function setPlatform(value: string) {
+  Object.defineProperty(navigator, 'platform', { value, configurable: true });
+}
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+});
+
+describe('isApplePlatform', () => {
+  it('detects macOS and iOS platforms', () => {
+    setPlatform('MacIntel');
+    expect(isApplePlatform()).toBe(true);
+    setPlatform('iPhone');
+    expect(isApplePlatform()).toBe(true);
+  });
+
+  it('rejects other platforms', () => {
+    setPlatform('Win32');
+    expect(isApplePlatform()).toBe(false);
+    setPlatform('Linux x86_64');
+    expect(isApplePlatform()).toBe(false);
+  });
+});
+
+describe('isSubmitShortcut', () => {
+  it('accepts Cmd+Enter and Alt+Enter', () => {
+    expect(isSubmitShortcut({ key: 'Enter', metaKey: true, altKey: false })).toBe(true);
+    expect(isSubmitShortcut({ key: 'Enter', metaKey: false, altKey: true })).toBe(true);
+  });
+
+  it('rejects plain Enter and modified non-Enter keys', () => {
+    expect(isSubmitShortcut({ key: 'Enter', metaKey: false, altKey: false })).toBe(false);
+    expect(isSubmitShortcut({ key: 'a', metaKey: true, altKey: false })).toBe(false);
+  });
+});
+
+describe('submitShortcutLabel', () => {
+  it('speaks the platform dialect', () => {
+    setPlatform('MacIntel');
+    expect(submitShortcutLabel()).toBe('⌘⏎');
+    setPlatform('Win32');
+    expect(submitShortcutLabel()).toBe('Alt+⏎');
+  });
+});

--- a/qnop-ui/src/utils/platform.ts
+++ b/qnop-ui/src/utils/platform.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/** True on Apple platforms — where shortcuts speak ⌘ instead of Alt/Ctrl. */
+export function isApplePlatform(): boolean {
+  return /Mac|iPhone|iPod|iPad/i.test(navigator.platform || navigator.userAgent);
+}
+
+/**
+ * True when a keyboard event is the submit chord: ⌘+Enter (Mac) or Alt+Enter
+ * (Windows/Linux). Both modifiers are accepted on every platform.
+ */
+export function isSubmitShortcut(event: {
+  key: string;
+  metaKey: boolean;
+  altKey: boolean;
+}): boolean {
+  return event.key === 'Enter' && (event.metaKey || event.altKey);
+}
+
+/** The submit chord spelled for the current platform, e.g. "⌘⏎" or "Alt+⏎". */
+export function submitShortcutLabel(): string {
+  return isApplePlatform() ? '⌘⏎' : 'Alt+⏎';
+}

--- a/qnop-ui/vitest.config.ts
+++ b/qnop-ui/vitest.config.ts
@@ -40,6 +40,10 @@ export default defineConfig({
         'src/components/auth/RoleRoute.tsx',
         'src/components/auth/AuthHydrationBoundary.tsx',
         'src/components/shell/navConfig.tsx',
+        // The viewer's pure anchor-building logic (#250); the presentational
+        // viewer/panel components are covered by component tests, and the
+        // pdf.js wiring (usePdfDocument, SurfacePage canvas) by E2E later.
+        'src/components/reviews/viewer/anchoring.ts',
         'src/theme/**/*.ts',
       ],
       thresholds: {


### PR DESCRIPTION
Closes #250. Part of epic #241.

## What

The review surface for a single document: a **lazy-loaded PDF viewer with an annotation layer**, replacing nothing (the `/reviews` list remains the placeholder until #251) and reachable at `/reviews/:documentId?version=n`.

### Architecture (per ADR-0032/0009)

- **Hybrid rendering**: pdf.js draws the original page pixels for fidelity; **every anchoring coordinate comes from the server** — highlight overlays are positioned from the stored normalized `RenderedDocument` boxes, and text selection runs over an invisible span layer built from the server-extracted `textSpans`, never from pdf.js's own text layer.
- **Multi-layer anchors**: a text selection produces region + text-quote (±32 chars context) + text-position; a rubber-band drag produces the universal region-only anchor. Pure, unit-tested logic in `anchoring.ts`.
- **Placement-status cues**: `MOVED` renders amber/dashed, `PENDING` dimmed, `ORPHANED`/`FAILED` listed in a separate "Not placed on this version" panel section with explanatory badges.
- **Extraction lifecycle** (ADR-0033): the original renders immediately after upload; annotating enables once extraction is `READY` (version list polls while `PENDING`); `FAILED` shows an error state.
- **Server-mediated binary**: the PDF bytes load as an `ArrayBuffer` through the shared axios instance (bearer token attached) from the deliberately out-of-contract `…/original` endpoint (ADR-0028/0032 §5).

### UI pieces

- `ViewerToolbar` — version switcher, extraction cue, text/region tool toggle, zoom (fit-width default)
- `DocumentViewer`/`SurfacePage` — page stack, per-page canvas rendered lazily via IntersectionObserver, overlay stack aligned by percent positioning
- `AnnotationPanel` — position-ordered list, status + placement badges, composer for a drawn anchor, expandable flat comment thread (oldest first)
- New query hooks (`useDocuments`, `useAnnotations`, `useComments`) + `documentsApi`/`annotationsApi` singletons

New dependency: `pdfjs-dist` (Apache-2.0), confined to the lazy route chunk (worker emitted as its own asset; main bundle unchanged).

## Test plan

- [x] `anchoring.ts` unit tests: canonical text, box math/clamping, partial-span trimming, anchor building (text + region), position ordering (17 tests)
- [x] Query-hook tests for documents/annotations/comments incl. enabled-gating (15 tests)
- [x] Component tests: `HighlightLayer` (stored-box positioning, status styling, a11y activation), `AnnotationPanel` (composer, sections, toggling), `CommentThread` (authorship, submit), `DocumentReviewPage` orchestration (happy path, processing banner, anti-enumeration error)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test:run` (209 passing), `pnpm build` green; viewer ships as its own async chunk
- [ ] Manual: open a real uploaded PDF, annotate a quote and a region, verify overlay agreement with PDFBox boxes (incl. a rotated-page document) — needs the running stack

🤖 Co-Author: Claude (Fable 5) via Claude Code
🤖 Generated with [Claude Code](https://claude.com/claude-code)