### PR TITLE
feat(core): document listing, participants & principal directory API (#292)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -82,6 +82,15 @@ tags:
       the review core (issue #245, ADR-0032). Visible only to the owner, the
       review participants, and admins. The multipart upload and the
       original-binary download are deliberately outside this contract (ADR-0028).
+      The root listing and the participant management (issue #292, ADR-0011)
+      power the reviews overview: a participant is a reviewer — a user or a
+      whole team — while the owner stays structural on the document.
+  - name: Principals
+    description: |
+      A lightweight directory of assignable principals — enabled users and
+      teams — for picking review participants (issue #292). Available to every
+      authenticated user by deliberate Community decision; it exposes display
+      names only (no emails, no roles).
   - name: Annotations
     description: |
       Annotations, their comment threads, and per-version placements (issue #247,
@@ -1676,6 +1685,207 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /documents:
+    get:
+      tags:
+        - Documents
+      summary: List the caller's documents
+      description: |
+        Every document the caller owns or participates in — directly or through
+        a team membership. Deliberately personal: admins see their own list
+        here too and use the direct document endpoints for oversight.
+      operationId: listDocuments
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive search over the title.
+          schema:
+            type: string
+            maxLength: 200
+        - name: sort
+          in: query
+          required: false
+          description: |
+            Sort as `field,direction`. Allowed fields: updatedAt, createdAt,
+            title; direction asc|desc.
+          schema:
+            type: string
+            default: updatedAt,desc
+        - name: page
+          in: query
+          required: false
+          description: Zero-based page index.
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 0
+        - name: size
+          in: query
+          required: false
+          description: Page size.
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: A page of the caller's documents, with review progress.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /documents/{documentId}/participants:
+    get:
+      tags:
+        - Documents
+      summary: List review participants
+      description: |
+        The document's reviewers — users or teams (ADR-0011). The owner is
+        structural on the document and never appears here.
+      operationId: listParticipants
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/DocumentIdParam'
+      responses:
+        '200':
+          description: The participants, oldest first.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParticipantListResponse'
+        '404':
+          description: Unknown document, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      tags:
+        - Documents
+      summary: Add a review participant
+      description: |
+        Owner-only. Exactly one of `userId` or `teamId` — a participant is a
+        user XOR a team. Adding the owner, a disabled principal, or an unknown
+        principal is rejected with 400; adding a principal twice with 409.
+      operationId: addParticipant
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/DocumentIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParticipantCreateRequest'
+      responses:
+        '201':
+          description: The participant was added.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParticipantView'
+        '400':
+          description: Not exactly one principal, unknown or disabled principal, or the owner
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: The caller is a participant but not the owner
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown document, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The principal is already a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /documents/{documentId}/participants/{participantId}:
+    delete:
+      tags:
+        - Documents
+      summary: Remove a review participant
+      description: Owner-only.
+      operationId: removeParticipant
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/DocumentIdParam'
+        - $ref: '#/components/parameters/ParticipantIdParam'
+      responses:
+        '204':
+          description: The participant was removed.
+        '403':
+          description: The caller is a participant but not the owner
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown document or participant, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /principals:
+    get:
+      tags:
+        - Principals
+      summary: Search assignable principals
+      operationId: searchPrincipals
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive search over user display names/usernames and team names.
+          schema:
+            type: string
+            maxLength: 200
+        - name: size
+          in: query
+          required: false
+          description: Maximum number of principals to return.
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 50
+            default: 20
+      responses:
+        '200':
+          description: Matching enabled users and teams, sorted by display name.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrincipalListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /documents/{documentId}:
     get:
       tags:
@@ -2081,6 +2291,14 @@ components:
       in: path
       required: true
       description: The annotation's id.
+      schema:
+        type: string
+        format: uuid
+    ParticipantIdParam:
+      name: participantId
+      in: path
+      required: true
+      description: The participant row's id.
       schema:
         type: string
         format: uuid
@@ -3311,6 +3529,153 @@ components:
       required:
         - field
         - message
+    DocumentSummary:
+      type: object
+      description: One document in the caller's reviews overview (issue #292).
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+          maxLength: 500
+        ownerId:
+          type: string
+          format: uuid
+        workflowState:
+          type: string
+          description: The review workflow state (open string set, ADR-0011).
+        latestVersionNumber:
+          type: integer
+          description: The highest existing version number; 0 when none exist.
+        annotationCount:
+          type: integer
+          format: int32
+          description: All annotations on the document, regardless of status.
+        openAnnotationCount:
+          type: integer
+          format: int32
+          description: Annotations still in status OPEN.
+        participants:
+          type: array
+          description: The reviewers (users or teams), oldest first.
+          items:
+            $ref: '#/components/schemas/ParticipantView'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - title
+        - ownerId
+        - workflowState
+        - latestVersionNumber
+        - annotationCount
+        - openAnnotationCount
+        - participants
+        - createdAt
+        - updatedAt
+    DocumentListResponse:
+      type: object
+      description: A page of the caller's documents.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentSummary'
+        total:
+          type: integer
+          format: int64
+          description: Total number of documents matching the query.
+        page:
+          type: integer
+          format: int32
+          description: Zero-based page index.
+        size:
+          type: integer
+          format: int32
+          description: Page size.
+      required:
+        - items
+        - total
+        - page
+        - size
+    ParticipantKind:
+      type: string
+      description: What kind of principal a participant is.
+      enum:
+        - USER
+        - TEAM
+    ParticipantView:
+      type: object
+      description: A review participant — a user or a team acting as reviewer (ADR-0011).
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The participant row's id (used for removal).
+        kind:
+          $ref: '#/components/schemas/ParticipantKind'
+        principalId:
+          type: string
+          format: uuid
+          description: The user's or team's id.
+        displayName:
+          type: string
+          description: The user's display name or the team's name.
+      required:
+        - id
+        - kind
+        - principalId
+        - displayName
+    ParticipantListResponse:
+      type: object
+      description: The document's review participants.
+      properties:
+        participants:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParticipantView'
+      required:
+        - participants
+    ParticipantCreateRequest:
+      type: object
+      description: Add a reviewer — exactly one of `userId` or `teamId`.
+      properties:
+        userId:
+          type: string
+          format: uuid
+        teamId:
+          type: string
+          format: uuid
+    PrincipalView:
+      type: object
+      description: An assignable principal — an enabled user or team.
+      properties:
+        id:
+          type: string
+          format: uuid
+        kind:
+          $ref: '#/components/schemas/ParticipantKind'
+        displayName:
+          type: string
+      required:
+        - id
+        - kind
+        - displayName
+    PrincipalListResponse:
+      type: object
+      description: Principals matching a directory search.
+      properties:
+        principals:
+          type: array
+          items:
+            $ref: '#/components/schemas/PrincipalView'
+      required:
+        - principals
     DocumentResponse:
       type: object
       description: A review document's metadata.

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -24,17 +24,25 @@ import io.qnop.api.v1.endpoint.DocumentsApi;
 import io.qnop.api.v1.model.DiffChange;
 import io.qnop.api.v1.model.DiffChangeType;
 import io.qnop.api.v1.model.DiffLocation;
+import io.qnop.api.v1.model.DocumentListResponse;
 import io.qnop.api.v1.model.DocumentResponse;
+import io.qnop.api.v1.model.DocumentSummary;
 import io.qnop.api.v1.model.DocumentVersionListResponse;
 import io.qnop.api.v1.model.DocumentVersionSummary;
 import io.qnop.api.v1.model.ExtractionStatus;
 import io.qnop.api.v1.model.NormalizedBox;
+import io.qnop.api.v1.model.ParticipantCreateRequest;
+import io.qnop.api.v1.model.ParticipantKind;
+import io.qnop.api.v1.model.ParticipantListResponse;
+import io.qnop.api.v1.model.ParticipantView;
 import io.qnop.api.v1.model.RenderedDocumentResponse;
 import io.qnop.api.v1.model.VersionDiffResponse;
 import io.qnop.service.diff.VersionDiffService;
 import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.document.DocumentAccessService.DocumentVersionView;
 import io.qnop.service.document.DocumentAccessService.DocumentView;
+import io.qnop.service.document.DocumentOverviewService;
+import io.qnop.service.document.ReviewParticipantService;
 import java.time.ZoneOffset;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -53,10 +61,90 @@ public class DocumentsController implements DocumentsApi {
 
   private final DocumentAccessService documents;
   private final VersionDiffService diffs;
+  private final DocumentOverviewService overview;
+  private final ReviewParticipantService participants;
 
-  public DocumentsController(DocumentAccessService documents, VersionDiffService diffs) {
+  public DocumentsController(
+      DocumentAccessService documents,
+      VersionDiffService diffs,
+      DocumentOverviewService overview,
+      ReviewParticipantService participants) {
     this.documents = documents;
     this.diffs = diffs;
+    this.overview = overview;
+    this.participants = participants;
+  }
+
+  @Override
+  public ResponseEntity<DocumentListResponse> listDocuments(
+      String q, String sort, Integer page, Integer size) {
+    DocumentOverviewService.DocumentPage result =
+        overview.listVisible(
+            CurrentUser.requireUserId(),
+            q,
+            sort,
+            page == null ? 0 : page,
+            size == null ? 20 : size);
+    return ResponseEntity.ok(
+        new DocumentListResponse()
+            .items(result.items().stream().map(DocumentsController::toSummary).toList())
+            .total(result.total())
+            .page(result.page())
+            .size(result.size()));
+  }
+
+  @Override
+  public ResponseEntity<ParticipantListResponse> listParticipants(UUID documentId) {
+    return ResponseEntity.ok(
+        new ParticipantListResponse()
+            .participants(
+                participants
+                    .list(documentId, CurrentUser.requireUserId(), CurrentUser.isAdmin())
+                    .stream()
+                    .map(DocumentsController::toParticipant)
+                    .toList()));
+  }
+
+  @Override
+  public ResponseEntity<ParticipantView> addParticipant(
+      UUID documentId, ParticipantCreateRequest request) {
+    ReviewParticipantService.ParticipantView added =
+        participants.add(
+            documentId,
+            CurrentUser.requireUserId(),
+            CurrentUser.isAdmin(),
+            request.getUserId(),
+            request.getTeamId());
+    return ResponseEntity.status(201).body(toParticipant(added));
+  }
+
+  @Override
+  public ResponseEntity<Void> removeParticipant(UUID documentId, UUID participantId) {
+    participants.remove(
+        documentId, participantId, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.noContent().build();
+  }
+
+  private static DocumentSummary toSummary(DocumentOverviewService.DocumentSummaryView view) {
+    return new DocumentSummary()
+        .id(view.id())
+        .title(view.title())
+        .ownerId(view.ownerId())
+        .workflowState(view.workflowState())
+        .latestVersionNumber(view.latestVersionNumber())
+        .annotationCount(view.annotationCount())
+        .openAnnotationCount(view.openAnnotationCount())
+        .participants(view.participants().stream().map(DocumentsController::toParticipant).toList())
+        .createdAt(view.createdAt().atOffset(ZoneOffset.UTC))
+        .updatedAt(view.updatedAt().atOffset(ZoneOffset.UTC));
+  }
+
+  private static ParticipantView toParticipant(ReviewParticipantService.ParticipantView view) {
+    return new ParticipantView()
+        .id(view.id())
+        .kind(view.team() ? ParticipantKind.TEAM : ParticipantKind.USER)
+        .principalId(view.principalId())
+        .displayName(view.displayName());
   }
 
   @Override

--- a/qnop-app/src/main/java/io/qnop/web/PrincipalsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/PrincipalsController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.PrincipalsApi;
+import io.qnop.api.v1.model.ParticipantKind;
+import io.qnop.api.v1.model.PrincipalListResponse;
+import io.qnop.api.v1.model.PrincipalView;
+import io.qnop.service.PrincipalDirectoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The assignable-principal directory (issue #292): enabled users and teams for picking review
+ * participants — display names only, available to every authenticated user.
+ */
+@RestController
+public class PrincipalsController implements PrincipalsApi {
+
+  private final PrincipalDirectoryService directory;
+
+  public PrincipalsController(PrincipalDirectoryService directory) {
+    this.directory = directory;
+  }
+
+  @Override
+  public ResponseEntity<PrincipalListResponse> searchPrincipals(String q, Integer size) {
+    CurrentUser.requireUserId();
+    return ResponseEntity.ok(
+        new PrincipalListResponse()
+            .principals(
+                directory.search(q, size == null ? 20 : size).stream()
+                    .map(
+                        view ->
+                            new PrincipalView()
+                                .id(view.id())
+                                .kind(view.team() ? ParticipantKind.TEAM : ParticipantKind.USER)
+                                .displayName(view.displayName()))
+                    .toList()));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/DocumentOverviewApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DocumentOverviewApiIT.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.Annotation;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.Team;
+import io.qnop.entity.TeamMembership;
+import io.qnop.entity.TeamRole;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.repository.TeamMembershipRepository;
+import io.qnop.repository.TeamRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * The reviews overview, participant management and the principal directory (issue #292, ADR-0011):
+ * visibility through ownership, direct participation and team membership; owner-only mutations with
+ * the 404/403 anti-enumeration split; the directory's names-only exposure.
+ */
+class DocumentOverviewApiIT extends SeededIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+  @Autowired private AnnotationRepository annotations;
+  @Autowired private TeamRepository teams;
+  @Autowired private TeamMembershipRepository memberships;
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  /** Owner MEMBER, direct participant AUDITOR, team participant with MEMBER2 as team member. */
+  private UUID seedReview(String title) {
+    Document document = documents.save(new Document(MEMBER_ID, title));
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    Team team = teams.save(Team.create("review-team-" + UUID.randomUUID(), null));
+    memberships.save(TeamMembership.of(team.getId(), MEMBER2_ID, TeamRole.MEMBER));
+    participants.save(ReviewParticipant.forTeam(document.getId(), team.getId()));
+    versions.save(
+        new DocumentVersion(
+            document.getId(),
+            1,
+            "sha256/aa/cafebabe",
+            "cafebabe",
+            "application/pdf",
+            42L,
+            MEMBER_ID));
+    return document.getId();
+  }
+
+  // ── GET /documents ──────────────────────────────────────────────────────
+
+  @Test
+  void ownerDirectParticipantAndTeamMemberSeeTheDocument() throws Exception {
+    UUID documentId = seedReview("Overview visibility agreement");
+
+    for (UUID viewer : new UUID[] {MEMBER_ID, AUDITOR_ID, MEMBER2_ID}) {
+      mockMvc
+          .perform(as(get("/api/v1/documents?q=Overview visibility"), viewer))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.total").value(1))
+          .andExpect(jsonPath("$.items[0].id").value(documentId.toString()))
+          .andExpect(jsonPath("$.items[0].workflowState").value("DRAFT"))
+          .andExpect(jsonPath("$.items[0].latestVersionNumber").value(1));
+    }
+  }
+
+  @Test
+  void strangerSeesAnEmptyOverview() throws Exception {
+    seedReview("Overview stranger agreement");
+
+    mockMvc
+        .perform(as(get("/api/v1/documents?q=Overview stranger"), EXTERNAL_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(0));
+  }
+
+  @Test
+  void overviewCarriesAnnotationProgressAndParticipantNames() throws Exception {
+    UUID documentId = seedReview("Overview progress agreement");
+    annotations.save(new Annotation(documentId, AUDITOR_ID));
+    Annotation decided = new Annotation(documentId, AUDITOR_ID);
+    decided.accept();
+    annotations.save(decided);
+
+    mockMvc
+        .perform(as(get("/api/v1/documents?q=Overview progress"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].annotationCount").value(2))
+        .andExpect(jsonPath("$.items[0].openAnnotationCount").value(1))
+        .andExpect(jsonPath("$.items[0].participants.length()").value(2))
+        .andExpect(jsonPath("$.items[0].participants[0].kind").value("USER"))
+        .andExpect(jsonPath("$.items[0].participants[0].displayName").value("Avery Auditor"))
+        .andExpect(jsonPath("$.items[0].participants[1].kind").value("TEAM"));
+  }
+
+  // ── participants ────────────────────────────────────────────────────────
+
+  @Test
+  void participantListsReviewersButStrangerSees404() throws Exception {
+    UUID documentId = seedReview("Participants list agreement");
+
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/participants"), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.participants.length()").value(2))
+        .andExpect(jsonPath("$.participants[0].displayName").value("Avery Auditor"));
+
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/participants"), EXTERNAL_ID))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  void ownerAddsAndRemovesAUserParticipant() throws Exception {
+    UUID documentId = seedReview("Participants mutate agreement");
+
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/participants"), MEMBER_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"userId\":\"" + MEMBER2_ID + "\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.kind").value("USER"))
+            .andExpect(jsonPath("$.displayName").value("Max Member"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String participantId = JsonPath.read(json, "$.id");
+
+    // Adding the same user again conflicts.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER2_ID + "\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("DUPLICATE_PARTICIPANT"));
+
+    mockMvc
+        .perform(
+            as(
+                delete("/api/v1/documents/" + documentId + "/participants/" + participantId),
+                MEMBER_ID))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void addValidatesPrincipalAndXor() throws Exception {
+    UUID documentId = seedReview("Participants validation agreement");
+
+    // Both principals → 400.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER2_ID + "\",\"teamId\":\"" + TEAM_BETA_ID + "\"}"))
+        .andExpect(status().isBadRequest());
+
+    // Neither → 400.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+
+    // The owner is structural — not addable.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER_ID + "\"}"))
+        .andExpect(status().isBadRequest());
+
+    // A disabled user is not assignable.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + DISABLED_ID + "\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void mutationsAreOwnerOnlyWithAntiEnumeration() throws Exception {
+    UUID documentId = seedReview("Participants authz agreement");
+    UUID otherDocument = seedReview("Participants authz other");
+    UUID foreignParticipantId = participants.findByDocumentId(otherDocument).get(0).getId();
+
+    // A participant (not owner) gets 403.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), AUDITOR_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER2_ID + "\"}"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("NOT_OWNER"));
+
+    // A stranger gets 404, indistinguishable from an unknown document.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), EXTERNAL_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER2_ID + "\"}"))
+        .andExpect(status().isNotFound());
+
+    // A participant row of ANOTHER document reads as unknown.
+    mockMvc
+        .perform(
+            as(
+                delete("/api/v1/documents/" + documentId + "/participants/" + foreignParticipantId),
+                MEMBER_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  // ── GET /principals ─────────────────────────────────────────────────────
+
+  @Test
+  void principalDirectoryReturnsEnabledUsersAndTeamsForPlainMembers() throws Exception {
+    mockMvc
+        .perform(as(get("/api/v1/principals?q=member"), MEMBER2_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.principals[?(@.displayName == 'Mia Member')].kind").value("USER"))
+        .andExpect(jsonPath("$.principals[?(@.displayName == 'Max Member')]").exists());
+
+    mockMvc
+        .perform(as(get("/api/v1/principals?q=alpha"), MEMBER2_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.principals[?(@.displayName == 'Alpha')].kind").value("TEAM"));
+  }
+
+  @Test
+  void principalDirectoryHidesDisabledUsersAndNeverMatchesEmails() throws Exception {
+    mockMvc
+        .perform(as(get("/api/v1/principals?q=dana"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.principals.length()").value(0));
+
+    // Email fragments must not confirm addresses.
+    mockMvc
+        .perform(as(get("/api/v1/principals?q=qnop.test"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.principals.length()").value(0));
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/AnnotationRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/AnnotationRepository.java
@@ -22,9 +22,12 @@ package io.qnop.repository;
 
 import io.qnop.entity.Annotation;
 import io.qnop.entity.AnnotationStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Data access for annotations raised against a document (issue #244, ADR-0011). */
 public interface AnnotationRepository extends JpaRepository<Annotation, UUID> {
@@ -39,4 +42,12 @@ public interface AnnotationRepository extends JpaRepository<Annotation, UUID> {
    * How many annotations on a document are in a given status — e.g. OPEN, for the finalize gate.
    */
   long countByDocumentIdAndStatus(UUID documentId, AnnotationStatus status);
+
+  /** Batched total/open annotation counts for the reviews overview (issue #292). */
+  @Query(
+      "SELECT new io.qnop.repository.DocumentAnnotationCounts(a.documentId, COUNT(a),"
+          + " SUM(CASE WHEN a.status = io.qnop.entity.AnnotationStatus.OPEN THEN 1 ELSE 0 END))"
+          + " FROM Annotation a WHERE a.documentId IN :documentIds GROUP BY a.documentId")
+  List<DocumentAnnotationCounts> countByDocumentIds(
+      @Param("documentIds") Collection<UUID> documentIds);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentAnnotationCounts.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentAnnotationCounts.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/** Per-document annotation totals for the reviews overview (issue #292). */
+public record DocumentAnnotationCounts(UUID documentId, Long total, Long open) {}

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentMaxVersion.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentMaxVersion.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/** The highest version number per document, batched for the reviews overview (issue #292). */
+public record DocumentMaxVersion(UUID documentId, Integer maxVersion) {}

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -23,11 +23,29 @@ package io.qnop.repository;
 import io.qnop.entity.Document;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Data access for review aggregate roots (issue #244, ADR-0011). */
 public interface DocumentRepository extends JpaRepository<Document, UUID> {
 
   /** Documents owned by the given user. */
   List<Document> findByOwnerId(UUID ownerId);
+
+  /**
+   * The documents visible to a user for the reviews overview (issue #292): owned, joined as a
+   * direct participant, or joined through membership in a participating team. {@code q} must be
+   * passed pre-lowercased and {@code LIKE}-wrapped; {@code null} disables the title filter.
+   */
+  @Query(
+      "SELECT d FROM Document d WHERE (:q IS NULL OR LOWER(d.title) LIKE :q)"
+          + " AND (d.ownerId = :actor"
+          + " OR EXISTS (SELECT 1 FROM ReviewParticipant p"
+          + "   WHERE p.documentId = d.id AND p.userId = :actor)"
+          + " OR EXISTS (SELECT 1 FROM ReviewParticipant pt, TeamMembership m"
+          + "   WHERE pt.documentId = d.id AND pt.teamId = m.teamId AND m.userId = :actor))")
+  Page<Document> findVisibleTo(@Param("actor") UUID actor, @Param("q") String q, Pageable pageable);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentVersionRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentVersionRepository.java
@@ -21,10 +21,13 @@
 package io.qnop.repository;
 
 import io.qnop.entity.DocumentVersion;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Data access for the immutable version chain of a document (issue #244, ADR-0011). */
 public interface DocumentVersionRepository extends JpaRepository<DocumentVersion, UUID> {
@@ -37,4 +40,11 @@ public interface DocumentVersionRepository extends JpaRepository<DocumentVersion
 
   /** The latest (highest-numbered) version of a document, if any. */
   Optional<DocumentVersion> findTopByDocumentIdOrderByVersionNumberDesc(UUID documentId);
+
+  /** Batched highest version numbers for the reviews overview (issue #292). */
+  @Query(
+      "SELECT new io.qnop.repository.DocumentMaxVersion(v.documentId, MAX(v.versionNumber))"
+          + " FROM DocumentVersion v WHERE v.documentId IN :documentIds GROUP BY v.documentId")
+  List<DocumentMaxVersion> findMaxVersionsByDocumentIds(
+      @Param("documentIds") Collection<UUID> documentIds);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/ParticipantProjection.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ParticipantProjection.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A review participant joined with its principal's display name — the user's display name or the
+ * team's name (issue #292, ADR-0011).
+ */
+public record ParticipantProjection(
+    UUID id, UUID documentId, UUID userId, UUID teamId, String displayName, Instant createdAt) {}

--- a/qnop-core/src/main/java/io/qnop/repository/ReviewParticipantRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ReviewParticipantRepository.java
@@ -21,9 +21,12 @@
 package io.qnop.repository;
 
 import io.qnop.entity.ReviewParticipant;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Data access for the reviewer set of a document (issue #244, ADR-0011). */
 public interface ReviewParticipantRepository extends JpaRepository<ReviewParticipant, UUID> {
@@ -36,4 +39,24 @@ public interface ReviewParticipantRepository extends JpaRepository<ReviewPartici
 
   /** The reviews a given team is a participant in. */
   List<ReviewParticipant> findByTeamId(UUID teamId);
+
+  boolean existsByDocumentIdAndUserId(UUID documentId, UUID userId);
+
+  boolean existsByDocumentIdAndTeamId(UUID documentId, UUID teamId);
+
+  String VIEW_SELECT =
+      "SELECT new io.qnop.repository.ParticipantProjection(p.id, p.documentId, p.userId,"
+          + " p.teamId, COALESCE(u.displayName, t.name), p.createdAt)"
+          + " FROM ReviewParticipant p"
+          + " LEFT JOIN User u ON u.id = p.userId"
+          + " LEFT JOIN Team t ON t.id = p.teamId";
+
+  /** The participants of one document with display names, oldest first (issue #292). */
+  @Query(VIEW_SELECT + " WHERE p.documentId = :documentId ORDER BY p.createdAt")
+  List<ParticipantProjection> findViewsByDocumentId(@Param("documentId") UUID documentId);
+
+  /** Batched participant views for the reviews overview — avoids N+1 (issue #292). */
+  @Query(VIEW_SELECT + " WHERE p.documentId IN :documentIds ORDER BY p.createdAt")
+  List<ParticipantProjection> findViewsByDocumentIds(
+      @Param("documentIds") Collection<UUID> documentIds);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/TeamRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/TeamRepository.java
@@ -21,6 +21,7 @@
 package io.qnop.repository;
 
 import io.qnop.entity.Team;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -46,4 +47,13 @@ public interface TeamRepository extends JpaRepository<Team, UUID> {
       "SELECT t FROM Team t WHERE :q IS NULL OR LOWER(t.name) LIKE :q"
           + " OR (t.description IS NOT NULL AND LOWER(t.description) LIKE :q)")
   Page<Team> search(@Param("q") String q, Pageable pageable);
+
+  /**
+   * Principal-directory search (issue #292): enabled teams by name. {@code q} pre-lowercased and
+   * {@code LIKE}-wrapped; {@code null} disables the filter. Limit via {@code Pageable}.
+   */
+  @Query(
+      "SELECT t FROM Team t WHERE t.enabled = TRUE AND (:q IS NULL OR LOWER(t.name) LIKE :q)"
+          + " ORDER BY LOWER(t.name)")
+  List<Team> searchEnabledPrincipals(@Param("q") String q, Pageable pageable);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
@@ -24,6 +24,7 @@ import io.qnop.entity.User;
 import io.qnop.entity.UserRole;
 import io.qnop.entity.UserSource;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -95,4 +96,17 @@ public interface UserRepository extends JpaRepository<User, UUID> {
       "UPDATE User u SET u.passwordHash = :hash, u.passwordChangeRequired = false,"
           + " u.version = u.version + 1 WHERE u.id = :id")
   int updatePasswordHash(@Param("id") UUID id, @Param("hash") String hash);
+
+  /**
+   * Principal-directory search (issue #292): enabled users by display name or username.
+   * Deliberately does NOT match on email — the directory must not confirm email addresses. {@code
+   * q} pre-lowercased and {@code LIKE}-wrapped; {@code null} disables the filter. Limit via {@code
+   * Pageable}.
+   */
+  @Query(
+      "SELECT u FROM User u WHERE u.enabled = TRUE AND (:q IS NULL"
+          + " OR LOWER(u.displayName) LIKE :q"
+          + " OR (u.username IS NOT NULL AND LOWER(u.username) LIKE :q))"
+          + " ORDER BY LOWER(u.displayName)")
+  List<User> searchEnabledPrincipals(@Param("q") String q, Pageable pageable);
 }

--- a/qnop-core/src/main/java/io/qnop/service/PrincipalDirectoryService.java
+++ b/qnop-core/src/main/java/io/qnop/service/PrincipalDirectoryService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.repository.TeamRepository;
+import io.qnop.repository.UserRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The assignable-principal directory (issue #292): enabled users and teams for picking review
+ * participants. Available to every authenticated user by deliberate Community decision — it exposes
+ * display names only, and the user search does not match on email so the directory can never
+ * confirm an address.
+ */
+@Service
+public class PrincipalDirectoryService {
+
+  private final UserRepository users;
+  private final TeamRepository teams;
+
+  public PrincipalDirectoryService(UserRepository users, TeamRepository teams) {
+    this.users = users;
+    this.teams = teams;
+  }
+
+  @Transactional(readOnly = true)
+  public List<PrincipalView> search(String query, int size) {
+    String like =
+        query == null || query.isBlank() ? null : "%" + query.trim().toLowerCase(Locale.ROOT) + "%";
+    Pageable limit = PageRequest.of(0, size);
+    Stream<PrincipalView> userViews =
+        users.searchEnabledPrincipals(like, limit).stream()
+            .map(user -> new PrincipalView(user.getId(), false, user.getDisplayName()));
+    Stream<PrincipalView> teamViews =
+        teams.searchEnabledPrincipals(like, limit).stream()
+            .map(team -> new PrincipalView(team.getId(), true, team.getName()));
+    return Stream.concat(userViews, teamViews)
+        .sorted(Comparator.comparing(view -> view.displayName().toLowerCase(Locale.ROOT)))
+        .limit(size)
+        .toList();
+  }
+
+  /** An assignable principal — an enabled user or team. */
+  public record PrincipalView(UUID id, boolean team, String displayName) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.document;
+
+import io.qnop.entity.Document;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.DocumentAnnotationCounts;
+import io.qnop.repository.DocumentMaxVersion;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ParticipantProjection;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.service.document.ReviewParticipantService.ParticipantView;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The reviews overview (issue #292): every document the caller owns or participates in — directly
+ * or through a team — with review progress and the reviewer set. Deliberately personal: admins get
+ * their own list here too and use the direct document endpoints for oversight. Counts and
+ * participants are batched per page to avoid N+1.
+ */
+@Service
+public class DocumentOverviewService {
+
+  private static final Map<String, String> SORT_FIELDS =
+      Map.of("updatedAt", "updatedAt", "createdAt", "createdAt", "title", "title");
+
+  private final DocumentRepository documents;
+  private final DocumentVersionRepository versions;
+  private final AnnotationRepository annotations;
+  private final ReviewParticipantRepository participants;
+
+  public DocumentOverviewService(
+      DocumentRepository documents,
+      DocumentVersionRepository versions,
+      AnnotationRepository annotations,
+      ReviewParticipantRepository participants) {
+    this.documents = documents;
+    this.versions = versions;
+    this.annotations = annotations;
+    this.participants = participants;
+  }
+
+  @Transactional(readOnly = true)
+  public DocumentPage listVisible(UUID actor, String query, String sort, int page, int size) {
+    String like =
+        query == null || query.isBlank() ? null : "%" + query.trim().toLowerCase(Locale.ROOT) + "%";
+    Page<Document> result =
+        documents.findVisibleTo(actor, like, PageRequest.of(page, size, parseSort(sort)));
+
+    List<UUID> ids = result.getContent().stream().map(Document::getId).toList();
+    Map<UUID, Integer> maxVersions =
+        ids.isEmpty()
+            ? Map.of()
+            : versions.findMaxVersionsByDocumentIds(ids).stream()
+                .collect(
+                    Collectors.toMap(
+                        DocumentMaxVersion::documentId, DocumentMaxVersion::maxVersion));
+    Map<UUID, DocumentAnnotationCounts> counts =
+        ids.isEmpty()
+            ? Map.of()
+            : annotations.countByDocumentIds(ids).stream()
+                .collect(
+                    Collectors.toMap(DocumentAnnotationCounts::documentId, Function.identity()));
+    Map<UUID, List<ParticipantProjection>> participantsByDocument =
+        ids.isEmpty()
+            ? Map.of()
+            : participants.findViewsByDocumentIds(ids).stream()
+                .collect(Collectors.groupingBy(ParticipantProjection::documentId));
+
+    List<DocumentSummaryView> items =
+        result.getContent().stream()
+            .map(
+                document -> {
+                  DocumentAnnotationCounts count = counts.get(document.getId());
+                  return new DocumentSummaryView(
+                      document.getId(),
+                      document.getTitle(),
+                      document.getOwnerId(),
+                      document.getWorkflowState(),
+                      maxVersions.getOrDefault(document.getId(), 0),
+                      count == null ? 0 : Math.toIntExact(count.total()),
+                      count == null ? 0 : Math.toIntExact(count.open()),
+                      participantsByDocument.getOrDefault(document.getId(), List.of()).stream()
+                          .map(ParticipantView::of)
+                          .toList(),
+                      document.getCreatedAt(),
+                      document.getUpdatedAt());
+                })
+            .toList();
+    return new DocumentPage(items, result.getTotalElements(), page, size);
+  }
+
+  private Sort parseSort(String sort) {
+    String field = "updatedAt";
+    Sort.Direction direction = Sort.Direction.DESC;
+    if (sort != null && !sort.isBlank()) {
+      String[] parts = sort.split(",", 2);
+      String candidate = SORT_FIELDS.get(parts[0].trim());
+      if (candidate != null) {
+        field = candidate;
+        direction =
+            parts.length > 1 && "asc".equalsIgnoreCase(parts[1].trim())
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+      }
+    }
+    return Sort.by(direction, field);
+  }
+
+  /** One document in the caller's overview. */
+  public record DocumentSummaryView(
+      UUID id,
+      String title,
+      UUID ownerId,
+      String workflowState,
+      int latestVersionNumber,
+      int annotationCount,
+      int openAnnotationCount,
+      List<ParticipantView> participants,
+      Instant createdAt,
+      Instant updatedAt) {}
+
+  /** A page of the caller's documents. */
+  public record DocumentPage(List<DocumentSummaryView> items, long total, int page, int size) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentValidationException.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentValidationException.java
@@ -62,6 +62,10 @@ public class DocumentValidationException extends RuntimeException {
     return new DocumentValidationException(413, "PAYLOAD_TOO_LARGE", detail);
   }
 
+  public static DocumentValidationException duplicateParticipant(String detail) {
+    return new DocumentValidationException(409, "DUPLICATE_PARTICIPANT", detail);
+  }
+
   public static DocumentValidationException invalidRequest(String detail) {
     return new DocumentValidationException(400, "VALIDATION_ERROR", detail);
   }

--- a/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.document;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.Team;
+import io.qnop.entity.User;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.ParticipantProjection;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.repository.TeamRepository;
+import io.qnop.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Manages the reviewer set of a document (issue #292, ADR-0011): a participant is a user XOR a
+ * team; the owner stays structural on the document and is never a participant row. Reads follow the
+ * anti-enumeration rule (unknown and invisible look identical, 404); mutations are owner-only (403
+ * for participants, 404 for strangers — mirroring {@code DocumentIngestService.addVersion}).
+ */
+@Service
+public class ReviewParticipantService {
+
+  private final DocumentRepository documents;
+  private final ReviewParticipantRepository participants;
+  private final UserRepository users;
+  private final TeamRepository teams;
+  private final DocumentAccessService access;
+
+  public ReviewParticipantService(
+      DocumentRepository documents,
+      ReviewParticipantRepository participants,
+      UserRepository users,
+      TeamRepository teams,
+      DocumentAccessService access) {
+    this.documents = documents;
+    this.participants = participants;
+    this.users = users;
+    this.teams = teams;
+    this.access = access;
+  }
+
+  /** The document's reviewers with display names, oldest first. */
+  @Transactional(readOnly = true)
+  public List<ParticipantView> list(UUID documentId, UUID actor, boolean admin) {
+    if (!access.isVisible(documentId, actor, admin)) {
+      throw DocumentValidationException.notFound("document " + documentId);
+    }
+    return participants.findViewsByDocumentId(documentId).stream()
+        .map(ParticipantView::of)
+        .toList();
+  }
+
+  /** Adds a reviewer (owner-only): exactly one of {@code userId} / {@code teamId}. */
+  @Transactional
+  public ParticipantView add(UUID documentId, UUID actor, boolean admin, UUID userId, UUID teamId) {
+    Document document = requireOwned(documentId, actor, admin);
+    if ((userId == null) == (teamId == null)) {
+      throw DocumentValidationException.invalidRequest(
+          "exactly one of userId or teamId is required");
+    }
+    if (userId != null) {
+      User user =
+          users
+              .findById(userId)
+              .filter(User::isEnabled)
+              .orElseThrow(
+                  () -> DocumentValidationException.invalidRequest("unknown or disabled user"));
+      if (document.getOwnerId().equals(userId)) {
+        throw DocumentValidationException.invalidRequest("the owner is already part of the review");
+      }
+      if (participants.existsByDocumentIdAndUserId(documentId, userId)) {
+        throw DocumentValidationException.duplicateParticipant("user is already a participant");
+      }
+      ReviewParticipant saved = participants.save(ReviewParticipant.forUser(documentId, userId));
+      return new ParticipantView(
+          saved.getId(), userId, false, user.getDisplayName(), saved.getCreatedAt());
+    }
+    Team team =
+        teams
+            .findById(teamId)
+            .filter(Team::isEnabled)
+            .orElseThrow(
+                () -> DocumentValidationException.invalidRequest("unknown or disabled team"));
+    if (participants.existsByDocumentIdAndTeamId(documentId, teamId)) {
+      throw DocumentValidationException.duplicateParticipant("team is already a participant");
+    }
+    ReviewParticipant saved = participants.save(ReviewParticipant.forTeam(documentId, teamId));
+    return new ParticipantView(saved.getId(), teamId, true, team.getName(), saved.getCreatedAt());
+  }
+
+  /** Removes a reviewer (owner-only); a participant of another document reads as unknown. */
+  @Transactional
+  public void remove(UUID documentId, UUID participantId, UUID actor, boolean admin) {
+    requireOwned(documentId, actor, admin);
+    ReviewParticipant participant =
+        participants
+            .findById(participantId)
+            .filter(p -> p.getDocumentId().equals(documentId))
+            .orElseThrow(
+                () -> DocumentValidationException.notFound("participant " + participantId));
+    participants.delete(participant);
+  }
+
+  private Document requireOwned(UUID documentId, UUID actor, boolean admin) {
+    if (!access.isVisible(documentId, actor, admin)) {
+      throw DocumentValidationException.notFound("document " + documentId);
+    }
+    Document document =
+        documents
+            .findById(documentId)
+            .orElseThrow(() -> DocumentValidationException.notFound("document " + documentId));
+    if (!document.getOwnerId().equals(actor)) {
+      throw DocumentValidationException.notOwner("only the owner manages participants");
+    }
+    return document;
+  }
+
+  /** A participant with its principal's display name. */
+  public record ParticipantView(
+      UUID id, UUID principalId, boolean team, String displayName, Instant createdAt) {
+
+    static ParticipantView of(ParticipantProjection projection) {
+      boolean team = projection.teamId() != null;
+      return new ParticipantView(
+          projection.id(),
+          team ? projection.teamId() : projection.userId(),
+          team,
+          projection.displayName(),
+          projection.createdAt());
+    }
+  }
+}


### PR DESCRIPTION
Closes #292. Prerequisite for #251 (reviews list, upload wizard & workflow actions). Part of #241.

## What

Three additions to the published contract (OpenAPI-first, ADR-0021) that power the reviews overview around the viewer:

### `GET /documents`
The caller's personal reviews overview: documents they **own** plus those joined **directly or through a team membership** — one repository query (`DocumentRepository.findVisibleTo`), with max version numbers, annotation totals (`annotationCount` / `openAnnotationCount`) and participant views **batched per page** (no N+1). `q`/`sort`/`page`/`size` follow the admin-list conventions (sort whitelist: updatedAt, createdAt, title). Deliberately personal: admins see their own list here and use the direct document endpoints for oversight.

### Participants API (ADR-0011)
- `GET /documents/{id}/participants` — reviewers with display names (user's display name / team's name via a `LEFT JOIN` projection); 404 anti-enumeration for strangers, as in #247.
- `POST /documents/{id}/participants` — **owner-only**: exactly one of `userId`/`teamId` (XOR), unknown or disabled principals and the structural owner → 400, duplicates → 409 `DUPLICATE_PARTICIPANT` (guarded by the existing partial-unique indexes).
- `DELETE /documents/{id}/participants/{participantId}` — owner-only; a participant row of another document reads as unknown (404).

### `GET /principals?q=`
A lightweight directory of **enabled** users and teams (id, kind, displayName) for any authenticated user, so a non-admin owner can pick reviewers in the upload wizard. Deliberate Community decision, documented in the spec: names only — and the user search **never matches emails**, so the directory cannot confirm an address.

No schema changes; the existing `review_participant` FKs and indexes carry everything.

## Test plan

- [x] IT `DocumentOverviewApiIT` (Testcontainers): visibility matrix (owner / direct participant / team member see the document, stranger sees an empty list), progress counts and participant names in the overview, participant list + 404 for strangers, owner add/remove incl. 409 duplicate, XOR + owner + disabled-principal validation (400), owner-only 403 vs anti-enumeration 404, cross-document participant reads as 404, principal directory returns users+teams for plain members, hides disabled users, never matches email fragments
- [x] `./gradlew build` green (compile, Spotless, ArchUnit, all tests)
- [x] Client generation unaffected (`typescript-axios` regenerates the new models for #251)

🤖 Co-Author: Claude (Fable 5) via Claude Code
🤖 Generated with [Claude Code](https://claude.com/claude-code)