### PR TITLE
feat: make the annotation's first comment mandatory (#301)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -3954,6 +3954,7 @@ components:
       required:
         - versionNumber
         - anchor
+        - comment
       properties:
         versionNumber:
           type: integer
@@ -3965,7 +3966,10 @@ components:
           type: string
           minLength: 1
           maxLength: 20000
-          description: An optional first comment seeding the discussion thread.
+          description: >-
+            The first comment seeding the discussion thread. Required — an
+            annotation without text must not exist (issue #301); blank-only
+            comments are rejected.
     AnnotationView:
       type: object
       description: |

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -137,7 +137,7 @@ class AnnotationApiIT extends SeededIntegrationTest {
         .perform(
             as(post("/api/v1/documents/" + documentId + "/annotations"), EXTERNAL_ID)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"versionNumber\":1,\"anchor\":" + ANCHOR + "}"))
+                .content("{\"versionNumber\":1,\"anchor\":" + ANCHOR + ",\"comment\":\"hi\"}"))
         .andExpect(status().isNotFound());
   }
 
@@ -219,7 +219,36 @@ class AnnotationApiIT extends SeededIntegrationTest {
         .perform(
             as(post("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"versionNumber\":1,\"anchor\":{}}"))
+                .content("{\"versionNumber\":1,\"anchor\":{},\"comment\":\"please clarify\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  void rejectsAnAnnotationWithoutAComment() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+
+    // The first comment is mandatory (issue #301) — the contract itself rejects its absence.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"versionNumber\":1,\"anchor\":" + ANCHOR + "}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.fieldErrors[0].field").value("comment"));
+  }
+
+  @Test
+  void rejectsAnAnnotationWithABlankComment() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+
+    // Whitespace passes the schema's minLength, so the service guard must catch it (issue #301).
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"versionNumber\":1,\"anchor\":" + ANCHOR + ",\"comment\":\"   \"}"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
   }

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -99,7 +99,8 @@ public class AnnotationService {
       UUID id, UUID annotationId, UUID authorId, String body, Instant createdAt) {}
 
   /**
-   * Creates an annotation on {@code versionNumber}, placed immediately, with an optional comment.
+   * Creates an annotation on {@code versionNumber}, placed immediately, seeded with its mandatory
+   * first comment — an annotation without text must not exist (issue #301).
    */
   @Transactional
   public AnnotationView create(
@@ -109,6 +110,9 @@ public class AnnotationService {
       boolean admin,
       String anchorJson,
       String firstComment) {
+    if (firstComment == null || firstComment.isBlank()) {
+      throw DocumentValidationException.invalidRequest("annotation requires a first comment");
+    }
     documentAccess.getDocument(documentId, author, admin); // visibility → 404 if not a participant
     DocumentVersion version =
         versions
@@ -124,11 +128,8 @@ public class AnnotationService {
     placement.markPlaced(anchorJson);
     placements.save(placement);
 
-    int commentCount = 0;
-    if (firstComment != null && !firstComment.isBlank()) {
-      comments.save(new Comment(annotation.getId(), author, firstComment));
-      commentCount = 1;
-    }
+    comments.save(new Comment(annotation.getId(), author, firstComment));
+    int commentCount = 1;
     auditEvents.save(
         new AuditEvent(
             documentId,

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -172,6 +172,32 @@ describe('AnnotationPanel', () => {
     expect(props.onCancelPending).toHaveBeenCalled();
   });
 
+  it('requires a non-blank comment before an annotation can be created', () => {
+    const props = renderPanel({
+      pendingAnchor: {
+        region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.1 } },
+      },
+    });
+
+    const composer = within(screen.getByTestId('annotation-composer'));
+    const field = composer.getByLabelText('Annotation comment');
+    const create = composer.getByRole('button', { name: /Create annotation/ });
+
+    // Empty and whitespace-only comments keep creating disabled (issue #301) —
+    // the button as well as the submit shortcut.
+    expect(create).toBeDisabled();
+    fireEvent.keyDown(field, { key: 'Enter', metaKey: true });
+    fireEvent.change(field, { target: { value: '   ' } });
+    expect(create).toBeDisabled();
+    fireEvent.keyDown(field, { key: 'Enter', metaKey: true });
+    expect(props.onCreate).not.toHaveBeenCalled();
+
+    fireEvent.change(field, { target: { value: 'Needs a source' } });
+    expect(create).toBeEnabled();
+    fireEvent.click(create);
+    expect(props.onCreate).toHaveBeenCalledWith('Needs a source');
+  });
+
   it('offers Accept/Reject to the owner on an open active annotation', () => {
     useAuthStore.setState({ userId: 'owner-1' });
     renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -113,7 +113,11 @@ function DecisionBar({
   );
 }
 
-/** The composer for a freshly drawn anchor: optional first comment, then create. */
+/**
+ * The composer for a freshly drawn anchor. The first comment is mandatory
+ * (issue #301) — an annotation without text must not exist, so creating stays
+ * disabled (button and submit shortcut) until the trimmed comment is non-empty.
+ */
 function Composer({
   pendingAnchor,
   creating,
@@ -126,6 +130,7 @@ function Composer({
   onCancel: () => void;
 }) {
   const [comment, setComment] = useState('');
+  const canCreate = !creating && comment.trim().length > 0;
   const quote = pendingAnchor.textQuote?.quote;
   return (
     <Paper variant="outlined" sx={{ p: 1.5 }} data-testid="annotation-composer">
@@ -146,15 +151,16 @@ function Composer({
         </Typography>
         <TextField
           multiline
-          minRows={2}
+          minRows={5}
           size="small"
-          placeholder="Add a comment (optional)"
+          required
+          placeholder="Add a comment"
           value={comment}
           onChange={(event) => setComment(event.target.value)}
           onKeyDown={(event) => {
-            if (isSubmitShortcut(event) && !creating) {
+            if (isSubmitShortcut(event)) {
               event.preventDefault();
-              onCreate(comment);
+              if (canCreate) onCreate(comment);
             }
           }}
           slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Annotation comment' } }}
@@ -164,7 +170,7 @@ function Composer({
             size="small"
             variant="contained"
             onClick={() => onCreate(comment)}
-            disabled={creating}
+            disabled={!canCreate}
           >
             Create annotation ({submitShortcutLabel()})
           </Button>

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -165,9 +165,12 @@ export function DocumentReviewPage() {
   };
 
   const handleCreate = (comment: string) => {
-    if (!pending || versionNumber === undefined) return;
+    // The first comment is mandatory (issue #301) — the composer only submits
+    // non-blank text; this guard keeps the invariant at the API boundary too.
+    const trimmed = comment.trim();
+    if (!pending || versionNumber === undefined || trimmed.length === 0) return;
     createAnnotation.mutate(
-      { versionNumber, anchor: pending.anchor, comment: comment.trim() || undefined },
+      { versionNumber, anchor: pending.anchor, comment: trimmed },
       {
         onSuccess: (created) => {
           setPending(null);


### PR DESCRIPTION
Closes #301.

> **Stacked on #299** (base: `feat/issue-290-char-advances-v2`). Merge #299 first; deleting its branch retargets this PR to `main` automatically.

An annotation without text must not exist (ADR-0011: annotation = mark + comment thread).

## What

- **Contract**: `comment` is now `required` on `AnnotationCreateRequest` — the generated endpoint rejects a missing comment via Bean Validation (`400 VALIDATION_ERROR`, field error on `comment`).
- **Backend**: `AnnotationService.create` rejects null/blank first comments (`400 VALIDATION_ERROR`) — whitespace passes the schema's `minLength`, so the service guard enforces the domain rule; every created annotation now seeds its thread with exactly one comment (`commentCount: 1`).
- **UI composer**: field grows from 2 to **5 rows**, placeholder is *"Add a comment"* (no "(optional)"), and **Create annotation** — button and ⌘/Ctrl-Enter shortcut — stays disabled until the trimmed comment is non-empty.

## Test plan

- [x] `AnnotationApiIT`: new cases — missing comment → 400 with `fieldErrors[0].field == "comment"`; blank comment → 400; existing cases updated to always send a comment (they previously relied on it being optional)
- [x] `AnnotationPanel.test.tsx`: new case — empty/whitespace comment keeps button and shortcut inert, real text enables and submits
- [x] Full gates green: `./gradlew build` (Spotless/ArchUnit), 310 UI tests, `tsc`, `eslint`, `prettier`
- [x] Verified live in the running app: composer shows 5 rows, disabled button for empty/whitespace input, enabled after real text

🤖 Co-Author: Claude (Fable 5) via Claude Code