### PR TITLE
feat(ui): reviews surface — overview, wizard, hub head & decisions (#251)

### DIFF
--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -31,6 +31,8 @@ import {
   AuthPasswordResetApi,
   AuthRegistrationApi,
   DocumentsApi,
+  PrincipalsApi,
+  ReviewWorkflowApi,
   ServerConfigApi,
   UsersApi,
 } from './generated';
@@ -96,3 +98,5 @@ export const adminOidcProvidersApi = new AdminOidcProvidersApi(undefined, undefi
 export const adminEmailApi = new AdminEmailApi(undefined, undefined, axiosInstance);
 export const documentsApi = new DocumentsApi(undefined, undefined, axiosInstance);
 export const annotationsApi = new AnnotationsApi(undefined, undefined, axiosInstance);
+export const principalsApi = new PrincipalsApi(undefined, undefined, axiosInstance);
+export const reviewWorkflowApi = new ReviewWorkflowApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useAnnotations.test.tsx
+++ b/qnop-ui/src/api/hooks/useAnnotations.test.tsx
@@ -24,13 +24,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AnnotationListResponse } from '../generated';
-import { annotationKeys, useAnnotations, useCreateAnnotation } from './useAnnotations';
+import {
+  annotationKeys,
+  useAnnotations,
+  useCreateAnnotation,
+  useDecideAnnotation,
+} from './useAnnotations';
 import { annotationsApi } from '../config';
 
 vi.mock('../config', () => ({
   annotationsApi: {
     listAnnotations: vi.fn(),
     createAnnotation: vi.fn(),
+    decideAnnotation: vi.fn(),
   },
 }));
 
@@ -89,6 +95,22 @@ describe('useCreateAnnotation', () => {
     expect(annotationsApi.createAnnotation).toHaveBeenCalledWith({
       documentId: DOC_ID,
       annotationCreateRequest: request,
+    });
+  });
+});
+
+describe('useDecideAnnotation', () => {
+  it('posts the decision', async () => {
+    vi.mocked(annotationsApi.decideAnnotation).mockResolvedValue({ data: { id: 'a1' } } as Awaited<
+      ReturnType<typeof annotationsApi.decideAnnotation>
+    >);
+
+    const { result } = renderHook(() => useDecideAnnotation(), { wrapper });
+    await result.current.mutateAsync({ annotationId: 'a1', decision: 'ACCEPTED' });
+
+    expect(annotationsApi.decideAnnotation).toHaveBeenCalledWith({
+      annotationId: 'a1',
+      annotationDecisionRequest: { decision: 'ACCEPTED' },
     });
   });
 });

--- a/qnop-ui/src/api/hooks/useAnnotations.ts
+++ b/qnop-ui/src/api/hooks/useAnnotations.ts
@@ -20,7 +20,11 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { AnnotationCreateRequest, AnnotationListResponse } from '../generated';
+import type {
+  AnnotationCreateRequest,
+  AnnotationDecision,
+  AnnotationListResponse,
+} from '../generated';
 import { annotationsApi } from '../config';
 
 export const annotationKeys = {
@@ -57,5 +61,27 @@ export function useCreateAnnotation(documentId: string) {
       return response.data;
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: annotationKeys.all }),
+  });
+}
+
+/**
+ * Decides an annotation (owner or author): OPEN -> ACCEPTED | REJECTED. The
+ * first acceptance moves the workflow to CHANGES_REQUESTED (ADR-0011), so the
+ * reviews/workflow caches are invalidated alongside the annotation lists.
+ */
+export function useDecideAnnotation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { annotationId: string; decision: AnnotationDecision }) => {
+      const response = await annotationsApi.decideAnnotation({
+        annotationId: vars.annotationId,
+        annotationDecisionRequest: { decision: vars.decision },
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: annotationKeys.all });
+      queryClient.invalidateQueries({ queryKey: ['reviews'] });
+    },
   });
 }

--- a/qnop-ui/src/api/hooks/useReviews.test.tsx
+++ b/qnop-ui/src/api/hooks/useReviews.test.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type {
+  DocumentListResponse,
+  ParticipantListResponse,
+  PrincipalListResponse,
+  WorkflowStatus,
+} from '../generated';
+import {
+  reviewKeys,
+  useAddParticipant,
+  useCreateReview,
+  useParticipants,
+  usePrincipalSearch,
+  useReviews,
+  useTransitionWorkflow,
+  useUploadVersion,
+  useWorkflow,
+} from './useReviews';
+import { axiosInstance, documentsApi, principalsApi, reviewWorkflowApi } from '../config';
+
+vi.mock('../config', () => ({
+  documentsApi: {
+    listDocuments: vi.fn(),
+    listParticipants: vi.fn(),
+    addParticipant: vi.fn(),
+    removeParticipant: vi.fn(),
+  },
+  principalsApi: {
+    searchPrincipals: vi.fn(),
+  },
+  reviewWorkflowApi: {
+    getDocumentWorkflow: vi.fn(),
+    transitionDocumentWorkflow: vi.fn(),
+  },
+  axiosInstance: {
+    post: vi.fn(),
+  },
+}));
+
+const DOC_ID = '3f6f6f6f-0000-0000-0000-000000000001';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('reviewKeys', () => {
+  it('namespaces per concern', () => {
+    expect(reviewKeys.participants(DOC_ID)).toEqual(['reviews', 'participants', DOC_ID]);
+    expect(reviewKeys.workflow(DOC_ID)).toEqual(['reviews', 'workflow', DOC_ID]);
+  });
+});
+
+describe('useReviews', () => {
+  it('forwards query, sort and pagination', async () => {
+    const empty: DocumentListResponse = { items: [], total: 0, page: 0, size: 20 };
+    vi.mocked(documentsApi.listDocuments).mockResolvedValue({ data: empty } as Awaited<
+      ReturnType<typeof documentsApi.listDocuments>
+    >);
+
+    const { result } = renderHook(
+      () => useReviews({ q: 'nda', sort: 'title,asc', page: 1, size: 10 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(documentsApi.listDocuments).toHaveBeenCalledWith({
+      q: 'nda',
+      sort: 'title,asc',
+      page: 1,
+      size: 10,
+    });
+  });
+});
+
+describe('useParticipants', () => {
+  it('fetches the reviewer set', async () => {
+    const empty: ParticipantListResponse = { participants: [] };
+    vi.mocked(documentsApi.listParticipants).mockResolvedValue({ data: empty } as Awaited<
+      ReturnType<typeof documentsApi.listParticipants>
+    >);
+
+    const { result } = renderHook(() => useParticipants(DOC_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(documentsApi.listParticipants).toHaveBeenCalledWith({ documentId: DOC_ID });
+  });
+});
+
+describe('useAddParticipant', () => {
+  it('posts the principal', async () => {
+    vi.mocked(documentsApi.addParticipant).mockResolvedValue({ data: { id: 'p1' } } as Awaited<
+      ReturnType<typeof documentsApi.addParticipant>
+    >);
+
+    const { result } = renderHook(() => useAddParticipant(DOC_ID), { wrapper });
+    await result.current.mutateAsync({ userId: 'u9' });
+
+    expect(documentsApi.addParticipant).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+      participantCreateRequest: { userId: 'u9' },
+    });
+  });
+});
+
+describe('usePrincipalSearch', () => {
+  it('searches the directory', async () => {
+    const empty: PrincipalListResponse = { principals: [] };
+    vi.mocked(principalsApi.searchPrincipals).mockResolvedValue({ data: empty } as Awaited<
+      ReturnType<typeof principalsApi.searchPrincipals>
+    >);
+
+    const { result } = renderHook(() => usePrincipalSearch('al'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(principalsApi.searchPrincipals).toHaveBeenCalledWith({ q: 'al' });
+  });
+});
+
+describe('useWorkflow / useTransitionWorkflow', () => {
+  it('reads the state and posts a transition', async () => {
+    const draft: WorkflowStatus = { state: 'DRAFT', allowedTransitions: ['IN_REVIEW'] };
+    const inReview: WorkflowStatus = { state: 'IN_REVIEW', allowedTransitions: [] };
+    vi.mocked(reviewWorkflowApi.getDocumentWorkflow).mockResolvedValue({ data: draft } as Awaited<
+      ReturnType<typeof reviewWorkflowApi.getDocumentWorkflow>
+    >);
+    vi.mocked(reviewWorkflowApi.transitionDocumentWorkflow).mockResolvedValue({
+      data: inReview,
+    } as Awaited<ReturnType<typeof reviewWorkflowApi.transitionDocumentWorkflow>>);
+
+    const workflow = renderHook(() => useWorkflow(DOC_ID), { wrapper });
+    await waitFor(() => expect(workflow.result.current.isSuccess).toBe(true));
+    expect(workflow.result.current.data?.allowedTransitions).toEqual(['IN_REVIEW']);
+
+    const transition = renderHook(() => useTransitionWorkflow(DOC_ID), { wrapper });
+    await transition.result.current.mutateAsync('IN_REVIEW');
+    expect(reviewWorkflowApi.transitionDocumentWorkflow).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+      workflowTransitionRequest: { targetState: 'IN_REVIEW' },
+    });
+  });
+});
+
+describe('uploads', () => {
+  it('creates a review via multipart with title and file', async () => {
+    vi.mocked(axiosInstance.post).mockResolvedValue({
+      data: { documentId: DOC_ID, versionNumber: 1, extractionStatus: 'PENDING' },
+    });
+
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+    const file = new File(['%PDF'], 'contract.pdf', { type: 'application/pdf' });
+    const created = await result.current.mutateAsync({ title: 'NDA', file });
+
+    expect(created.documentId).toBe(DOC_ID);
+    const [url, form] = vi.mocked(axiosInstance.post).mock.calls[0];
+    expect(url).toBe('/documents');
+    expect((form as FormData).get('title')).toBe('NDA');
+    expect((form as FormData).get('file')).toBe(file);
+  });
+
+  it('uploads a new version to the document', async () => {
+    vi.mocked(axiosInstance.post).mockResolvedValue({
+      data: { documentId: DOC_ID, versionNumber: 2, extractionStatus: 'PENDING' },
+    });
+
+    const { result } = renderHook(() => useUploadVersion(DOC_ID), { wrapper });
+    const file = new File(['%PDF'], 'v2.pdf', { type: 'application/pdf' });
+    await result.current.mutateAsync({ file });
+
+    expect(vi.mocked(axiosInstance.post).mock.calls[0][0]).toBe(`/documents/${DOC_ID}/versions`);
+  });
+});

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+  DocumentListResponse,
+  ParticipantCreateRequest,
+  ParticipantListResponse,
+  PrincipalListResponse,
+  WorkflowStatus,
+} from '../generated';
+import { axiosInstance, documentsApi, principalsApi, reviewWorkflowApi } from '../config';
+import { documentKeys } from './useDocuments';
+
+export interface ReviewListParams {
+  q?: string;
+  sort?: string;
+  page: number;
+  size: number;
+}
+
+export const reviewKeys = {
+  all: ['reviews'] as const,
+  list: (params: ReviewListParams) => [...reviewKeys.all, 'list', params] as const,
+  participants: (documentId: string) => [...reviewKeys.all, 'participants', documentId] as const,
+  workflow: (documentId: string) => [...reviewKeys.all, 'workflow', documentId] as const,
+  principals: (q: string) => [...reviewKeys.all, 'principals', q] as const,
+};
+
+/** A page of the caller's reviews (owned or participating, incl. via team). */
+export function useReviews(params: ReviewListParams) {
+  return useQuery<DocumentListResponse>({
+    queryKey: reviewKeys.list(params),
+    queryFn: async () => {
+      const response = await documentsApi.listDocuments({
+        q: params.q || undefined,
+        sort: params.sort,
+        page: params.page,
+        size: params.size,
+      });
+      return response.data;
+    },
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** The document's reviewers (users or teams) with display names. */
+export function useParticipants(documentId: string, enabled = true) {
+  return useQuery<ParticipantListResponse>({
+    queryKey: reviewKeys.participants(documentId),
+    queryFn: async () => {
+      const response = await documentsApi.listParticipants({ documentId });
+      return response.data;
+    },
+    enabled,
+  });
+}
+
+export function useAddParticipant(documentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request: ParticipantCreateRequest) => {
+      const response = await documentsApi.addParticipant({
+        documentId,
+        participantCreateRequest: request,
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reviewKeys.participants(documentId) });
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+    },
+  });
+}
+
+export function useRemoveParticipant(documentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (participantId: string) => {
+      await documentsApi.removeParticipant({ documentId, participantId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reviewKeys.participants(documentId) });
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+    },
+  });
+}
+
+/** Directory search for the reviewer picker (enabled users and teams, names only). */
+export function usePrincipalSearch(q: string) {
+  return useQuery<PrincipalListResponse>({
+    queryKey: reviewKeys.principals(q),
+    queryFn: async () => {
+      const response = await principalsApi.searchPrincipals({ q: q || undefined });
+      return response.data;
+    },
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** The document's workflow state and structurally reachable transitions. */
+export function useWorkflow(documentId: string, enabled = true) {
+  return useQuery<WorkflowStatus>({
+    queryKey: reviewKeys.workflow(documentId),
+    queryFn: async () => {
+      const response = await reviewWorkflowApi.getDocumentWorkflow({ documentId });
+      return response.data;
+    },
+    enabled,
+  });
+}
+
+/**
+ * Executes a workflow transition. The POST is authoritative — guards may veto
+ * with 409 even when a transition is structurally offered (ADR-0011).
+ */
+export function useTransitionWorkflow(documentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (targetState: string) => {
+      const response = await reviewWorkflowApi.transitionDocumentWorkflow({
+        documentId,
+        workflowTransitionRequest: { targetState },
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reviewKeys.workflow(documentId) });
+      queryClient.invalidateQueries({ queryKey: documentKeys.detail(documentId) });
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+    },
+  });
+}
+
+export interface UploadResult {
+  documentId: string;
+  versionNumber: number;
+  extractionStatus: string;
+}
+
+/**
+ * Creates a new review from a first upload. The multipart upload endpoint is
+ * deliberately outside the generated contract (ADR-0028), hence the plain
+ * axios call; `onProgress` reports 0..1 for the wizard's progress bar.
+ */
+export function useCreateReview() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: {
+      title: string;
+      file: File;
+      onProgress?: (fraction: number) => void;
+    }) => {
+      const form = new FormData();
+      form.append('title', input.title);
+      form.append('file', input.file);
+      const response = await axiosInstance.post<UploadResult>('/documents', form, {
+        onUploadProgress: (event) => {
+          if (event.total) input.onProgress?.(event.loaded / event.total);
+        },
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: reviewKeys.all }),
+  });
+}
+
+/** Uploads a new version to an existing review (owner-only re-upload, ADR-0011). */
+export function useUploadVersion(documentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { file: File; onProgress?: (fraction: number) => void }) => {
+      const form = new FormData();
+      form.append('file', input.file);
+      const response = await axiosInstance.post<UploadResult>(
+        `/documents/${documentId}/versions`,
+        form,
+        {
+          onUploadProgress: (event) => {
+            if (event.total) input.onProgress?.(event.loaded / event.total);
+          },
+        },
+      );
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: documentKeys.all });
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+    },
+  });
+}

--- a/qnop-ui/src/components/reviews/WorkflowBadge.tsx
+++ b/qnop-ui/src/components/reviews/WorkflowBadge.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ToneBadge } from '../admin/ToneBadge';
+import { WORKFLOW_TONES, workflowLabel } from './workflowMeta';
+
+export function WorkflowBadge({ state }: { state: string }) {
+  return <ToneBadge tone={WORKFLOW_TONES[state] ?? 'neutral'} label={workflowLabel(state)} />;
+}

--- a/qnop-ui/src/components/reviews/hub/ParticipantsDialog.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ParticipantsDialog.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+import { AxiosError, type AxiosResponse } from 'axios';
+import type { ParticipantListResponse, PrincipalListResponse } from '../../../api/generated';
+import { ParticipantKind } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { documentsApi, principalsApi } from '../../../api/config';
+import { ParticipantsDialog } from './ParticipantsDialog';
+
+vi.mock('../../../api/config', () => ({
+  axiosInstance: { post: vi.fn(), get: vi.fn() },
+  documentsApi: {
+    listParticipants: vi.fn(),
+    addParticipant: vi.fn(),
+    removeParticipant: vi.fn(),
+  },
+  principalsApi: { searchPrincipals: vi.fn() },
+  reviewWorkflowApi: {
+    getDocumentWorkflow: vi.fn(),
+    transitionDocumentWorkflow: vi.fn(),
+  },
+}));
+
+const DOC_ID = '00000000-0000-0000-0000-0000000000d1';
+const ME = '00000000-0000-0000-0000-0000000000aa';
+
+const PARTICIPANTS: ParticipantListResponse = {
+  participants: [
+    { id: 'p1', kind: ParticipantKind.User, principalId: 'u-max', displayName: 'Max Member' },
+    { id: 'p2', kind: ParticipantKind.Team, principalId: 't-alpha', displayName: 'Team Alpha' },
+  ],
+};
+
+const PRINCIPALS: PrincipalListResponse = {
+  principals: [
+    { id: 'u-max', kind: ParticipantKind.User, displayName: 'Max Member' },
+    { id: ME, kind: ParticipantKind.User, displayName: 'Me Myself' },
+    { id: 'u-ava', kind: ParticipantKind.User, displayName: 'Avery Auditor' },
+  ],
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <ThemeProvider theme={buildTheme('light')}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </ThemeProvider>
+  );
+}
+
+const notify = vi.fn();
+
+function renderDialog(isOwner: boolean) {
+  return render(
+    <ParticipantsDialog
+      documentId={DOC_ID}
+      open
+      onClose={vi.fn()}
+      isOwner={isOwner}
+      ownUserId={ME}
+      notify={notify}
+    />,
+    { wrapper },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(documentsApi.listParticipants).mockResolvedValue({
+    data: PARTICIPANTS,
+  } as Awaited<ReturnType<typeof documentsApi.listParticipants>>);
+  vi.mocked(principalsApi.searchPrincipals).mockResolvedValue({
+    data: PRINCIPALS,
+  } as Awaited<ReturnType<typeof principalsApi.searchPrincipals>>);
+  vi.mocked(documentsApi.addParticipant).mockResolvedValue({ data: { id: 'p3' } } as Awaited<
+    ReturnType<typeof documentsApi.addParticipant>
+  >);
+  vi.mocked(documentsApi.removeParticipant).mockResolvedValue(
+    undefined as unknown as Awaited<ReturnType<typeof documentsApi.removeParticipant>>,
+  );
+});
+
+describe('ParticipantsDialog — read-only for participants', () => {
+  it('lists reviewers without management controls', async () => {
+    renderDialog(false);
+
+    expect(await screen.findByText('Max Member')).toBeInTheDocument();
+    expect(screen.getByText('Team Alpha')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Add people or teams…')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Remove/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('ParticipantsDialog — owner management', () => {
+  it('offers only principals that are not the owner or already reviewing', async () => {
+    renderDialog(true);
+
+    expect(await screen.findByTestId('add-principal-u-ava')).toBeInTheDocument();
+    expect(screen.queryByTestId('add-principal-u-max')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`add-principal-${ME}`)).not.toBeInTheDocument();
+  });
+
+  it('adds a principal and notifies', async () => {
+    renderDialog(true);
+
+    fireEvent.click(await screen.findByTestId('add-principal-u-ava'));
+
+    await waitFor(() =>
+      expect(documentsApi.addParticipant).toHaveBeenCalledWith({
+        documentId: DOC_ID,
+        participantCreateRequest: { userId: 'u-ava' },
+      }),
+    );
+    await waitFor(() => expect(notify).toHaveBeenCalledWith('Avery Auditor added.'));
+  });
+
+  it('removes a participant and notifies', async () => {
+    renderDialog(true);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove Max Member' }));
+
+    await waitFor(() =>
+      expect(documentsApi.removeParticipant).toHaveBeenCalledWith({
+        documentId: DOC_ID,
+        participantId: 'p1',
+      }),
+    );
+    await waitFor(() => expect(notify).toHaveBeenCalledWith('Max Member removed.'));
+  });
+
+  it('maps a duplicate conflict (409) to friendly text', async () => {
+    const conflict = new AxiosError('conflict');
+    conflict.response = {
+      status: 409,
+      data: { code: 'DUPLICATE_PARTICIPANT', message: 'server prose' },
+    } as AxiosResponse;
+    vi.mocked(documentsApi.addParticipant).mockRejectedValue(conflict);
+    renderDialog(true);
+
+    fireEvent.click(await screen.findByTestId('add-principal-u-ava'));
+
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith('Already a reviewer on this document.', 'error'),
+    );
+  });
+});

--- a/qnop-ui/src/components/reviews/hub/ParticipantsDialog.tsx
+++ b/qnop-ui/src/components/reviews/hub/ParticipantsDialog.tsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { Plus, Search, Users, X } from 'lucide-react';
+import type { ParticipantView, PrincipalView } from '../../../api/generated';
+import { ParticipantKind } from '../../../api/generated';
+import {
+  useAddParticipant,
+  useParticipants,
+  usePrincipalSearch,
+  useRemoveParticipant,
+} from '../../../api/hooks/useReviews';
+import type { ToastSeverity } from '../../admin/layout/useToast';
+import { UserAvatar } from '../../shell/UserAvatar';
+import { apiErrorCode } from '../../../utils/apiError';
+
+/** Known participant conflicts — codes map to friendly text (never server prose). */
+const PARTICIPANT_CONFLICTS: Record<string, string> = {
+  DUPLICATE_PARTICIPANT: 'Already a reviewer on this document.',
+};
+
+interface ParticipantsDialogProps {
+  documentId: string;
+  open: boolean;
+  onClose: () => void;
+  /** Owners manage the reviewer set; participants only see it (ADR-0011). */
+  isOwner: boolean;
+  /** The owner cannot become a participant, so hide them from the picker. */
+  ownUserId: string | null;
+  notify: (message: string, severity?: ToastSeverity) => void;
+}
+
+function PrincipalIcon({ kind, size }: { kind: ParticipantKind; size: number }) {
+  const theme = useTheme();
+  if (kind !== ParticipantKind.Team) return null;
+  return (
+    <Box
+      sx={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        bgcolor: theme.qnop.surface2,
+        color: 'text.secondary',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+      }}
+    >
+      <Users size={Math.round(size / 2)} aria-hidden />
+    </Box>
+  );
+}
+
+/** View & (owner-only) manage the reviewers of one document. */
+export function ParticipantsDialog({
+  documentId,
+  open,
+  onClose,
+  isOwner,
+  ownUserId,
+  notify,
+}: ParticipantsDialogProps) {
+  const theme = useTheme();
+  const [query, setQuery] = useState('');
+
+  const participantsQuery = useParticipants(documentId, open);
+  const searchQuery = usePrincipalSearch(open && isOwner ? query.trim() : '');
+  const addParticipant = useAddParticipant(documentId);
+  const removeParticipant = useRemoveParticipant(documentId);
+
+  const participants = participantsQuery.data?.participants ?? [];
+  const participantKeys = new Set(participants.map((p) => `${p.kind}:${p.principalId}`));
+  const candidates = (searchQuery.data?.principals ?? []).filter(
+    (principal) =>
+      !participantKeys.has(`${principal.kind}:${principal.id}`) &&
+      !(principal.kind === ParticipantKind.User && principal.id === ownUserId),
+  );
+
+  const handleAdd = (principal: PrincipalView) => {
+    addParticipant.mutate(
+      principal.kind === ParticipantKind.Team ? { teamId: principal.id } : { userId: principal.id },
+      {
+        onSuccess: () => notify(`${principal.displayName} added.`),
+        onError: (error) =>
+          notify(
+            PARTICIPANT_CONFLICTS[apiErrorCode(error) ?? ''] ?? 'The reviewer could not be added.',
+            'error',
+          ),
+      },
+    );
+  };
+
+  const handleRemove = (participant: ParticipantView) => {
+    removeParticipant.mutate(participant.id, {
+      onSuccess: () => notify(`${participant.displayName} removed.`),
+      onError: () => notify('The reviewer could not be removed.', 'error'),
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Participants</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2.5}>
+          {participants.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              {participantsQuery.isPending ? 'Loading…' : 'No reviewers on this review yet.'}
+            </Typography>
+          ) : (
+            <Stack spacing={0.5} data-testid="participants-list">
+              {participants.map((participant) => (
+                <Stack
+                  key={participant.id}
+                  direction="row"
+                  spacing={1.25}
+                  sx={{ alignItems: 'center', py: 0.5 }}
+                >
+                  {participant.kind === ParticipantKind.Team ? (
+                    <PrincipalIcon kind={participant.kind} size={28} />
+                  ) : (
+                    <UserAvatar name={participant.displayName} size={28} />
+                  )}
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+                      {participant.displayName}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {participant.kind === ParticipantKind.Team ? 'Team' : 'User'}
+                    </Typography>
+                  </Box>
+                  {isOwner && (
+                    <Tooltip title={`Remove ${participant.displayName}`}>
+                      <IconButton
+                        size="small"
+                        aria-label={`Remove ${participant.displayName}`}
+                        disabled={removeParticipant.isPending}
+                        onClick={() => handleRemove(participant)}
+                      >
+                        <X size={15} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Stack>
+              ))}
+            </Stack>
+          )}
+
+          {isOwner && (
+            <Box>
+              <TextField
+                size="small"
+                fullWidth
+                placeholder="Add people or teams…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                sx={{ mb: 1 }}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <Search size={15} />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
+              <Box
+                sx={{
+                  border: `1px solid ${theme.palette.divider}`,
+                  borderRadius: 2,
+                  overflow: 'hidden',
+                  maxHeight: 220,
+                  overflowY: 'auto',
+                }}
+              >
+                {candidates.length === 0 ? (
+                  <Typography variant="body2" color="text.disabled" sx={{ px: 2, py: 1.5 }}>
+                    {searchQuery.isPending ? 'Searching…' : 'No matching people or teams.'}
+                  </Typography>
+                ) : (
+                  candidates.map((principal, i) => (
+                    <ButtonBase
+                      key={`${principal.kind}:${principal.id}`}
+                      onClick={() => handleAdd(principal)}
+                      disabled={addParticipant.isPending}
+                      data-testid={`add-principal-${principal.id}`}
+                      sx={{
+                        display: 'flex',
+                        width: '100%',
+                        alignItems: 'center',
+                        gap: 1.25,
+                        px: 1.5,
+                        py: 1,
+                        textAlign: 'left',
+                        borderBottom:
+                          i < candidates.length - 1 ? `1px solid ${theme.palette.divider}` : 'none',
+                        '&:hover': { bgcolor: theme.qnop.surface2 },
+                        '&:focus-visible': { boxShadow: `inset ${theme.qnop.focusRing}` },
+                      }}
+                    >
+                      {principal.kind === ParticipantKind.Team ? (
+                        <PrincipalIcon kind={principal.kind} size={26} />
+                      ) : (
+                        <UserAvatar name={principal.displayName} size={26} />
+                      )}
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography variant="body2" noWrap>
+                          {principal.displayName}
+                        </Typography>
+                      </Box>
+                      <Plus size={14} aria-hidden style={{ color: theme.palette.text.disabled }} />
+                    </ButtonBase>
+                  ))
+                )}
+              </Box>
+            </Box>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} color="inherit">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+import { AxiosError, type AxiosResponse } from 'axios';
+import type {
+  AnnotationView,
+  ParticipantListResponse,
+  WorkflowStatus,
+} from '../../../api/generated';
+import { AnnotationStatus, ParticipantKind, PlacementStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { axiosInstance, documentsApi, reviewWorkflowApi } from '../../../api/config';
+import { ReviewHubHead } from './ReviewHubHead';
+
+vi.mock('../../../api/config', () => ({
+  axiosInstance: { post: vi.fn(), get: vi.fn() },
+  documentsApi: {
+    listParticipants: vi.fn(),
+    addParticipant: vi.fn(),
+    removeParticipant: vi.fn(),
+  },
+  principalsApi: { searchPrincipals: vi.fn() },
+  reviewWorkflowApi: {
+    getDocumentWorkflow: vi.fn(),
+    transitionDocumentWorkflow: vi.fn(),
+  },
+  configApi: { getServerConfig: vi.fn() },
+}));
+vi.mock('../../../api/hooks/useConfig', () => ({
+  useConfig: () => ({ data: { upload: { maxDocumentSizeMb: 50 } } }),
+}));
+
+const DOC_ID = '00000000-0000-0000-0000-0000000000d1';
+const ME = '00000000-0000-0000-0000-0000000000aa';
+
+function annotation(status: AnnotationStatus): AnnotationView {
+  return {
+    id: `a-${Math.random().toString(36).slice(2)}`,
+    documentId: DOC_ID,
+    authorId: ME,
+    status,
+    placementStatus: PlacementStatus.Placed,
+    anchor: { region: { surfaceIndex: 0, box: { x: 0, y: 0, width: 0.1, height: 0.1 } } },
+    commentCount: 0,
+    createdAt: '2026-07-01T10:00:00Z',
+    updatedAt: '2026-07-01T10:00:00Z',
+  };
+}
+
+const PARTICIPANTS: ParticipantListResponse = {
+  participants: [
+    {
+      id: 'p1',
+      kind: ParticipantKind.User,
+      principalId: 'u-max',
+      displayName: 'Max Member',
+    },
+  ],
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <ThemeProvider theme={buildTheme('light')}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </ThemeProvider>
+  );
+}
+
+const notify = vi.fn();
+const onVersionUploaded = vi.fn();
+
+function renderHub({ isOwner = true, annotations = [] as AnnotationView[] } = {}) {
+  return render(
+    <ReviewHubHead
+      documentId={DOC_ID}
+      isOwner={isOwner}
+      ownUserId={ME}
+      annotations={annotations}
+      notify={notify}
+      onVersionUploaded={onVersionUploaded}
+    />,
+    { wrapper },
+  );
+}
+
+function mockWorkflow(status: WorkflowStatus) {
+  vi.mocked(reviewWorkflowApi.getDocumentWorkflow).mockResolvedValue({
+    data: status,
+  } as Awaited<ReturnType<typeof reviewWorkflowApi.getDocumentWorkflow>>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(documentsApi.listParticipants).mockResolvedValue({
+    data: PARTICIPANTS,
+  } as Awaited<ReturnType<typeof documentsApi.listParticipants>>);
+  mockWorkflow({ state: 'IN_REVIEW', allowedTransitions: ['FINALIZED', 'CANCELLED'] });
+});
+
+describe('ReviewHubHead — progress & participants', () => {
+  it('shows decided/total progress from the annotations', async () => {
+    renderHub({
+      annotations: [
+        annotation(AnnotationStatus.Open),
+        annotation(AnnotationStatus.Accepted),
+        annotation(AnnotationStatus.Rejected),
+      ],
+    });
+
+    expect(
+      screen.getByRole('progressbar', { name: '2 of 3 annotations decided' }),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('1')).toBeInTheDocument());
+  });
+
+  it('opens the participants dialog from the avatar stack', async () => {
+    renderHub();
+
+    fireEvent.click(await screen.findByTestId('participants-button'));
+
+    expect(await screen.findByText('Participants')).toBeInTheDocument();
+    expect(await screen.findByText('Max Member')).toBeInTheDocument();
+  });
+});
+
+describe('ReviewHubHead — workflow transitions', () => {
+  it('confirms and executes a transition from the allowed set', async () => {
+    const finalized: WorkflowStatus = { state: 'FINALIZED', allowedTransitions: [] };
+    vi.mocked(reviewWorkflowApi.transitionDocumentWorkflow).mockResolvedValue({
+      data: finalized,
+    } as Awaited<ReturnType<typeof reviewWorkflowApi.transitionDocumentWorkflow>>);
+    renderHub();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Change status/ }));
+    fireEvent.click(await screen.findByText('Move to Finalized'));
+    fireEvent.click(screen.getByRole('button', { name: 'Change status' }));
+
+    await waitFor(() =>
+      expect(reviewWorkflowApi.transitionDocumentWorkflow).toHaveBeenCalledWith({
+        documentId: DOC_ID,
+        workflowTransitionRequest: { targetState: 'FINALIZED' },
+      }),
+    );
+    await waitFor(() => expect(notify).toHaveBeenCalledWith('Review moved to Finalized.'));
+  });
+
+  it('surfaces a guard veto (409 INVALID_TRANSITION) as a mapped error toast', async () => {
+    const veto = new AxiosError('conflict');
+    veto.response = {
+      status: 409,
+      data: { code: 'INVALID_TRANSITION', message: 'server prose' },
+    } as AxiosResponse;
+    vi.mocked(reviewWorkflowApi.transitionDocumentWorkflow).mockRejectedValue(veto);
+    renderHub();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Change status/ }));
+    fireEvent.click(await screen.findByText('Move to Finalized'));
+    fireEvent.click(screen.getByRole('button', { name: 'Change status' }));
+
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith(
+        'This status change is not possible right now — open annotations or pending placements may remain.',
+        'error',
+      ),
+    );
+  });
+
+  it('hides the status button when no transitions are offered', async () => {
+    mockWorkflow({ state: 'FINALIZED', allowedTransitions: [] });
+    renderHub();
+
+    await screen.findByTestId('participants-button');
+    expect(screen.queryByRole('button', { name: /Change status/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('ReviewHubHead — new version upload', () => {
+  it('uploads a PDF and reports the new version', async () => {
+    vi.mocked(axiosInstance.post).mockResolvedValue({
+      data: { documentId: DOC_ID, versionNumber: 3, extractionStatus: 'PENDING' },
+    });
+    renderHub();
+
+    const file = new File(['%PDF-1.4'], 'v3.pdf', { type: 'application/pdf' });
+    fireEvent.change(screen.getByTestId('version-file-input'), { target: { files: [file] } });
+
+    await waitFor(() => expect(onVersionUploaded).toHaveBeenCalledWith(3));
+    expect(vi.mocked(axiosInstance.post).mock.calls[0][0]).toBe(`/documents/${DOC_ID}/versions`);
+    expect(notify).toHaveBeenCalledWith('Version 3 uploaded.');
+  });
+
+  it('rejects a non-PDF without calling the API', async () => {
+    renderHub();
+
+    const file = new File(['x'], 'notes.txt', { type: 'text/plain' });
+    fireEvent.change(screen.getByTestId('version-file-input'), { target: { files: [file] } });
+
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith('Only PDF documents are supported.', 'error'),
+    );
+    expect(axiosInstance.post).not.toHaveBeenCalled();
+  });
+
+  it('hides the upload control for non-owners', async () => {
+    renderHub({ isOwner: false });
+
+    await screen.findByTestId('participants-button');
+    expect(screen.queryByRole('button', { name: /New version/ })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('version-file-input')).not.toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { ChevronDown, Upload, UserPlus, Users } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus, ParticipantKind } from '../../../api/generated';
+import { useConfig } from '../../../api/hooks/useConfig';
+import {
+  useParticipants,
+  useTransitionWorkflow,
+  useUploadVersion,
+  useWorkflow,
+} from '../../../api/hooks/useReviews';
+import { ConfirmDialog } from '../../admin/ConfirmDialog';
+import type { Notify } from '../../admin/layout/useToast';
+import { UserAvatar } from '../../shell/UserAvatar';
+import { ProgressBar } from '../list/ReviewListParts';
+import { workflowLabel } from '../workflowMeta';
+import { validateDocumentFile } from '../wizard/wizardModel';
+import { apiErrorCode, apiErrorMessage } from '../../../utils/apiError';
+import { ParticipantsDialog } from './ParticipantsDialog';
+
+const FALLBACK_MAX_SIZE_MB = 50;
+const MAX_STACK_AVATARS = 3;
+
+/** Known 409 guard vetoes from the workflow choke-point (ADR-0011). */
+const TRANSITION_CONFLICTS: Record<string, string> = {
+  INVALID_TRANSITION:
+    'This status change is not possible right now — open annotations or pending placements may remain.',
+};
+
+interface ReviewHubHeadProps {
+  documentId: string;
+  isOwner: boolean;
+  ownUserId: string | null;
+  annotations: AnnotationView[];
+  notify: Notify;
+  /** Called with the new version number after a successful re-upload. */
+  onVersionUploaded: (versionNumber: number) => void;
+}
+
+/**
+ * The review hub controls in the page header (#251): decided/total progress,
+ * the participant stack with its management dialog, workflow transitions
+ * (POST is authoritative — guard vetoes surface as toasts, ADR-0011) and the
+ * owner-only new-version upload.
+ */
+export function ReviewHubHead({
+  documentId,
+  isOwner,
+  ownUserId,
+  annotations,
+  notify,
+  onVersionUploaded,
+}: ReviewHubHeadProps) {
+  const theme = useTheme();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [participantsOpen, setParticipantsOpen] = useState(false);
+  const [workflowMenuAnchor, setWorkflowMenuAnchor] = useState<HTMLElement | null>(null);
+  const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
+
+  const { data: config } = useConfig();
+  const participantsQuery = useParticipants(documentId);
+  const workflowQuery = useWorkflow(documentId);
+  const transition = useTransitionWorkflow(documentId);
+  const uploadVersion = useUploadVersion(documentId);
+
+  const participants = participantsQuery.data?.participants ?? [];
+  const transitions = workflowQuery.data?.allowedTransitions ?? [];
+  const maxSizeMb = config?.upload.maxDocumentSizeMb ?? FALLBACK_MAX_SIZE_MB;
+
+  const total = annotations.length;
+  const decided = annotations.filter((a) => a.status !== AnnotationStatus.Open).length;
+
+  const handleTransitionConfirmed = (targetState: string) => {
+    setConfirmTarget(null);
+    transition.mutate(targetState, {
+      onSuccess: () => notify(`Review moved to ${workflowLabel(targetState)}.`),
+      onError: (error) =>
+        notify(
+          TRANSITION_CONFLICTS[apiErrorCode(error) ?? ''] ??
+            apiErrorMessage(error, 'The status could not be changed.'),
+          'error',
+        ),
+    });
+  };
+
+  const handleFilePicked = (file: File) => {
+    const error = validateDocumentFile(file, maxSizeMb);
+    if (error) {
+      notify(error, 'error');
+      return;
+    }
+    uploadVersion.mutate(
+      { file },
+      {
+        onSuccess: (result) => {
+          notify(`Version ${result.versionNumber} uploaded.`);
+          onVersionUploaded(result.versionNumber);
+        },
+        onError: (uploadError) =>
+          notify(apiErrorMessage(uploadError, 'The new version could not be uploaded.'), 'error'),
+      },
+    );
+  };
+
+  const shown = participants.slice(0, MAX_STACK_AVATARS);
+
+  return (
+    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+      {total > 0 && <ProgressBar decided={decided} total={total} color={theme.qnop.brand.blue} />}
+
+      <Tooltip title={isOwner ? 'Manage participants' : 'View participants'}>
+        <ButtonBase
+          onClick={() => setParticipantsOpen(true)}
+          data-testid="participants-button"
+          aria-label={isOwner ? 'Manage participants' : 'View participants'}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.75,
+            px: 1,
+            py: 0.5,
+            borderRadius: 99,
+            '&:hover': { bgcolor: theme.qnop.surface2 },
+            '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+          }}
+        >
+          {shown.length === 0 ? (
+            <UserPlus size={16} aria-hidden style={{ color: theme.palette.text.secondary }} />
+          ) : (
+            <Stack direction="row" sx={{ alignItems: 'center' }}>
+              {shown.map((participant, index) => (
+                <Box
+                  key={participant.id}
+                  sx={{
+                    borderRadius: '50%',
+                    border: '2px solid',
+                    borderColor: 'background.paper',
+                    ml: index === 0 ? 0 : -0.75,
+                    display: 'flex',
+                    zIndex: shown.length - index,
+                  }}
+                >
+                  {participant.kind === ParticipantKind.Team ? (
+                    <Box
+                      sx={{
+                        width: 24,
+                        height: 24,
+                        borderRadius: '50%',
+                        bgcolor: theme.qnop.surface2,
+                        color: 'text.secondary',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <Users size={12} aria-hidden />
+                    </Box>
+                  ) : (
+                    <UserAvatar name={participant.displayName} size={24} />
+                  )}
+                </Box>
+              ))}
+            </Stack>
+          )}
+          <Typography variant="caption" color="text.secondary">
+            {participants.length === 0
+              ? isOwner
+                ? 'Add reviewers'
+                : 'No reviewers'
+              : participants.length}
+          </Typography>
+        </ButtonBase>
+      </Tooltip>
+
+      {transitions.length > 0 && (
+        <>
+          <Button
+            size="small"
+            variant="outlined"
+            color="inherit"
+            endIcon={<ChevronDown size={14} />}
+            disabled={transition.isPending}
+            onClick={(e) => setWorkflowMenuAnchor(e.currentTarget)}
+          >
+            Change status
+          </Button>
+          <Menu
+            open={Boolean(workflowMenuAnchor)}
+            anchorEl={workflowMenuAnchor}
+            onClose={() => setWorkflowMenuAnchor(null)}
+          >
+            {transitions.map((target) => (
+              <MenuItem
+                key={target}
+                onClick={() => {
+                  setWorkflowMenuAnchor(null);
+                  setConfirmTarget(target);
+                }}
+              >
+                Move to {workflowLabel(target)}
+              </MenuItem>
+            ))}
+          </Menu>
+        </>
+      )}
+
+      {isOwner && (
+        <>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<Upload size={14} />}
+            disabled={uploadVersion.isPending}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {uploadVersion.isPending ? 'Uploading…' : 'New version'}
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/pdf,.pdf"
+            hidden
+            data-testid="version-file-input"
+            onChange={(e) => {
+              const picked = e.target.files?.[0];
+              if (picked) handleFilePicked(picked);
+              e.target.value = '';
+            }}
+          />
+        </>
+      )}
+
+      <ParticipantsDialog
+        documentId={documentId}
+        open={participantsOpen}
+        onClose={() => setParticipantsOpen(false)}
+        isOwner={isOwner}
+        ownUserId={ownUserId}
+        notify={notify}
+      />
+
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        title="Change review status"
+        message={
+          confirmTarget
+            ? `Move this review to "${workflowLabel(confirmTarget)}"? Reviewers will see the new status immediately.`
+            : ''
+        }
+        confirmLabel="Change status"
+        destructive={confirmTarget === 'CANCELLED'}
+        onConfirm={() => confirmTarget && handleTransitionConfirmed(confirmTarget)}
+        onClose={() => setConfirmTarget(null)}
+      />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/list/ReviewCards.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewCards.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Divider from '@mui/material/Divider';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { History, MessageSquare } from 'lucide-react';
+import type { DocumentSummary } from '../../../api/generated';
+import { formatRelative } from '../../../utils/formatDate';
+import { WorkflowBadge } from '../WorkflowBadge';
+import { DocumentIcon, ProgressBar, ReviewerStack, RoleBadge } from './ReviewListParts';
+import { progressOf, roleOf } from './reviewListModel';
+
+interface ReviewCardsProps {
+  reviews: DocumentSummary[];
+  userId: string | null;
+  onOpen: (documentId: string) => void;
+}
+
+/** The overview's card view: hover-lift tiles (prototype `rv-card`). */
+export function ReviewCards({ reviews, userId, onOpen }: ReviewCardsProps) {
+  const theme = useTheme();
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+        gap: 2,
+      }}
+    >
+      {reviews.map((review) => {
+        const progress = progressOf(review);
+        return (
+          <ButtonBase
+            key={review.id}
+            onClick={() => onOpen(review.id)}
+            data-testid={`review-card-${review.id}`}
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'stretch',
+              textAlign: 'left',
+              gap: 1.5,
+              p: 2.25,
+              borderRadius: 1.5,
+              border: `1px solid ${theme.palette.divider}`,
+              bgcolor: 'background.paper',
+              transition: 'transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease',
+              '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+              '&:hover': {
+                transform: 'translateY(-3px)',
+                boxShadow: '0 14px 36px -14px rgba(1, 32, 66, 0.22)',
+                borderColor: theme.palette.text.disabled,
+              },
+              '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+            }}
+          >
+            <Stack
+              direction="row"
+              sx={{ justifyContent: 'space-between', alignItems: 'flex-start' }}
+            >
+              <DocumentIcon size={38} />
+              <RoleBadge role={roleOf(review, userId)} />
+            </Stack>
+            <Box>
+              <Typography variant="body1" sx={{ fontWeight: 500, lineHeight: 1.3 }}>
+                {review.title}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                v{review.latestVersionNumber}
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+              <WorkflowBadge state={review.workflowState} />
+              {progress && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontVariantNumeric: 'tabular-nums' }}
+                >
+                  {progress.decided}/{progress.total} decided
+                </Typography>
+              )}
+            </Stack>
+            {progress && (
+              <ProgressBar
+                decided={progress.decided}
+                total={progress.total}
+                color={theme.qnop.brand.blue}
+              />
+            )}
+            <Divider />
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              <ReviewerStack participants={review.participants} />
+              <Box sx={{ flex: 1 }} />
+              <Stack
+                direction="row"
+                spacing={0.5}
+                sx={{ alignItems: 'center', color: 'text.secondary' }}
+              >
+                <History size={12} aria-hidden />
+                <Typography variant="caption">{review.latestVersionNumber}</Typography>
+              </Stack>
+              <Stack
+                direction="row"
+                spacing={0.5}
+                sx={{ alignItems: 'center', color: 'text.secondary' }}
+              >
+                <MessageSquare size={12} aria-hidden />
+                <Typography variant="caption">{review.annotationCount}</Typography>
+              </Stack>
+            </Stack>
+            <Typography variant="caption" color="text.secondary">
+              {formatRelative(review.updatedAt)}
+            </Typography>
+          </ButtonBase>
+        );
+      })}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/list/ReviewListParts.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewListParts.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { Eye, FileText, User } from 'lucide-react';
+import type { ParticipantView } from '../../../api/generated';
+import { ToneBadge } from '../../admin/ToneBadge';
+import { UserAvatar } from '../../shell/UserAvatar';
+
+/** Shared bits of the reviews overview: role badge, doc icon, progress, reviewer stack. */
+
+export function RoleBadge({ role }: { role: 'owner' | 'reviewer' }) {
+  return role === 'owner' ? (
+    <ToneBadge tone="blue" label="Owner" />
+  ) : (
+    <ToneBadge tone="neutral" label="Reviewer" />
+  );
+}
+
+export function RoleIcon({ role }: { role: 'owner' | 'reviewer' }) {
+  return role === 'owner' ? <User size={12} aria-hidden /> : <Eye size={12} aria-hidden />;
+}
+
+/** The little document sheet icon leading every row/card (prototype). */
+export function DocumentIcon({ size = 30 }: { size?: number }) {
+  const theme = useTheme();
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        width: size,
+        height: Math.round(size * 1.2),
+        borderRadius: '5px',
+        bgcolor: theme.qnop.surface2,
+        border: `1px solid ${theme.palette.divider}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        color: 'text.secondary',
+      }}
+    >
+      <FileText size={Math.round(size / 2)} />
+    </Box>
+  );
+}
+
+/** Decided/total bar in the status colour. */
+export function ProgressBar({
+  decided,
+  total,
+  color,
+}: {
+  decided: number;
+  total: number;
+  color: string;
+}) {
+  const theme = useTheme();
+  return (
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+      <Box
+        sx={{
+          width: 54,
+          height: 5,
+          borderRadius: 99,
+          bgcolor: theme.palette.divider,
+          overflow: 'hidden',
+        }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={decided}
+        aria-label={`${decided} of ${total} annotations decided`}
+      >
+        <Box sx={{ width: `${(decided / total) * 100}%`, height: '100%', bgcolor: color }} />
+      </Box>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}
+      >
+        {decided}/{total}
+      </Typography>
+    </Stack>
+  );
+}
+
+/** Overlapping reviewer avatars with real display names (max 3 + counter). */
+export function ReviewerStack({ participants }: { participants: ParticipantView[] }) {
+  if (participants.length === 0) {
+    return (
+      <Typography variant="caption" color="text.secondary">
+        no reviewers
+      </Typography>
+    );
+  }
+  const shown = participants.slice(0, 3);
+  return (
+    <Stack direction="row" sx={{ alignItems: 'center' }}>
+      {shown.map((participant, index) => (
+        <Tooltip key={participant.id} title={participant.displayName}>
+          <Box
+            sx={{
+              borderRadius: '50%',
+              border: '2px solid',
+              borderColor: 'background.paper',
+              ml: index === 0 ? 0 : -0.75,
+              display: 'flex',
+              zIndex: shown.length - index,
+            }}
+          >
+            <UserAvatar name={participant.displayName} size={24} />
+          </Box>
+        </Tooltip>
+      ))}
+      {participants.length > 3 && (
+        <Typography variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+          +{participants.length - 3}
+        </Typography>
+      )}
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { ChevronRight } from 'lucide-react';
+import type { DocumentSummary } from '../../../api/generated';
+import { formatRelative } from '../../../utils/formatDate';
+import { WorkflowBadge } from '../WorkflowBadge';
+import { DocumentIcon, ProgressBar, ReviewerStack, RoleBadge } from './ReviewListParts';
+import { progressOf, roleOf } from './reviewListModel';
+
+interface ReviewsTableProps {
+  reviews: DocumentSummary[];
+  userId: string | null;
+  onOpen: (documentId: string) => void;
+}
+
+/** The overview's table view (prototype `reviews.jsx`): dense, scannable rows. */
+export function ReviewsTable({ reviews, userId, onOpen }: ReviewsTableProps) {
+  const theme = useTheme();
+  return (
+    <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+      <Box sx={{ overflowX: 'auto' }}>
+        <Table size="small" sx={{ minWidth: 720 }}>
+          <TableHead>
+            <TableRow sx={{ bgcolor: theme.qnop.surface2 }}>
+              {['Document', 'Role', 'Status', 'Progress', 'Reviewers', 'Updated', ''].map(
+                (header) => (
+                  <TableCell
+                    key={header}
+                    sx={{
+                      fontSize: 10.5,
+                      fontWeight: 500,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                      color: 'text.secondary',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {header}
+                  </TableCell>
+                ),
+              )}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {reviews.map((review) => {
+              const progress = progressOf(review);
+              return (
+                <TableRow
+                  key={review.id}
+                  hover
+                  onClick={() => onOpen(review.id)}
+                  data-testid={`review-row-${review.id}`}
+                  sx={{ cursor: 'pointer', '&:last-child td': { borderBottom: 0 } }}
+                >
+                  <TableCell sx={{ py: 1.5 }}>
+                    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+                      <DocumentIcon />
+                      <Box sx={{ minWidth: 0 }}>
+                        <Typography variant="body2" noWrap sx={{ fontWeight: 500, maxWidth: 320 }}>
+                          {review.title}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          v{review.latestVersionNumber}
+                        </Typography>
+                      </Box>
+                    </Stack>
+                  </TableCell>
+                  <TableCell>
+                    <RoleBadge role={roleOf(review, userId)} />
+                  </TableCell>
+                  <TableCell>
+                    <WorkflowBadge state={review.workflowState} />
+                  </TableCell>
+                  <TableCell sx={{ minWidth: 120 }}>
+                    {progress ? (
+                      <ProgressBar
+                        decided={progress.decided}
+                        total={progress.total}
+                        color={theme.qnop.brand.blue}
+                      />
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">
+                        —
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <ReviewerStack participants={review.participants} />
+                  </TableCell>
+                  <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                    <Typography variant="caption" color="text.secondary">
+                      {formatRelative(review.updatedAt)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right" sx={{ color: 'text.secondary' }}>
+                    <ChevronRight size={16} aria-hidden />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Box>
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/reviews/list/reviewListModel.ts
+++ b/qnop-ui/src/components/reviews/list/reviewListModel.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { DocumentSummary } from '../../../api/generated';
+
+/** The caller's role on a review — owner is structural (ADR-0011), everyone else reviews. */
+export function roleOf(review: DocumentSummary, userId: string | null): 'owner' | 'reviewer' {
+  return review.ownerId === userId ? 'owner' : 'reviewer';
+}
+
+/** Decided/total progress of a review; null when it has no annotations yet. */
+export function progressOf(review: DocumentSummary): { decided: number; total: number } | null {
+  if (review.annotationCount === 0) return null;
+  return {
+    decided: review.annotationCount - review.openAnnotationCount,
+    total: review.annotationCount,
+  };
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -19,12 +19,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';
+import { useAuthStore } from '../../../stores/authStore';
 import { AnnotationPanel } from './AnnotationPanel';
 
 vi.mock('./CommentThread', () => ({
@@ -36,6 +37,16 @@ vi.mock('./CommentThread', () => ({
 vi.mock('../../../api/hooks/useComments', () => ({
   useComments: vi.fn().mockReturnValue({ isPending: false, isError: false, data: undefined }),
 }));
+
+const { decideMutate } = vi.hoisted(() => ({ decideMutate: vi.fn() }));
+vi.mock('../../../api/hooks/useAnnotations', () => ({
+  useDecideAnnotation: () => ({ mutate: decideMutate, isPending: false }),
+}));
+
+beforeEach(() => {
+  decideMutate.mockClear();
+  useAuthStore.setState({ userId: null });
+});
 
 const annotation = (id: string, overrides: Partial<AnnotationView> = {}): AnnotationView => ({
   id,
@@ -63,6 +74,7 @@ function renderPanel(props: Partial<Parameters<typeof AnnotationPanel>[0]> = {})
     onCreate: vi.fn(),
     onCancelPending: vi.fn(),
     canAnnotate: true,
+    ownerId: 'owner-1',
     notify: vi.fn(),
   };
   const merged = { ...defaults, ...props };
@@ -158,6 +170,44 @@ describe('AnnotationPanel', () => {
 
     fireEvent.click(composer.getByRole('button', { name: 'Cancel' }));
     expect(props.onCancelPending).toHaveBeenCalled();
+  });
+
+  it('offers Accept/Reject to the owner on an open active annotation', () => {
+    useAuthStore.setState({ userId: 'owner-1' });
+    renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });
+
+    fireEvent.click(within(screen.getByTestId('decision-bar')).getByText('Accept'));
+
+    expect(decideMutate).toHaveBeenCalledWith(
+      { annotationId: 'a1', decision: 'ACCEPTED' },
+      expect.anything(),
+    );
+  });
+
+  it('offers the decision to the author as well', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });
+
+    fireEvent.click(within(screen.getByTestId('decision-bar')).getByText('Reject'));
+
+    expect(decideMutate).toHaveBeenCalledWith(
+      { annotationId: 'a1', decision: 'REJECTED' },
+      expect.anything(),
+    );
+  });
+
+  it('hides the decision bar from uninvolved participants and on decided annotations', () => {
+    useAuthStore.setState({ userId: 'stranger' });
+    renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });
+    expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
+    cleanup();
+
+    useAuthStore.setState({ userId: 'owner-1' });
+    renderPanel({
+      annotations: [annotation('a2', { status: AnnotationStatus.Accepted })],
+      activeAnnotationId: 'a2',
+    });
+    expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
   });
 
   it('creates via the submit shortcut and shows the hint', () => {

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -31,9 +31,12 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { ChevronRight, Link2, NotebookPen, Unlink } from 'lucide-react';
+import { Check, ChevronRight, Link2, NotebookPen, Unlink, X } from 'lucide-react';
 import type { Anchor, AnnotationView } from '../../../api/generated';
-import { AnnotationStatus } from '../../../api/generated';
+import { AnnotationDecision, AnnotationStatus } from '../../../api/generated';
+import { useDecideAnnotation } from '../../../api/hooks/useAnnotations';
+import { useAuthStore } from '../../../stores/authStore';
+import { apiErrorCode } from '../../../utils/apiError';
 import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
 import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
@@ -42,6 +45,11 @@ import { AnnotationListItem } from './AnnotationListItem';
 import { CommentThread } from './CommentThread';
 
 type StatusFilter = 'all' | 'open' | 'decided';
+
+/** Known decision conflicts (409) — mapped to friendly text, never server prose. */
+const DECISION_CONFLICTS: Record<string, string> = {
+  ANNOTATION_ALREADY_DECIDED: 'This annotation was already decided.',
+};
 
 const FILTERS: { value: StatusFilter; label: string }[] = [
   { value: 'all', label: 'All' },
@@ -61,7 +69,48 @@ interface AnnotationPanelProps {
   onCreate: (comment: string) => void;
   onCancelPending: () => void;
   canAnnotate: boolean;
+  /** The document owner — owner or author may decide an annotation (ADR-0011). */
+  ownerId: string | null;
   notify: Notify;
+}
+
+/** Accept/Reject for an open annotation, shown to the owner or the author. */
+function DecisionBar({
+  disabled,
+  onDecide,
+}: {
+  disabled: boolean;
+  onDecide: (decision: AnnotationDecision) => void;
+}) {
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      data-testid="decision-bar"
+      sx={{ alignItems: 'center', pl: 2, py: 1 }}
+    >
+      <Button
+        size="small"
+        variant="contained"
+        color="success"
+        startIcon={<Check size={14} />}
+        disabled={disabled}
+        onClick={() => onDecide(AnnotationDecision.Accepted)}
+      >
+        Accept
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        color="inherit"
+        startIcon={<X size={14} />}
+        disabled={disabled}
+        onClick={() => onDecide(AnnotationDecision.Rejected)}
+      >
+        Reject
+      </Button>
+    </Stack>
+  );
 }
 
 /** The composer for a freshly drawn anchor: optional first comment, then create. */
@@ -240,9 +289,36 @@ export function AnnotationPanel({
   onCreate,
   onCancelPending,
   canAnnotate,
+  ownerId,
   notify,
 }: AnnotationPanelProps) {
   const [filter, setFilter] = useState<StatusFilter>('all');
+  const userId = useAuthStore((state) => state.userId);
+  const decide = useDecideAnnotation();
+
+  const mayDecide = (annotation: AnnotationView) =>
+    annotation.status === AnnotationStatus.Open &&
+    userId !== null &&
+    (ownerId === userId || annotation.authorId === userId);
+
+  const handleDecide = (annotation: AnnotationView, decision: AnnotationDecision) => {
+    decide.mutate(
+      { annotationId: annotation.id, decision },
+      {
+        onSuccess: () =>
+          notify(
+            decision === AnnotationDecision.Accepted
+              ? 'Annotation accepted.'
+              : 'Annotation rejected.',
+          ),
+        onError: (error) =>
+          notify(
+            DECISION_CONFLICTS[apiErrorCode(error) ?? ''] ?? 'The decision could not be saved.',
+            'error',
+          ),
+      },
+    );
+  };
 
   const matchesFilter = (annotation: AnnotationView) =>
     filter === 'all' ||
@@ -267,6 +343,12 @@ export function AnnotationPanel({
           onHover={onHover}
         />
         <Collapse in={active} unmountOnExit>
+          {mayDecide(annotation) && (
+            <DecisionBar
+              disabled={decide.isPending}
+              onDecide={(decision) => handleDecide(annotation, decision)}
+            />
+          )}
           <CommentThread annotationId={annotation.id} notify={notify} />
         </Collapse>
       </Stack>

--- a/qnop-ui/src/components/reviews/wizard/DocumentStep.tsx
+++ b/qnop-ui/src/components/reviews/wizard/DocumentStep.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState } from 'react';
+import type { DragEvent } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { FileText, Upload, X } from 'lucide-react';
+import { formatFileSize } from './wizardModel';
+
+interface DocumentStepProps {
+  file: File | null;
+  title: string;
+  /** Validation error from the last file pick, if any. */
+  fileError: string | null;
+  maxSizeMb: number;
+  onFilePicked: (file: File) => void;
+  onFileCleared: () => void;
+  onTitleChange: (title: string) => void;
+}
+
+/** Step 1 — pick the PDF (dropzone or picker) and name the review. */
+export function DocumentStep({
+  file,
+  title,
+  fileError,
+  maxSizeMb,
+  onFilePicked,
+  onFileCleared,
+  onTitleChange,
+}: DocumentStepProps) {
+  const theme = useTheme();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const handleDrop = (event: DragEvent) => {
+    event.preventDefault();
+    setIsDragOver(false);
+    const dropped = event.dataTransfer.files[0];
+    if (dropped) onFilePicked(dropped);
+  };
+
+  return (
+    <Stack spacing={2.5}>
+      {!file ? (
+        <Box
+          data-testid="wizard-dropzone"
+          onClick={() => inputRef.current?.click()}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setIsDragOver(true);
+          }}
+          onDragLeave={() => setIsDragOver(false)}
+          onDrop={handleDrop}
+          sx={{
+            border: '2px dashed',
+            borderColor: isDragOver ? theme.qnop.brand.blue : theme.palette.divider,
+            borderRadius: 3,
+            px: 3,
+            py: 7,
+            textAlign: 'center',
+            cursor: 'pointer',
+            bgcolor: isDragOver ? theme.palette.primary.light : 'transparent',
+            transition: 'border-color 160ms ease, background-color 160ms ease',
+          }}
+        >
+          <Box
+            sx={{
+              width: 60,
+              height: 60,
+              borderRadius: 3.5,
+              bgcolor: theme.palette.primary.light,
+              color: theme.qnop.brand.blue,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              mb: 2,
+            }}
+          >
+            <Upload size={26} aria-hidden />
+          </Box>
+          <Typography sx={{ fontWeight: 600, fontSize: 18, mb: 0.5 }}>
+            Drop your document here or choose a file
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            PDF · max. {maxSizeMb} MB
+          </Typography>
+          <Button variant="contained" startIcon={<Upload size={16} />}>
+            Choose file
+          </Button>
+        </Box>
+      ) : (
+        <Stack
+          direction="row"
+          spacing={1.75}
+          sx={{
+            alignItems: 'center',
+            p: 2,
+            borderRadius: 2,
+            bgcolor: theme.qnop.surface2,
+          }}
+        >
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              bgcolor: theme.qnop.brand.blue,
+              color: '#fff',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <FileText size={20} aria-hidden />
+          </Box>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+              {file.name}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {formatFileSize(file.size)}
+            </Typography>
+          </Box>
+          <Tooltip title="Remove file">
+            <IconButton size="small" onClick={onFileCleared} aria-label="Remove file">
+              <X size={16} />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/pdf,.pdf"
+        hidden
+        data-testid="wizard-file-input"
+        onChange={(e) => {
+          const picked = e.target.files?.[0];
+          if (picked) onFilePicked(picked);
+          e.target.value = '';
+        }}
+      />
+
+      {fileError && <Alert severity="error">{fileError}</Alert>}
+
+      <TextField
+        label="Review title"
+        value={title}
+        onChange={(e) => onTitleChange(e.target.value)}
+        placeholder="e.g. NDA Acme Corp"
+        helperText="Shown in the overview and to every reviewer."
+        fullWidth
+      />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/wizard/ReviewerStep.tsx
+++ b/qnop-ui/src/components/reviews/wizard/ReviewerStep.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { Plus, Search, Users, X } from 'lucide-react';
+import type { PrincipalView } from '../../../api/generated';
+import { ParticipantKind } from '../../../api/generated';
+import { usePrincipalSearch } from '../../../api/hooks/useReviews';
+import { UserAvatar } from '../../shell/UserAvatar';
+
+interface ReviewerStepProps {
+  selected: PrincipalView[];
+  /** The current user — the owner is structural and cannot be a reviewer (ADR-0011). */
+  ownUserId: string | null;
+  onAdd: (principal: PrincipalView) => void;
+  onRemove: (principal: PrincipalView) => void;
+}
+
+function principalKey(p: PrincipalView): string {
+  return `${p.kind}:${p.id}`;
+}
+
+/** Step 2 — pick reviewers (users or teams) from the principal directory. */
+export function ReviewerStep({ selected, ownUserId, onAdd, onRemove }: ReviewerStepProps) {
+  const theme = useTheme();
+  const [query, setQuery] = useState('');
+  const { data, isPending } = usePrincipalSearch(query.trim());
+
+  const selectedKeys = new Set(selected.map(principalKey));
+  const candidates = (data?.principals ?? []).filter(
+    (p) =>
+      !selectedKeys.has(principalKey(p)) &&
+      !(p.kind === ParticipantKind.User && p.id === ownUserId),
+  );
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Selected reviewers
+        </Typography>
+        {selected.length === 0 ? (
+          <Typography variant="body2" color="text.disabled">
+            No reviewers yet — you can also add them later.
+          </Typography>
+        ) : (
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+            {selected.map((principal) => (
+              <Stack
+                key={principalKey(principal)}
+                direction="row"
+                spacing={1}
+                sx={{
+                  alignItems: 'center',
+                  pl: 0.75,
+                  pr: 0.5,
+                  py: 0.5,
+                  borderRadius: 1.75,
+                  bgcolor: theme.palette.primary.light,
+                  border: `1px solid ${theme.qnop.brand.blue}2E`,
+                }}
+              >
+                {principal.kind === ParticipantKind.Team ? (
+                  <Box
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: '50%',
+                      bgcolor: theme.qnop.surface2,
+                      color: 'text.secondary',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <Users size={12} aria-hidden />
+                  </Box>
+                ) : (
+                  <UserAvatar name={principal.displayName} size={22} />
+                )}
+                <Typography variant="body2" sx={{ fontSize: 12.5, fontWeight: 500 }}>
+                  {principal.displayName}
+                </Typography>
+                <IconButton
+                  size="small"
+                  onClick={() => onRemove(principal)}
+                  aria-label={`Remove ${principal.displayName}`}
+                  sx={{ width: 20, height: 20 }}
+                >
+                  <X size={12} />
+                </IconButton>
+              </Stack>
+            ))}
+          </Stack>
+        )}
+      </Box>
+
+      <Box>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="Search people or teams…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          sx={{ mb: 1.25 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={15} />
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+        <Box
+          sx={{
+            border: `1px solid ${theme.palette.divider}`,
+            borderRadius: 2,
+            overflow: 'hidden',
+          }}
+        >
+          {candidates.length === 0 ? (
+            <Typography variant="body2" color="text.disabled" sx={{ px: 2, py: 1.75 }}>
+              {isPending ? 'Searching…' : 'No matching people or teams.'}
+            </Typography>
+          ) : (
+            candidates.map((principal, i) => (
+              <ButtonBase
+                key={principalKey(principal)}
+                onClick={() => onAdd(principal)}
+                data-testid={`principal-${principal.id}`}
+                sx={{
+                  display: 'flex',
+                  width: '100%',
+                  alignItems: 'center',
+                  gap: 1.25,
+                  px: 1.75,
+                  py: 1.25,
+                  textAlign: 'left',
+                  borderBottom:
+                    i < candidates.length - 1 ? `1px solid ${theme.palette.divider}` : 'none',
+                  '&:hover': { bgcolor: theme.qnop.surface2 },
+                  '&:focus-visible': { boxShadow: `inset ${theme.qnop.focusRing}` },
+                }}
+              >
+                {principal.kind === ParticipantKind.Team ? (
+                  <Box
+                    sx={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: '50%',
+                      bgcolor: theme.qnop.surface2,
+                      color: 'text.secondary',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                    }}
+                  >
+                    <Users size={14} aria-hidden />
+                  </Box>
+                ) : (
+                  <UserAvatar name={principal.displayName} size={28} />
+                )}
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+                    {principal.displayName}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {principal.kind === ParticipantKind.Team ? 'Team' : 'User'}
+                  </Typography>
+                </Box>
+                <Plus size={14} aria-hidden style={{ color: theme.palette.text.disabled }} />
+              </ButtonBase>
+            ))
+          )}
+        </Box>
+      </Box>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/wizard/SummaryStep.tsx
+++ b/qnop-ui/src/components/reviews/wizard/SummaryStep.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { FileText, Play, Users } from 'lucide-react';
+import type { PrincipalView } from '../../../api/generated';
+import { formatFileSize } from './wizardModel';
+
+export type SubmitPhase = 'idle' | 'uploading' | 'finalizing';
+
+interface SummaryStepProps {
+  file: File;
+  title: string;
+  reviewers: PrincipalView[];
+  startImmediately: boolean;
+  onStartImmediatelyChange: (value: boolean) => void;
+  phase: SubmitPhase;
+  /** Upload progress 0..1, meaningful while phase is `uploading`. */
+  progress: number;
+}
+
+function SummaryRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Typography
+        variant="caption"
+        sx={{
+          display: 'block',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          fontSize: 10,
+          color: 'text.disabled',
+          mb: 0.5,
+        }}
+      >
+        {label}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
+
+/** Step 3 — confirm what will be created and optionally start the review. */
+export function SummaryStep({
+  file,
+  title,
+  reviewers,
+  startImmediately,
+  onStartImmediatelyChange,
+  phase,
+  progress,
+}: SummaryStepProps) {
+  const theme = useTheme();
+  const isSubmitting = phase !== 'idle';
+
+  return (
+    <Stack spacing={3}>
+      <SummaryRow label="Document">
+        <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center' }}>
+          <FileText size={16} aria-hidden style={{ color: theme.palette.text.secondary }} />
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            {title}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {file.name} · {formatFileSize(file.size)}
+          </Typography>
+        </Stack>
+      </SummaryRow>
+
+      <SummaryRow label="Reviewers">
+        {reviewers.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            None yet — the review starts with you only; reviewers can be added any time.
+          </Typography>
+        ) : (
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+            <Users size={16} aria-hidden style={{ color: theme.palette.text.secondary }} />
+            <Typography variant="body2">
+              {reviewers.map((r) => r.displayName).join(', ')}
+            </Typography>
+          </Stack>
+        )}
+      </SummaryRow>
+
+      <Stack
+        component="label"
+        direction="row"
+        spacing={1.5}
+        sx={{
+          alignItems: 'center',
+          p: 1.75,
+          borderRadius: 2,
+          cursor: isSubmitting ? 'default' : 'pointer',
+          border: `1px solid ${startImmediately ? theme.qnop.brand.blue : theme.palette.divider}`,
+          bgcolor: startImmediately ? theme.palette.primary.light : 'transparent',
+          transition: 'border-color 160ms ease, background-color 160ms ease',
+        }}
+      >
+        <Box
+          sx={{
+            width: 32,
+            height: 32,
+            borderRadius: 2,
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: startImmediately ? theme.qnop.brand.blue : theme.qnop.surface2,
+            color: startImmediately ? '#fff' : 'text.secondary',
+          }}
+        >
+          <Play size={16} aria-hidden />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            Start review immediately
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Moves the review from Draft to In review so reviewers can annotate right away.
+          </Typography>
+        </Box>
+        <Switch
+          checked={startImmediately}
+          disabled={isSubmitting}
+          onChange={(e) => onStartImmediatelyChange(e.target.checked)}
+          slotProps={{ input: { 'aria-label': 'Start review immediately' } }}
+        />
+      </Stack>
+
+      {isSubmitting && (
+        <Box data-testid="wizard-upload-progress">
+          <Stack direction="row" sx={{ justifyContent: 'space-between', mb: 0.75 }}>
+            <Typography variant="caption" color="text.secondary">
+              {phase === 'uploading' ? 'Uploading document…' : 'Setting up the review…'}
+            </Typography>
+            {phase === 'uploading' && (
+              <Typography variant="caption" color="text.secondary">
+                {Math.round(progress * 100)}%
+              </Typography>
+            )}
+          </Stack>
+          <LinearProgress
+            variant={phase === 'uploading' ? 'determinate' : 'indeterminate'}
+            value={progress * 100}
+            sx={{ borderRadius: 99 }}
+          />
+        </Box>
+      )}
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/wizard/WizardStepsHeader.tsx
+++ b/qnop-ui/src/components/reviews/wizard/WizardStepsHeader.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { Check } from 'lucide-react';
+
+export interface WizardStep {
+  label: string;
+}
+
+interface WizardStepsHeaderProps {
+  steps: WizardStep[];
+  /** 1-based index of the active step. */
+  active: number;
+}
+
+/** The wizard's progress strip (prototype `wizard.jsx`): numbered dots + connectors. */
+export function WizardStepsHeader({ steps, active }: WizardStepsHeaderProps) {
+  const theme = useTheme();
+  return (
+    <Paper variant="outlined" sx={{ px: 2.5, py: 2 }}>
+      <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+        {steps.map((step, i) => {
+          const n = i + 1;
+          const isDone = active > n;
+          const isActive = active === n;
+          return (
+            <Stack
+              key={step.label}
+              direction="row"
+              spacing={1.25}
+              sx={{ alignItems: 'center', flex: 1, minWidth: 0 }}
+            >
+              <Box
+                sx={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: '50%',
+                  flexShrink: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  fontVariantNumeric: 'tabular-nums',
+                  bgcolor: isDone
+                    ? theme.palette.success.main
+                    : isActive
+                      ? theme.qnop.brand.blue
+                      : theme.qnop.surface2,
+                  color: isDone || isActive ? '#fff' : 'text.disabled',
+                  boxShadow: isActive ? `0 0 0 3px ${theme.qnop.brand.blue}33` : 'none',
+                }}
+                aria-current={isActive ? 'step' : undefined}
+              >
+                {isDone ? <Check size={14} aria-label={`${step.label} done`} /> : n}
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    display: 'block',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                    fontSize: 10,
+                    color: 'text.disabled',
+                    lineHeight: 1.4,
+                  }}
+                >
+                  Step {n}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  noWrap
+                  sx={{
+                    fontWeight: 500,
+                    color: active >= n ? 'text.primary' : 'text.disabled',
+                    lineHeight: 1.3,
+                  }}
+                >
+                  {step.label}
+                </Typography>
+              </Box>
+              {i < steps.length - 1 && (
+                <Box
+                  aria-hidden
+                  sx={{
+                    flex: 1,
+                    height: 2,
+                    borderRadius: 99,
+                    mx: 1,
+                    bgcolor: isDone ? theme.palette.success.main : theme.palette.divider,
+                    transition: 'background-color 200ms ease',
+                  }}
+                />
+              )}
+            </Stack>
+          );
+        })}
+      </Stack>
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/reviews/wizard/wizardModel.test.ts
+++ b/qnop-ui/src/components/reviews/wizard/wizardModel.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatFileSize, titleFromFilename, validateDocumentFile } from './wizardModel';
+
+function fileOf(name: string, type: string, sizeBytes: number): File {
+  const file = new File(['x'], name, { type });
+  Object.defineProperty(file, 'size', { value: sizeBytes });
+  return file;
+}
+
+describe('validateDocumentFile', () => {
+  it('accepts a PDF under the limit', () => {
+    expect(validateDocumentFile(fileOf('a.pdf', 'application/pdf', 1024), 50)).toBeNull();
+  });
+
+  it('accepts by .pdf extension when the browser reports no MIME type', () => {
+    expect(validateDocumentFile(fileOf('Scan.PDF', '', 1024), 50)).toBeNull();
+  });
+
+  it('rejects non-PDF files', () => {
+    expect(validateDocumentFile(fileOf('a.docx', 'application/msword', 10), 50)).toBe(
+      'Only PDF documents are supported.',
+    );
+  });
+
+  it('rejects files over the configured limit', () => {
+    const tooBig = fileOf('big.pdf', 'application/pdf', 51 * 1024 * 1024);
+    expect(validateDocumentFile(tooBig, 50)).toBe('The file exceeds the maximum size of 50 MB.');
+  });
+});
+
+describe('titleFromFilename', () => {
+  it('strips the pdf extension case-insensitively', () => {
+    expect(titleFromFilename('NDA Acme Corp.pdf')).toBe('NDA Acme Corp');
+    expect(titleFromFilename('contract.PDF')).toBe('contract');
+  });
+
+  it('leaves other names untouched', () => {
+    expect(titleFromFilename('notes')).toBe('notes');
+  });
+});
+
+describe('formatFileSize', () => {
+  it('formats megabytes with one decimal', () => {
+    expect(formatFileSize(2.4 * 1024 * 1024)).toBe('2.4 MB');
+  });
+
+  it('formats kilobytes and never shows 0 KB for tiny files', () => {
+    expect(formatFileSize(412 * 1024)).toBe('412 KB');
+    expect(formatFileSize(3)).toBe('1 KB');
+  });
+});

--- a/qnop-ui/src/components/reviews/wizard/wizardModel.ts
+++ b/qnop-ui/src/components/reviews/wizard/wizardModel.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/** Pure logic of the new-review wizard — kept DOM-free for direct unit testing. */
+
+const BYTES_PER_MB = 1024 * 1024;
+
+/**
+ * Client-side pre-check of the chosen file (the backend re-validates and is
+ * authoritative). PDF-only mirrors the Community scope of the vertical slice.
+ */
+export function validateDocumentFile(file: File, maxSizeMb: number): string | null {
+  const isPdf = file.type === 'application/pdf' || /\.pdf$/i.test(file.name);
+  if (!isPdf) return 'Only PDF documents are supported.';
+  if (file.size > maxSizeMb * BYTES_PER_MB) {
+    return `The file exceeds the maximum size of ${maxSizeMb} MB.`;
+  }
+  return null;
+}
+
+/** Default review title derived from the file name (extension stripped). */
+export function titleFromFilename(filename: string): string {
+  return filename.replace(/\.pdf$/i, '').trim();
+}
+
+/** Human-readable file size ("2.4 MB", "412 KB"). */
+export function formatFileSize(bytes: number): string {
+  if (bytes >= BYTES_PER_MB) return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}

--- a/qnop-ui/src/components/reviews/workflowMeta.ts
+++ b/qnop-ui/src/components/reviews/workflowMeta.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { BadgeTone } from '../admin/ToneBadge';
+
+/**
+ * Presentation of the review workflow states (ADR-0011). The state set is
+ * deliberately open — an enterprise state machine may add states — so unknown
+ * values render neutrally and count as "open" (not finished).
+ */
+export const WORKFLOW_TONES: Record<string, BadgeTone> = {
+  DRAFT: 'neutral',
+  IN_REVIEW: 'blue',
+  CHANGES_REQUESTED: 'amber',
+  FINALIZED: 'green',
+  CANCELLED: 'red',
+};
+
+const CLOSED_STATES = new Set(['FINALIZED', 'CANCELLED']);
+
+/** Human label for a workflow state: `IN_REVIEW` → `In review`. */
+export function workflowLabel(state: string): string {
+  return state
+    .toLowerCase()
+    .replaceAll('_', ' ')
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+/** Whether the review is still running (unknown enterprise states count as open). */
+export function isOpenWorkflowState(state: string): boolean {
+  return !CLOSED_STATES.has(state);
+}

--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -43,8 +43,10 @@ export function AppShell() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   // The document review workspace (#250) spans the full width; every other
-  // surface keeps the centred reading container.
-  const fullBleed = Boolean(useMatch('/reviews/:documentId'));
+  // surface keeps the centred reading container. /reviews/new also matches the
+  // dynamic segment but is a regular centred page (the wizard, #251).
+  const reviewMatch = useMatch('/reviews/:documentId');
+  const fullBleed = Boolean(reviewMatch && reviewMatch.params.documentId !== 'new');
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
       return localStorage.getItem(COLLAPSE_KEY) === '1';

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../../api/hooks/useDocuments', () => ({
 vi.mock('../../api/hooks/useAnnotations', () => ({
   useAnnotations: vi.fn(),
   useCreateAnnotation: vi.fn(),
+  useDecideAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
 }));
 vi.mock('../../api/hooks/useComments', () => ({
   useComments: vi.fn().mockReturnValue({ isPending: true, isError: false, data: undefined }),

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -53,6 +53,13 @@ vi.mock('../../api/hooks/useComments', () => ({
 vi.mock('../../components/reviews/viewer/usePdfDocument', () => ({
   usePdfDocument: vi.fn(),
 }));
+// The hub head talks to its own hooks (participants, workflow, config) and has
+// dedicated tests; the page test only checks it receives the right identity.
+vi.mock('../../components/reviews/hub/ReviewHubHead', () => ({
+  ReviewHubHead: ({ isOwner }: { isOwner: boolean }) => (
+    <div data-testid="review-hub-head" data-is-owner={String(isOwner)} />
+  ),
+}));
 // The viewer needs a real pdf.js document and layout; the page test only
 // verifies the orchestration around it. The stub exposes a button that
 // simulates a completed text selection.

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -42,10 +42,9 @@ import {
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
-import type { BadgeTone } from '../../components/admin/ToneBadge';
-import { ToneBadge } from '../../components/admin/ToneBadge';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
 import { PANEL_MIN_WIDTH, PanelResizer } from '../../components/reviews/PanelResizer';
+import { WorkflowBadge } from '../../components/reviews/WorkflowBadge';
 import type {
   ScreenPosition,
   TextSelectionOffsets,
@@ -58,23 +57,6 @@ import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
 import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
 
 const PANEL_WIDTH_KEY = 'qnop-review-panel-width';
-
-/** Community workflow states with a badge tone; unknown (enterprise) states render neutral. */
-const WORKFLOW_TONES: Record<string, BadgeTone> = {
-  DRAFT: 'neutral',
-  IN_REVIEW: 'blue',
-  CHANGES_REQUESTED: 'amber',
-  FINALIZED: 'green',
-  CANCELLED: 'red',
-};
-
-function workflowBadge(state: string) {
-  const label = state
-    .toLowerCase()
-    .replaceAll('_', ' ')
-    .replace(/^./, (c) => c.toUpperCase());
-  return <ToneBadge tone={WORKFLOW_TONES[state] ?? 'neutral'} label={label} />;
-}
 
 /**
  * The review surface of one document (#250): pdf.js renders the original for
@@ -225,7 +207,7 @@ export function DocumentReviewPage() {
     >
       {/* No description line: the version lives in the toolbar dropdown, and
           every saved pixel goes to the document and its annotations. */}
-      <PageHeader title={document.title} titleAdornment={workflowBadge(document.workflowState)} />
+      <PageHeader title={document.title} titleAdornment={<WorkflowBadge state={document.workflowState} />} />
       {versionNumber === undefined ? (
         <Alert severity="info">This review has no uploaded document version yet.</Alert>
       ) : (

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -42,6 +42,7 @@ import {
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
+import { ReviewHubHead } from '../../components/reviews/hub/ReviewHubHead';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
 import { PANEL_MIN_WIDTH, PanelResizer } from '../../components/reviews/PanelResizer';
 import { WorkflowBadge } from '../../components/reviews/WorkflowBadge';
@@ -55,6 +56,7 @@ import { DocumentViewer } from '../../components/reviews/viewer/DocumentViewer';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
 import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
+import { useAuthStore } from '../../stores/authStore';
 
 const PANEL_WIDTH_KEY = 'qnop-review-panel-width';
 
@@ -69,6 +71,7 @@ export function DocumentReviewPage() {
   const { documentId = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const { toast, notify, clear } = useToast();
+  const userId = useAuthStore((s) => s.userId);
 
   const documentQuery = useDocument(documentId);
   const latestVersion = documentQuery.data?.latestVersionNumber ?? 0;
@@ -207,7 +210,20 @@ export function DocumentReviewPage() {
     >
       {/* No description line: the version lives in the toolbar dropdown, and
           every saved pixel goes to the document and its annotations. */}
-      <PageHeader title={document.title} titleAdornment={<WorkflowBadge state={document.workflowState} />} />
+      <PageHeader
+        title={document.title}
+        titleAdornment={<WorkflowBadge state={document.workflowState} />}
+        action={
+          <ReviewHubHead
+            documentId={documentId}
+            isOwner={document.ownerId === userId}
+            ownUserId={userId}
+            annotations={annotations}
+            notify={notify}
+            onVersionUploaded={handleVersionChange}
+          />
+        }
+      />
       {versionNumber === undefined ? (
         <Alert severity="info">This review has no uploaded document version yet.</Alert>
       ) : (

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -328,6 +328,7 @@ export function DocumentReviewPage() {
               onCreate={handleCreate}
               onCancelPending={() => setPending(null)}
               canAnnotate={canAnnotate}
+              ownerId={document.ownerId}
               notify={notify}
             />
           </Box>

--- a/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+import type { PrincipalListResponse, WorkflowStatus } from '../../api/generated';
+import { ParticipantKind } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { useAuthStore } from '../../stores/authStore';
+import { axiosInstance, documentsApi, principalsApi, reviewWorkflowApi } from '../../api/config';
+import { NewReviewPage } from './NewReviewPage';
+
+vi.mock('../../api/config', () => ({
+  axiosInstance: { post: vi.fn(), get: vi.fn() },
+  documentsApi: { addParticipant: vi.fn() },
+  principalsApi: { searchPrincipals: vi.fn() },
+  reviewWorkflowApi: { transitionDocumentWorkflow: vi.fn() },
+}));
+vi.mock('../../api/hooks/useConfig', () => ({
+  useConfig: () => ({ data: { upload: { maxDocumentSizeMb: 50 } } }),
+}));
+
+const ME = '00000000-0000-0000-0000-0000000000aa';
+const DOC_ID = '00000000-0000-0000-0000-0000000000d1';
+
+const PRINCIPALS: PrincipalListResponse = {
+  principals: [
+    { id: 'u-max', kind: ParticipantKind.User, displayName: 'Max Member' },
+    { id: ME, kind: ParticipantKind.User, displayName: 'Me Myself' },
+    { id: 't-alpha', kind: ParticipantKind.Team, displayName: 'Team Alpha' },
+  ],
+};
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/reviews/new']}>
+          <Routes>
+            <Route path="/reviews" element={<div data-testid="list-probe" />} />
+            <Route path="/reviews/new" element={<NewReviewPage />} />
+            <Route path="/reviews/:documentId" element={<div data-testid="detail-probe" />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ThemeProvider>,
+  );
+}
+
+function pickPdf(name = 'NDA Acme Corp.pdf') {
+  const file = new File(['%PDF-1.4'], name, { type: 'application/pdf' });
+  fireEvent.change(screen.getByTestId('wizard-file-input'), { target: { files: [file] } });
+  return file;
+}
+
+function goToStep2() {
+  pickPdf();
+  fireEvent.click(screen.getByRole('button', { name: /Next/ }));
+}
+
+async function goToStep3WithMax() {
+  goToStep2();
+  fireEvent.click(await screen.findByTestId('principal-u-max'));
+  fireEvent.click(screen.getByRole('button', { name: /Next/ }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({ userId: ME, isAuthenticated: true });
+  vi.mocked(principalsApi.searchPrincipals).mockResolvedValue({ data: PRINCIPALS } as Awaited<
+    ReturnType<typeof principalsApi.searchPrincipals>
+  >);
+  vi.mocked(axiosInstance.post).mockResolvedValue({
+    data: { documentId: DOC_ID, versionNumber: 1, extractionStatus: 'PENDING' },
+  });
+  vi.mocked(documentsApi.addParticipant).mockResolvedValue({ data: { id: 'p1' } } as Awaited<
+    ReturnType<typeof documentsApi.addParticipant>
+  >);
+  const started: WorkflowStatus = { state: 'IN_REVIEW', allowedTransitions: [] };
+  vi.mocked(reviewWorkflowApi.transitionDocumentWorkflow).mockResolvedValue({
+    data: started,
+  } as Awaited<ReturnType<typeof reviewWorkflowApi.transitionDocumentWorkflow>>);
+});
+
+describe('NewReviewPage — step 1', () => {
+  it('blocks Next until a file is picked and prefills the title', () => {
+    renderPage();
+
+    expect(screen.getByRole('button', { name: /Next/ })).toBeDisabled();
+
+    pickPdf();
+
+    expect(screen.getByDisplayValue('NDA Acme Corp')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Next/ })).toBeEnabled();
+  });
+
+  it('rejects a non-PDF file with an error and keeps Next disabled', () => {
+    renderPage();
+
+    const file = new File(['hi'], 'notes.docx', { type: 'application/msword' });
+    fireEvent.change(screen.getByTestId('wizard-file-input'), { target: { files: [file] } });
+
+    expect(screen.getByText('Only PDF documents are supported.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+
+  it('keeps a manually entered title when picking the file', () => {
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText(/Review title/), { target: { value: 'My title' } });
+    pickPdf();
+
+    expect(screen.getByDisplayValue('My title')).toBeInTheDocument();
+  });
+
+  it('cancel returns to the overview', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/ }));
+
+    expect(screen.getByTestId('list-probe')).toBeInTheDocument();
+  });
+});
+
+describe('NewReviewPage — step 2', () => {
+  it('lists principals excluding myself and already selected ones', async () => {
+    renderPage();
+    goToStep2();
+
+    expect(await screen.findByTestId('principal-u-max')).toBeInTheDocument();
+    expect(screen.getByTestId('principal-t-alpha')).toBeInTheDocument();
+    expect(screen.queryByTestId(`principal-${ME}`)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('principal-u-max'));
+
+    expect(screen.queryByTestId('principal-u-max')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove Max Member' })).toBeInTheDocument();
+  });
+
+  it('removes a selected reviewer again', async () => {
+    renderPage();
+    goToStep2();
+
+    fireEvent.click(await screen.findByTestId('principal-u-max'));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Max Member' }));
+
+    expect(screen.getByText('No reviewers yet — you can also add them later.')).toBeInTheDocument();
+    expect(await screen.findByTestId('principal-u-max')).toBeInTheDocument();
+  });
+});
+
+describe('NewReviewPage — step 3 & submit', () => {
+  it('creates the review, adds reviewers, starts it and navigates to it', async () => {
+    renderPage();
+    await goToStep3WithMax();
+
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('Max Member')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Create & start review/ }));
+
+    await waitFor(() => expect(screen.getByTestId('detail-probe')).toBeInTheDocument());
+    const [url, form] = vi.mocked(axiosInstance.post).mock.calls[0];
+    expect(url).toBe('/documents');
+    expect((form as FormData).get('title')).toBe('NDA Acme Corp');
+    expect(documentsApi.addParticipant).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+      participantCreateRequest: { userId: 'u-max' },
+    });
+    expect(reviewWorkflowApi.transitionDocumentWorkflow).toHaveBeenCalledWith({
+      documentId: DOC_ID,
+      workflowTransitionRequest: { targetState: 'IN_REVIEW' },
+    });
+  });
+
+  it('skips the workflow transition when start-immediately is off', async () => {
+    renderPage();
+    await goToStep3WithMax();
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Start review immediately' }));
+    fireEvent.click(screen.getByRole('button', { name: /Create review/ }));
+
+    await waitFor(() => expect(screen.getByTestId('detail-probe')).toBeInTheDocument());
+    expect(reviewWorkflowApi.transitionDocumentWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('shows an error and stays on the wizard when the upload fails', async () => {
+    vi.mocked(axiosInstance.post).mockRejectedValue(new Error('network down'));
+    renderPage();
+    await goToStep3WithMax();
+
+    fireEvent.click(screen.getByRole('button', { name: /Create & start review/ }));
+
+    expect(await screen.findByText('The upload failed. Please try again.')).toBeInTheDocument();
+    expect(screen.queryByTestId('detail-probe')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Create & start review/ })).toBeEnabled();
+  });
+
+  it('reports a partial result when a follow-up step fails after the upload', async () => {
+    vi.mocked(documentsApi.addParticipant).mockRejectedValue(new Error('conflict'));
+    renderPage();
+    await goToStep3WithMax();
+
+    fireEvent.click(screen.getByRole('button', { name: /Create & start review/ }));
+
+    expect(await screen.findByText(/some steps could not be completed/)).toBeInTheDocument();
+    expect(screen.getByText(/add reviewer “Max Member”/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Open review/ }));
+    expect(screen.getByTestId('detail-probe')).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/pages/reviews/NewReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/NewReviewPage.tsx
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useQueryClient } from '@tanstack/react-query';
+import { ChevronLeft, ChevronRight, Zap } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { PrincipalView } from '../../api/generated';
+import { ParticipantKind } from '../../api/generated';
+import { documentsApi, reviewWorkflowApi } from '../../api/config';
+import { useConfig } from '../../api/hooks/useConfig';
+import { reviewKeys, useCreateReview } from '../../api/hooks/useReviews';
+import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { DocumentStep } from '../../components/reviews/wizard/DocumentStep';
+import { ReviewerStep } from '../../components/reviews/wizard/ReviewerStep';
+import { SummaryStep } from '../../components/reviews/wizard/SummaryStep';
+import type { SubmitPhase } from '../../components/reviews/wizard/SummaryStep';
+import { WizardStepsHeader } from '../../components/reviews/wizard/WizardStepsHeader';
+import {
+  titleFromFilename,
+  validateDocumentFile,
+} from '../../components/reviews/wizard/wizardModel';
+import { useAuthStore } from '../../stores/authStore';
+import { apiErrorMessage } from '../../utils/apiError';
+
+const STEPS = [{ label: 'Document' }, { label: 'Reviewers' }, { label: 'Summary & start' }];
+const FALLBACK_MAX_SIZE_MB = 50;
+
+interface SubmitState {
+  phase: SubmitPhase;
+  progress: number;
+  error: string | null;
+  /** Set when the review exists but a follow-up step (reviewer, start) failed. */
+  partial: { documentId: string; failures: string[] } | null;
+}
+
+const SUBMIT_IDLE: SubmitState = { phase: 'idle', progress: 0, error: null, partial: null };
+
+/** The guided 3-step new-review wizard at /reviews/new (#251). */
+export function NewReviewPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const userId = useAuthStore((s) => s.userId);
+  const { data: config } = useConfig();
+  const createReview = useCreateReview();
+
+  const [step, setStep] = useState(1);
+  const [file, setFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [title, setTitle] = useState('');
+  const [reviewers, setReviewers] = useState<PrincipalView[]>([]);
+  const [startImmediately, setStartImmediately] = useState(true);
+  const [submit, setSubmit] = useState<SubmitState>(SUBMIT_IDLE);
+
+  const maxSizeMb = config?.upload.maxDocumentSizeMb ?? FALLBACK_MAX_SIZE_MB;
+  const isSubmitting = submit.phase !== 'idle';
+
+  const handleFilePicked = (picked: File) => {
+    const error = validateDocumentFile(picked, maxSizeMb);
+    if (error) {
+      setFileError(error);
+      return;
+    }
+    setFileError(null);
+    setFile(picked);
+    if (title.trim() === '') setTitle(titleFromFilename(picked.name));
+  };
+
+  const addReviewer = (principal: PrincipalView) =>
+    setReviewers((current) => [...current, principal]);
+  const removeReviewer = (principal: PrincipalView) =>
+    setReviewers((current) =>
+      current.filter((p) => !(p.kind === principal.kind && p.id === principal.id)),
+    );
+
+  const canProceed = step !== 1 || (file !== null && title.trim() !== '');
+
+  const handleCreate = async () => {
+    if (!file) return;
+    setSubmit({ ...SUBMIT_IDLE, phase: 'uploading' });
+    let documentId: string;
+    try {
+      const created = await createReview.mutateAsync({
+        title: title.trim(),
+        file,
+        onProgress: (fraction) => setSubmit((s) => ({ ...s, progress: fraction })),
+      });
+      documentId = created.documentId;
+    } catch (error) {
+      setSubmit({
+        ...SUBMIT_IDLE,
+        error: apiErrorMessage(error, 'The upload failed. Please try again.'),
+      });
+      return;
+    }
+
+    // The review now exists — follow-up failures must not look like a failed
+    // creation, so they are collected and reported as a partial result.
+    setSubmit((s) => ({ ...s, phase: 'finalizing', progress: 1 }));
+    const failures: string[] = [];
+    for (const principal of reviewers) {
+      try {
+        await documentsApi.addParticipant({
+          documentId,
+          participantCreateRequest:
+            principal.kind === ParticipantKind.Team
+              ? { teamId: principal.id }
+              : { userId: principal.id },
+        });
+      } catch {
+        failures.push(`add reviewer “${principal.displayName}”`);
+      }
+    }
+    if (startImmediately) {
+      try {
+        await reviewWorkflowApi.transitionDocumentWorkflow({
+          documentId,
+          workflowTransitionRequest: { targetState: 'IN_REVIEW' },
+        });
+      } catch {
+        failures.push('start the review');
+      }
+    }
+    queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+
+    if (failures.length > 0) {
+      setSubmit({ ...SUBMIT_IDLE, partial: { documentId, failures } });
+      return;
+    }
+    navigate(`/reviews/${documentId}`);
+  };
+
+  if (submit.partial) {
+    return (
+      <Stack spacing={3} sx={{ maxWidth: 720, mx: 'auto' }}>
+        <PageHeader title="Review created" />
+        <Alert severity="warning">
+          The review was created, but some steps could not be completed:{' '}
+          {submit.partial.failures.join(', ')}. You can finish these from the review page.
+        </Alert>
+        <Box>
+          <Button
+            variant="contained"
+            onClick={() => navigate(`/reviews/${submit.partial?.documentId}`)}
+          >
+            Open review
+          </Button>
+        </Box>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={3} sx={{ maxWidth: 860, mx: 'auto' }}>
+      <PageHeader
+        title="New review"
+        description="Guided three-step setup: document, reviewers, start."
+      />
+
+      <WizardStepsHeader steps={STEPS} active={step} />
+
+      {submit.error && <Alert severity="error">{submit.error}</Alert>}
+
+      <Paper variant="outlined" sx={{ p: { xs: 2.5, sm: 3.5 } }}>
+        {step === 1 && (
+          <DocumentStep
+            file={file}
+            title={title}
+            fileError={fileError}
+            maxSizeMb={maxSizeMb}
+            onFilePicked={handleFilePicked}
+            onFileCleared={() => setFile(null)}
+            onTitleChange={setTitle}
+          />
+        )}
+        {step === 2 && (
+          <ReviewerStep
+            selected={reviewers}
+            ownUserId={userId}
+            onAdd={addReviewer}
+            onRemove={removeReviewer}
+          />
+        )}
+        {step === 3 && file && (
+          <SummaryStep
+            file={file}
+            title={title.trim()}
+            reviewers={reviewers}
+            startImmediately={startImmediately}
+            onStartImmediatelyChange={setStartImmediately}
+            phase={submit.phase}
+            progress={submit.progress}
+          />
+        )}
+      </Paper>
+
+      <Stack direction="row" sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
+        <Button
+          color="inherit"
+          startIcon={<ChevronLeft size={16} />}
+          disabled={isSubmitting}
+          onClick={() => (step > 1 ? setStep(step - 1) : navigate('/reviews'))}
+        >
+          {step > 1 ? 'Back' : 'Cancel'}
+        </Button>
+        <Typography variant="caption" color="text.secondary">
+          Step {step} of {STEPS.length}
+        </Typography>
+        {step < STEPS.length ? (
+          <Button
+            variant="contained"
+            endIcon={<ChevronRight size={16} />}
+            disabled={!canProceed}
+            onClick={() => setStep(step + 1)}
+          >
+            Next
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            startIcon={<Zap size={16} />}
+            disabled={isSubmitting}
+            onClick={handleCreate}
+          >
+            {startImmediately ? 'Create & start review' : 'Create review'}
+          </Button>
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import type { DocumentSummary } from '../../api/generated';
+import { ParticipantKind } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { useAuthStore } from '../../stores/authStore';
+import { useReviews } from '../../api/hooks/useReviews';
+import { ReviewsPage } from './ReviewsPage';
+
+vi.mock('../../api/hooks/useReviews', () => ({
+  useReviews: vi.fn(),
+}));
+
+const ME = '00000000-0000-0000-0000-0000000000aa';
+const OTHER = '00000000-0000-0000-0000-0000000000bb';
+
+function summary(overrides: Partial<DocumentSummary>): DocumentSummary {
+  return {
+    id: 'doc-x',
+    title: 'Untitled',
+    ownerId: ME,
+    workflowState: 'DRAFT',
+    latestVersionNumber: 1,
+    annotationCount: 0,
+    openAnnotationCount: 0,
+    participants: [],
+    createdAt: '2026-07-01T10:00:00Z',
+    updatedAt: '2026-07-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+const REVIEWS: DocumentSummary[] = [
+  summary({
+    id: 'doc-1',
+    title: 'NDA Acme Corp',
+    workflowState: 'IN_REVIEW',
+    annotationCount: 3,
+    openAnnotationCount: 1,
+    participants: [
+      { id: 'p1', kind: ParticipantKind.User, principalId: OTHER, displayName: 'Max Member' },
+    ],
+    updatedAt: '2026-07-02T12:00:00Z',
+  }),
+  summary({
+    id: 'doc-2',
+    title: 'Architecture handbook',
+    ownerId: OTHER,
+    workflowState: 'DRAFT',
+    updatedAt: '2026-07-01T09:00:00Z',
+  }),
+  summary({
+    id: 'doc-3',
+    title: 'Final contract',
+    ownerId: OTHER,
+    workflowState: 'FINALIZED',
+    annotationCount: 2,
+    openAnnotationCount: 0,
+    updatedAt: '2026-06-20T08:00:00Z',
+  }),
+];
+
+type Queryish = { data?: unknown; isPending?: boolean; isError?: boolean; refetch?: () => void };
+function mockReviews(value: Queryish) {
+  vi.mocked(useReviews).mockReturnValue({
+    isPending: false,
+    isError: false,
+    refetch: vi.fn(),
+    ...value,
+  } as unknown as ReturnType<typeof useReviews>);
+}
+
+function renderPage() {
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter initialEntries={['/reviews']}>
+        <Routes>
+          <Route path="/reviews" element={<ReviewsPage />} />
+          <Route path="/reviews/new" element={<div data-testid="new-review-probe" />} />
+          <Route path="/reviews/:documentId" element={<div data-testid="detail-probe" />} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  useAuthStore.setState({ userId: ME, isAuthenticated: true });
+  mockReviews({ data: { items: REVIEWS, total: REVIEWS.length, page: 0, size: 100 } });
+});
+
+describe('ReviewsPage', () => {
+  it('lists all reviews with role and workflow badges', () => {
+    renderPage();
+
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('Architecture handbook')).toBeInTheDocument();
+    expect(screen.getByText('Final contract')).toBeInTheDocument();
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.getAllByText('Reviewer')).toHaveLength(2);
+    expect(screen.getByText('In review')).toBeInTheDocument();
+    expect(screen.getByText('Finalized')).toBeInTheDocument();
+  });
+
+  it('shows decided/total progress for reviews with annotations', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('progressbar', { name: '2 of 3 annotations decided' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('2/3')).toBeInTheDocument();
+  });
+
+  it('filters by title search', () => {
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText('Search reviews…'), {
+      target: { value: 'nda' },
+    });
+
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+    expect(screen.queryByText('Architecture handbook')).not.toBeInTheDocument();
+  });
+
+  it('filters by role via the chip and shows counts', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByText('Owned by me (1)'));
+
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+    expect(screen.queryByText('Architecture handbook')).not.toBeInTheDocument();
+    expect(screen.queryByText('Final contract')).not.toBeInTheDocument();
+  });
+
+  it('filters by workflow status and toggles the chip off again', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByText('Closed (1)'));
+    expect(screen.getByText('Final contract')).toBeInTheDocument();
+    expect(screen.queryByText('NDA Acme Corp')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Closed (1)'));
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+  });
+
+  it('offers to clear filters when nothing matches', () => {
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText('Search reviews…'), {
+      target: { value: 'does-not-exist' },
+    });
+    expect(screen.getByText('No reviews match your filters.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Clear filters'));
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+  });
+
+  it('navigates to the review on row click', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('review-row-doc-1'));
+
+    expect(screen.getByTestId('detail-probe')).toBeInTheDocument();
+  });
+
+  it('navigates to the wizard from the header CTA', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /New review/ }));
+
+    expect(screen.getByTestId('new-review-probe')).toBeInTheDocument();
+  });
+
+  it('switches to cards and persists the choice', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Card view' }));
+
+    expect(screen.getByTestId('review-card-doc-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('review-row-doc-1')).not.toBeInTheDocument();
+    expect(localStorage.getItem('qnop-reviews-view')).toBe('cards');
+  });
+
+  it('restores the persisted card view', () => {
+    localStorage.setItem('qnop-reviews-view', 'cards');
+    renderPage();
+
+    expect(screen.getByTestId('review-card-doc-1')).toBeInTheDocument();
+  });
+
+  it('shows the hero empty state without any reviews', () => {
+    mockReviews({ data: { items: [], total: 0, page: 0, size: 100 } });
+    renderPage();
+
+    expect(screen.getByText('No reviews yet')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /New review/ })).not.toHaveLength(0);
+  });
+
+  it('shows a loading skeleton while pending', () => {
+    mockReviews({ isPending: true });
+    renderPage();
+
+    expect(screen.getByTestId('reviews-loading')).toBeInTheDocument();
+  });
+
+  it('shows an error with retry', () => {
+    const refetch = vi.fn();
+    mockReviews({ isError: true, refetch });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(refetch).toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMemo, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import InputAdornment from '@mui/material/InputAdornment';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Typography from '@mui/material/Typography';
+import { FileText, LayoutGrid, Plus, Rows3, Search } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { DocumentSummary } from '../../api/generated';
+import { useReviews } from '../../api/hooks/useReviews';
+import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { isOpenWorkflowState } from '../../components/reviews/workflowMeta';
+import { roleOf } from '../../components/reviews/list/reviewListModel';
+import { ReviewCards } from '../../components/reviews/list/ReviewCards';
+import { ReviewsTable } from '../../components/reviews/list/ReviewsTable';
+import { useAuthStore } from '../../stores/authStore';
+
+type RoleFilter = 'all' | 'owner' | 'reviewer';
+type StatusFilter = 'all' | 'open' | 'closed';
+type SortBy = 'updated' | 'name';
+type ViewMode = 'table' | 'cards';
+
+const VIEW_STORAGE_KEY = 'qnop-reviews-view';
+// The overview loads one big page and filters client-side so the chip counters
+// stay consistent with what is on screen; server paging arrives when real
+// installations outgrow this (documented trade-off in #251).
+const FETCH_SIZE = 100;
+
+function readStoredView(): ViewMode {
+  try {
+    return localStorage.getItem(VIEW_STORAGE_KEY) === 'cards' ? 'cards' : 'table';
+  } catch {
+    return 'table';
+  }
+}
+
+function matchesRole(review: DocumentSummary, filter: RoleFilter, userId: string | null): boolean {
+  return filter === 'all' || roleOf(review, userId) === filter;
+}
+
+function matchesStatus(review: DocumentSummary, filter: StatusFilter): boolean {
+  if (filter === 'all') return true;
+  return isOpenWorkflowState(review.workflowState) === (filter === 'open');
+}
+
+function matchesSearch(review: DocumentSummary, query: string): boolean {
+  return query === '' || review.title.toLowerCase().includes(query);
+}
+
+function sortReviews(reviews: DocumentSummary[], sortBy: SortBy): DocumentSummary[] {
+  const sorted = [...reviews];
+  if (sortBy === 'name') {
+    sorted.sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
+  } else {
+    sorted.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+  return sorted;
+}
+
+function FilterChip({
+  label,
+  count,
+  selected,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Chip
+      label={`${label} (${count})`}
+      size="small"
+      color={selected ? 'primary' : 'default'}
+      variant={selected ? 'filled' : 'outlined'}
+      onClick={onClick}
+      sx={{ fontWeight: selected ? 600 : 400 }}
+    />
+  );
+}
+
+/** Reviews overview (#251): every review the user owns or participates in. */
+export function ReviewsPage() {
+  const navigate = useNavigate();
+  const userId = useAuthStore((s) => s.userId);
+  const { data, isPending, isError, refetch } = useReviews({
+    page: 0,
+    size: FETCH_SIZE,
+    sort: 'updatedAt,desc',
+  });
+
+  const [search, setSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [sortBy, setSortBy] = useState<SortBy>('updated');
+  const [view, setView] = useState<ViewMode>(readStoredView);
+
+  const items = useMemo(() => data?.items ?? [], [data]);
+  const query = search.trim().toLowerCase();
+
+  // Faceted counts: each chip group is counted against the search + the OTHER
+  // group's filter, so a chip's number always predicts what clicking it shows.
+  const searched = useMemo(() => items.filter((r) => matchesSearch(r, query)), [items, query]);
+  const roleCounts = useMemo(() => {
+    const base = searched.filter((r) => matchesStatus(r, statusFilter));
+    return {
+      all: base.length,
+      owner: base.filter((r) => roleOf(r, userId) === 'owner').length,
+      reviewer: base.filter((r) => roleOf(r, userId) === 'reviewer').length,
+    };
+  }, [searched, statusFilter, userId]);
+  const statusCounts = useMemo(() => {
+    const base = searched.filter((r) => matchesRole(r, roleFilter, userId));
+    return {
+      all: base.length,
+      open: base.filter((r) => isOpenWorkflowState(r.workflowState)).length,
+      closed: base.filter((r) => !isOpenWorkflowState(r.workflowState)).length,
+    };
+  }, [searched, roleFilter, userId]);
+
+  const visible = useMemo(
+    () =>
+      sortReviews(
+        searched.filter(
+          (r) => matchesRole(r, roleFilter, userId) && matchesStatus(r, statusFilter),
+        ),
+        sortBy,
+      ),
+    [searched, roleFilter, statusFilter, sortBy, userId],
+  );
+
+  const hasActiveFilters = query !== '' || roleFilter !== 'all' || statusFilter !== 'all';
+
+  const changeView = (next: ViewMode | null) => {
+    if (!next) return;
+    setView(next);
+    try {
+      localStorage.setItem(VIEW_STORAGE_KEY, next);
+    } catch {
+      // View preference is a nicety; private-mode storage failures are fine.
+    }
+  };
+
+  const clearFilters = () => {
+    setSearch('');
+    setRoleFilter('all');
+    setStatusFilter('all');
+  };
+
+  const openReview = (documentId: string) => navigate(`/reviews/${documentId}`);
+
+  const newReviewButton = (
+    <Button
+      variant="contained"
+      startIcon={<Plus size={16} />}
+      onClick={() => navigate('/reviews/new')}
+    >
+      New review
+    </Button>
+  );
+
+  return (
+    <Stack spacing={3}>
+      <PageHeader
+        title="Reviews"
+        description="Documents you own or review — pick one up where it stands."
+        action={newReviewButton}
+      />
+
+      {isError && (
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" onClick={() => refetch()}>
+              Retry
+            </Button>
+          }
+        >
+          Reviews could not be loaded.
+        </Alert>
+      )}
+
+      {isPending && !isError && (
+        <Stack spacing={1.5} data-testid="reviews-loading">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} variant="rounded" height={56} />
+          ))}
+        </Stack>
+      )}
+
+      {data && items.length === 0 && (
+        <Paper variant="outlined" sx={{ py: 8, px: 3, textAlign: 'center' }}>
+          <Stack spacing={2} sx={{ alignItems: 'center' }}>
+            <FileText size={40} aria-hidden style={{ opacity: 0.4 }} />
+            <Box>
+              <Typography variant="h6" component="p" sx={{ fontWeight: 500 }}>
+                No reviews yet
+              </Typography>
+              <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+                Upload a document to start your first review.
+              </Typography>
+            </Box>
+            {newReviewButton}
+          </Stack>
+        </Paper>
+      )}
+
+      {data && items.length > 0 && (
+        <>
+          <Stack
+            direction={{ xs: 'column', md: 'row' }}
+            spacing={2}
+            sx={{ alignItems: { md: 'center' } }}
+          >
+            <TextField
+              size="small"
+              placeholder="Search reviews…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              sx={{ width: { xs: '100%', md: 280 } }}
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Search size={16} />
+                    </InputAdornment>
+                  ),
+                },
+              }}
+            />
+            <Box sx={{ flex: 1 }} />
+            <TextField
+              select
+              size="small"
+              label="Sort"
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value as SortBy)}
+              sx={{ width: 180 }}
+            >
+              <MenuItem value="updated">Recently updated</MenuItem>
+              <MenuItem value="name">Name</MenuItem>
+            </TextField>
+            <ToggleButtonGroup
+              exclusive
+              size="small"
+              value={view}
+              onChange={(_e, next: ViewMode | null) => changeView(next)}
+              aria-label="View mode"
+            >
+              <ToggleButton value="table" aria-label="Table view">
+                <Rows3 size={16} />
+              </ToggleButton>
+              <ToggleButton value="cards" aria-label="Card view">
+                <LayoutGrid size={16} />
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
+
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+            <FilterChip
+              label="All"
+              count={roleCounts.all}
+              selected={roleFilter === 'all'}
+              onClick={() => setRoleFilter('all')}
+            />
+            <FilterChip
+              label="Owned by me"
+              count={roleCounts.owner}
+              selected={roleFilter === 'owner'}
+              onClick={() => setRoleFilter('owner')}
+            />
+            <FilterChip
+              label="Reviewing"
+              count={roleCounts.reviewer}
+              selected={roleFilter === 'reviewer'}
+              onClick={() => setRoleFilter('reviewer')}
+            />
+            <Box sx={{ width: 8 }} />
+            <FilterChip
+              label="Open"
+              count={statusCounts.open}
+              selected={statusFilter === 'open'}
+              onClick={() => setStatusFilter(statusFilter === 'open' ? 'all' : 'open')}
+            />
+            <FilterChip
+              label="Closed"
+              count={statusCounts.closed}
+              selected={statusFilter === 'closed'}
+              onClick={() => setStatusFilter(statusFilter === 'closed' ? 'all' : 'closed')}
+            />
+          </Stack>
+
+          {visible.length === 0 ? (
+            <Paper variant="outlined" sx={{ py: 6, px: 3, textAlign: 'center' }}>
+              <Typography color="text.secondary">No reviews match your filters.</Typography>
+              {hasActiveFilters && (
+                <Button size="small" onClick={clearFilters} sx={{ mt: 1.5 }}>
+                  Clear filters
+                </Button>
+              )}
+            </Paper>
+          ) : view === 'table' ? (
+            <ReviewsTable reviews={visible} userId={userId} onOpen={openReview} />
+          ) : (
+            <ReviewCards reviews={visible} userId={userId} onOpen={openReview} />
+          )}
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -21,7 +21,7 @@
 
 import { lazy, Suspense } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
-import { FileText, ShieldCheck } from 'lucide-react';
+import { ShieldCheck } from 'lucide-react';
 import { AppShell } from '../components/shell/AppShell';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { ProtectedRoute } from '../components/auth/ProtectedRoute';
@@ -45,6 +45,7 @@ import { ResetPasswordPage } from '../pages/auth/ResetPasswordPage';
 import { VerifyEmailPage } from '../pages/auth/VerifyEmailPage';
 import { ForbiddenPage } from '../pages/errors/ForbiddenPage';
 import { NotFoundPage } from '../pages/errors/NotFoundPage';
+import { ReviewsPage } from '../pages/reviews/ReviewsPage';
 
 // The template editor pulls in CodeMirror; load it lazily so the rest of the app stays light.
 const MailTemplateEditPage = lazy(() =>
@@ -84,16 +85,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> },
       { path: 'profile', element: <ProfilePage /> },
-      {
-        path: 'reviews',
-        element: (
-          <ComingSoonPage
-            title="Reviews"
-            description="Upload, review and approve documents — the review surface arrives in the PDF vertical slice."
-            icon={FileText}
-          />
-        ),
-      },
+      { path: 'reviews', element: <ReviewsPage /> },
       {
         path: 'reviews/:documentId',
         element: (

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -45,6 +45,7 @@ import { ResetPasswordPage } from '../pages/auth/ResetPasswordPage';
 import { VerifyEmailPage } from '../pages/auth/VerifyEmailPage';
 import { ForbiddenPage } from '../pages/errors/ForbiddenPage';
 import { NotFoundPage } from '../pages/errors/NotFoundPage';
+import { NewReviewPage } from '../pages/reviews/NewReviewPage';
 import { ReviewsPage } from '../pages/reviews/ReviewsPage';
 
 // The template editor pulls in CodeMirror; load it lazily so the rest of the app stays light.
@@ -86,6 +87,7 @@ export const router = createBrowserRouter([
       { index: true, element: <HomePage /> },
       { path: 'profile', element: <ProfilePage /> },
       { path: 'reviews', element: <ReviewsPage /> },
+      { path: 'reviews/new', element: <NewReviewPage /> },
       {
         path: 'reviews/:documentId',
         element: (


### PR DESCRIPTION
Closes #251.

## What

The complete reviews UI on top of the #292 backend API (merged as #293), oriented on the design prototype (`docs/qnop-design-prototype`):

### Reviews overview (`/reviews`)
- Replaces the ComingSoon placeholder: search, role chips (All / Owned by me / Reviewing) and status chips (Open / Closed) with faceted counts, recent/name sort, and a persisted table ⇄ cards toggle.
- Rows/cards show role badge, workflow badge, decided/total progress, reviewer avatar stack (real display names) and relative updated time; dedicated empty, filtered-empty, loading and error states.
- Client-side filtering over one fetched page (size 100, `updatedAt,desc`) keeps the chip counters consistent with what is on screen — documented trade-off until real installations outgrow it.

### New-review wizard (`/reviews/new`)
- Guided 3 steps per the prototype: **Document** (PDF dropzone with client-side type/size pre-check against `/config`, title prefilled from filename) → **Reviewers** (principal directory search, user/team chips, owner excluded per ADR-0011) → **Summary & start** (optional immediate `DRAFT → IN_REVIEW` transition).
- Determinate upload progress; follow-up failures after a successful upload surface as an explicit partial result with a link to the review — never as a fake creation error.
- `/reviews/new` keeps the centred layout; full-bleed stays reserved for the viewer route.

### Review hub head (viewer page header)
- Decided/total progress bar, participant avatar stack with management dialog (owner adds/removes via the principal directory; participants get a read-only view).
- Workflow transitions from `allowedTransitions` behind a confirm dialog — the POST stays authoritative; guard vetoes (`INVALID_TRANSITION`, `DUPLICATE_PARTICIPANT`) map to friendly toasts, never server prose.
- Owner-only "New version" upload that jumps to the uploaded version.

### Annotation decisions
- Accept/Reject bar on the expanded card for the document owner or the annotation's author (ADR-0011); `ANNOTATION_ALREADY_DECIDED` (409) maps to a friendly toast. Unplaced (orphaned/failed) annotations keep their dedicated "Not placed on this version" section.

### Shared modules
- `workflowMeta.ts` (state tones/labels/open-set) + `WorkflowBadge` extracted so the overview and the viewer render states identically; `reviewListModel.ts` for role/progress derivation; `wizardModel.ts` for file validation (pure, unit-tested).

## Out of scope (follow-ups)
- #252 version diff view, #291 focus/spotlight mode, versions tab.

## Test plan
- [x] 52 test files / 295 tests green (`vitest run`), coverage gates met
- [x] `tsc -b --noEmit`, `eslint .`, `prettier --check .` clean
- [x] `pnpm build` production build green
- [x] New suites: ReviewsPage (13), NewReviewPage (10), wizardModel (8), ReviewHubHead (8), ParticipantsDialog (5), AnnotationPanel decisions (3)
- [ ] Manual browser pass over upload → invite → annotate → decide → finalize (reviewer welcome)

🤖 Co-Author: Claude (Fable 5) via Claude Code