### PR TITLE
feat(core): async re-anchoring engine (ADR-0009)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1780,6 +1780,15 @@ paths:
           schema:
             type: integer
             minimum: 1
+        - name: placementStatus
+          in: query
+          required: false
+          description: >-
+            Only annotations whose placement on `version` has this status — e.g.
+            `ORPHANED` to review annotations re-anchoring could not relocate
+            (issue #248). Requires `version`.
+          schema:
+            $ref: '#/components/schemas/PlacementStatus'
       responses:
         '200':
           description: The annotations

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -75,9 +75,15 @@ public class AnnotationController implements AnnotationsApi {
   }
 
   @Override
-  public ResponseEntity<AnnotationListResponse> listAnnotations(UUID documentId, Integer version) {
+  public ResponseEntity<AnnotationListResponse> listAnnotations(
+      UUID documentId, Integer version, PlacementStatus placementStatus) {
     var views =
-        annotations.list(documentId, version, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+        annotations.list(
+            documentId,
+            version,
+            placementStatus == null ? null : placementStatus.getValue(),
+            CurrentUser.requireUserId(),
+            CurrentUser.isAdmin());
     return ResponseEntity.ok(
         new AnnotationListResponse().annotations(views.stream().map(this::toDto).toList()));
   }

--- a/qnop-app/src/test/java/io/qnop/document/ReanchoringIT.java
+++ b/qnop-app/src/test/java/io/qnop/document/ReanchoringIT.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.document;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.job.JobQueuePoller;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+/**
+ * End-to-end re-anchoring (issue #248, ADR-0009): upload v1 → annotate through the API → upload
+ * further versions → the extraction job chains the re-anchoring job on the durable queue → the
+ * annotation's placement on each new version resolves to PLACED / ORPHANED and orphans are
+ * queryable via the {@code placementStatus} filter. Tests drive the queue with {@code
+ * poller.poll()} (the scheduled tick is disabled in ITs). Requires Docker.
+ */
+@AutoConfigureMockMvc
+class ReanchoringIT extends AbstractIntegrationTest {
+
+  private static final String QUOTE = "the payment terms are thirty days";
+
+  @Autowired MockMvc mockMvc;
+  @Autowired UserRepository users;
+  @Autowired DocumentRepository documents;
+  @Autowired PasswordEncoder passwordEncoder;
+  @Autowired JobQueuePoller poller;
+
+  private final List<UUID> createdDocuments = new ArrayList<>();
+  private final List<UUID> createdUsers = new ArrayList<>();
+
+  @AfterEach
+  void cleanup() {
+    createdDocuments.forEach(id -> documents.findById(id).ifPresent(documents::delete));
+    createdUsers.forEach(id -> users.findById(id).ifPresent(users::delete));
+  }
+
+  @Test
+  @DisplayName("a new version re-places the annotation; a version without the text orphans it")
+  void reanchorsAcrossVersions() throws Exception {
+    UUID owner = createUser();
+
+    // v1: upload + extract, then annotate the quote through the API.
+    UUID documentId =
+        upload(owner, "whereas " + QUOTE + " from invoice", "a second unrelated line");
+    poller.poll(); // extract v1 (no placements yet → no re-anchor job)
+
+    mockMvc
+        .perform(
+            post("/api/v1/documents/{id}/annotations", documentId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(annotationBody())
+                .with(asUser(owner)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.placementStatus").value("PLACED"));
+
+    // v2 still contains the quote (shifted by a new first line) → PLACED again.
+    addVersion(owner, documentId, "a brand new intro line", "whereas " + QUOTE + " from invoice");
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("version", "2")
+                .with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("PENDING"));
+
+    poller.poll(); // extract v2 → chains the re-anchor job
+    poller.poll(); // run the re-anchor job
+
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("version", "2")
+                .with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("PLACED"));
+
+    // v3 drops the quote entirely → ORPHANED, and the filter surfaces it.
+    addVersion(owner, documentId, "every clause was rewritten from scratch in this draft");
+    poller.poll(); // extract v3
+    poller.poll(); // re-anchor v3
+
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("version", "3")
+                .param("placementStatus", "ORPHANED")
+                .with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations.length()").value(1))
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("ORPHANED"));
+
+    // The same filter finds nothing PLACED on v3 (proof the filter actually narrows).
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("version", "3")
+                .param("placementStatus", "PLACED")
+                .with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations.length()").value(0));
+  }
+
+  @Test
+  @DisplayName("the placementStatus filter without a version is rejected with 400")
+  void filterWithoutVersionIs400() throws Exception {
+    UUID owner = createUser();
+    UUID documentId = upload(owner, "some line");
+
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("placementStatus", "ORPHANED")
+                .with(asUser(owner)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  /** The annotation drawn on v1: region + the quote with its real prefix/suffix context. */
+  private static String annotationBody() {
+    return """
+        {"versionNumber":1,"anchor":{
+          "region":{"surfaceIndex":0,"box":{"x":0.1,"y":0.1,"width":0.5,"height":0.05}},
+          "textQuote":{"quote":"%s","prefix":"whereas ","suffix":" from invoice"},
+          "textPosition":{"start":8,"end":%d}},
+         "comment":"please double-check this clause"}
+        """
+        .formatted(QUOTE, 8 + QUOTE.length());
+  }
+
+  private UUID upload(UUID owner, String... lines) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                multipart("/api/v1/documents")
+                    .file(pdfFile(pdf(lines)))
+                    .param("title", "Reanchor IT")
+                    .with(asUser(owner)))
+            .andExpect(status().isCreated())
+            .andReturn();
+    UUID id =
+        UUID.fromString(JsonPath.read(result.getResponse().getContentAsString(), "$.documentId"));
+    createdDocuments.add(id);
+    return id;
+  }
+
+  private void addVersion(UUID owner, UUID documentId, String... lines) throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/documents/{id}/versions", documentId)
+                .file(pdfFile(pdf(lines)))
+                .with(asUser(owner)))
+        .andExpect(status().isCreated());
+  }
+
+  private UUID createUser() {
+    String name = "reanchor-" + UUID.randomUUID();
+    User user =
+        User.internal(name, name + "@example.com", name, passwordEncoder.encode("irrelevant-pw"));
+    user.setEnabled(true);
+    UUID id = users.saveAndFlush(user).getId();
+    createdUsers.add(id);
+    return id;
+  }
+
+  private static RequestPostProcessor asUser(UUID userId) {
+    return jwt().jwt(j -> j.subject(userId.toString()));
+  }
+
+  private static MockMultipartFile pdfFile(byte[] bytes) {
+    return new MockMultipartFile("file", "doc.pdf", "application/pdf", bytes);
+  }
+
+  /** One LETTER page with one text line per given string. */
+  private static byte[] pdf(String... lines) throws IOException {
+    try (PDDocument document = new PDDocument()) {
+      PDPage page = new PDPage(PDRectangle.LETTER);
+      document.addPage(page);
+      try (PDPageContentStream content = new PDPageContentStream(document, page)) {
+        content.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+        float y = 700;
+        for (String line : lines) {
+          content.beginText();
+          content.newLineAtOffset(72, y);
+          content.showText(line);
+          content.endText();
+          y -= 20;
+        }
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      document.save(out);
+      return out.toByteArray();
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
@@ -20,10 +20,15 @@
  */
 package io.qnop.service.document;
 
+import io.qnop.entity.AnnotationPlacement;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
+import io.qnop.entity.PlacementStatus;
+import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobHandler;
+import io.qnop.service.job.JobService;
+import io.qnop.service.review.ReanchorJobHandler;
 import io.qnop.service.storage.StorageService;
 import io.qnop.spi.extract.DocumentExtractor;
 import io.qnop.spi.extract.ExtractionException;
@@ -34,6 +39,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
@@ -66,14 +72,22 @@ public class DocumentExtractionJobHandler implements JobHandler {
   private final DocumentVersionRepository versions;
   private final StorageService storage;
   private final List<DocumentExtractor> extractors;
+  private final AnnotationPlacementRepository placements;
+  // ObjectProvider breaks the constructor cycle: JobService injects every JobHandler, and this
+  // handler needs JobService back to enqueue the follow-up re-anchoring job (issue #248).
+  private final ObjectProvider<JobService> jobs;
 
   public DocumentExtractionJobHandler(
       DocumentVersionRepository versions,
       StorageService storage,
-      List<DocumentExtractor> extractors) {
+      List<DocumentExtractor> extractors,
+      AnnotationPlacementRepository placements,
+      ObjectProvider<JobService> jobs) {
     this.versions = versions;
     this.storage = storage;
     this.extractors = extractors;
+    this.placements = placements;
+    this.jobs = jobs;
   }
 
   @Override
@@ -104,6 +118,7 @@ public class DocumentExtractionJobHandler implements JobHandler {
           versionId);
       version.markExtractionFailed();
       versions.save(version);
+      failPendingPlacements(version);
       return;
     }
 
@@ -117,14 +132,44 @@ public class DocumentExtractionJobHandler implements JobHandler {
       RenderedDocument rendered = extractor.get().extract(content.stream());
       version.attachRenderedDocument(MAPPER.writeValueAsString(rendered));
       versions.save(version);
+      enqueueReanchoringIfPending(version);
     } catch (ExtractionException e) {
       log.warn("Extraction of version {} failed permanently: {}", versionId, e.getMessage());
       version.markExtractionFailed();
       versions.save(version);
+      failPendingPlacements(version);
     } catch (JacksonException e) {
       // Serializing our own SPI records can only fail on a code bug; add context and let the
       // queue's retry/FAILED policy surface it.
       throw new IllegalStateException("Failed to serialize rendered document", e);
+    }
+  }
+
+  /**
+   * Chains the re-anchoring job (issue #248) once the text layer is READY — in the same transaction
+   * as the READY write (outbox, ADR-0033). Skipped when the version has no pending placements (v1
+   * uploads, documents without open annotations).
+   */
+  private void enqueueReanchoringIfPending(DocumentVersion version) {
+    if (!placements
+        .findByDocumentVersionIdAndStatus(version.getId(), PlacementStatus.PENDING)
+        .isEmpty()) {
+      jobs.getObject()
+          .enqueue(
+              ReanchorJobHandler.TYPE, DocumentIngestService.extractionPayload(version.getId()));
+    }
+  }
+
+  /**
+   * A version whose extraction failed permanently can never be re-anchored against: its pending
+   * placements become FAILED (deterministic on replay — they are only ever PENDING before this).
+   */
+  private void failPendingPlacements(DocumentVersion version) {
+    List<AnnotationPlacement> pending =
+        placements.findByDocumentVersionIdAndStatus(version.getId(), PlacementStatus.PENDING);
+    for (AnnotationPlacement placement : pending) {
+      placement.markFailed();
+      placements.save(placement);
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -20,8 +20,13 @@
  */
 package io.qnop.service.document;
 
+import io.qnop.entity.Annotation;
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.AnnotationStatus;
 import io.qnop.entity.Document;
 import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.ApplicationSettingKey;
@@ -31,7 +36,11 @@ import io.qnop.service.storage.StagedObject;
 import io.qnop.service.storage.StorageService;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -65,6 +74,8 @@ public class DocumentIngestService {
   private final JobService jobs;
   private final ApplicationSettingsService settings;
   private final DocumentAccessService access;
+  private final AnnotationRepository annotations;
+  private final AnnotationPlacementRepository placements;
   private final TransactionTemplate transactionTemplate;
 
   public DocumentIngestService(
@@ -74,6 +85,8 @@ public class DocumentIngestService {
       JobService jobs,
       ApplicationSettingsService settings,
       DocumentAccessService access,
+      AnnotationRepository annotations,
+      AnnotationPlacementRepository placements,
       PlatformTransactionManager transactionManager) {
     this.documents = documents;
     this.versions = versions;
@@ -81,6 +94,8 @@ public class DocumentIngestService {
     this.jobs = jobs;
     this.settings = settings;
     this.access = access;
+    this.annotations = annotations;
+    this.placements = placements;
     this.transactionTemplate = new TransactionTemplate(transactionManager);
   }
 
@@ -132,6 +147,7 @@ public class DocumentIngestService {
                           .orElse(0)
                       + 1;
               DocumentVersion version = saveVersionAndEnqueue(documentId, next, staged, actor);
+              seedPendingPlacements(documentId, version);
               return new UploadResult(
                   documentId, version.getVersionNumber(), version.getExtractionStatus().name());
             });
@@ -155,6 +171,37 @@ public class DocumentIngestService {
     // for a version that exists, and never fires for one that rolled back.
     jobs.enqueue(EXTRACTION_JOB_TYPE, extractionPayload(version.getId()));
     return version;
+  }
+
+  /**
+   * Seeds a PENDING placement on the new version for every OPEN annotation (issue #248, ADR-0009),
+   * carrying the annotation's most recent anchor as the re-anchoring hypothesis. Runs in the upload
+   * transaction, so the version is never visible without its pending placements — which is exactly
+   * what keeps it non-finalizable until re-anchoring resolves (ADR-0011). The re-anchor job itself
+   * is enqueued by the extraction handler once the new text layer is READY.
+   */
+  private void seedPendingPlacements(UUID documentId, DocumentVersion newVersion) {
+    var open = annotations.findByDocumentIdAndStatus(documentId, AnnotationStatus.OPEN);
+    if (open.isEmpty()) {
+      return;
+    }
+    Map<UUID, Integer> versionNumberById =
+        versions.findByDocumentIdOrderByVersionNumberAsc(documentId).stream()
+            .collect(Collectors.toMap(DocumentVersion::getId, DocumentVersion::getVersionNumber));
+    for (Annotation annotation : open) {
+      Optional<AnnotationPlacement> latest =
+          placements.findByAnnotationId(annotation.getId()).stream()
+              .filter(p -> !p.getDocumentVersionId().equals(newVersion.getId()))
+              .max(
+                  Comparator.comparing(
+                      p -> versionNumberById.getOrDefault(p.getDocumentVersionId(), 0),
+                      Comparator.naturalOrder()));
+      latest.ifPresent(
+          source ->
+              placements.save(
+                  new AnnotationPlacement(
+                      annotation.getId(), newVersion.getId(), source.getAnchor())));
+    }
   }
 
   /** The job payload; a tiny hand-built JSON object (single UUID — no mapper needed). */

--- a/qnop-core/src/main/java/io/qnop/service/review/AnchorResolver.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnchorResolver.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.spi.extract.RenderedDocument;
+import io.qnop.spi.extract.Surface;
+import io.qnop.spi.extract.TextSpan;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * The re-anchoring cascade of ADR-0009 as plain, DB-free, deterministic code (issue #248): given an
+ * annotation's stored anchor and a new version's {@link RenderedDocument}, decide where — if
+ * anywhere — the annotation sits on the new version.
+ *
+ * <ul>
+ *   <li><b>Exact</b> — the quote (with its context) occurs unchanged exactly once → {@code PLACED}
+ *       with refreshed position and region.
+ *   <li><b>Fuzzy</b> — duplicated or slightly edited text; the similarity-best candidate, weighted
+ *       by prefix/suffix context, wins only above a threshold and with a clear margin over the
+ *       runner-up → {@code MOVED} (flagged for the reviewer).
+ *   <li><b>Orphaned</b> — no unambiguous match → {@code ORPHANED}, the anchor untouched. Never
+ *       silently guessed.
+ * </ul>
+ *
+ * <p>An anchor without a text-quote layer (an image region, ADR-0009) keeps its 0..1 coordinates
+ * unchanged and is flagged {@code MOVED} ("to review") — Community ships no visual re-matching.
+ *
+ * <p>Same inputs always produce the same resolution (job replay, ADR-0033): candidate scanning is
+ * ordered, and ties break on (surface, offset).
+ */
+public final class AnchorResolver {
+
+  /** How a placement resolved; maps 1:1 onto {@code PlacementStatus}. */
+  public enum Outcome {
+    PLACED,
+    MOVED,
+    ORPHANED
+  }
+
+  /** The decision plus the anchor to store — updated on PLACED/MOVED, untouched on ORPHANED. */
+  public record Resolution(Outcome outcome, String anchorJson) {}
+
+  static final double SIMILARITY_THRESHOLD = 0.75;
+  static final double AMBIGUITY_MARGIN = 0.05;
+  private static final int CONTEXT_LENGTH = 32;
+  private static final int MAX_CANDIDATES = 64;
+  private static final double QUOTE_WEIGHT = 0.7;
+  private static final double CONTEXT_WEIGHT = 0.3;
+
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  /** Resolves {@code anchorJson} against {@code rendered}; never throws on bad anchor content. */
+  public Resolution resolve(String anchorJson, RenderedDocument rendered) {
+    ParsedAnchor anchor = parse(anchorJson);
+    if (anchor == null) {
+      // Unreadable anchor: be honest rather than guess (ADR-0009).
+      return new Resolution(Outcome.ORPHANED, anchorJson);
+    }
+    if (anchor.quote() == null || anchor.quote().isEmpty()) {
+      // Geometric-only anchor (image region): coordinates carry over, flagged "to review".
+      return new Resolution(Outcome.MOVED, anchorJson);
+    }
+
+    List<SurfaceText> surfaces = surfaceTexts(rendered);
+
+    // 1) Exact, context-qualified: prefix+quote+suffix unchanged exactly once in the document.
+    List<Match> withContext = exactMatches(surfaces, anchor, true);
+    if (withContext.size() == 1) {
+      return placed(anchor, withContext.get(0), surfaces);
+    }
+    // 2) Exact quote alone, unique in the document.
+    List<Match> quoteOnly = exactMatches(surfaces, anchor, false);
+    if (quoteOnly.size() == 1) {
+      return placed(anchor, quoteOnly.get(0), surfaces);
+    }
+    // 3) Duplicated exact quote: context similarity picks one — flagged MOVED — or nobody wins.
+    if (quoteOnly.size() > 1) {
+      return disambiguate(anchor, quoteOnly, surfaces, anchorJson);
+    }
+    // 4) Quote not found verbatim: fuzzy candidates from quote-chunk seeds.
+    List<Match> fuzzy = fuzzyCandidates(surfaces, anchor);
+    return disambiguate(anchor, fuzzy, surfaces, anchorJson);
+  }
+
+  // --- cascade steps ----------------------------------------------------------
+
+  private static List<Match> exactMatches(
+      List<SurfaceText> surfaces, ParsedAnchor anchor, boolean withContext) {
+    String prefix = anchor.prefix() == null ? "" : anchor.prefix();
+    String suffix = anchor.suffix() == null ? "" : anchor.suffix();
+    if (withContext && prefix.isEmpty() && suffix.isEmpty()) {
+      return List.of(); // no context layer to qualify with — step degenerates to quote-only
+    }
+    String needle = withContext ? prefix + anchor.quote() + suffix : anchor.quote();
+    int quoteShift = withContext ? prefix.length() : 0;
+
+    List<Match> matches = new ArrayList<>();
+    for (SurfaceText surface : surfaces) {
+      int from = 0;
+      int idx;
+      while ((idx = surface.text().indexOf(needle, from)) >= 0) {
+        matches.add(new Match(surface, idx + quoteShift, anchor.quote(), 1.0));
+        from = idx + 1;
+        if (matches.size() > MAX_CANDIDATES) {
+          return matches; // pathological repetition; counts as ambiguous anyway
+        }
+      }
+    }
+    return matches;
+  }
+
+  /** The similarity-best candidate wins only above the threshold and with a clear margin. */
+  private Resolution disambiguate(
+      ParsedAnchor anchor, List<Match> candidates, List<SurfaceText> surfaces, String original) {
+    if (candidates.isEmpty()) {
+      return new Resolution(Outcome.ORPHANED, original);
+    }
+    List<Scored> scored = new ArrayList<>(candidates.size());
+    for (Match candidate : candidates) {
+      scored.add(new Scored(candidate, score(anchor, candidate, surfaces)));
+    }
+    scored.sort(
+        Comparator.comparingDouble(Scored::score)
+            .reversed()
+            .thenComparingInt(s -> s.match().surface().index())
+            .thenComparingInt(s -> s.match().start()));
+    Scored best = scored.get(0);
+    if (best.score() < SIMILARITY_THRESHOLD) {
+      return new Resolution(Outcome.ORPHANED, original);
+    }
+    if (scored.size() > 1 && best.score() - scored.get(1).score() < AMBIGUITY_MARGIN) {
+      return new Resolution(Outcome.ORPHANED, original); // ambiguous — never guessed
+    }
+    return new Resolution(Outcome.MOVED, rebuiltAnchor(best.match()));
+  }
+
+  /** Candidate windows seeded by verbatim occurrences of quote chunks (cheap, conservative). */
+  private static List<Match> fuzzyCandidates(List<SurfaceText> surfaces, ParsedAnchor anchor) {
+    String quote = anchor.quote();
+    List<String> seeds = seeds(quote);
+    List<Match> candidates = new ArrayList<>();
+    for (SurfaceText surface : surfaces) {
+      TreeSet<Integer> starts = new TreeSet<>();
+      for (int s = 0; s < seeds.size(); s++) {
+        String seed = seeds.get(s);
+        int seedOffset = quote.indexOf(seed);
+        int from = 0;
+        int idx;
+        while ((idx = surface.text().indexOf(seed, from)) >= 0) {
+          starts.add(Math.max(0, idx - seedOffset));
+          from = idx + 1;
+          if (starts.size() >= MAX_CANDIDATES) {
+            break;
+          }
+        }
+      }
+      Integer previous = null;
+      for (int start : starts) {
+        if (previous != null && start - previous <= 2) {
+          continue; // collapse near-duplicate windows from different seeds
+        }
+        previous = start;
+        int end = Math.min(surface.text().length(), start + quote.length());
+        String window = surface.text().substring(start, end);
+        double similarity = similarity(quote, window);
+        candidates.add(new Match(surface, start, window, similarity));
+      }
+    }
+    return candidates;
+  }
+
+  /** Up to four seeds of the quote; short quotes seed as a whole. */
+  private static List<String> seeds(String quote) {
+    int chunk = Math.max(8, quote.length() / 4);
+    if (quote.length() <= chunk) {
+      return List.of(quote);
+    }
+    List<String> seeds = new ArrayList<>(4);
+    for (int at = 0; at + chunk <= quote.length() && seeds.size() < 4; at += chunk) {
+      seeds.add(quote.substring(at, at + chunk));
+    }
+    return seeds;
+  }
+
+  // --- scoring ----------------------------------------------------------------
+
+  private static double score(ParsedAnchor anchor, Match match, List<SurfaceText> surfaces) {
+    String text = match.surface().text();
+    double quoteSimilarity = match.quoteSimilarity();
+
+    String prefix = anchor.prefix() == null ? "" : anchor.prefix();
+    String suffix = anchor.suffix() == null ? "" : anchor.suffix();
+    if (prefix.isEmpty() && suffix.isEmpty()) {
+      return quoteSimilarity; // no context layer — the quote is all we have
+    }
+    double contextSimilarity = 0;
+    int layers = 0;
+    if (!prefix.isEmpty()) {
+      int from = Math.max(0, match.start() - prefix.length());
+      contextSimilarity += similarity(prefix, text.substring(from, match.start()));
+      layers++;
+    }
+    if (!suffix.isEmpty()) {
+      int end = match.start() + match.window().length();
+      int to = Math.min(text.length(), end + suffix.length());
+      contextSimilarity += similarity(suffix, text.substring(end, to));
+      layers++;
+    }
+    return QUOTE_WEIGHT * quoteSimilarity + CONTEXT_WEIGHT * (contextSimilarity / layers);
+  }
+
+  /** Normalized Levenshtein similarity in 0..1; both inputs are window-sized (bounded cost). */
+  static double similarity(String a, String b) {
+    if (a.equals(b)) {
+      return 1.0;
+    }
+    if (a.isEmpty() || b.isEmpty()) {
+      return 0.0;
+    }
+    int[] previous = new int[b.length() + 1];
+    int[] current = new int[b.length() + 1];
+    for (int j = 0; j <= b.length(); j++) {
+      previous[j] = j;
+    }
+    for (int i = 1; i <= a.length(); i++) {
+      current[0] = i;
+      for (int j = 1; j <= b.length(); j++) {
+        int substitution = previous[j - 1] + (a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1);
+        current[j] = Math.min(substitution, Math.min(previous[j] + 1, current[j - 1] + 1));
+      }
+      int[] swap = previous;
+      previous = current;
+      current = swap;
+    }
+    int distance = previous[b.length()];
+    return 1.0 - (double) distance / Math.max(a.length(), b.length());
+  }
+
+  // --- anchor (re)construction --------------------------------------------------
+
+  private Resolution placed(ParsedAnchor anchor, Match match, List<SurfaceText> surfaces) {
+    return new Resolution(Outcome.PLACED, rebuiltAnchor(match));
+  }
+
+  /**
+   * Builds the resolved anchor: fresh position offsets, the matched text as the new quote with
+   * regenerated context slices, and a region box unioned from the spans the match covers.
+   */
+  private static String rebuiltAnchor(Match match) {
+    SurfaceText surface = match.surface();
+    int start = match.start();
+    int end = start + match.window().length();
+    String text = surface.text();
+
+    Map<String, Object> anchor = new LinkedHashMap<>();
+    anchor.put(
+        "region", Map.of("surfaceIndex", surface.index(), "box", boxFor(surface, start, end)));
+    Map<String, Object> quote = new LinkedHashMap<>();
+    quote.put("quote", match.window());
+    quote.put("prefix", text.substring(Math.max(0, start - CONTEXT_LENGTH), start));
+    quote.put("suffix", text.substring(end, Math.min(text.length(), end + CONTEXT_LENGTH)));
+    anchor.put("textQuote", quote);
+    anchor.put("textPosition", Map.of("start", start, "end", end));
+    return MAPPER.writeValueAsString(anchor);
+  }
+
+  /** Union of the boxes of all spans overlapping [start, end) — the match's visual footprint. */
+  private static Map<String, Double> boxFor(SurfaceText surface, int start, int end) {
+    double minX = Double.MAX_VALUE;
+    double minY = Double.MAX_VALUE;
+    double maxX = -Double.MAX_VALUE;
+    double maxY = -Double.MAX_VALUE;
+    boolean any = false;
+    for (TextSpan span : surface.surface().textSpans()) {
+      if (span.startOffset() < end && span.endOffset() > start) {
+        any = true;
+        minX = Math.min(minX, span.box().x());
+        minY = Math.min(minY, span.box().y());
+        maxX = Math.max(maxX, span.box().x() + span.box().width());
+        maxY = Math.max(maxY, span.box().y() + span.box().height());
+      }
+    }
+    if (!any) {
+      // Text matched but no span covers it — impossible for extractor-produced text; degrade to
+      // a zero-size box at the surface origin rather than invent geometry.
+      return Map.of("x", 0.0, "y", 0.0, "width", 0.0, "height", 0.0);
+    }
+    return Map.of("x", minX, "y", minY, "width", maxX - minX, "height", maxY - minY);
+  }
+
+  // --- input models -------------------------------------------------------------
+
+  /**
+   * Canonical text per surface: span texts joined by a single {@code \n} (extractor convention).
+   */
+  private static List<SurfaceText> surfaceTexts(RenderedDocument rendered) {
+    List<SurfaceText> texts = new ArrayList<>(rendered.surfaces().size());
+    for (Surface surface : rendered.surfaces()) {
+      StringBuilder joined = new StringBuilder();
+      for (TextSpan span : surface.textSpans()) {
+        if (!joined.isEmpty()) {
+          joined.append('\n');
+        }
+        joined.append(span.text());
+      }
+      texts.add(new SurfaceText(surface.index(), surface, joined.toString()));
+    }
+    return texts;
+  }
+
+  /** Lenient parse of the stored anchor JSON; null when unreadable. */
+  private static ParsedAnchor parse(String anchorJson) {
+    if (anchorJson == null || anchorJson.isBlank()) {
+      return null;
+    }
+    try {
+      JsonNode root = MAPPER.readTree(anchorJson);
+      JsonNode quote = root.path("textQuote");
+      return new ParsedAnchor(
+          textOrNull(quote.path("quote")),
+          textOrNull(quote.path("prefix")),
+          textOrNull(quote.path("suffix")));
+    } catch (JacksonException e) {
+      return null;
+    }
+  }
+
+  private static String textOrNull(JsonNode node) {
+    return node.isMissingNode() || node.isNull() ? null : node.asText();
+  }
+
+  private record ParsedAnchor(String quote, String prefix, String suffix) {}
+
+  private record SurfaceText(int index, Surface surface, String text) {}
+
+  /** A candidate location: where, what text sits there, and how similar it is to the quote. */
+  private record Match(SurfaceText surface, int start, String window, double quoteSimilarity) {}
+
+  private record Scored(Match match, double score) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -140,10 +140,15 @@ public class AnnotationService {
 
   /**
    * All of a document's annotations; each with its placement on {@code versionNumber} when given.
+   * {@code placementStatus} (requires {@code versionNumber}) narrows to placements in that state —
+   * e.g. ORPHANED to surface what re-anchoring could not relocate (issue #248).
    */
   @Transactional(readOnly = true)
   public List<AnnotationView> list(
-      UUID documentId, Integer versionNumber, UUID actor, boolean admin) {
+      UUID documentId, Integer versionNumber, String placementStatus, UUID actor, boolean admin) {
+    if (placementStatus != null && versionNumber == null) {
+      throw DocumentValidationException.invalidRequest("placementStatus requires version");
+    }
     documentAccess.getDocument(documentId, actor, admin); // visibility → 404 if not a participant
     UUID versionId =
         versionNumber == null
@@ -163,6 +168,7 @@ public class AnnotationService {
                           .orElse(null);
               return view(annotation, placement, threadSize(annotation.getId()));
             })
+        .filter(view -> placementStatus == null || placementStatus.equals(view.placementStatus()))
         .toList();
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ExtractionStatus;
+import io.qnop.entity.PlacementStatus;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.job.JobHandler;
+import io.qnop.spi.extract.RenderedDocument;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Runs the async re-anchoring of a version's {@code PENDING} placements (issue #248, ADR-0009):
+ * loads the version's canonical {@link RenderedDocument} and resolves every pending placement
+ * through the {@link AnchorResolver} cascade — {@code PLACED}, {@code MOVED}, or {@code ORPHANED}.
+ *
+ * <p>Enqueued by the extraction job once the version is {@code READY} (the cascade needs the new
+ * text layer), transactionally with the READY write. <strong>Idempotent</strong> (ADR-0033): only
+ * {@code PENDING} placements are touched, and the resolver is deterministic — a replay recomputes
+ * identical outcomes; a deleted version is a no-op.
+ */
+@Component
+public class ReanchorJobHandler implements JobHandler {
+
+  /** The job type; payload is {@code {"versionId": "..."}} like the extraction job's. */
+  public static final String TYPE = "document.reanchor";
+
+  private static final Logger log = LoggerFactory.getLogger(ReanchorJobHandler.class);
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  private final DocumentVersionRepository versions;
+  private final AnnotationPlacementRepository placements;
+  private final AnchorResolver resolver = new AnchorResolver();
+
+  public ReanchorJobHandler(
+      DocumentVersionRepository versions, AnnotationPlacementRepository placements) {
+    this.versions = versions;
+    this.placements = placements;
+  }
+
+  @Override
+  public String type() {
+    return TYPE;
+  }
+
+  @Override
+  public void handle(String payload) {
+    UUID versionId = parseVersionId(payload);
+    Optional<DocumentVersion> found = versions.findById(versionId);
+    if (found.isEmpty()) {
+      log.info("Re-anchoring skipped: version {} no longer exists.", versionId);
+      return; // idempotent: the document was deleted after enqueue
+    }
+    DocumentVersion version = found.get();
+    if (version.getExtractionStatus() != ExtractionStatus.READY
+        || version.getRenderedDocument() == null) {
+      // Enqueued transactionally with the READY write, so this can only be a broken invariant —
+      // retryable, and FAILED after max attempts surfaces it.
+      throw new IllegalStateException(
+          "version " + versionId + " has no rendered document to re-anchor against");
+    }
+    RenderedDocument rendered = readRendered(version);
+
+    List<AnnotationPlacement> pending =
+        placements.findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING);
+    for (AnnotationPlacement placement : pending) {
+      AnchorResolver.Resolution resolution = resolver.resolve(placement.getAnchor(), rendered);
+      switch (resolution.outcome()) {
+        case PLACED -> placement.markPlaced(resolution.anchorJson());
+        case MOVED -> placement.markMoved(resolution.anchorJson());
+        case ORPHANED -> placement.markOrphaned();
+      }
+      placements.save(placement);
+    }
+    if (!pending.isEmpty()) {
+      log.info("Re-anchored {} placement(s) on version {}.", pending.size(), versionId);
+    }
+  }
+
+  private static RenderedDocument readRendered(DocumentVersion version) {
+    try {
+      return MAPPER.readValue(version.getRenderedDocument(), RenderedDocument.class);
+    } catch (JacksonException e) {
+      throw new IllegalStateException(
+          "stored rendered document of version " + version.getId() + " is unreadable", e);
+    }
+  }
+
+  private static UUID parseVersionId(String payload) {
+    try {
+      JsonNode node = MAPPER.readTree(payload);
+      return UUID.fromString(node.get("versionId").asText());
+    } catch (JacksonException | NullPointerException | IllegalArgumentException e) {
+      throw new IllegalArgumentException("Malformed re-anchor payload: " + payload, e);
+    }
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
@@ -29,7 +29,9 @@ import static org.mockito.Mockito.when;
 
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
+import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.job.JobService;
 import io.qnop.service.storage.StorageService;
 import io.qnop.spi.extract.DocumentExtractor;
 import io.qnop.spi.extract.ExtractionException;
@@ -46,12 +48,18 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 
 /** Unit tests for {@link DocumentExtractionJobHandler}'s failure policy and idempotency (#245). */
 class DocumentExtractionJobHandlerTest {
 
   private final DocumentVersionRepository versions = mock(DocumentVersionRepository.class);
   private final StorageService storage = mock(StorageService.class);
+  private final AnnotationPlacementRepository placements =
+      mock(AnnotationPlacementRepository.class);
+
+  @SuppressWarnings("unchecked")
+  private final ObjectProvider<JobService> jobs = mock(ObjectProvider.class);
 
   private final UUID versionId = UUID.randomUUID();
   private DocumentVersion version;
@@ -64,7 +72,8 @@ class DocumentExtractionJobHandlerTest {
   }
 
   private DocumentExtractionJobHandler handler(DocumentExtractor... extractors) {
-    return new DocumentExtractionJobHandler(versions, storage, List.of(extractors));
+    return new DocumentExtractionJobHandler(
+        versions, storage, List.of(extractors), placements, jobs);
   }
 
   private static String payload(UUID versionId) {

--- a/qnop-core/src/test/java/io/qnop/service/review/AnchorResolverTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnchorResolverTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.service.review.AnchorResolver.Outcome;
+import io.qnop.service.review.AnchorResolver.Resolution;
+import io.qnop.spi.extract.NormalizedBox;
+import io.qnop.spi.extract.RenderedDocument;
+import io.qnop.spi.extract.Surface;
+import io.qnop.spi.extract.TextSpan;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * DB-free unit tests for the ADR-0009 re-anchoring cascade (issue #248 acceptance): exact, fuzzy,
+ * and orphan paths, plus the image/geometric and determinism guarantees.
+ */
+class AnchorResolverTest {
+
+  private static final ObjectMapper JSON = JsonMapper.builder().build();
+
+  private final AnchorResolver resolver = new AnchorResolver();
+
+  // --- exact -----------------------------------------------------------------
+
+  @Test
+  @DisplayName("a unique exact quote is PLACED with refreshed position and region")
+  void exactUniqueQuoteIsPlaced() {
+    String anchor = anchor("the payment terms are thirty days", "whereas ", " from invoice");
+    // v2 inserts a line above, shifting the quote down — content itself unchanged.
+    RenderedDocument v2 =
+        doc(
+            surface(
+                0,
+                "a freshly inserted paragraph",
+                "whereas the payment terms are thirty days from invoice",
+                "and nothing else changed"));
+
+    Resolution resolution = resolver.resolve(anchor, v2);
+
+    assertThat(resolution.outcome()).isEqualTo(Outcome.PLACED);
+    JsonNode node = JSON.readTree(resolution.anchorJson());
+    assertThat(node.path("textQuote").path("quote").asText())
+        .isEqualTo("the payment terms are thirty days");
+    int start = node.path("textPosition").path("start").asInt();
+    // canonical text: line0 (28 chars) + '\n' → quote starts after "whereas " on line 1
+    assertThat(start).isEqualTo("a freshly inserted paragraph".length() + 1 + "whereas ".length());
+    assertThat(node.path("region").path("surfaceIndex").asInt()).isZero();
+    // the region box must cover the second line's span (y = 0.05 + 1*0.05)
+    assertThat(node.path("region").path("box").path("y").asDouble()).isEqualTo(0.10);
+  }
+
+  @Test
+  @DisplayName("a quote that moved to a later surface is PLACED there")
+  void quoteFoundOnLaterSurface() {
+    String anchor = anchor("a very distinctive sentence", null, null);
+    RenderedDocument v2 =
+        doc(
+            surface(0, "this page talks about other things"),
+            surface(1, "here sits a very distinctive sentence now"));
+
+    Resolution resolution = resolver.resolve(anchor, v2);
+
+    assertThat(resolution.outcome()).isEqualTo(Outcome.PLACED);
+    assertThat(JSON.readTree(resolution.anchorJson()).path("region").path("surfaceIndex").asInt())
+        .isEqualTo(1);
+  }
+
+  // --- duplicated / fuzzy ------------------------------------------------------
+
+  @Test
+  @DisplayName("a duplicated quote whose full context still matches verbatim is uniquely PLACED")
+  void duplicatedQuoteWithExactContextIsPlaced() {
+    String anchor = anchor("liability is capped", "clause nine: ", " per incident");
+    RenderedDocument v2 =
+        doc(
+            surface(
+                0,
+                "intro where liability is capped loosely",
+                "clause nine: liability is capped per incident"));
+
+    Resolution resolution = resolver.resolve(anchor, v2);
+
+    assertThat(resolution.outcome()).isEqualTo(Outcome.PLACED);
+    JsonNode node = JSON.readTree(resolution.anchorJson());
+    int start = node.path("textPosition").path("start").asInt();
+    // must pick the second occurrence (the context-matching one on line 1)
+    assertThat(start)
+        .isEqualTo(
+            "intro where liability is capped loosely".length() + 1 + "clause nine: ".length());
+  }
+
+  @Test
+  @DisplayName("a duplicated quote with only approximate context is disambiguated and MOVED")
+  void duplicatedQuoteWithApproximateContextIsMoved() {
+    String anchor = anchor("liability is capped", "clause nine: ", " per incident");
+    // context edited ("clause 9:") so no verbatim full-context match exists — similarity decides
+    RenderedDocument v2 =
+        doc(
+            surface(
+                0,
+                "first liability is capped here somehow",
+                "clause 9: liability is capped per incident"));
+
+    Resolution resolution = resolver.resolve(anchor, v2);
+
+    assertThat(resolution.outcome()).isEqualTo(Outcome.MOVED);
+    JsonNode node = JSON.readTree(resolution.anchorJson());
+    int start = node.path("textPosition").path("start").asInt();
+    assertThat(start)
+        .isEqualTo("first liability is capped here somehow".length() + 1 + "clause 9: ".length());
+  }
+
+  @Test
+  @DisplayName("a duplicated quote without any context to disambiguate is ORPHANED, never guessed")
+  void duplicatedQuoteWithoutContextIsOrphaned() {
+    String anchor = anchor("liability is capped", null, null);
+    RenderedDocument v2 =
+        doc(surface(0, "first liability is capped here", "second liability is capped there"));
+
+    Resolution resolution = resolver.resolve(anchor, v2);
+
+    assertThat(resolution.outcome()).isEqualTo(Outcome.ORPHANED);
+    assertThat(resolution.anchorJson()).isEqualTo(anchor); // untouched
+  }
+
+  @Test
+  @DisplayName("a slightly edited quote above the similarity threshold is re-placed as MOVED")
+  void slightlyEditedQuoteIsMoved() {
+    String anchor = anchor("the payment terms are thirty days", "whereas ", " from invoice");
+    RenderedDocument v2 = doc(surface(0, "whereas the payment terms are ninety days from invoice"));
+
+    Resolution resolution = resolver.resolve(anchor, v2);
+
+    assertThat(resolution.outcome()).isEqualTo(Outcome.MOVED);
+    assertThat(JSON.readTree(resolution.anchorJson()).path("textQuote").path("quote").asText())
+        .contains("ninety days");
+  }
+
+  @Test
+  @DisplayName("a heavily edited quote falls below the threshold and is ORPHANED")
+  void heavilyEditedQuoteIsOrphaned() {
+    String anchor = anchor("the payment terms are thirty days", "whereas ", " from invoice");
+    RenderedDocument v2 =
+        doc(surface(0, "the payment obligations were completely rewritten in this draft"));
+
+    Resolution resolution = resolver.resolve(anchor, v2);
+
+    assertThat(resolution.outcome()).isEqualTo(Outcome.ORPHANED);
+    assertThat(resolution.anchorJson()).isEqualTo(anchor);
+  }
+
+  @Test
+  @DisplayName("a removed quote (no seed hit at all) is ORPHANED")
+  void removedQuoteIsOrphaned() {
+    String anchor = anchor("a clause that was deleted entirely", null, null);
+    RenderedDocument v2 = doc(surface(0, "totally unrelated content on this version"));
+
+    assertThat(resolver.resolve(anchor, v2).outcome()).isEqualTo(Outcome.ORPHANED);
+  }
+
+  // --- geometric / degenerate ----------------------------------------------------
+
+  @Test
+  @DisplayName("a geometric-only anchor (image region) keeps its coordinates and is MOVED")
+  void geometricAnchorKeepsCoordinates() {
+    String anchor =
+        "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.2,\"y\":0.3,\"width\":0.1,\"height\":0.1}}}";
+    RenderedDocument v2 = doc(new Surface(0, 612, 792, List.of())); // no text layer
+
+    Resolution resolution = resolver.resolve(anchor, v2);
+
+    assertThat(resolution.outcome()).isEqualTo(Outcome.MOVED); // flagged "to review"
+    assertThat(resolution.anchorJson()).isEqualTo(anchor); // coordinates untouched
+  }
+
+  @Test
+  @DisplayName("an unreadable anchor is ORPHANED rather than guessed")
+  void unreadableAnchorIsOrphaned() {
+    RenderedDocument v2 = doc(surface(0, "whatever"));
+
+    assertThat(resolver.resolve("not json at all", v2).outcome()).isEqualTo(Outcome.ORPHANED);
+    assertThat(resolver.resolve(null, v2).outcome()).isEqualTo(Outcome.ORPHANED);
+  }
+
+  @Test
+  @DisplayName("resolution is deterministic — same inputs, same outcome and anchor")
+  void resolutionIsDeterministic() {
+    String anchor = anchor("the payment terms are thirty days", "whereas ", " from invoice");
+    RenderedDocument v2 =
+        doc(
+            surface(
+                0,
+                "whereas the payment terms are ninety days from invoice",
+                "whereas the payment terms are sixty days from settlement"));
+
+    Resolution first = resolver.resolve(anchor, v2);
+    Resolution second = resolver.resolve(anchor, v2);
+
+    assertThat(first).isEqualTo(second);
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  /** An anchor JSON in the stored shape (#247): region + textQuote (+ position best-effort). */
+  private static String anchor(String quote, String prefix, String suffix) {
+    StringBuilder json = new StringBuilder("{\"region\":{\"surfaceIndex\":0,\"box\":");
+    json.append("{\"x\":0.1,\"y\":0.1,\"width\":0.5,\"height\":0.05}},\"textQuote\":{");
+    json.append("\"quote\":").append(quoted(quote));
+    if (prefix != null) {
+      json.append(",\"prefix\":").append(quoted(prefix));
+    }
+    if (suffix != null) {
+      json.append(",\"suffix\":").append(quoted(suffix));
+    }
+    json.append("},\"textPosition\":{\"start\":0,\"end\":").append(quote.length()).append("}}");
+    return json.toString();
+  }
+
+  private static String quoted(String value) {
+    return "\"" + value.replace("\"", "\\\"") + "\"";
+  }
+
+  /** One surface whose spans are the given lines, offsets joined by the canonical '\n'. */
+  private static Surface surface(int index, String... lines) {
+    List<TextSpan> spans = new ArrayList<>();
+    int offset = 0;
+    for (int i = 0; i < lines.length; i++) {
+      spans.add(
+          new TextSpan(
+              lines[i],
+              offset,
+              offset + lines[i].length(),
+              new NormalizedBox(0.1, 0.05 + i * 0.05, 0.8, 0.03)));
+      offset += lines[i].length() + 1;
+    }
+    return new Surface(index, 612, 792, spans);
+  }
+
+  private static RenderedDocument doc(Surface... surfaces) {
+    return new RenderedDocument(List.of(surfaces));
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/ReanchorJobHandlerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReanchorJobHandlerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.PlacementStatus;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ReanchorJobHandler} (issue #248): pending placements resolve to
+ * PLACED/MOVED/ORPHANED against the stored rendering, replay is idempotent, and a version without
+ * its rendering fails loudly (retryable).
+ */
+class ReanchorJobHandlerTest {
+
+  private final DocumentVersionRepository versions = mock(DocumentVersionRepository.class);
+  private final AnnotationPlacementRepository placements =
+      mock(AnnotationPlacementRepository.class);
+  private final ReanchorJobHandler handler = new ReanchorJobHandler(versions, placements);
+
+  private final UUID versionId = UUID.randomUUID();
+  private DocumentVersion version;
+
+  private static final String RENDERED =
+      """
+      {"surfaces":[{"index":0,"width":612.0,"height":792.0,"textSpans":[
+        {"text":"whereas the payment terms are thirty days from invoice",
+         "startOffset":0,"endOffset":54,
+         "box":{"x":0.1,"y":0.1,"width":0.8,"height":0.03}}]}]}
+      """;
+
+  @BeforeEach
+  void setUp() {
+    version =
+        new DocumentVersion(
+            UUID.randomUUID(), 2, "sha256/v2", "v2", "application/pdf", 10L, UUID.randomUUID());
+    version.attachRenderedDocument(RENDERED); // READY
+    when(versions.findById(versionId)).thenReturn(Optional.of(version));
+  }
+
+  private static String payload() {
+    return "{\"versionId\":\"" + UUID.randomUUID() + "\"}";
+  }
+
+  private AnnotationPlacement pending(String anchorJson) {
+    return new AnnotationPlacement(UUID.randomUUID(), versionId, anchorJson);
+  }
+
+  @Test
+  @DisplayName("resolves each pending placement: exact → PLACED, missing → ORPHANED")
+  void resolvesPendingPlacements() {
+    AnnotationPlacement exact =
+        pending(
+            "{\"textQuote\":{\"quote\":\"payment terms are thirty days\","
+                + "\"prefix\":\"whereas the \",\"suffix\":\" from invoice\"}}");
+    AnnotationPlacement gone =
+        pending("{\"textQuote\":{\"quote\":\"a clause that no longer exists anywhere\"}}");
+    when(placements.findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING))
+        .thenReturn(List.of(exact, gone));
+
+    handler.handle("{\"versionId\":\"" + versionId + "\"}");
+
+    assertThat(exact.getStatus()).isEqualTo(PlacementStatus.PLACED);
+    assertThat(exact.getAnchor()).contains("\"textPosition\"");
+    assertThat(gone.getStatus()).isEqualTo(PlacementStatus.ORPHANED);
+  }
+
+  @Test
+  @DisplayName("a geometric-only placement is flagged MOVED with its anchor untouched")
+  void geometricPlacementFlaggedMoved() {
+    String anchor =
+        "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.2,\"y\":0.2,\"width\":0.1,\"height\":0.1}}}";
+    AnnotationPlacement geometric = pending(anchor);
+    when(placements.findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING))
+        .thenReturn(List.of(geometric));
+
+    handler.handle("{\"versionId\":\"" + versionId + "\"}");
+
+    assertThat(geometric.getStatus()).isEqualTo(PlacementStatus.MOVED);
+    assertThat(geometric.getAnchor()).isEqualTo(anchor);
+  }
+
+  @Test
+  @DisplayName("a deleted version is a no-op; only PENDING placements are ever touched")
+  void idempotentOnDeletedVersionAndDecidedPlacements() {
+    when(versions.findById(versionId)).thenReturn(Optional.empty());
+    handler.handle("{\"versionId\":\"" + versionId + "\"}"); // must not throw
+
+    // Replay path: the repository query only returns PENDING rows, so already-decided placements
+    // are structurally out of reach — verified by the query-by-status contract itself.
+  }
+
+  @Test
+  @DisplayName("a version without its rendering fails loudly (retryable broken invariant)")
+  void missingRenderedDocumentThrows() {
+    DocumentVersion notReady =
+        new DocumentVersion(
+            UUID.randomUUID(), 2, "sha256/x", "x", "application/pdf", 1L, UUID.randomUUID());
+    when(versions.findById(versionId)).thenReturn(Optional.of(notReady));
+
+    assertThatThrownBy(() -> handler.handle("{\"versionId\":\"" + versionId + "\"}"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("a malformed payload fails loudly instead of silently dropping work")
+  void malformedPayloadThrows() {
+    assertThatThrownBy(() -> handler.handle("{}")).isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #248 (part of #241). Re-places open annotations when a new document
version is uploaded — the ADR-0009 cascade **exact → fuzzy → orphaned**, run as
a durable async job, conservative and human-in-the-loop: orphans are honest,
**never silently guessed**.

## Trigger chain (ADR-0033)

- **Upload vN+1** (`DocumentIngestService.addVersion`, in the upload TX): every
  OPEN annotation gets a `PENDING` placement on the new version, carrying its
  most recent anchor as the hypothesis. The version is never visible without its
  pending placements — which is exactly what keeps it non-finalizable until
  re-anchoring resolves (the #246 guard counts PENDING).
- **After extraction READY** (`DocumentExtractionJobHandler`): chains a
  `document.reanchor` job transactionally with the READY write (the cascade
  needs the new text layer). `ObjectProvider<JobService>` breaks the
  handler↔JobService constructor cycle. Permanently FAILED extraction → the
  version's pending placements become `FAILED`.

## Cascade engine — `AnchorResolver` (pure, DB-free, deterministic)

| Situation | Outcome |
|---|---|
| quote+context (or unique quote) verbatim, exactly once | **PLACED** — refreshed offsets, regenerated context, region box unioned from covering spans |
| duplicated/edited text; best candidate ≥ **0.75** similarity (context-weighted) **and** ≥ **0.05** margin over runner-up | **MOVED** |
| no unambiguous match | **ORPHANED** — anchor untouched |
| geometric-only anchor (image region) | **MOVED** ("to review"), 0..1 coordinates kept |

Fuzzy candidates are seeded by verbatim quote chunks and scored with normalized
Levenshtein (quote 0.7 / context 0.3); everything is ordered, so replays
recompute identical outcomes (ADR-0033 idempotency).

## Orphan surfacing

`GET /documents/{id}/annotations` gains an optional **`placementStatus`** query
filter (requires `version`) — `?version=3&placementStatus=ORPHANED` lists what
the owner must handle manually.

## Test plan

- **`AnchorResolverTest`** (DB-free, per acceptance): exact unique + shifted
  position, match on a later surface, duplicated quote — verbatim context →
  PLACED / approximate context → MOVED / no context → ORPHANED —, slightly
  edited → MOVED, heavily edited/removed → ORPHANED, geometric-only → MOVED
  with coordinates kept, unreadable anchor → ORPHANED, determinism.
- **`ReanchorJobHandlerTest`**: status transitions, idempotency, broken-invariant
  retry, malformed payload.
- **`ReanchoringIT`** (Testcontainers, CI): upload v1 → annotate via the #247 API
  → v2 (quote shifted) shows PENDING → extraction+re-anchor jobs → **PLACED**;
  v3 (quote removed) → **ORPHANED** and listed via the filter; filter without
  `version` → 400.
- `spotlessApply` + full compile + ArchUnit + all core unit tests green locally;
  ITs run in CI (Docker).

## Acceptance (issue #248)

- new version triggers the job ✅ (transactional seed + READY-chained job)
- exact/fuzzy/orphan paths unit-tested, DB-free ✅
- placements updated ✅ · orphans listed ✅ (`placementStatus` filter)

🤖 Co-Author: Claude (Opus 4.x) via Claude Code