### PR TITLE
feat(core): glyph-true per-character span geometry & pointer selection (#290)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -3812,6 +3812,20 @@ components:
           description: Exclusive end (startOffset + text length).
         box:
           $ref: '#/components/schemas/NormalizedBox'
+        charAdvances:
+          type: array
+          items:
+            type: number
+            format: double
+          description: >-
+            Glyph-true sub-line geometry (issue #290): the normalized x of
+            each character's right edge on the surface, in the same coordinate
+            space as `box`. Character i spans from `i == 0 ? box.x :
+            charAdvances[i-1]` to `charAdvances[i]`. Values are non-decreasing
+            and the array length equals the text length. Absent for
+            representations extracted before this field existed or when
+            per-character geometry cannot be attributed — clients then
+            distribute the characters uniformly across the box.
       required:
         - text
         - startOffset

--- a/qnop-core/src/main/java/io/qnop/service/document/PdfBoxDocumentExtractor.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/PdfBoxDocumentExtractor.java
@@ -106,10 +106,17 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
   }
 
   /**
-   * One collected text run before canonical offsets exist: its text, normalized box, and the raw
-   * geometry (PDF points) plus collection sequence used to establish a deterministic reading order.
+   * One collected text run before canonical offsets exist: its text, normalized box, optional
+   * per-character right edges (issue #290), and the raw geometry (PDF points) plus collection
+   * sequence used to establish a deterministic reading order.
    */
-  private record RawRun(String text, NormalizedBox box, double baselineY, double minX, int seq) {}
+  private record RawRun(
+      String text,
+      NormalizedBox box,
+      List<Double> charAdvances,
+      double baselineY,
+      double minX,
+      int seq) {}
 
   /**
    * Collects one run per stripper-written string with a glyph bounding box normalized to the crop
@@ -139,7 +146,9 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
       List<TextSpan> spans = new ArrayList<>(ordered.size());
       int offset = 0;
       for (RawRun run : ordered) {
-        spans.add(new TextSpan(run.text(), offset, offset + run.text().length(), run.box()));
+        spans.add(
+            new TextSpan(
+                run.text(), offset, offset + run.text().length(), run.box(), run.charAdvances()));
         offset += run.text().length() + 1; // +1 for the canonical '\n' joiner between runs
       }
       return spans;
@@ -161,7 +170,9 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
         glyphs.append(position.getUnicode());
       }
       if (!glyphs.toString().equals(text)) {
-        addRun(text, positions);
+        // Stripper-inserted separators have no glyph of their own, so per-character
+        // geometry cannot be attributed — consumers fall back to uniform distribution.
+        addRun(text, positions, false);
         return;
       }
       List<TextPosition> current = new ArrayList<>();
@@ -182,7 +193,7 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
       for (TextPosition position : positions) {
         text.append(position.getUnicode());
       }
-      addRun(text.toString(), positions);
+      addRun(text.toString(), positions, true);
     }
 
     private static boolean startsNewSegment(TextPosition previous, TextPosition next) {
@@ -194,7 +205,7 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
       return jumpsBack || changesBaseline;
     }
 
-    private void addRun(String text, List<TextPosition> positions) {
+    private void addRun(String text, List<TextPosition> positions, boolean glyphsMatchText) {
       if (text.isBlank()) {
         return;
       }
@@ -214,7 +225,32 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
               clamp(minTop / pageHeight),
               clamp((maxX - minX) / pageWidth),
               clamp((maxBottom - minTop) / pageHeight));
-      runs.add(new RawRun(text, box, maxBottom, minX, runs.size()));
+      List<Double> advances = glyphsMatchText ? charAdvances(positions) : null;
+      runs.add(new RawRun(text, box, advances, maxBottom, minX, runs.size()));
+    }
+
+    /**
+     * Glyph-true per-character right edges (issue #290), normalized to the crop box. A multi-char
+     * position (ligature) distributes its width evenly over its characters. Edges are forced
+     * non-decreasing (kerning can nudge a glyph left) so consumers can binary-search them.
+     */
+    private List<Double> charAdvances(List<TextPosition> positions) {
+      List<Double> edges = new ArrayList<>();
+      double previousEdge = 0.0d;
+      for (TextPosition position : positions) {
+        int glyphChars = position.getUnicode().length();
+        if (glyphChars == 0) {
+          continue;
+        }
+        double left = position.getXDirAdj();
+        double width = position.getWidthDirAdj();
+        for (int i = 1; i <= glyphChars; i++) {
+          double edge = clamp((left + width * i / glyphChars) / pageWidth);
+          previousEdge = Math.max(previousEdge, edge);
+          edges.add(previousEdge);
+        }
+      }
+      return edges;
     }
 
     private static double clamp(double value) {

--- a/qnop-core/src/test/java/io/qnop/service/document/PdfBoxDocumentExtractorTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/PdfBoxDocumentExtractorTest.java
@@ -126,6 +126,29 @@ class PdfBoxDocumentExtractorTest {
   }
 
   @Test
+  @DisplayName("spans carry glyph-true, non-decreasing per-character right edges (#290)")
+  void spansCarryCharAdvances() throws Exception {
+    byte[] pdf = pdf("Wim mi Wim"); // proportional font: W wide, i narrow
+
+    Surface surface = extractor.extract(new ByteArrayInputStream(pdf)).surfaces().get(0);
+    TextSpan span = surface.textSpans().get(0);
+
+    assertThat(span.charAdvances()).isNotNull().hasSize(span.text().length());
+    double previous = span.box().x();
+    for (double edge : span.charAdvances()) {
+      assertThat(edge).isGreaterThanOrEqualTo(previous).isBetween(0.0, 1.0);
+      previous = edge;
+    }
+    // The last edge is the right end of the box (same coordinate space).
+    assertThat(span.charAdvances().get(span.text().length() - 1))
+        .isCloseTo(span.box().x() + span.box().width(), org.assertj.core.data.Offset.offset(1e-6));
+    // Glyph-true means non-uniform: the wide 'W' (char 0) is wider than the narrow 'i' (char 1).
+    double wWidth = span.charAdvances().get(0) - span.box().x();
+    double iWidth = span.charAdvances().get(1) - span.charAdvances().get(0);
+    assertThat(wWidth).isGreaterThan(iWidth * 2);
+  }
+
+  @Test
   @DisplayName("vertically overlapping runs stay character-intact as separate spans (#296)")
   void overlappingRunsAreNotInterleaved() throws Exception {
     // A small kicker line with a large headline right below: the 36 pt glyphs extend upward

--- a/qnop-spi/src/main/java/io/qnop/spi/extract/TextSpan.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/extract/TextSpan.java
@@ -20,18 +20,29 @@
  */
 package io.qnop.spi.extract;
 
+import java.util.List;
+
 /**
  * One extracted text run on a {@link Surface} (ADR-0032): the text itself, its character-offset
  * range within the surface's canonical text (spans joined by a single {@code \n}), and the
  * normalized bounding box covering its glyphs. Offsets give annotations a text-quote anchor; the
  * box gives them geometry (ADR-0009).
  *
+ * <p>{@code charAdvances} optionally carries glyph-true sub-line geometry (issue #290): the
+ * normalized x of each character's <em>right edge</em> on the surface, in the same coordinate space
+ * as {@code box}. Character {@code i} spans from {@code i == 0 ? box.x() : charAdvances.get(i - 1)}
+ * to {@code charAdvances.get(i)}. Values are non-decreasing and the list length equals the text
+ * length. Extractors that cannot attribute per-character geometry emit {@code null}; consumers then
+ * distribute characters uniformly across the box.
+ *
  * @param text the run's text, never blank
  * @param startOffset inclusive start within the surface's canonical text
  * @param endOffset exclusive end ({@code startOffset + text.length()})
  * @param box normalized glyph bounding box on the surface
+ * @param charAdvances per-character right-edge x positions, or null for uniform fallback
  */
-public record TextSpan(String text, int startOffset, int endOffset, NormalizedBox box) {
+public record TextSpan(
+    String text, int startOffset, int endOffset, NormalizedBox box, List<Double> charAdvances) {
 
   public TextSpan {
     if (text == null || text.isEmpty()) {
@@ -45,5 +56,18 @@ public record TextSpan(String text, int startOffset, int endOffset, NormalizedBo
     if (box == null) {
       throw new IllegalArgumentException("box is required");
     }
+    if (charAdvances != null) {
+      if (charAdvances.size() != text.length()) {
+        throw new IllegalArgumentException(
+            "charAdvances length %d does not match text length %d"
+                .formatted(charAdvances.size(), text.length()));
+      }
+      charAdvances = List.copyOf(charAdvances);
+    }
+  }
+
+  /** A span without per-character geometry — consumers fall back to uniform distribution. */
+  public TextSpan(String text, int startOffset, int endOffset, NormalizedBox box) {
+    this(text, startOffset, endOffset, box, null);
   }
 }

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -126,7 +126,6 @@ export function SurfacePage({
   }, [pdf, pageIndex, surface, width, visible]);
 
   const aspect = surface ? surface.width / surface.height : (fallbackAspect ?? Math.SQRT1_2);
-  const pageHeight = width / aspect;
 
   return (
     <Paper
@@ -157,8 +156,6 @@ export function SurfacePage({
           <TextSpanLayer
             spans={surface.textSpans}
             surfaceIndex={surface.index}
-            pageWidth={width}
-            pageHeight={pageHeight}
             enabled={canAnnotate && tool === 'text' && surface.textSpans.length > 0}
             onTextSelected={onTextSelected}
           />

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -26,14 +26,21 @@ import type { RenderedTextSpan } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';
 import { TextSpanLayer } from './TextSpanLayer';
 
+// "Hello world" with glyph-true edges: "Hello " narrow (0.02 each), "world"
+// wide (0.076 each) — deliberately far from the uniform grid (0.0454 each), so
+// any test passing below proves the advances are honoured.
+const ADVANCES = [0.12, 0.14, 0.16, 0.18, 0.2, 0.22, 0.296, 0.372, 0.448, 0.524, 0.6];
+
 const SPANS: RenderedTextSpan[] = [
   {
     text: 'Hello world',
     startOffset: 0,
     endOffset: 11,
     box: { x: 0.1, y: 0.1, width: 0.5, height: 0.02 },
+    charAdvances: ADVANCES,
   },
   {
+    // No charAdvances — exercises the uniform fallback (0.4/11 per char).
     text: 'Second line',
     startOffset: 12,
     endOffset: 23,
@@ -41,15 +48,33 @@ const SPANS: RenderedTextSpan[] = [
   },
 ];
 
-function renderLayer(onTextSelected = vi.fn()) {
+/** The layer maps pointer pixels through its bounding rect: pin it to 1000×1000. */
+function layerAt(): HTMLElement {
+  const layer = screen.getByTestId('text-layer-0');
+  Object.defineProperty(layer, 'getBoundingClientRect', {
+    value: () => ({
+      left: 0,
+      top: 0,
+      width: 1000,
+      height: 1000,
+      right: 1000,
+      bottom: 1000,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+  });
+  return layer;
+}
+
+function renderLayer({ enabled = true } = {}) {
+  const onTextSelected = vi.fn();
   render(
     <ThemeProvider theme={buildTheme('light')}>
       <TextSpanLayer
         spans={SPANS}
         surfaceIndex={0}
-        pageWidth={800}
-        pageHeight={1035}
-        enabled
+        enabled={enabled}
         onTextSelected={onTextSelected}
       />
     </ThemeProvider>,
@@ -58,66 +83,92 @@ function renderLayer(onTextSelected = vi.fn()) {
 }
 
 describe('TextSpanLayer', () => {
-  it('positions each span centred on its box with marker overshoot and transparent glyphs', () => {
-    renderLayer();
-
-    const span = screen.getByText('Hello world');
-    expect(span).toHaveAttribute('data-span-start', '0');
-    expect(span).toHaveAttribute('data-span-length', '11');
-    // Fixture pitch 0.05 on 0.02-tall boxes → the marker line paints the full
-    // pitch (5%), with a quarter of the extra height above the box top.
-    expect(span).toHaveStyle({ left: '10%', color: 'rgba(0, 0, 0, 0)' });
-    expect(parseFloat(span.style.top)).toBeCloseTo(9.25);
-    expect(parseFloat(span.style.height)).toBeCloseTo(5);
-  });
-
-  it('reports a cross-span selection as canonical-text offsets', () => {
+  it('selects glyph-true via charAdvances — never the uniform grid', () => {
     const onTextSelected = renderLayer();
+    const layer = layerAt();
 
-    // Select "world" (6..11) through "Second" (12..18) via a real DOM range.
-    const first = screen.getByText('Hello world').firstChild!;
-    const second = screen.getByText('Second line').firstChild!;
-    const range = document.createRange();
-    range.setStart(first, 6);
-    range.setEnd(second, 6);
-    const selection = window.getSelection()!;
-    selection.removeAllRanges();
-    selection.addRange(range);
-
-    fireEvent.pointerUp(screen.getByTestId('text-layer-0'), { clientX: 120, clientY: 240 });
+    // Down just right of the boundary before "world" (advance edge 0.22);
+    // the uniform grid would place this pixel between characters 2 and 3.
+    fireEvent.pointerDown(layer, { button: 0, clientX: 225, clientY: 110 });
+    fireEvent.pointerMove(layer, { clientX: 600, clientY: 110 });
+    fireEvent.pointerUp(layer, { clientX: 600, clientY: 110 });
 
     expect(onTextSelected).toHaveBeenCalledWith(
-      { surfaceIndex: 0, start: 6, end: 18 },
-      { left: 120, top: 240 },
+      { surfaceIndex: 0, start: 6, end: 11 },
+      { left: 600, top: 110 },
     );
   });
 
-  it('ignores a collapsed selection', () => {
+  it('falls back to the uniform grid for spans without advances', () => {
     const onTextSelected = renderLayer();
-    window.getSelection()?.removeAllRanges();
+    const layer = layerAt();
 
-    fireEvent.pointerUp(screen.getByTestId('text-layer-0'));
+    // Span 2: uniform char width 0.4/11 ≈ 0.0364 → boundary 6 at x ≈ 0.318.
+    fireEvent.pointerDown(layer, { button: 0, clientX: 100, clientY: 160 });
+    fireEvent.pointerUp(layer, { clientX: 318, clientY: 160 });
+
+    expect(onTextSelected).toHaveBeenCalledWith(
+      { surfaceIndex: 0, start: 12, end: 18 },
+      { left: 318, top: 160 },
+    );
+  });
+
+  it('spans lines: dragging from the first into the second selects across', () => {
+    const onTextSelected = renderLayer();
+    const layer = layerAt();
+
+    fireEvent.pointerDown(layer, { button: 0, clientX: 225, clientY: 110 });
+    fireEvent.pointerUp(layer, { clientX: 318, clientY: 160 });
+
+    expect(onTextSelected).toHaveBeenCalledWith(
+      { surfaceIndex: 0, start: 6, end: 18 },
+      { left: 318, top: 160 },
+    );
+  });
+
+  it('mirrors the drag as live marker bands and clears them on release', () => {
+    renderLayer();
+    const layer = layerAt();
+
+    fireEvent.pointerDown(layer, { button: 0, clientX: 225, clientY: 110 });
+    fireEvent.pointerMove(layer, { clientX: 600, clientY: 110 });
+    expect(screen.getByTestId('live-selection-0')).toBeInTheDocument();
+
+    fireEvent.pointerUp(layer, { clientX: 600, clientY: 110 });
+    expect(screen.queryByTestId('live-selection-0')).not.toBeInTheDocument();
+  });
+
+  it('ignores a click without a drag', () => {
+    const onTextSelected = renderLayer();
+    const layer = layerAt();
+
+    fireEvent.pointerDown(layer, { button: 0, clientX: 225, clientY: 110 });
+    fireEvent.pointerUp(layer, { clientX: 225, clientY: 110 });
 
     expect(onTextSelected).not.toHaveBeenCalled();
   });
 
-  it('mirrors the live selection as marker bands and clears them on collapse', () => {
-    renderLayer();
+  it('selects the word under the pointer on double click', () => {
+    const onTextSelected = renderLayer();
+    const layer = layerAt();
 
-    const first = screen.getByText('Hello world').firstChild!;
-    const range = document.createRange();
-    range.setStart(first, 0);
-    range.setEnd(first, 5);
-    const selection = window.getSelection()!;
-    selection.removeAllRanges();
-    selection.addRange(range);
-    fireEvent(document, new Event('selectionchange'));
+    // x = 0.4 sits inside "world" (0.22..0.6) on the first line.
+    fireEvent.doubleClick(layer, { clientX: 400, clientY: 110 });
 
-    expect(screen.getByTestId('live-selection-0')).toBeInTheDocument();
+    expect(onTextSelected).toHaveBeenCalledWith(
+      { surfaceIndex: 0, start: 6, end: 11 },
+      { left: 400, top: 110 },
+    );
+  });
 
-    selection.removeAllRanges();
-    fireEvent(document, new Event('selectionchange'));
+  it('does nothing while disabled', () => {
+    const onTextSelected = renderLayer({ enabled: false });
+    const layer = layerAt();
 
-    expect(screen.queryByTestId('live-selection-0')).not.toBeInTheDocument();
+    fireEvent.pointerDown(layer, { button: 0, clientX: 225, clientY: 110 });
+    fireEvent.pointerUp(layer, { clientX: 600, clientY: 110 });
+    fireEvent.doubleClick(layer, { clientX: 400, clientY: 110 });
+
+    expect(onTextSelected).not.toHaveBeenCalled();
   });
 });

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -19,127 +19,114 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useEffect, useRef, useState } from 'react';
-import type { PointerEvent } from 'react';
+import { useRef, useState } from 'react';
+import type { MouseEvent, PointerEvent } from 'react';
 import Box from '@mui/material/Box';
 import type { RenderedTextSpan } from '../../../api/generated';
 import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
-import { boxesForRange, markerLineBox, surfaceLinePitch } from './anchoring';
+import {
+  boxesForRange,
+  caretOffsetAtPoint,
+  markerLineBox,
+  surfaceLinePitch,
+  wordRangeAt,
+} from './anchoring';
 import { SELECTION_MARKER_BG } from './markerColors';
-
-/**
- * The font the invisible glyphs are measured and rendered with. Monospace is
- * deliberate: with the run stretched to the span box (scaleX), every character
- * then sits at i/len of the box — the same uniform-grid model boxesForRange
- * uses for drawing. A proportional layer font would only match the box in
- * total width, so dragging over the printed glyphs would hit neighbouring
- * characters in the invisible run (selection offsets shifted by a few chars).
- */
-const LAYER_FONT_FAMILY = 'monospace';
 
 interface TextSpanLayerProps {
   spans: RenderedTextSpan[];
   surfaceIndex: number;
-  /** Current display width of the page in CSS pixels — scales glyph runs to their boxes. */
-  pageWidth: number;
-  /** Current display height of the page in CSS pixels — sizes the invisible glyphs. */
-  pageHeight: number;
   enabled: boolean;
   onTextSelected: (selection: TextSelectionOffsets, at: ScreenPosition) => void;
 }
 
-/** Finds the enclosing span element carrying canonical-text offsets. */
-function spanElementFor(node: Node | null): HTMLElement | null {
-  if (!node) return null;
-  const element = node instanceof HTMLElement ? node : node.parentElement;
-  return element?.closest<HTMLElement>('[data-span-start]') ?? null;
-}
-
-// One shared 2D context for glyph-run measurement (null in jsdom → scale 1).
-let sharedMeasureContext: CanvasRenderingContext2D | null | undefined;
-
-/** The width of a glyph run in the layer font, or null when measuring is unavailable. */
-function measureGlyphRun(text: string, fontSize: number): number | null {
-  if (sharedMeasureContext === undefined) {
-    sharedMeasureContext = document.createElement('canvas').getContext('2d');
-  }
-  if (!sharedMeasureContext) return null;
-  sharedMeasureContext.font = `${fontSize}px ${LAYER_FONT_FAMILY}`;
-  const width = sharedMeasureContext.measureText(text).width;
-  return width > 0 ? width : null;
-}
-
-/** The current DOM selection as canonical-text offsets within this layer, or null. */
-function resolveSelectionOffsets(root: HTMLElement): { start: number; end: number } | null {
-  const selection = window.getSelection();
-  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
-  const range = selection.getRangeAt(0);
-  const startElement = spanElementFor(range.startContainer);
-  const endElement = spanElementFor(range.endContainer);
-  // Both ends must sit on this surface's spans; cross-surface selections are ignored.
-  if (!startElement || !endElement || !root.contains(startElement) || !root.contains(endElement)) {
-    return null;
-  }
-  const start =
-    Number(startElement.dataset.spanStart) +
-    (range.startContainer.nodeType === Node.TEXT_NODE ? range.startOffset : 0);
-  const end =
-    Number(endElement.dataset.spanStart) +
-    (range.endContainer.nodeType === Node.TEXT_NODE
-      ? range.endOffset
-      : Number(endElement.dataset.spanLength));
-  return end > start ? { start, end } : null;
-}
-
 /**
- * An invisible, selectable text layer built from the server-extracted spans
- * (ADR-0032 — the client is not the authority on where text is; it only makes
- * the server's text selectable). Like pdf.js's own text layer, each span is
- * absolutely positioned at its normalized box and its glyph run is stretched
- * horizontally (scaleX from a canvas measurement) to cover the box, so the
- * browser's selection hit-testing traces the printed text.
- *
- * The native selection paint is fully suppressed (a translucent ::selection
- * over the canvas would tint the printed glyphs); instead the layer follows
- * `selectionchange` and draws its own marker bands with multiply blending —
- * the page's text keeps its original colour, exactly like the pending preview
- * and persisted highlights. The offsets attached to each span are the
- * canonical-text offsets the anchor model needs (ADR-0009).
+ * The text-selection layer, driven entirely by the server-extracted spans
+ * (ADR-0032 — the client is not the authority on where text is). Selection is
+ * pointer-based (#290): the caret maps through the spans' glyph-true
+ * charAdvances (uniform fallback for older representations), so dragging over
+ * the printed glyphs selects exactly the characters under the pointer — no
+ * invisible DOM text whose approximated grid could drift from the print. The
+ * layer draws its own multiply-blended marker bands while dragging, identical
+ * to the pending preview and persisted highlights; double-click selects the
+ * word under the pointer. The emitted offsets are the canonical-text offsets
+ * the anchor model needs (ADR-0009).
  */
 export function TextSpanLayer({
   spans,
   surfaceIndex,
-  pageWidth,
-  pageHeight,
   enabled,
   onTextSelected,
 }: TextSpanLayerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ anchor: number } | null>(null);
   const [liveRange, setLiveRange] = useState<{ start: number; end: number } | null>(null);
 
-  // Follow the native selection while it is being dragged and mirror it as
-  // marker bands; a collapsed or foreign selection clears the bands.
-  useEffect(() => {
-    if (!enabled) return undefined;
-    const handleSelectionChange = () => {
-      const root = rootRef.current;
-      setLiveRange(root ? resolveSelectionOffsets(root) : null);
-    };
-    document.addEventListener('selectionchange', handleSelectionChange);
-    return () => document.removeEventListener('selectionchange', handleSelectionChange);
-  }, [enabled]);
+  const pitch = surfaceLinePitch(spans);
 
-  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+  const caretAt = (event: PointerEvent | MouseEvent): number | null => {
     const root = rootRef.current;
-    if (!root) return;
-    const offsets = resolveSelectionOffsets(root);
-    if (!offsets) return;
-    window.getSelection()?.removeAllRanges();
-    setLiveRange(null);
-    onTextSelected({ surfaceIndex, ...offsets }, { left: event.clientX, top: event.clientY });
+    if (!root) return null;
+    const rect = root.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    const x = (event.clientX - rect.left) / rect.width;
+    const y = (event.clientY - rect.top) / rect.height;
+    return caretOffsetAtPoint(spans, x, y, pitch);
   };
 
-  const pitch = surfaceLinePitch(spans);
+  const rangeTo = (focus: number): { start: number; end: number } | null => {
+    const drag = dragRef.current;
+    if (!drag) return null;
+    const start = Math.min(drag.anchor, focus);
+    const end = Math.max(drag.anchor, focus);
+    return end > start ? { start, end } : null;
+  };
+
+  const endDrag = () => {
+    dragRef.current = null;
+    setLiveRange(null);
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (!enabled || event.button !== 0) return;
+    const offset = caretAt(event);
+    if (offset === null) return;
+    dragRef.current = { anchor: offset };
+    setLiveRange(null);
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Synthetic pointer events (tests) have no active pointer to capture.
+    }
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    const offset = caretAt(event);
+    if (offset === null) return;
+    setLiveRange(rangeTo(offset));
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    const offset = caretAt(event);
+    const range = offset === null ? liveRange : rangeTo(offset);
+    endDrag();
+    if (range) {
+      onTextSelected({ surfaceIndex, ...range }, { left: event.clientX, top: event.clientY });
+    }
+  };
+
+  const handleDoubleClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (!enabled) return;
+    const offset = caretAt(event);
+    if (offset === null) return;
+    const range = wordRangeAt(spans, offset);
+    if (range) {
+      onTextSelected({ surfaceIndex, ...range }, { left: event.clientX, top: event.clientY });
+    }
+  };
+
   // Guarded by `enabled` so a stale range never paints on a disabled layer.
   const liveBoxes =
     enabled && liveRange
@@ -150,23 +137,19 @@ export function TextSpanLayer({
     <Box
       ref={rootRef}
       data-testid={`text-layer-${surfaceIndex}`}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
+      onPointerCancel={endDrag}
+      onDoubleClick={handleDoubleClick}
       sx={{
         position: 'absolute',
         inset: 0,
         overflow: 'hidden',
         cursor: enabled ? 'text' : 'default',
         pointerEvents: enabled ? 'auto' : 'none',
-        userSelect: enabled ? 'text' : 'none',
-        // Suppress the native selection paint entirely: a translucent
-        // ::selection sits ABOVE the canvas and would tint the printed glyphs
-        // (no blend modes on pseudo-selections). The visible marking comes
-        // from the layer's own multiply-blended bands below; the color
-        // override keeps the browser from repainting the invisible glyphs.
-        '& span::selection': {
-          backgroundColor: 'transparent',
-          color: 'transparent',
-        },
+        userSelect: 'none',
+        touchAction: 'none',
       }}
     >
       {liveBoxes.map((box, index) => (
@@ -186,40 +169,6 @@ export function TextSpanLayer({
           }}
         />
       ))}
-      {spans.map((span) => {
-        const fontSize = Math.max(span.box.height * pageHeight * 0.85, 6);
-        const measured = span.text.length > 0 ? measureGlyphRun(span.text, fontSize) : null;
-        const scaleX = measured ? (span.box.width * pageWidth) / measured : 1;
-        // The selection paints the line box: grown to the surface's line pitch
-        // and shifted like the persisted markers, so selecting and the created
-        // highlight cover the printed line identically (Word-style full line).
-        const line = markerLineBox(span.box, pitch);
-        const lineHeightPx = Math.max(line.height * pageHeight, 9);
-        return (
-          <span
-            key={span.startOffset}
-            data-span-start={span.startOffset}
-            data-span-length={span.text.length}
-            style={{
-              position: 'absolute',
-              left: `${span.box.x * 100}%`,
-              top: `${line.y * 100}%`,
-              height: `${line.height * 100}%`,
-              color: 'transparent',
-              whiteSpace: 'pre',
-              fontFamily: LAYER_FONT_FAMILY,
-              fontSize: `${fontSize}px`,
-              lineHeight: `${lineHeightPx}px`,
-              // Stretch the glyph run to the server box so the selection
-              // rectangles trace the printed text (same trick as pdf.js).
-              transform: `scaleX(${scaleX})`,
-              transformOrigin: '0 0',
-            }}
-          >
-            {span.text}
-          </span>
-        );
-      })}
     </Box>
   );
 }

--- a/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
@@ -30,6 +30,9 @@ import {
   boxesForRange,
   buildRegionAnchor,
   buildTextAnchor,
+  caretOffsetAtPoint,
+  charLeftEdge,
+  charRightEdge,
   clampBox,
   compareAnnotationsByPosition,
   highlightBoxesForAnchor,
@@ -37,6 +40,7 @@ import {
   surfaceLinePitch,
   surfaceText,
   unionBoxes,
+  wordRangeAt,
 } from './anchoring';
 
 /** Two lines: "Hello world" (0..11) + '\n' (11) + "Second line" (12..23). */
@@ -54,6 +58,82 @@ const SPANS: RenderedTextSpan[] = [
     box: { x: 0.1, y: 0.15, width: 0.4, height: 0.02 },
   },
 ];
+
+/** "abc" with glyph-true edges: a=0.10..0.14, b=0.14..0.30, c=0.30..0.40. */
+const ADVANCED_SPAN: RenderedTextSpan = {
+  text: 'abc',
+  startOffset: 0,
+  endOffset: 3,
+  box: { x: 0.1, y: 0.1, width: 0.3, height: 0.02 },
+  charAdvances: [0.14, 0.3, 0.4],
+};
+
+describe('charLeftEdge / charRightEdge', () => {
+  it('reads glyph-true edges from charAdvances', () => {
+    expect(charLeftEdge(ADVANCED_SPAN, 0)).toBeCloseTo(0.1);
+    expect(charRightEdge(ADVANCED_SPAN, 0)).toBeCloseTo(0.14);
+    expect(charLeftEdge(ADVANCED_SPAN, 1)).toBeCloseTo(0.14);
+    expect(charRightEdge(ADVANCED_SPAN, 2)).toBeCloseTo(0.4);
+  });
+
+  it('falls back to the uniform grid without advances', () => {
+    const span = SPANS[0]; // width 0.5 over 11 chars
+    expect(charLeftEdge(span, 0)).toBeCloseTo(0.1);
+    expect(charRightEdge(span, 0)).toBeCloseTo(0.1 + 0.5 / 11);
+    expect(charRightEdge(span, 10)).toBeCloseTo(0.6);
+  });
+});
+
+describe('caretOffsetAtPoint', () => {
+  it('snaps to the nearest glyph-true boundary', () => {
+    // 0.145 is just right of b's left edge (0.14) — uniform would say char 0.
+    expect(caretOffsetAtPoint([ADVANCED_SPAN], 0.145, 0.11, null)).toBe(1);
+    expect(caretOffsetAtPoint([ADVANCED_SPAN], 0.29, 0.11, null)).toBe(2);
+  });
+
+  it('clamps outside-x points to the line start and visible end', () => {
+    expect(caretOffsetAtPoint([ADVANCED_SPAN], 0.01, 0.11, null)).toBe(0);
+    expect(caretOffsetAtPoint([ADVANCED_SPAN], 0.9, 0.11, null)).toBe(3);
+  });
+
+  it('picks the vertically nearest line for a point between lines', () => {
+    // y = 0.148 sits between the two SPANS lines, nearer to the second band.
+    const offset = caretOffsetAtPoint(SPANS, 0.1, 0.16, surfaceLinePitch(SPANS));
+    expect(offset).toBe(12);
+  });
+
+  it('returns null when the surface has no text', () => {
+    expect(caretOffsetAtPoint([], 0.5, 0.5, null)).toBeNull();
+  });
+});
+
+describe('wordRangeAt', () => {
+  it('expands to the word around the caret', () => {
+    expect(wordRangeAt(SPANS, 8)).toEqual({ start: 6, end: 11 });
+    expect(wordRangeAt(SPANS, 0)).toEqual({ start: 0, end: 5 });
+  });
+
+  it('takes the word left of a caret sitting on the following space', () => {
+    expect(wordRangeAt(SPANS, 5)).toEqual({ start: 0, end: 5 });
+  });
+
+  it('never crosses the canonical newline between lines', () => {
+    expect(wordRangeAt(SPANS, 12)).toEqual({ start: 12, end: 18 });
+  });
+
+  it('returns null on empty text', () => {
+    expect(wordRangeAt([], 0)).toBeNull();
+  });
+});
+
+describe('boxesForRange with charAdvances', () => {
+  it('cuts partial lines at the true glyph edges', () => {
+    const boxes = boxesForRange([ADVANCED_SPAN], 1, 2); // just "b"
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].x).toBeCloseTo(0.14);
+    expect(boxes[0].width).toBeCloseTo(0.16);
+  });
+});
 
 describe('surfaceText', () => {
   it('joins spans with single newlines, matching the server offsets', () => {

--- a/qnop-ui/src/components/reviews/viewer/anchoring.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.ts
@@ -115,13 +115,30 @@ function visibleLength(text: string): number {
 }
 
 /**
- * The highlight boxes covering the canonical-text range [start, end).
- * Partially selected spans are trimmed proportionally by character count — an
- * approximation (glyph widths vary), acceptable because the authoritative
- * anchor is the text quote; the box only needs to visually cover the selection.
- * Each line is clamped to its visible text: trailing whitespace (e.g. lines
- * padded to a fixed width) never paints — matching Word/Acrobat, where a
- * highlight ends at the last printed character.
+ * The x of the right edge of the span's character `index` (0-based): glyph-true
+ * from the server's charAdvances (#290) when present, otherwise the uniform
+ * i/len approximation across the box.
+ */
+export function charRightEdge(span: RenderedTextSpan, index: number): number {
+  const advances = span.charAdvances;
+  if (advances && advances.length === span.text.length) {
+    return advances[Math.min(index, advances.length - 1)];
+  }
+  return span.box.x + (span.box.width * (index + 1)) / span.text.length;
+}
+
+/** The x of the left edge of the span's character `index` (0-based). */
+export function charLeftEdge(span: RenderedTextSpan, index: number): number {
+  return index <= 0 ? span.box.x : charRightEdge(span, index - 1);
+}
+
+/**
+ * The highlight boxes covering the canonical-text range [start, end). Partial
+ * lines are cut at the true glyph edges when the span carries charAdvances
+ * (#290); without them the cut falls back to the proportional character-count
+ * approximation. Each line is clamped to its visible text: trailing whitespace
+ * (e.g. lines padded to a fixed width) never paints — matching Word/Acrobat,
+ * where a highlight ends at the last printed character.
  */
 export function boxesForRange(
   spans: RenderedTextSpan[],
@@ -134,18 +151,86 @@ export function boxesForRange(
     const overlapStart = Math.max(start, span.startOffset);
     const overlapEnd = Math.min(end, span.endOffset, visibleEnd);
     if (overlapEnd <= overlapStart || span.text.length === 0) continue;
-    const fromFraction = (overlapStart - span.startOffset) / span.text.length;
-    const widthFraction = (overlapEnd - overlapStart) / span.text.length;
+    const fromX = charLeftEdge(span, overlapStart - span.startOffset);
+    const toX = charRightEdge(span, overlapEnd - 1 - span.startOffset);
     boxes.push(
       clampBox({
-        x: span.box.x + span.box.width * fromFraction,
+        x: fromX,
         y: span.box.y,
-        width: span.box.width * widthFraction,
+        width: toX - fromX,
         height: span.box.height,
       }),
     );
   }
   return boxes;
+}
+
+/**
+ * The canonical-text caret offset nearest to a point on the surface (both
+ * normalized 0..1). Hit-testing prefers the line whose marker band contains
+ * the y (the same band the selection paints), then the nearest band; within a
+ * line the caret snaps to the closest character boundary — glyph-true when
+ * charAdvances exist. Null when the surface has no text.
+ */
+export function caretOffsetAtPoint(
+  spans: RenderedTextSpan[],
+  x: number,
+  y: number,
+  pitch: number | null,
+): number | null {
+  let best: { offset: number; dy: number; dx: number } | null = null;
+  for (const span of spans) {
+    if (span.text.length === 0) continue;
+    const band = markerLineBox(span.box, pitch);
+    const dy = y < band.y ? band.y - y : y > band.y + band.height ? y - (band.y + band.height) : 0;
+    const right = span.box.x + span.box.width;
+    let dx = 0;
+    let offset: number;
+    if (x <= span.box.x) {
+      dx = span.box.x - x;
+      offset = span.startOffset;
+    } else if (x >= right) {
+      dx = x - right;
+      offset = span.startOffset + visibleLength(span.text);
+    } else {
+      // Nearest character boundary: boundary i sits at the left edge of char i.
+      offset = span.startOffset + span.text.length;
+      let bestDist = Math.abs(x - right);
+      for (let i = 0; i < span.text.length; i++) {
+        const boundary = charLeftEdge(span, i);
+        const dist = Math.abs(x - boundary);
+        if (dist < bestDist) {
+          bestDist = dist;
+          offset = span.startOffset + i;
+        }
+      }
+    }
+    if (!best || dy < best.dy || (dy === best.dy && dx < best.dx)) {
+      best = { offset, dy, dx };
+    }
+  }
+  return best ? best.offset : null;
+}
+
+/**
+ * The word range (canonical-text offsets) around a caret offset — the
+ * double-click selection. When the caret sits on whitespace (e.g. at a word
+ * end) the word to its left counts. Null on empty text or plain whitespace.
+ */
+export function wordRangeAt(
+  spans: RenderedTextSpan[],
+  offset: number,
+): { start: number; end: number } | null {
+  const text = surfaceText(spans);
+  if (text.length === 0) return null;
+  let at = Math.min(Math.max(offset, 0), text.length - 1);
+  if (/\s/.test(text[at]) && at > 0 && /\S/.test(text[at - 1])) at--;
+  if (/\s/.test(text[at])) return null;
+  let start = at;
+  let end = at + 1;
+  while (start > 0 && /\S/.test(text[start - 1])) start--;
+  while (end < text.length && /\S/.test(text[end])) end++;
+  return { start, end };
 }
 
 /**


### PR DESCRIPTION
Closes #290. **Stacked on #297** (extraction interleaving fix) — merge #297 first, then retarget/merge this.

## What

Character-accurate text selection for proportional-font PDFs, end to end (option 2 from the issue — additive contract change):

### Contract & backend
- `RenderedTextSpan.charAdvances` (optional `double[]`): the normalized x of each character's **right edge**, same coordinate space as `box`; non-decreasing, length = text length. Absent for pre-existing representations or when geometry cannot be attributed (stripper-inserted separators) — clients fall back to the previous uniform distribution. The canonical-text contract (lines joined by `\n`) is untouched, so existing text-quote anchors keep resolving.
- `TextSpan` (SPI) carries the advances; the extractor derives them from the PDFBox glyph positions (multi-char ligature positions distribute evenly; edges forced non-decreasing so consumers can search them).

### Viewer
- Text selection is now **pointer-based**: pointer position → nearest character boundary via the glyph-true edges (uniform fallback without them). The invisible stretched-monospace DOM text layer — whose uniform grid drifted from the printed glyphs and caused selections to start mid-letter and capture neighbouring characters — is removed entirely, along with the native-selection suppression machinery.
- Partial-line highlight boxes cut at true glyph edges (`boxesForRange`).
- Double-click selects the word under the pointer.

## Verification
- Extractor test: proportional-font PDF → non-uniform, non-decreasing advances whose last edge equals the box's right edge; wide 'W' measurably wider than narrow 'i'.
- Viewer tests: glyph-true selection (a case where the uniform grid would pick different characters), uniform fallback, cross-line drag, live marker bands, click-without-drag, double-click word selection, disabled layer.
- Manually verified against the real-world PDF from #296: v3 extraction carries advances; selecting "Einkommen" in the 24pt title yields exactly that word.
- `./gradlew build` green; qnop-ui: 253 tests, tsc/eslint/prettier clean.

🤖 Co-Author: Claude (Fable 5) via Claude Code