### PR TITLE
feat(ui): version diff view with located change highlights (#252)

### DIFF
--- a/qnop-ui/src/api/hooks/useVersionDiff.ts
+++ b/qnop-ui/src/api/hooks/useVersionDiff.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import type { VersionDiffResponse } from '../generated';
+import { documentsApi } from '../config';
+import { apiErrorCode } from '../../utils/apiError';
+
+export const versionDiffKeys = {
+  pair: (documentId: string, from: number, to: number) =>
+    ['documents', 'diff', documentId, from, to] as const,
+};
+
+/**
+ * The located changes between two versions (ADR-0034). Versions are immutable,
+ * so a pair's diff never changes: `staleTime: Infinity`, no refetching. The
+ * server answers 409 while extraction of either side is still PENDING (or
+ * FAILED) — surfaced via {@link versionDiffErrorCode}, not retried (the version
+ * poller drives when to re-enable the query).
+ */
+export function useVersionDiff(documentId: string, from?: number, to?: number) {
+  const validPair = from !== undefined && to !== undefined && from !== to;
+  return useQuery<VersionDiffResponse>({
+    queryKey: versionDiffKeys.pair(documentId, from ?? 0, to ?? 0),
+    queryFn: async () => {
+      const response = await documentsApi.getVersionDiff({
+        documentId,
+        from: from as number,
+        to: to as number,
+      });
+      return response.data;
+    },
+    enabled: documentId.length > 0 && validPair,
+    staleTime: Infinity,
+    retry: (failureCount, error) => {
+      // 4xx/409 are stable answers for this pair — retrying cannot help.
+      if (isAxiosError(error) && error.response && error.response.status < 500) return false;
+      return failureCount < 2;
+    },
+  });
+}
+
+/** The stable error code of a failed diff query (`EXTRACTION_PENDING`, …). */
+export function versionDiffErrorCode(error: unknown): string | undefined {
+  return apiErrorCode(error);
+}

--- a/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { DiffChange } from '../../../api/generated';
+import { DiffChangeType } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { ChangeSummaryPanel } from './ChangeSummaryPanel';
+
+const CHANGES: DiffChange[] = [
+  {
+    type: DiffChangeType.Changed,
+    fromText: 'fourteen days',
+    toText: 'thirty days',
+    fromLocations: [{ surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.02 } }],
+    toLocations: [{ surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.02 } }],
+  },
+  {
+    type: DiffChangeType.Deleted,
+    fromText: 'the prepayment clause',
+    toText: '',
+    fromLocations: [{ surfaceIndex: 2, box: { x: 0.1, y: 0.4, width: 0.4, height: 0.02 } }],
+    toLocations: [],
+  },
+];
+
+function renderPanel(changes: DiffChange[] = CHANGES, active: number | null = null) {
+  const onSelectChange = vi.fn();
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <ChangeSummaryPanel
+        changes={changes}
+        activeChangeIndex={active}
+        onSelectChange={onSelectChange}
+      />
+    </ThemeProvider>,
+  );
+  return onSelectChange;
+}
+
+describe('ChangeSummaryPanel', () => {
+  it('renders one card per change with type label, excerpt and page', () => {
+    renderPanel();
+    expect(screen.getByText('Changes (2)')).toBeInTheDocument();
+    expect(screen.getByText('Changed')).toBeInTheDocument();
+    expect(screen.getByText('Deleted')).toBeInTheDocument();
+    expect(screen.getByText('fourteen days')).toBeInTheDocument();
+    expect(screen.getByText('thirty days')).toBeInTheDocument();
+    expect(screen.getByText('the prepayment clause')).toBeInTheDocument();
+    expect(screen.getByText('p. 1')).toBeInTheDocument();
+    expect(screen.getByText('p. 3')).toBeInTheDocument();
+  });
+
+  it('selects a change on click and clears it when clicked again', () => {
+    const onSelectChange = renderPanel();
+    fireEvent.click(screen.getByTestId('change-card-1'));
+    expect(onSelectChange).toHaveBeenCalledWith(1);
+  });
+
+  it('clears the active change when its card is clicked again', () => {
+    const onSelectChange = renderPanel(CHANGES, 1);
+    fireEvent.click(screen.getByTestId('change-card-1'));
+    expect(onSelectChange).toHaveBeenCalledWith(null);
+    expect(screen.getByTestId('change-card-1')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows the word statistics per direction', () => {
+    renderPanel();
+    // +2 (thirty days) / −5 (fourteen days + the prepayment clause)
+    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(screen.getByText('−5')).toBeInTheDocument();
+    expect(screen.getByText('1, 3')).toBeInTheDocument();
+  });
+
+  it('states identical content for an empty diff and hides the statistics', () => {
+    renderPanel([]);
+    expect(screen.getByText(/identical text content/)).toBeInTheDocument();
+    expect(screen.queryByText('Statistics')).not.toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.test.tsx
@@ -84,17 +84,8 @@ describe('ChangeSummaryPanel', () => {
     expect(screen.getByTestId('change-card-1')).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('shows the word statistics per direction', () => {
-    renderPanel();
-    // +2 (thirty days) / −5 (fourteen days + the prepayment clause)
-    expect(screen.getByText('+2')).toBeInTheDocument();
-    expect(screen.getByText('−5')).toBeInTheDocument();
-    expect(screen.getByText('1, 3')).toBeInTheDocument();
-  });
-
-  it('states identical content for an empty diff and hides the statistics', () => {
+  it('states identical content for an empty diff', () => {
     renderPanel([]);
     expect(screen.getByText(/identical text content/)).toBeInTheDocument();
-    expect(screen.queryByText('Statistics')).not.toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.tsx
+++ b/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.tsx
@@ -19,7 +19,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -28,7 +27,7 @@ import { ArrowRight } from 'lucide-react';
 import type { DiffChange } from '../../../api/generated';
 import { DiffChangeType } from '../../../api/generated';
 import { tokens } from '../../../theme/tokens';
-import { CHANGE_KIND, changePageNumber, diffStats, excerpt } from './diffModel';
+import { CHANGE_KIND, changePageNumber, excerpt } from './diffModel';
 
 interface ChangeSummaryPanelProps {
   changes: DiffChange[];
@@ -40,9 +39,10 @@ interface ChangeSummaryPanelProps {
 /**
  * The comparison's right-hand summary (design prototype `diff.jsx`): one card
  * per change — type label in the diff colour language, the affected text, the
- * page — plus the statistics block. Clicking a card selects the change and
- * scrolls both panes to its location; the active card carries the deeper
- * left rail, mirroring the highlight's deeper wash.
+ * page. Clicking a card selects the change and scrolls both panes to its
+ * location; the active card carries the deeper left rail, mirroring the
+ * highlight's deeper wash. The aggregate statistics live in the control strip
+ * above the panes (CompareToolbar).
  */
 export function ChangeSummaryPanel({
   changes,
@@ -51,7 +51,6 @@ export function ChangeSummaryPanel({
 }: ChangeSummaryPanelProps) {
   const theme = useTheme();
   const dark = theme.palette.mode === 'dark';
-  const stats = diffStats(changes);
 
   const railColor = (type: DiffChangeType) =>
     type === DiffChangeType.Inserted
@@ -166,65 +165,6 @@ export function ChangeSummaryPanel({
           </ButtonBase>
         );
       })}
-
-      {changes.length > 0 && (
-        <Box
-          sx={{
-            mt: 1,
-            p: 1.5,
-            borderRadius: 2,
-            bgcolor: theme.qnop.surface2,
-            border: `1px solid ${theme.palette.divider}`,
-          }}
-        >
-          <Typography
-            variant="overline"
-            sx={{ color: 'text.secondary', lineHeight: 2, letterSpacing: '0.08em' }}
-          >
-            Statistics
-          </Typography>
-          <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.25 }}>
-            {[
-              {
-                label: 'Words +',
-                value: `+${stats.addedWords}`,
-                color: dark ? tokens.badge.green.fgDark : tokens.semantic.successStrong,
-              },
-              {
-                label: 'Words −',
-                value: `−${stats.removedWords}`,
-                color: dark ? tokens.badge.red.fgDark : tokens.semantic.dangerStrong,
-              },
-              {
-                label: 'Changes',
-                value: `${changes.length}`,
-                color: theme.palette.text.primary,
-              },
-              {
-                label: stats.pages.length === 1 ? 'Page' : 'Pages',
-                value: stats.pages.join(', ') || '—',
-                color: theme.palette.text.primary,
-              },
-            ].map((stat) => (
-              <Box key={stat.label}>
-                <Typography sx={{ fontSize: 10.5, color: 'text.secondary' }}>
-                  {stat.label}
-                </Typography>
-                <Typography
-                  sx={{
-                    fontFamily: tokens.font.mono,
-                    fontSize: 13,
-                    fontWeight: 600,
-                    color: stat.color,
-                  }}
-                >
-                  {stat.value}
-                </Typography>
-              </Box>
-            ))}
-          </Box>
-        </Box>
-      )}
     </Stack>
   );
 }

--- a/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.tsx
+++ b/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.tsx
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { ArrowRight } from 'lucide-react';
+import type { DiffChange } from '../../../api/generated';
+import { DiffChangeType } from '../../../api/generated';
+import { tokens } from '../../../theme/tokens';
+import { CHANGE_KIND, changePageNumber, diffStats, excerpt } from './diffModel';
+
+interface ChangeSummaryPanelProps {
+  changes: DiffChange[];
+  activeChangeIndex: number | null;
+  /** Toggles: selecting the active change again clears the selection. */
+  onSelectChange: (changeIndex: number | null) => void;
+}
+
+/**
+ * The comparison's right-hand summary (design prototype `diff.jsx`): one card
+ * per change — type label in the diff colour language, the affected text, the
+ * page — plus the statistics block. Clicking a card selects the change and
+ * scrolls both panes to its location; the active card carries the deeper
+ * left rail, mirroring the highlight's deeper wash.
+ */
+export function ChangeSummaryPanel({
+  changes,
+  activeChangeIndex,
+  onSelectChange,
+}: ChangeSummaryPanelProps) {
+  const theme = useTheme();
+  const dark = theme.palette.mode === 'dark';
+  const stats = diffStats(changes);
+
+  const railColor = (type: DiffChangeType) =>
+    type === DiffChangeType.Inserted
+      ? theme.palette.success.main
+      : type === DiffChangeType.Deleted
+        ? theme.palette.error.main
+        : theme.palette.warning.main;
+
+  return (
+    <Stack spacing={1.5} data-testid="change-summary">
+      <Typography
+        variant="overline"
+        sx={{ color: 'text.secondary', lineHeight: 1.5, letterSpacing: '0.08em' }}
+      >
+        Changes ({changes.length})
+      </Typography>
+
+      {changes.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          The compared versions have identical text content.
+        </Typography>
+      )}
+
+      {changes.map((change, index) => {
+        const kind = CHANGE_KIND[change.type];
+        const badge = tokens.badge[kind.tone];
+        const rail = railColor(change.type);
+        const active = index === activeChangeIndex;
+        const page = changePageNumber(change);
+        const isChanged = change.type === DiffChangeType.Changed;
+        return (
+          <ButtonBase
+            key={index}
+            data-testid={`change-card-${index}`}
+            onClick={() => onSelectChange(active ? null : index)}
+            aria-pressed={active}
+            sx={{
+              display: 'block',
+              textAlign: 'left',
+              width: '100%',
+              p: 1.5,
+              borderRadius: 2,
+              bgcolor: badge.bg,
+              borderLeft: `3px solid ${rail}`,
+              transition: 'box-shadow 120ms ease, background-color 120ms ease',
+              ...(active && { boxShadow: `inset 0 0 0 1px ${alpha(rail, 0.55)}` }),
+              '&:hover': { bgcolor: alpha(rail, dark ? 0.18 : 0.14) },
+              '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+              '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+            }}
+          >
+            <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.5 }}>
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  letterSpacing: '0.06em',
+                  textTransform: 'uppercase',
+                  color: dark ? badge.fgDark : badge.fg,
+                }}
+              >
+                {kind.label}
+              </Typography>
+              {page !== null && (
+                <Typography
+                  component="span"
+                  sx={{
+                    fontSize: 11,
+                    color: 'text.secondary',
+                    fontFamily: tokens.font.mono,
+                    marginLeft: 'auto',
+                  }}
+                >
+                  p. {page}
+                </Typography>
+              )}
+            </Stack>
+            {isChanged ? (
+              <Stack spacing={0.25}>
+                <Typography
+                  variant="body2"
+                  sx={{ color: 'text.secondary', textDecoration: 'line-through', lineHeight: 1.45 }}
+                >
+                  {excerpt(change.fromText, 90)}
+                </Typography>
+                <Stack direction="row" spacing={0.5} sx={{ alignItems: 'flex-start' }}>
+                  <ArrowRight
+                    size={13}
+                    aria-hidden
+                    style={{ color: theme.palette.text.secondary, flexShrink: 0, marginTop: 3 }}
+                  />
+                  <Typography variant="body2" sx={{ lineHeight: 1.45 }}>
+                    {excerpt(change.toText, 90)}
+                  </Typography>
+                </Stack>
+              </Stack>
+            ) : (
+              <Typography
+                variant="body2"
+                sx={{
+                  lineHeight: 1.45,
+                  ...(change.type === DiffChangeType.Deleted && {
+                    textDecoration: 'line-through',
+                    color: 'text.secondary',
+                  }),
+                }}
+              >
+                {excerpt(change.type === DiffChangeType.Deleted ? change.fromText : change.toText)}
+              </Typography>
+            )}
+          </ButtonBase>
+        );
+      })}
+
+      {changes.length > 0 && (
+        <Box
+          sx={{
+            mt: 1,
+            p: 1.5,
+            borderRadius: 2,
+            bgcolor: theme.qnop.surface2,
+            border: `1px solid ${theme.palette.divider}`,
+          }}
+        >
+          <Typography
+            variant="overline"
+            sx={{ color: 'text.secondary', lineHeight: 2, letterSpacing: '0.08em' }}
+          >
+            Statistics
+          </Typography>
+          <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.25 }}>
+            {[
+              {
+                label: 'Words +',
+                value: `+${stats.addedWords}`,
+                color: dark ? tokens.badge.green.fgDark : tokens.semantic.successStrong,
+              },
+              {
+                label: 'Words −',
+                value: `−${stats.removedWords}`,
+                color: dark ? tokens.badge.red.fgDark : tokens.semantic.dangerStrong,
+              },
+              {
+                label: 'Changes',
+                value: `${changes.length}`,
+                color: theme.palette.text.primary,
+              },
+              {
+                label: stats.pages.length === 1 ? 'Page' : 'Pages',
+                value: stats.pages.join(', ') || '—',
+                color: theme.palette.text.primary,
+              },
+            ].map((stat) => (
+              <Box key={stat.label}>
+                <Typography sx={{ fontSize: 10.5, color: 'text.secondary' }}>
+                  {stat.label}
+                </Typography>
+                <Typography
+                  sx={{
+                    fontFamily: tokens.font.mono,
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: stat.color,
+                  }}
+                >
+                  {stat.value}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      )}
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/diff/ComparePane.tsx
+++ b/qnop-ui/src/components/reviews/diff/ComparePane.tsx
@@ -19,8 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useEffect, useRef, useState } from 'react';
-import type { Ref } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Paper from '@mui/material/Paper';
@@ -52,8 +51,10 @@ interface ComparePaneProps {
   changes: DiffChange[];
   activeChangeIndex: number | null;
   onSelectChange: (changeIndex: number) => void;
-  /** The scroll container ref (callback ref) — the page couples both panes (sync scroll). */
-  scrollRef: Ref<HTMLDivElement>;
+  /** Callback ref for the scroll container — the page couples both panes (sync scroll). */
+  scrollRef: (element: HTMLDivElement | null) => void;
+  /** Fit-width factor shared by both panes (1 = fit width, >1 overflows horizontally). */
+  zoom: number;
 }
 
 /**
@@ -76,25 +77,39 @@ export function ComparePane({
   activeChangeIndex,
   onSelectChange,
   scrollRef,
+  zoom,
 }: ComparePaneProps) {
   const theme = useTheme();
-  const stackRef = useRef<HTMLDivElement>(null);
-  const [stackWidth, setStackWidth] = useState(0);
+  const scrollElRef = useRef<HTMLDivElement | null>(null);
+  const [paneWidth, setPaneWidth] = useState(0);
   const [fallbackAspects, setFallbackAspects] = useState<Record<number, number>>({});
 
+  // One element, two consumers: the page's sync-scroll coupling (external
+  // callback ref) and the width observer below. The SCROLL CONTAINER is
+  // measured — the page stack grows with the zoom (max-content) and would
+  // feed its own width back into the page size.
+  const setScrollElement = useCallback(
+    (element: HTMLDivElement | null) => {
+      scrollElRef.current = element;
+      scrollRef(element);
+    },
+    [scrollRef],
+  );
+
   useEffect(() => {
-    const element = stackRef.current;
+    const element = scrollElRef.current;
     if (!element) return undefined;
+    // contentRect excludes the container's padding — the gutter is already out.
     const observer = new ResizeObserver((entries) => {
       const width = entries[0]?.contentRect.width;
-      if (width) setStackWidth(width);
+      if (width) setPaneWidth(width);
     });
     observer.observe(element);
-    setStackWidth(element.clientWidth);
+    setPaneWidth(Math.max(0, element.clientWidth - 2 * PAGE_GUTTER_PX));
     return () => observer.disconnect();
   }, []);
 
-  const pageWidth = Math.max(0, stackWidth - 2 * PAGE_GUTTER_PX);
+  const pageWidth = Math.max(0, paneWidth * zoom);
   const pageCount = surfaces?.length ?? pdf?.numPages ?? 0;
   const isTo = side === 'to';
   const badge = isTo ? theme.qnop.badge.blue : null;
@@ -155,11 +170,19 @@ export function ComparePane({
       </Stack>
 
       <Box
-        ref={scrollRef}
+        ref={setScrollElement}
         data-testid={`compare-scroll-${side}`}
-        sx={{ flex: 1, minHeight: 0, overflow: 'auto', bgcolor: theme.qnop.surface2 }}
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          overflow: 'auto',
+          bgcolor: theme.qnop.surface2,
+          p: `${PAGE_GUTTER_PX}px`,
+        }}
       >
-        <Stack ref={stackRef} spacing={2} sx={{ p: `${PAGE_GUTTER_PX}px`, alignItems: 'center' }}>
+        {/* max-content + centred items: zoomed pages overflow horizontally
+            without the flexbox centring clip (same trick as the viewer). */}
+        <Stack spacing={2} sx={{ width: 'max-content', minWidth: '100%', alignItems: 'center' }}>
           {pdfError && (
             <Typography variant="body2" color="error" sx={{ py: 4 }}>
               The document could not be rendered. {pdfError}

--- a/qnop-ui/src/components/reviews/diff/ComparePane.tsx
+++ b/qnop-ui/src/components/reviews/diff/ComparePane.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
-import type { RefObject } from 'react';
+import type { Ref } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Paper from '@mui/material/Paper';
@@ -52,8 +52,8 @@ interface ComparePaneProps {
   changes: DiffChange[];
   activeChangeIndex: number | null;
   onSelectChange: (changeIndex: number) => void;
-  /** The scroll container ref — the page couples both panes (sync scroll). */
-  scrollRef: RefObject<HTMLDivElement | null>;
+  /** The scroll container ref (callback ref) — the page couples both panes (sync scroll). */
+  scrollRef: Ref<HTMLDivElement>;
 }
 
 /**

--- a/qnop-ui/src/components/reviews/diff/ComparePane.tsx
+++ b/qnop-ui/src/components/reviews/diff/ComparePane.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { History } from 'lucide-react';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+import type { DiffChange, RenderedSurface } from '../../../api/generated';
+import { tokens } from '../../../theme/tokens';
+import { PageCanvas } from '../viewer/PageCanvas';
+import { DiffHighlightLayer } from './DiffHighlightLayer';
+import type { DiffSide } from './diffModel';
+
+const PAGE_GUTTER_PX = 24;
+
+interface ComparePaneProps {
+  side: DiffSide;
+  versionNumber: number;
+  /** Header meta, e.g. "12 Jun 2026 · Maxim Kalina". */
+  metaText: string;
+  /** Extra header text on the right, e.g. "3 changes" (the newer pane). */
+  trailingText?: string;
+  /** Parsed pdf.js document; null while the original is still loading/parsing. */
+  pdf: PDFDocumentProxy | null;
+  pdfError: string | null;
+  /** Server surfaces of this version — page aspect + line pitch for the bands. */
+  surfaces?: RenderedSurface[];
+  changes: DiffChange[];
+  activeChangeIndex: number | null;
+  onSelectChange: (changeIndex: number) => void;
+  /** The scroll container ref — the page couples both panes (sync scroll). */
+  scrollRef: RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * One side of the version comparison: a sticky version header over the
+ * scrollable page stack of that version's rendered original, with the located
+ * changes painted by {@link DiffHighlightLayer}. The baseline pane reads
+ * neutral, the newer pane carries the brand-blue accent — the prototype's
+ * from/to colour cue. Fit-width like the review viewer: the page width tracks
+ * the pane via ResizeObserver.
+ */
+export function ComparePane({
+  side,
+  versionNumber,
+  metaText,
+  trailingText,
+  pdf,
+  pdfError,
+  surfaces,
+  changes,
+  activeChangeIndex,
+  onSelectChange,
+  scrollRef,
+}: ComparePaneProps) {
+  const theme = useTheme();
+  const stackRef = useRef<HTMLDivElement>(null);
+  const [stackWidth, setStackWidth] = useState(0);
+  const [fallbackAspects, setFallbackAspects] = useState<Record<number, number>>({});
+
+  useEffect(() => {
+    const element = stackRef.current;
+    if (!element) return undefined;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) setStackWidth(width);
+    });
+    observer.observe(element);
+    setStackWidth(element.clientWidth);
+    return () => observer.disconnect();
+  }, []);
+
+  const pageWidth = Math.max(0, stackWidth - 2 * PAGE_GUTTER_PX);
+  const pageCount = surfaces?.length ?? pdf?.numPages ?? 0;
+  const isTo = side === 'to';
+  const badge = isTo ? theme.qnop.badge.blue : null;
+
+  return (
+    <Box
+      data-testid={`compare-pane-${side}`}
+      sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0, flex: 1 }}
+    >
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{
+          alignItems: 'center',
+          px: 2,
+          py: 1,
+          bgcolor: 'background.paper',
+          borderBottom: `1px solid ${theme.palette.divider}`,
+          flexShrink: 0,
+        }}
+      >
+        <Stack
+          direction="row"
+          spacing={0.5}
+          component="span"
+          sx={{
+            alignItems: 'center',
+            px: 1,
+            py: 0.25,
+            borderRadius: 99,
+            fontSize: 12,
+            fontWeight: 600,
+            fontFamily: tokens.font.mono,
+            ...(badge
+              ? {
+                  bgcolor: badge.bg,
+                  color: theme.palette.mode === 'dark' ? badge.fgDark : badge.fg,
+                  border: `1px solid ${badge.border}`,
+                }
+              : {
+                  color: 'text.secondary',
+                  border: `1px solid ${theme.palette.divider}`,
+                }),
+          }}
+        >
+          <History size={11} aria-hidden />
+          <span>{`v${versionNumber}`}</span>
+        </Stack>
+        <Typography variant="caption" color="text.secondary" noWrap>
+          {metaText}
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        {trailingText && (
+          <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+            {trailingText}
+          </Typography>
+        )}
+      </Stack>
+
+      <Box
+        ref={scrollRef}
+        data-testid={`compare-scroll-${side}`}
+        sx={{ flex: 1, minHeight: 0, overflow: 'auto', bgcolor: theme.qnop.surface2 }}
+      >
+        <Stack ref={stackRef} spacing={2} sx={{ p: `${PAGE_GUTTER_PX}px`, alignItems: 'center' }}>
+          {pdfError && (
+            <Typography variant="body2" color="error" sx={{ py: 4 }}>
+              The document could not be rendered. {pdfError}
+            </Typography>
+          )}
+          {!pdf && !pdfError && <CircularProgress size={24} sx={{ my: 6 }} />}
+          {pdf &&
+            pageWidth > 0 &&
+            Array.from({ length: pageCount }, (_, pageIndex) => {
+              const surface = surfaces?.[pageIndex];
+              const aspect = surface
+                ? surface.width / surface.height
+                : (fallbackAspects[pageIndex] ?? Math.SQRT1_2);
+              return (
+                <Paper
+                  key={pageIndex}
+                  elevation={0}
+                  square
+                  data-testid={`compare-page-${side}-${pageIndex}`}
+                  sx={{
+                    position: 'relative',
+                    width: pageWidth,
+                    aspectRatio: `${aspect}`,
+                    bgcolor: '#fff',
+                    overflow: 'hidden',
+                    borderRadius: '3px',
+                    flexShrink: 0,
+                    boxShadow:
+                      theme.palette.mode === 'light' ? '0 4px 24px rgba(1, 32, 66, 0.10)' : 'none',
+                    border:
+                      theme.palette.mode === 'dark' ? `1px solid ${theme.palette.divider}` : 'none',
+                  }}
+                >
+                  <PageCanvas
+                    pdf={pdf}
+                    pageIndex={pageIndex}
+                    width={pageWidth}
+                    ariaLabel={`Version ${versionNumber}, page ${pageIndex + 1}`}
+                    onAspect={
+                      surface
+                        ? undefined
+                        : (value) =>
+                            setFallbackAspects((current) =>
+                              current[pageIndex] === value
+                                ? current
+                                : { ...current, [pageIndex]: value },
+                            )
+                    }
+                  />
+                  <DiffHighlightLayer
+                    changes={changes}
+                    side={side}
+                    surfaceIndex={pageIndex}
+                    spans={surface?.textSpans}
+                    activeChangeIndex={activeChangeIndex}
+                    onSelectChange={onSelectChange}
+                  />
+                </Paper>
+              );
+            })}
+        </Stack>
+      </Box>
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/diff/CompareToolbar.test.tsx
+++ b/qnop-ui/src/components/reviews/diff/CompareToolbar.test.tsx
@@ -49,6 +49,8 @@ function renderToolbar(overrides: Partial<Parameters<typeof CompareToolbar>[0]> 
     syncScroll: true,
     onSyncScrollChange: vi.fn(),
     changeCount: 4,
+    zoom: 1,
+    onZoomChange: vi.fn(),
     ...overrides,
   };
   render(
@@ -92,5 +94,15 @@ describe('CompareToolbar', () => {
     const props = renderToolbar();
     fireEvent.click(screen.getByRole('switch', { name: 'Sync scroll' }));
     expect(props.onSyncScrollChange).toHaveBeenCalledWith(false);
+  });
+
+  it('steps the shared zoom and resets to fit width', () => {
+    const props = renderToolbar({ zoom: 1.5 });
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+    expect(props.onZoomChange).toHaveBeenCalledWith(1.75);
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom out' }));
+    expect(props.onZoomChange).toHaveBeenCalledWith(1.25);
+    fireEvent.click(screen.getByRole('button', { name: 'Reset zoom to fit width' }));
+    expect(props.onZoomChange).toHaveBeenCalledWith(1);
   });
 });

--- a/qnop-ui/src/components/reviews/diff/CompareToolbar.test.tsx
+++ b/qnop-ui/src/components/reviews/diff/CompareToolbar.test.tsx
@@ -22,10 +22,27 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
-import type { DocumentVersionSummary } from '../../../api/generated';
-import { ExtractionStatus } from '../../../api/generated';
+import type { DiffChange, DocumentVersionSummary } from '../../../api/generated';
+import { DiffChangeType, ExtractionStatus } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';
 import { CompareToolbar } from './CompareToolbar';
+
+const CHANGES: DiffChange[] = [
+  {
+    type: DiffChangeType.Changed,
+    fromText: 'fourteen days now', // 3 words out
+    toText: 'thirty days', // 2 words in
+    fromLocations: [{ surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.02 } }],
+    toLocations: [{ surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.02 } }],
+  },
+  {
+    type: DiffChangeType.Deleted,
+    fromText: 'the prepayment clause',
+    toText: '',
+    fromLocations: [{ surfaceIndex: 2, box: { x: 0.1, y: 0.4, width: 0.4, height: 0.02 } }],
+    toLocations: [],
+  },
+];
 
 const version = (
   versionNumber: number,
@@ -48,7 +65,7 @@ function renderToolbar(overrides: Partial<Parameters<typeof CompareToolbar>[0]> 
     onChangePair: vi.fn(),
     syncScroll: true,
     onSyncScrollChange: vi.fn(),
-    changeCount: 4,
+    changes: CHANGES,
     zoom: 1,
     onZoomChange: vi.fn(),
     ...overrides,
@@ -62,14 +79,33 @@ function renderToolbar(overrides: Partial<Parameters<typeof CompareToolbar>[0]> 
 }
 
 describe('CompareToolbar', () => {
-  it('shows the change count', () => {
+  it('shows the diff statistics', () => {
     renderToolbar();
-    expect(screen.getByText('4 changes')).toBeInTheDocument();
+    const stats = within(screen.getByTestId('toolbar-diff-stats'));
+    expect(stats.getByText('+2')).toBeInTheDocument(); // words in ("thirty days")
+    expect(stats.getByText('−6')).toBeInTheDocument(); // words out (3 + 3)
+    expect(stats.getByText('Changes')).toBeInTheDocument();
+    expect(stats.getByText('2')).toBeInTheDocument();
+    expect(stats.getByText('Pages')).toBeInTheDocument();
+    expect(stats.getByText('1, 3')).toBeInTheDocument();
   });
 
   it('shows a comparing state while the diff loads', () => {
-    renderToolbar({ changeCount: null });
+    renderToolbar({ changes: null });
     expect(screen.getByText('Comparing…')).toBeInTheDocument();
+    expect(screen.queryByTestId('toolbar-diff-stats')).not.toBeInTheDocument();
+  });
+
+  it('collapses long page lists to a count', () => {
+    const spread = [0, 1, 2, 3].map((surfaceIndex) => ({
+      type: DiffChangeType.Inserted,
+      fromText: '',
+      toText: 'word',
+      fromLocations: [],
+      toLocations: [{ surfaceIndex, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.02 } }],
+    }));
+    renderToolbar({ changes: spread });
+    expect(screen.getByText('4 pages')).toBeInTheDocument();
   });
 
   it('disables unextracted versions and the other side in a picker', () => {

--- a/qnop-ui/src/components/reviews/diff/CompareToolbar.test.tsx
+++ b/qnop-ui/src/components/reviews/diff/CompareToolbar.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { DocumentVersionSummary } from '../../../api/generated';
+import { ExtractionStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { CompareToolbar } from './CompareToolbar';
+
+const version = (
+  versionNumber: number,
+  extractionStatus: ExtractionStatus = ExtractionStatus.Ready,
+): DocumentVersionSummary => ({
+  versionNumber,
+  contentType: 'application/pdf',
+  sizeBytes: 1000,
+  contentHash: `hash-${versionNumber}`,
+  extractionStatus,
+  createdBy: 'u1',
+  createdAt: '2026-07-01T10:00:00Z',
+});
+
+function renderToolbar(overrides: Partial<Parameters<typeof CompareToolbar>[0]> = {}) {
+  const props: Parameters<typeof CompareToolbar>[0] = {
+    versions: [version(1), version(2), version(3, ExtractionStatus.Pending)],
+    from: 1,
+    to: 2,
+    onChangePair: vi.fn(),
+    syncScroll: true,
+    onSyncScrollChange: vi.fn(),
+    changeCount: 4,
+    ...overrides,
+  };
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <CompareToolbar {...props} />
+    </ThemeProvider>,
+  );
+  return props;
+}
+
+describe('CompareToolbar', () => {
+  it('shows the change count', () => {
+    renderToolbar();
+    expect(screen.getByText('4 changes')).toBeInTheDocument();
+  });
+
+  it('shows a comparing state while the diff loads', () => {
+    renderToolbar({ changeCount: null });
+    expect(screen.getByText('Comparing…')).toBeInTheDocument();
+  });
+
+  it('disables unextracted versions and the other side in a picker', () => {
+    renderToolbar();
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Baseline' }));
+    const listbox = within(screen.getByRole('listbox'));
+    expect(listbox.getByRole('option', { name: 'v3' })).toHaveAttribute('aria-disabled', 'true');
+    expect(listbox.getByRole('option', { name: 'v2' })).toHaveAttribute('aria-disabled', 'true');
+    expect(listbox.getByRole('option', { name: 'v1' })).not.toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  });
+
+  it('swaps the pair', () => {
+    const props = renderToolbar();
+    fireEvent.click(screen.getByRole('button', { name: 'Swap the compared versions' }));
+    expect(props.onChangePair).toHaveBeenCalledWith(2, 1);
+  });
+
+  it('toggles sync scroll', () => {
+    const props = renderToolbar();
+    fireEvent.click(screen.getByRole('switch', { name: 'Sync scroll' }));
+    expect(props.onSyncScrollChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/qnop-ui/src/components/reviews/diff/CompareToolbar.tsx
+++ b/qnop-ui/src/components/reviews/diff/CompareToolbar.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { ArrowLeftRight, MoveRight } from 'lucide-react';
+import type { DocumentVersionSummary } from '../../../api/generated';
+import { ExtractionStatus } from '../../../api/generated';
+
+interface CompareToolbarProps {
+  versions: DocumentVersionSummary[];
+  from: number;
+  to: number;
+  onChangePair: (from: number, to: number) => void;
+  syncScroll: boolean;
+  onSyncScrollChange: (value: boolean) => void;
+  /** Null while the diff is still loading. */
+  changeCount: number | null;
+}
+
+/**
+ * The comparison's control strip: the baseline/compare version pickers (only
+ * extracted versions are selectable, the two sides never collapse onto the
+ * same version), a swap button, the change count, and the sync-scroll toggle.
+ */
+export function CompareToolbar({
+  versions,
+  from,
+  to,
+  onChangePair,
+  syncScroll,
+  onSyncScrollChange,
+  changeCount,
+}: CompareToolbarProps) {
+  const pickerItems = (other: number) =>
+    versions.map((version) => (
+      <MenuItem
+        key={version.versionNumber}
+        value={String(version.versionNumber)}
+        disabled={
+          version.extractionStatus !== ExtractionStatus.Ready || version.versionNumber === other
+        }
+      >
+        v{version.versionNumber}
+      </MenuItem>
+    ));
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ px: 1.5, py: 1, display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}
+    >
+      <TextField
+        select
+        size="small"
+        label="Baseline"
+        value={String(from)}
+        onChange={(event) => onChangePair(Number(event.target.value), to)}
+        sx={{ minWidth: 110 }}
+      >
+        {pickerItems(to)}
+      </TextField>
+      <MoveRight size={16} aria-hidden style={{ flexShrink: 0, opacity: 0.6 }} />
+      <TextField
+        select
+        size="small"
+        label="Compare"
+        value={String(to)}
+        onChange={(event) => onChangePair(from, Number(event.target.value))}
+        sx={{ minWidth: 110 }}
+      >
+        {pickerItems(from)}
+      </TextField>
+      <Tooltip title="Swap sides">
+        <IconButton
+          size="small"
+          aria-label="Swap the compared versions"
+          onClick={() => onChangePair(to, from)}
+        >
+          <ArrowLeftRight size={15} />
+        </IconButton>
+      </Tooltip>
+
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        aria-live="polite"
+        sx={{ ml: 'auto', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}
+      >
+        {changeCount === null
+          ? 'Comparing…'
+          : changeCount === 1
+            ? '1 change'
+            : `${changeCount} changes`}
+      </Typography>
+
+      <FormControlLabel
+        control={
+          <Switch
+            size="small"
+            checked={syncScroll}
+            onChange={(event) => onSyncScrollChange(event.target.checked)}
+          />
+        }
+        label="Sync scroll"
+        slotProps={{ typography: { variant: 'body2', color: 'text.secondary' } }}
+        sx={{ mr: 0 }}
+      />
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/reviews/diff/CompareToolbar.tsx
+++ b/qnop-ui/src/components/reviews/diff/CompareToolbar.tsx
@@ -19,19 +19,24 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
 import { ArrowLeftRight, MoveRight } from 'lucide-react';
-import type { DocumentVersionSummary } from '../../../api/generated';
+import type { DiffChange, DocumentVersionSummary } from '../../../api/generated';
 import { ExtractionStatus } from '../../../api/generated';
+import { tokens } from '../../../theme/tokens';
 import { ZoomControls } from '../viewer/ZoomControls';
+import { diffStats } from './diffModel';
 
 interface CompareToolbarProps {
   versions: DocumentVersionSummary[];
@@ -40,17 +45,42 @@ interface CompareToolbarProps {
   onChangePair: (from: number, to: number) => void;
   syncScroll: boolean;
   onSyncScrollChange: (value: boolean) => void;
-  /** Null while the diff is still loading. */
-  changeCount: number | null;
+  /** The diff's changes; null while the comparison is still loading. */
+  changes: DiffChange[] | null;
   /** Shared fit-width zoom of both panes (1 = fit width). */
   zoom: number;
   onZoomChange: (zoom: number) => void;
 }
 
+/** One compact statistic in the control strip: a tiny label over a mono value. */
+function Stat({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <Box sx={{ textAlign: 'left' }}>
+      <Typography sx={{ fontSize: 10, lineHeight: 1.3, color: 'text.secondary' }}>
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: tokens.font.mono,
+          fontSize: 12.5,
+          fontWeight: 600,
+          lineHeight: 1.2,
+          fontVariantNumeric: 'tabular-nums',
+          color: color ?? 'text.primary',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
 /**
  * The comparison's control strip: the baseline/compare version pickers (only
  * extracted versions are selectable, the two sides never collapse onto the
- * same version), a swap button, the change count, and the sync-scroll toggle.
+ * same version), a swap button, the diff statistics (±words, changes, pages),
+ * the shared zoom and the sync-scroll toggle.
  */
 export function CompareToolbar({
   versions,
@@ -59,10 +89,21 @@ export function CompareToolbar({
   onChangePair,
   syncScroll,
   onSyncScrollChange,
-  changeCount,
+  changes,
   zoom,
   onZoomChange,
 }: CompareToolbarProps) {
+  const theme = useTheme();
+  const dark = theme.palette.mode === 'dark';
+  const stats = changes ? diffStats(changes) : null;
+  const pagesValue =
+    stats === null
+      ? ''
+      : stats.pages.length === 0
+        ? '—'
+        : stats.pages.length > 3
+          ? `${stats.pages.length} pages`
+          : stats.pages.join(', ');
   const pickerItems = (other: number) =>
     versions.map((version) => (
       <MenuItem
@@ -112,18 +153,32 @@ export function CompareToolbar({
         </IconButton>
       </Tooltip>
 
-      <Typography
-        variant="body2"
-        color="text.secondary"
-        aria-live="polite"
-        sx={{ ml: 'auto', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}
-      >
-        {changeCount === null
-          ? 'Comparing…'
-          : changeCount === 1
-            ? '1 change'
-            : `${changeCount} changes`}
-      </Typography>
+      {stats === null ? (
+        <Typography variant="body2" color="text.secondary" aria-live="polite" sx={{ ml: 'auto' }}>
+          Comparing…
+        </Typography>
+      ) : (
+        <Stack
+          direction="row"
+          spacing={2}
+          aria-live="polite"
+          data-testid="toolbar-diff-stats"
+          sx={{ ml: 'auto', alignItems: 'center' }}
+        >
+          <Stat
+            label="Words +"
+            value={`+${stats.addedWords}`}
+            color={dark ? tokens.badge.green.fgDark : tokens.semantic.successStrong}
+          />
+          <Stat
+            label="Words −"
+            value={`−${stats.removedWords}`}
+            color={dark ? tokens.badge.red.fgDark : tokens.semantic.dangerStrong}
+          />
+          <Stat label="Changes" value={String(changes?.length ?? 0)} />
+          <Stat label={stats.pages.length === 1 ? 'Page' : 'Pages'} value={pagesValue} />
+        </Stack>
+      )}
 
       <Divider orientation="vertical" flexItem />
 

--- a/qnop-ui/src/components/reviews/diff/CompareToolbar.tsx
+++ b/qnop-ui/src/components/reviews/diff/CompareToolbar.tsx
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import Divider from '@mui/material/Divider';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
@@ -30,6 +31,7 @@ import Typography from '@mui/material/Typography';
 import { ArrowLeftRight, MoveRight } from 'lucide-react';
 import type { DocumentVersionSummary } from '../../../api/generated';
 import { ExtractionStatus } from '../../../api/generated';
+import { ZoomControls } from '../viewer/ZoomControls';
 
 interface CompareToolbarProps {
   versions: DocumentVersionSummary[];
@@ -40,6 +42,9 @@ interface CompareToolbarProps {
   onSyncScrollChange: (value: boolean) => void;
   /** Null while the diff is still loading. */
   changeCount: number | null;
+  /** Shared fit-width zoom of both panes (1 = fit width). */
+  zoom: number;
+  onZoomChange: (zoom: number) => void;
 }
 
 /**
@@ -55,6 +60,8 @@ export function CompareToolbar({
   syncScroll,
   onSyncScrollChange,
   changeCount,
+  zoom,
+  onZoomChange,
 }: CompareToolbarProps) {
   const pickerItems = (other: number) =>
     versions.map((version) => (
@@ -117,6 +124,10 @@ export function CompareToolbar({
             ? '1 change'
             : `${changeCount} changes`}
       </Typography>
+
+      <Divider orientation="vertical" flexItem />
+
+      <ZoomControls zoom={zoom} onZoomChange={onZoomChange} />
 
       <FormControlLabel
         control={

--- a/qnop-ui/src/components/reviews/diff/DiffHighlightLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/diff/DiffHighlightLayer.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { DiffChange } from '../../../api/generated';
+import { DiffChangeType } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { DiffHighlightLayer } from './DiffHighlightLayer';
+
+const CHANGES: DiffChange[] = [
+  {
+    type: DiffChangeType.Deleted,
+    fromText: 'gone',
+    toText: '',
+    fromLocations: [{ surfaceIndex: 0, box: { x: 0.1, y: 0.2, width: 0.3, height: 0.02 } }],
+    toLocations: [],
+  },
+  {
+    type: DiffChangeType.Inserted,
+    fromText: '',
+    toText: 'fresh',
+    fromLocations: [],
+    toLocations: [{ surfaceIndex: 0, box: { x: 0.4, y: 0.5, width: 0.2, height: 0.02 } }],
+  },
+  {
+    type: DiffChangeType.Changed,
+    fromText: 'old',
+    toText: 'new',
+    fromLocations: [{ surfaceIndex: 1, box: { x: 0.1, y: 0.1, width: 0.1, height: 0.02 } }],
+    toLocations: [{ surfaceIndex: 0, box: { x: 0.1, y: 0.7, width: 0.1, height: 0.02 } }],
+  },
+];
+
+function renderLayer(side: 'from' | 'to', surfaceIndex = 0, active: number | null = null) {
+  const onSelectChange = vi.fn();
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <DiffHighlightLayer
+        changes={CHANGES}
+        side={side}
+        surfaceIndex={surfaceIndex}
+        activeChangeIndex={active}
+        onSelectChange={onSelectChange}
+      />
+    </ThemeProvider>,
+  );
+  return onSelectChange;
+}
+
+describe('DiffHighlightLayer', () => {
+  it('paints deletions only on the baseline pane', () => {
+    renderLayer('from');
+    expect(screen.getByTestId('diff-highlight-from-0')).toBeInTheDocument();
+    expect(screen.queryByTestId('diff-highlight-from-1')).not.toBeInTheDocument();
+    // The changed change's from-geometry lives on surface 1, not this one.
+    expect(screen.queryByTestId('diff-highlight-from-2')).not.toBeInTheDocument();
+  });
+
+  it('paints insertions and in-place changes on the newer pane', () => {
+    renderLayer('to');
+    expect(screen.queryByTestId('diff-highlight-to-0')).not.toBeInTheDocument();
+    expect(screen.getByTestId('diff-highlight-to-1')).toBeInTheDocument();
+    expect(screen.getByTestId('diff-highlight-to-2')).toBeInTheDocument();
+  });
+
+  it('reports a click with the change index and marks the active change', () => {
+    const onSelectChange = renderLayer('to', 0, 2);
+    fireEvent.click(screen.getByTestId('diff-highlight-to-1'));
+    expect(onSelectChange).toHaveBeenCalledWith(1);
+    expect(screen.getByTestId('diff-highlight-to-2')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('positions the band from the located box', () => {
+    renderLayer('from');
+    const band = screen.getByTestId('diff-highlight-from-0');
+    expect(band).toHaveStyle({ left: '10%', width: '30%' });
+  });
+});

--- a/qnop-ui/src/components/reviews/diff/DiffHighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/diff/DiffHighlightLayer.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Fragment } from 'react';
+import Box from '@mui/material/Box';
+import { alpha, useTheme } from '@mui/material/styles';
+import type { DiffChange, RenderedTextSpan } from '../../../api/generated';
+import { DiffChangeType } from '../../../api/generated';
+import { markerLineBox, surfaceLinePitch } from '../viewer/anchoring';
+import type { DiffSide } from './diffModel';
+import { CHANGE_KIND, surfaceChangeBoxes } from './diffModel';
+
+interface DiffHighlightLayerProps {
+  /** All located changes of the compared pair — the layer picks this surface's. */
+  changes: DiffChange[];
+  side: DiffSide;
+  surfaceIndex: number;
+  /** The surface's text spans — grows the bands to the line pitch when present. */
+  spans?: RenderedTextSpan[];
+  activeChangeIndex: number | null;
+  onSelectChange: (changeIndex: number) => void;
+}
+
+/**
+ * The change overlay of one surface in one compare pane (ADR-0034): every
+ * located change paints as multiply-blended marker bands over the rendered
+ * original — insertions green, deletions red, in-place changes amber, exactly
+ * the annotation-marker look. Geometry comes from the server's located boxes,
+ * grown to the surface's line pitch like the annotation highlights. Clicking
+ * a band selects its change card in the summary panel (and vice versa — the
+ * active change paints deeper).
+ */
+export function DiffHighlightLayer({
+  changes,
+  side,
+  surfaceIndex,
+  spans,
+  activeChangeIndex,
+  onSelectChange,
+}: DiffHighlightLayerProps) {
+  const theme = useTheme();
+  const entries = surfaceChangeBoxes(changes, side, surfaceIndex);
+  if (entries.length === 0) return null;
+
+  const pitch = spans && spans.length > 0 ? surfaceLinePitch(spans) : null;
+  const colorFor = (type: DiffChangeType) =>
+    type === DiffChangeType.Inserted
+      ? theme.palette.success.main
+      : type === DiffChangeType.Deleted
+        ? theme.palette.error.main
+        : theme.palette.warning.main;
+
+  return (
+    <Box sx={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+      {entries.map(({ changeIndex, type, boxes }) => {
+        const color = colorFor(type);
+        const active = changeIndex === activeChangeIndex;
+        return (
+          <Fragment key={changeIndex}>
+            {boxes.map((box, index) => {
+              const band = markerLineBox(box, pitch);
+              const primary = index === 0;
+              return (
+                <Box
+                  key={index}
+                  id={primary ? `diff-change-${side}-${changeIndex}` : undefined}
+                  data-testid={primary ? `diff-highlight-${side}-${changeIndex}` : undefined}
+                  role={primary ? 'button' : undefined}
+                  tabIndex={primary ? 0 : undefined}
+                  aria-pressed={primary ? active : undefined}
+                  aria-label={primary ? `${CHANGE_KIND[type].label} change` : undefined}
+                  aria-hidden={primary ? undefined : true}
+                  onClick={() => onSelectChange(changeIndex)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onSelectChange(changeIndex);
+                    }
+                  }}
+                  sx={{
+                    position: 'absolute',
+                    left: `${band.x * 100}%`,
+                    top: `${band.y * 100}%`,
+                    width: `${band.width * 100}%`,
+                    height: `${band.height * 100}%`,
+                    pointerEvents: 'auto',
+                    cursor: 'pointer',
+                    // Marker look shared with the annotation highlights: a
+                    // borderless wash that multiplies over the page pixels;
+                    // the active change simply paints deeper.
+                    bgcolor: alpha(color, active ? 0.55 : 0.28),
+                    mixBlendMode: 'multiply',
+                    borderRadius: '1px',
+                    transition: 'background-color 120ms ease',
+                    '&:hover': { bgcolor: alpha(color, 0.45) },
+                    '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
+                    '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+                  }}
+                />
+              );
+            })}
+          </Fragment>
+        );
+      })}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/diff/diffModel.test.ts
+++ b/qnop-ui/src/components/reviews/diff/diffModel.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { DiffChange } from '../../../api/generated';
+import { DiffChangeType } from '../../../api/generated';
+import {
+  changePageNumber,
+  diffStats,
+  excerpt,
+  paintsOnSide,
+  surfaceChangeBoxes,
+  wordCount,
+} from './diffModel';
+
+const box = (x: number) => ({ x, y: 0.1, width: 0.2, height: 0.02 });
+
+const change = (
+  type: DiffChangeType,
+  fromSurfaces: number[],
+  toSurfaces: number[],
+  overrides: Partial<DiffChange> = {},
+): DiffChange => ({
+  type,
+  fromText: fromSurfaces.length > 0 ? 'old words here' : '',
+  toText: toSurfaces.length > 0 ? 'new words' : '',
+  fromLocations: fromSurfaces.map((surfaceIndex, i) => ({ surfaceIndex, box: box(i * 0.1) })),
+  toLocations: toSurfaces.map((surfaceIndex, i) => ({ surfaceIndex, box: box(i * 0.1) })),
+  ...overrides,
+});
+
+describe('paintsOnSide', () => {
+  it('routes deletions to the baseline, insertions to the newer version, changes to both', () => {
+    const deleted = change(DiffChangeType.Deleted, [0], []);
+    const inserted = change(DiffChangeType.Inserted, [], [0]);
+    const changed = change(DiffChangeType.Changed, [0], [0]);
+
+    expect(paintsOnSide(deleted, 'from')).toBe(true);
+    expect(paintsOnSide(deleted, 'to')).toBe(false);
+    expect(paintsOnSide(inserted, 'from')).toBe(false);
+    expect(paintsOnSide(inserted, 'to')).toBe(true);
+    expect(paintsOnSide(changed, 'from')).toBe(true);
+    expect(paintsOnSide(changed, 'to')).toBe(true);
+  });
+});
+
+describe('surfaceChangeBoxes', () => {
+  it('groups only the matching surface boxes and keeps the change index', () => {
+    const changes = [
+      change(DiffChangeType.Deleted, [0, 1], []),
+      change(DiffChangeType.Inserted, [], [1]),
+      change(DiffChangeType.Changed, [1], [1]),
+    ];
+
+    const fromPage1 = surfaceChangeBoxes(changes, 'from', 1);
+
+    expect(fromPage1.map((entry) => entry.changeIndex)).toEqual([0, 2]);
+    expect(fromPage1[0].boxes).toHaveLength(1);
+    // The inserted change has no baseline geometry: absent from the from pane.
+    expect(surfaceChangeBoxes(changes, 'from', 1).some((e) => e.changeIndex === 1)).toBe(false);
+    expect(surfaceChangeBoxes(changes, 'to', 1).map((e) => e.changeIndex)).toEqual([1, 2]);
+  });
+});
+
+describe('changePageNumber', () => {
+  it('prefers the newer version location and falls back to the baseline', () => {
+    expect(changePageNumber(change(DiffChangeType.Changed, [3], [2]))).toBe(3);
+    expect(changePageNumber(change(DiffChangeType.Deleted, [4], []))).toBe(5);
+    expect(changePageNumber(change(DiffChangeType.Inserted, [], []))).toBeNull();
+  });
+});
+
+describe('diffStats', () => {
+  it('counts words per direction and collects touched pages ascending', () => {
+    const stats = diffStats([
+      change(DiffChangeType.Deleted, [2], []), // -3 words
+      change(DiffChangeType.Inserted, [], [0]), // +2 words
+      change(DiffChangeType.Changed, [1], [1]), // -3 / +2 words
+    ]);
+
+    expect(stats.addedWords).toBe(4);
+    expect(stats.removedWords).toBe(6);
+    expect(stats.pages).toEqual([1, 2, 3]);
+  });
+
+  it('is empty for an empty diff', () => {
+    expect(diffStats([])).toEqual({ addedWords: 0, removedWords: 0, pages: [] });
+  });
+});
+
+describe('wordCount', () => {
+  it('splits on any whitespace and ignores blank text', () => {
+    expect(wordCount('  one\n two\tthree ')).toBe(3);
+    expect(wordCount('   ')).toBe(0);
+    expect(wordCount('')).toBe(0);
+  });
+});
+
+describe('excerpt', () => {
+  it('collapses whitespace and cuts on a word boundary with an ellipsis', () => {
+    expect(excerpt('a  b\nc')).toBe('a b c');
+    const long = `${'word '.repeat(40)}tail`;
+    const cut = excerpt(long, 60);
+    expect(cut.length).toBeLessThanOrEqual(61);
+    expect(cut.endsWith('…')).toBe(true);
+    expect(cut).not.toContain('  ');
+  });
+});

--- a/qnop-ui/src/components/reviews/diff/diffModel.ts
+++ b/qnop-ui/src/components/reviews/diff/diffModel.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { DiffChange, DiffLocation, NormalizedBox } from '../../../api/generated';
+import { DiffChangeType } from '../../../api/generated';
+
+/**
+ * Pure model helpers for the version-diff view (ADR-0034, issue #252). All
+ * geometry comes from the server's located changes — the client only groups
+ * and counts; it never derives positions from its own rendering (ADR-0032).
+ */
+
+/** Which pane a box list belongs to: `from` = baseline, `to` = newer version. */
+export type DiffSide = 'from' | 'to';
+
+/**
+ * Card/highlight presentation of a change type: the label text and the badge
+ * tone (mapping onto `theme.qnop.badge` and the MUI palette). Follows the
+ * design prototype's diff colour language — insertions green, deletions red,
+ * in-place changes amber.
+ */
+export const CHANGE_KIND: Record<
+  DiffChangeType,
+  { label: string; tone: 'green' | 'red' | 'amber' }
+> = {
+  [DiffChangeType.Inserted]: { label: 'Added', tone: 'green' },
+  [DiffChangeType.Deleted]: { label: 'Deleted', tone: 'red' },
+  [DiffChangeType.Changed]: { label: 'Changed', tone: 'amber' },
+};
+
+/** The locations of a change on one side. */
+export function sideLocations(change: DiffChange, side: DiffSide): DiffLocation[] {
+  return side === 'from' ? change.fromLocations : change.toLocations;
+}
+
+/**
+ * Whether a change paints on the given pane: deletions exist only in the
+ * baseline, insertions only in the newer version, in-place changes in both.
+ */
+export function paintsOnSide(change: DiffChange, side: DiffSide): boolean {
+  if (change.type === DiffChangeType.Changed) return true;
+  return side === 'from'
+    ? change.type === DiffChangeType.Deleted
+    : change.type === DiffChangeType.Inserted;
+}
+
+/** One change's boxes on one surface of one pane, keyed by its list index. */
+export interface SurfaceChangeBoxes {
+  /** The change's index in the response list — the card↔highlight link key. */
+  changeIndex: number;
+  type: DiffChangeType;
+  boxes: NormalizedBox[];
+}
+
+/** The changes that paint on `surfaceIndex` of the given pane, with their boxes. */
+export function surfaceChangeBoxes(
+  changes: DiffChange[],
+  side: DiffSide,
+  surfaceIndex: number,
+): SurfaceChangeBoxes[] {
+  const result: SurfaceChangeBoxes[] = [];
+  changes.forEach((change, changeIndex) => {
+    if (!paintsOnSide(change, side)) return;
+    const boxes = sideLocations(change, side)
+      .filter((location) => location.surfaceIndex === surfaceIndex)
+      .map((location) => location.box);
+    if (boxes.length > 0) result.push({ changeIndex, type: change.type, boxes });
+  });
+  return result;
+}
+
+/**
+ * The 1-based page a change lives on — the newer version's first location,
+ * falling back to the baseline's (a DELETED change has no `to` geometry).
+ * Null when the change carries no geometry at all (no text layer).
+ */
+export function changePageNumber(change: DiffChange): number | null {
+  const location = change.toLocations[0] ?? change.fromLocations[0];
+  return location ? location.surfaceIndex + 1 : null;
+}
+
+/** Words in a text — the unit of the diff statistics. */
+export function wordCount(text: string): number {
+  const trimmed = text.trim();
+  return trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+}
+
+export interface DiffStats {
+  addedWords: number;
+  removedWords: number;
+  /** 1-based page numbers touched by any change, ascending. */
+  pages: number[];
+}
+
+/** Aggregate statistics over all changes (the sidebar's stats block). */
+export function diffStats(changes: DiffChange[]): DiffStats {
+  let addedWords = 0;
+  let removedWords = 0;
+  const pages = new Set<number>();
+  for (const change of changes) {
+    addedWords += wordCount(change.toText);
+    removedWords += wordCount(change.fromText);
+    for (const location of [...change.fromLocations, ...change.toLocations]) {
+      pages.add(location.surfaceIndex + 1);
+    }
+  }
+  return { addedWords, removedWords, pages: [...pages].sort((a, b) => a - b) };
+}
+
+/** Shortens a card excerpt to a readable length, on a word boundary. */
+export function excerpt(text: string, maxChars = 140): string {
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxChars) return clean;
+  const cut = clean.slice(0, maxChars);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${cut.slice(0, lastSpace > maxChars / 2 ? lastSpace : maxChars)}…`;
+}

--- a/qnop-ui/src/components/reviews/diff/useSyncScroll.test.ts
+++ b/qnop-ui/src/components/reviews/diff/useSyncScroll.test.ts
@@ -33,11 +33,26 @@ function scrollable(scrollHeight: number, clientHeight: number): HTMLDivElement 
 function setup(enabled = true) {
   const left = scrollable(2000, 500); // 1500 scrollable
   const right = scrollable(3500, 500); // 3000 scrollable
-  renderHook(({ on }) => useSyncScroll({ current: left }, { current: right }, on), {
+  renderHook(({ on }) => useSyncScroll(left, right, on), {
     initialProps: { on: enabled },
   });
   return { left, right };
 }
+
+it('attaches once the elements appear after a guarded first render', () => {
+  const left = scrollable(2000, 500);
+  const right = scrollable(3500, 500);
+  const { rerender } = renderHook(
+    ({ l, r }: { l: HTMLDivElement | null; r: HTMLDivElement | null }) => useSyncScroll(l, r, true),
+    { initialProps: { l: null as HTMLDivElement | null, r: null as HTMLDivElement | null } },
+  );
+  rerender({ l: left, r: right });
+
+  left.scrollTop = 750;
+  left.dispatchEvent(new Event('scroll'));
+
+  expect(right.scrollTop).toBe(1500);
+});
 
 describe('useSyncScroll', () => {
   it('follows a scroll proportionally on the other pane', () => {

--- a/qnop-ui/src/components/reviews/diff/useSyncScroll.test.ts
+++ b/qnop-ui/src/components/reviews/diff/useSyncScroll.test.ts
@@ -23,16 +23,23 @@ import { describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useSyncScroll } from './useSyncScroll';
 
-function scrollable(scrollHeight: number, clientHeight: number): HTMLDivElement {
+function scrollable(
+  scrollHeight: number,
+  clientHeight: number,
+  scrollWidth = 0,
+  clientWidth = 0,
+): HTMLDivElement {
   const element = document.createElement('div');
   Object.defineProperty(element, 'scrollHeight', { value: scrollHeight, configurable: true });
   Object.defineProperty(element, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(element, 'scrollWidth', { value: scrollWidth, configurable: true });
+  Object.defineProperty(element, 'clientWidth', { value: clientWidth, configurable: true });
   return element;
 }
 
 function setup(enabled = true) {
-  const left = scrollable(2000, 500); // 1500 scrollable
-  const right = scrollable(3500, 500); // 3000 scrollable
+  const left = scrollable(2000, 500, 1400, 600); // 1500 / 800 scrollable
+  const right = scrollable(3500, 500, 1000, 600); // 3000 / 400 scrollable
   renderHook(({ on }) => useSyncScroll(left, right, on), {
     initialProps: { on: enabled },
   });
@@ -62,6 +69,27 @@ describe('useSyncScroll', () => {
     left.dispatchEvent(new Event('scroll'));
 
     expect(right.scrollTop).toBe(1500); // half of the right range
+  });
+
+  it('follows both axes of a diagonal scroll', () => {
+    const { left, right } = setup();
+
+    left.scrollTop = 750; // half of the vertical range
+    left.scrollLeft = 200; // a quarter of the horizontal range
+    left.dispatchEvent(new Event('scroll'));
+
+    expect(right.scrollTop).toBe(1500);
+    expect(right.scrollLeft).toBe(100); // a quarter of the right range
+  });
+
+  it('follows a purely horizontal scroll', () => {
+    const { left, right } = setup();
+
+    left.scrollLeft = 400; // half of the horizontal range
+    left.dispatchEvent(new Event('scroll'));
+
+    expect(right.scrollLeft).toBe(200);
+    expect(right.scrollTop).toBe(0);
   });
 
   it('does not bounce the programmatic follow back to the source', () => {

--- a/qnop-ui/src/components/reviews/diff/useSyncScroll.test.ts
+++ b/qnop-ui/src/components/reviews/diff/useSyncScroll.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSyncScroll } from './useSyncScroll';
+
+function scrollable(scrollHeight: number, clientHeight: number): HTMLDivElement {
+  const element = document.createElement('div');
+  Object.defineProperty(element, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(element, 'clientHeight', { value: clientHeight, configurable: true });
+  return element;
+}
+
+function setup(enabled = true) {
+  const left = scrollable(2000, 500); // 1500 scrollable
+  const right = scrollable(3500, 500); // 3000 scrollable
+  renderHook(({ on }) => useSyncScroll({ current: left }, { current: right }, on), {
+    initialProps: { on: enabled },
+  });
+  return { left, right };
+}
+
+describe('useSyncScroll', () => {
+  it('follows a scroll proportionally on the other pane', () => {
+    const { left, right } = setup();
+
+    left.scrollTop = 750; // half of the left range
+    left.dispatchEvent(new Event('scroll'));
+
+    expect(right.scrollTop).toBe(1500); // half of the right range
+  });
+
+  it('does not bounce the programmatic follow back to the source', () => {
+    const { left, right } = setup();
+
+    left.scrollTop = 150; // 10% of the left range
+    left.dispatchEvent(new Event('scroll'));
+    expect(right.scrollTop).toBe(300);
+    // The browser fires a scroll event for the programmatic follow — the echo
+    // guard must swallow it instead of re-syncing the left pane.
+    right.dispatchEvent(new Event('scroll'));
+
+    expect(left.scrollTop).toBe(150);
+  });
+
+  it('stays inert when disabled', () => {
+    const { left, right } = setup(false);
+
+    left.scrollTop = 750;
+    left.dispatchEvent(new Event('scroll'));
+
+    expect(right.scrollTop).toBe(0);
+  });
+});

--- a/qnop-ui/src/components/reviews/diff/useSyncScroll.ts
+++ b/qnop-ui/src/components/reviews/diff/useSyncScroll.ts
@@ -21,11 +21,19 @@
 
 import { useEffect } from 'react';
 
+/** The proportional position on the target range, or null when an axis cannot scroll. */
+function mapped(value: number, sourceMax: number, targetMax: number): number | null {
+  if (sourceMax <= 0 || targetMax <= 0) return null;
+  return (value / sourceMax) * targetMax;
+}
+
 /**
- * Couples the two compare panes' vertical scrolling proportionally (the
- * versions rarely share a pixel height — inserted pages shift everything).
- * An echo guard swallows the scroll event a programmatic follow triggers on
- * the other pane, so the panes never feed back into each other.
+ * Couples the two compare panes' scrolling proportionally on BOTH axes (the
+ * versions rarely share a pixel height, and zoomed pages overflow
+ * horizontally). A mute flag plus a sub-pixel delta check swallow the scroll
+ * events a programmatic follow triggers on the other pane — writing two
+ * scroll properties can fire more than one event, so a one-shot echo marker
+ * would bounce back.
  *
  * Takes the ELEMENTS (from callback refs held in state), not ref objects: the
  * panes mount after the data guards, so the listeners must (re)attach when
@@ -38,19 +46,28 @@ export function useSyncScroll(
 ) {
   useEffect(() => {
     if (!enabled || !left || !right) return undefined;
-    let echo: HTMLElement | null = null;
+    let muted = false;
     const follow = (source: HTMLElement, target: HTMLElement) => () => {
-      if (echo === source) {
-        echo = null;
-        return;
-      }
-      const sourceMax = source.scrollHeight - source.clientHeight;
-      const targetMax = target.scrollHeight - target.clientHeight;
-      if (sourceMax <= 0 || targetMax <= 0) return;
-      const next = (source.scrollTop / sourceMax) * targetMax;
-      if (Math.abs(next - target.scrollTop) < 1) return;
-      echo = target;
-      target.scrollTop = next;
+      if (muted) return;
+      const nextTop = mapped(
+        source.scrollTop,
+        source.scrollHeight - source.clientHeight,
+        target.scrollHeight - target.clientHeight,
+      );
+      const nextLeft = mapped(
+        source.scrollLeft,
+        source.scrollWidth - source.clientWidth,
+        target.scrollWidth - target.clientWidth,
+      );
+      const moveTop = nextTop !== null && Math.abs(nextTop - target.scrollTop) >= 1;
+      const moveLeft = nextLeft !== null && Math.abs(nextLeft - target.scrollLeft) >= 1;
+      if (!moveTop && !moveLeft) return;
+      muted = true;
+      if (moveTop) target.scrollTop = nextTop;
+      if (moveLeft) target.scrollLeft = nextLeft;
+      requestAnimationFrame(() => {
+        muted = false;
+      });
     };
     const onLeft = follow(left, right);
     const onRight = follow(right, left);

--- a/qnop-ui/src/components/reviews/diff/useSyncScroll.ts
+++ b/qnop-ui/src/components/reviews/diff/useSyncScroll.ts
@@ -20,22 +20,23 @@
  */
 
 import { useEffect } from 'react';
-import type { RefObject } from 'react';
 
 /**
  * Couples the two compare panes' vertical scrolling proportionally (the
  * versions rarely share a pixel height — inserted pages shift everything).
  * An echo guard swallows the scroll event a programmatic follow triggers on
  * the other pane, so the panes never feed back into each other.
+ *
+ * Takes the ELEMENTS (from callback refs held in state), not ref objects: the
+ * panes mount after the data guards, so the listeners must (re)attach when
+ * the elements appear — a plain ref would leave the effect bound to null.
  */
 export function useSyncScroll(
-  leftRef: RefObject<HTMLDivElement | null>,
-  rightRef: RefObject<HTMLDivElement | null>,
+  left: HTMLDivElement | null,
+  right: HTMLDivElement | null,
   enabled: boolean,
 ) {
   useEffect(() => {
-    const left = leftRef.current;
-    const right = rightRef.current;
     if (!enabled || !left || !right) return undefined;
     let echo: HTMLElement | null = null;
     const follow = (source: HTMLElement, target: HTMLElement) => () => {
@@ -59,5 +60,5 @@ export function useSyncScroll(
       left.removeEventListener('scroll', onLeft);
       right.removeEventListener('scroll', onRight);
     };
-  }, [leftRef, rightRef, enabled]);
+  }, [left, right, enabled]);
 }

--- a/qnop-ui/src/components/reviews/diff/useSyncScroll.ts
+++ b/qnop-ui/src/components/reviews/diff/useSyncScroll.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Couples the two compare panes' vertical scrolling proportionally (the
+ * versions rarely share a pixel height — inserted pages shift everything).
+ * An echo guard swallows the scroll event a programmatic follow triggers on
+ * the other pane, so the panes never feed back into each other.
+ */
+export function useSyncScroll(
+  leftRef: RefObject<HTMLDivElement | null>,
+  rightRef: RefObject<HTMLDivElement | null>,
+  enabled: boolean,
+) {
+  useEffect(() => {
+    const left = leftRef.current;
+    const right = rightRef.current;
+    if (!enabled || !left || !right) return undefined;
+    let echo: HTMLElement | null = null;
+    const follow = (source: HTMLElement, target: HTMLElement) => () => {
+      if (echo === source) {
+        echo = null;
+        return;
+      }
+      const sourceMax = source.scrollHeight - source.clientHeight;
+      const targetMax = target.scrollHeight - target.clientHeight;
+      if (sourceMax <= 0 || targetMax <= 0) return;
+      const next = (source.scrollTop / sourceMax) * targetMax;
+      if (Math.abs(next - target.scrollTop) < 1) return;
+      echo = target;
+      target.scrollTop = next;
+    };
+    const onLeft = follow(left, right);
+    const onRight = follow(right, left);
+    left.addEventListener('scroll', onLeft, { passive: true });
+    right.addEventListener('scroll', onRight, { passive: true });
+    return () => {
+      left.removeEventListener('scroll', onLeft);
+      right.removeEventListener('scroll', onRight);
+    };
+  }, [leftRef, rightRef, enabled]);
+}

--- a/qnop-ui/src/components/reviews/viewer/PageCanvas.tsx
+++ b/qnop-ui/src/components/reviews/viewer/PageCanvas.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
+
+interface PageCanvasProps {
+  pdf: PDFDocumentProxy;
+  /** Zero-based page index. */
+  pageIndex: number;
+  /** Display width in CSS pixels — the backing store scales by devicePixelRatio. */
+  width: number;
+  ariaLabel: string;
+  /**
+   * Reports the pdf.js aspect ratio (width/height) once the page header is
+   * read — callers without a server surface size their page box from it.
+   */
+  onAspect?: (aspect: number) => void;
+}
+
+/**
+ * One pdf.js pixel canvas, shared by the review viewer and the version-diff
+ * panes (pixels only — all annotation/diff geometry comes from the server,
+ * ADR-0032). Renders lazily: pages far outside the viewport keep an empty
+ * canvas. Re-renders cancel the previous pass; the canvas fills its positioned
+ * parent, so overlay layers in percent stay aligned at any zoom.
+ */
+export function PageCanvas({ pdf, pageIndex, width, ariaLabel, onAspect }: PageCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [visible, setVisible] = useState(false);
+  // The latest callback without retriggering the render effect on identity churn.
+  const onAspectRef = useRef(onAspect);
+  useEffect(() => {
+    onAspectRef.current = onAspect;
+  }, [onAspect]);
+
+  useEffect(() => {
+    const element = canvasRef.current;
+    if (!element) return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setVisible(true);
+      },
+      { rootMargin: '100% 0px' },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return undefined;
+    let cancelled = false;
+    let renderTask: RenderTask | undefined;
+    void pdf.getPage(pageIndex + 1).then((page) => {
+      if (cancelled) return;
+      const base = page.getViewport({ scale: 1 });
+      onAspectRef.current?.(base.width / base.height);
+      const dpr = window.devicePixelRatio || 1;
+      const viewport = page.getViewport({ scale: (width / base.width) * dpr });
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      canvas.width = Math.floor(viewport.width);
+      canvas.height = Math.floor(viewport.height);
+      renderTask = page.render({ canvas, viewport });
+      // Re-renders cancel the previous pass; swallow the cancellation rejection.
+      renderTask.promise.catch(() => {});
+    });
+    return () => {
+      cancelled = true;
+      renderTask?.cancel();
+    };
+  }, [pdf, pageIndex, width, visible]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-label={ariaLabel}
+      style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+    />
+  );
+}

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -19,9 +19,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import Paper from '@mui/material/Paper';
-import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
 import type {
   Anchor,
   AnnotationView,
@@ -30,6 +30,7 @@ import type {
 } from '../../../api/generated';
 import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
 import { HighlightLayer } from './HighlightLayer';
+import { PageCanvas } from './PageCanvas';
 import { RegionSelectLayer } from './RegionSelectLayer';
 import { TextSpanLayer } from './TextSpanLayer';
 import type { ViewerTool } from './ViewerToolbar';
@@ -82,54 +83,12 @@ export function SurfacePage({
   onTextSelected,
   onRegionSelected,
 }: SurfacePageProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [visible, setVisible] = useState(false);
   const [fallbackAspect, setFallbackAspect] = useState<number | null>(null);
-
-  // Render lazily: pages far outside the viewport keep an empty canvas.
-  useEffect(() => {
-    const element = containerRef.current;
-    if (!element) return undefined;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) setVisible(true);
-      },
-      { rootMargin: '100% 0px' },
-    );
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    if (!visible) return undefined;
-    let cancelled = false;
-    let renderTask: RenderTask | undefined;
-    void pdf.getPage(pageIndex + 1).then((page) => {
-      if (cancelled) return;
-      const base = page.getViewport({ scale: 1 });
-      if (!surface) setFallbackAspect(base.width / base.height);
-      const dpr = window.devicePixelRatio || 1;
-      const viewport = page.getViewport({ scale: (width / base.width) * dpr });
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      canvas.width = Math.floor(viewport.width);
-      canvas.height = Math.floor(viewport.height);
-      renderTask = page.render({ canvas, viewport });
-      // Re-renders cancel the previous pass; swallow the cancellation rejection.
-      renderTask.promise.catch(() => {});
-    });
-    return () => {
-      cancelled = true;
-      renderTask?.cancel();
-    };
-  }, [pdf, pageIndex, surface, width, visible]);
 
   const aspect = surface ? surface.width / surface.height : (fallbackAspect ?? Math.SQRT1_2);
 
   return (
     <Paper
-      ref={containerRef}
       elevation={0}
       square
       data-testid={`surface-page-${pageIndex}`}
@@ -146,10 +105,12 @@ export function SurfacePage({
         border: theme.palette.mode === 'dark' ? `1px solid ${theme.palette.divider}` : 'none',
       })}
     >
-      <canvas
-        ref={canvasRef}
-        aria-label={`Page ${pageIndex + 1}`}
-        style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+      <PageCanvas
+        pdf={pdf}
+        pageIndex={pageIndex}
+        width={width}
+        ariaLabel={`Page ${pageIndex + 1}`}
+        onAspect={surface ? undefined : setFallbackAspect}
       />
       {surface && (
         <>

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -30,7 +30,16 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { BoxSelect, ChevronDown, ChevronUp, TextCursor, ZoomIn, ZoomOut } from 'lucide-react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  BoxSelect,
+  ChevronDown,
+  ChevronUp,
+  GitCompareArrows,
+  TextCursor,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
 import type { DocumentVersionSummary } from '../../../api/generated';
 import { ExtractionStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
@@ -56,6 +65,8 @@ interface ViewerToolbarProps {
   canAnnotate: boolean;
   zoom: number;
   onZoomChange: (zoom: number) => void;
+  /** Link to the version comparison (#252); undefined hides the button (fewer than two extracted versions). */
+  compareHref?: string;
 }
 
 /**
@@ -78,6 +89,7 @@ export function ViewerToolbar({
   canAnnotate,
   zoom,
   onZoomChange,
+  compareHref,
 }: ViewerToolbarProps) {
   return (
     <Paper
@@ -105,6 +117,18 @@ export function ViewerToolbar({
           </MenuItem>
         ))}
       </TextField>
+      {compareHref && (
+        <Tooltip title="Compare versions">
+          <IconButton
+            size="small"
+            aria-label="Compare versions"
+            component={RouterLink}
+            to={compareHref}
+          >
+            <GitCompareArrows size={16} />
+          </IconButton>
+        </Tooltip>
+      )}
 
       <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center' }}>
         <IconButton

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -31,24 +31,15 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { Link as RouterLink } from 'react-router-dom';
-import {
-  BoxSelect,
-  ChevronDown,
-  ChevronUp,
-  GitCompareArrows,
-  TextCursor,
-  ZoomIn,
-  ZoomOut,
-} from 'lucide-react';
+import { BoxSelect, ChevronDown, ChevronUp, GitCompareArrows, TextCursor } from 'lucide-react';
 import type { DocumentVersionSummary } from '../../../api/generated';
 import { ExtractionStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
+import { ZoomControls } from './ZoomControls';
 
 export type ViewerTool = 'text' | 'region';
 
-export const MIN_ZOOM = 0.5;
-export const MAX_ZOOM = 3;
-const ZOOM_STEP = 0.25;
+export { MAX_ZOOM, MIN_ZOOM } from './ZoomControls';
 
 interface ViewerToolbarProps {
   versions: DocumentVersionSummary[];
@@ -192,44 +183,7 @@ export function ViewerToolbar({
 
         <Divider orientation="vertical" flexItem />
 
-        <IconButton
-          size="small"
-          aria-label="Zoom out"
-          disabled={zoom <= MIN_ZOOM}
-          onClick={() => onZoomChange(Math.max(MIN_ZOOM, zoom - ZOOM_STEP))}
-        >
-          <ZoomOut size={16} />
-        </IconButton>
-        <Tooltip title="Reset zoom to fit width">
-          <Typography
-            component="button"
-            variant="body2"
-            color="text.secondary"
-            aria-label="Reset zoom to fit width"
-            onClick={() => onZoomChange(1)}
-            sx={{
-              minWidth: 44,
-              textAlign: 'center',
-              fontVariantNumeric: 'tabular-nums',
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              font: 'inherit',
-              borderRadius: 1,
-              '&:focus-visible': (theme) => ({ outline: 'none', boxShadow: theme.qnop.focusRing }),
-            }}
-          >
-            {Math.round(zoom * 100)}%
-          </Typography>
-        </Tooltip>
-        <IconButton
-          size="small"
-          aria-label="Zoom in"
-          disabled={zoom >= MAX_ZOOM}
-          onClick={() => onZoomChange(Math.min(MAX_ZOOM, zoom + ZOOM_STEP))}
-        >
-          <ZoomIn size={16} />
-        </IconButton>
+        <ZoomControls zoom={zoom} onZoomChange={onZoomChange} />
       </Stack>
     </Paper>
   );

--- a/qnop-ui/src/components/reviews/viewer/ZoomControls.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ZoomControls.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { ZoomIn, ZoomOut } from 'lucide-react';
+
+export const MIN_ZOOM = 0.5;
+export const MAX_ZOOM = 3;
+const ZOOM_STEP = 0.25;
+
+interface ZoomControlsProps {
+  /** 1 = fit width; the pages track their container times this factor. */
+  zoom: number;
+  onZoomChange: (zoom: number) => void;
+}
+
+/**
+ * The shared zoom triplet of the document surfaces (review viewer and version
+ * comparison): step out, click the percentage to reset to fit-width, step in.
+ */
+export function ZoomControls({ zoom, onZoomChange }: ZoomControlsProps) {
+  return (
+    <>
+      <IconButton
+        size="small"
+        aria-label="Zoom out"
+        disabled={zoom <= MIN_ZOOM}
+        onClick={() => onZoomChange(Math.max(MIN_ZOOM, zoom - ZOOM_STEP))}
+      >
+        <ZoomOut size={16} />
+      </IconButton>
+      <Tooltip title="Reset zoom to fit width">
+        <Typography
+          component="button"
+          variant="body2"
+          color="text.secondary"
+          aria-label="Reset zoom to fit width"
+          onClick={() => onZoomChange(1)}
+          sx={{
+            minWidth: 44,
+            textAlign: 'center',
+            fontVariantNumeric: 'tabular-nums',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            font: 'inherit',
+            borderRadius: 1,
+            '&:focus-visible': (theme) => ({ outline: 'none', boxShadow: theme.qnop.focusRing }),
+          }}
+        >
+          {Math.round(zoom * 100)}%
+        </Typography>
+      </Tooltip>
+      <IconButton
+        size="small"
+        aria-label="Zoom in"
+        disabled={zoom >= MAX_ZOOM}
+        onClick={() => onZoomChange(Math.min(MAX_ZOOM, zoom + ZOOM_STEP))}
+      >
+        <ZoomIn size={16} />
+      </IconButton>
+    </>
+  );
+}

--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -42,11 +42,15 @@ const COLLAPSE_KEY = 'qnop-nav-collapsed';
 export function AppShell() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-  // The document review workspace (#250) spans the full width; every other
-  // surface keeps the centred reading container. /reviews/new also matches the
-  // dynamic segment but is a regular centred page (the wizard, #251).
+  // The document review workspace (#250) and the version comparison (#252)
+  // span the full width; every other surface keeps the centred reading
+  // container. /reviews/new also matches the dynamic segment but is a regular
+  // centred page (the wizard, #251).
   const reviewMatch = useMatch('/reviews/:documentId');
-  const fullBleed = Boolean(reviewMatch && reviewMatch.params.documentId !== 'new');
+  const compareMatch = useMatch('/reviews/:documentId/compare');
+  const fullBleed = Boolean(
+    (reviewMatch && reviewMatch.params.documentId !== 'new') || compareMatch,
+  );
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
       return localStorage.getItem(COLLAPSE_KEY) === '1';

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -248,6 +248,13 @@ export function DocumentReviewPage() {
               canAnnotate={canAnnotate}
               zoom={zoom}
               onZoomChange={setZoom}
+              compareHref={
+                (versionsQuery.data?.versions.filter(
+                  (version) => version.extractionStatus === ExtractionStatus.Ready,
+                ).length ?? 0) >= 2
+                  ? `/reviews/${documentId}/compare`
+                  : undefined
+              }
             />
             {extractionStatus === ExtractionStatus.Pending && (
               <Alert severity="info">

--- a/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
@@ -20,7 +20,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import type { DiffChange, DocumentVersionSummary } from '../../api/generated';
@@ -166,11 +166,13 @@ describe('VersionComparePage', () => {
     expect(screen.queryByTestId('pane-from')).not.toBeInTheDocument();
   });
 
-  it('feeds the changes into panes, toolbar count and summary', () => {
+  it('feeds the changes into panes, toolbar statistics and summary', () => {
     mockData();
     renderPage();
     expect(screen.getByTestId('pane-to')).toHaveAttribute('data-changes', '1');
-    expect(screen.getByText('1 change')).toBeInTheDocument();
+    const stats = within(screen.getByTestId('toolbar-diff-stats'));
+    expect(stats.getByText('+3')).toBeInTheDocument(); // "brand new sentence"
+    expect(stats.getByText('−0')).toBeInTheDocument();
     expect(screen.getByText('brand new sentence')).toBeInTheDocument();
   });
 

--- a/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import type { DiffChange, DocumentVersionSummary } from '../../api/generated';
+import { DiffChangeType, ExtractionStatus } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { VersionComparePage } from './VersionComparePage';
+import {
+  useDocument,
+  useDocumentVersions,
+  useOriginalPdf,
+  useRenderedDocument,
+} from '../../api/hooks/useDocuments';
+import { useParticipants } from '../../api/hooks/useReviews';
+import { useVersionDiff } from '../../api/hooks/useVersionDiff';
+import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
+
+vi.mock('../../api/hooks/useDocuments', () => ({
+  useDocument: vi.fn(),
+  useDocumentVersions: vi.fn(),
+  useOriginalPdf: vi.fn(),
+  useRenderedDocument: vi.fn(),
+}));
+vi.mock('../../api/hooks/useReviews', () => ({
+  useParticipants: vi.fn(),
+}));
+vi.mock('../../api/hooks/useVersionDiff', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useVersionDiff: vi.fn(),
+}));
+vi.mock('../../components/reviews/viewer/usePdfDocument', () => ({
+  usePdfDocument: vi.fn(),
+}));
+// The pane needs a real pdf.js document and layout; the page test verifies the
+// orchestration around it and drives selection through the summary cards.
+vi.mock('../../components/reviews/diff/ComparePane', () => ({
+  ComparePane: ({
+    side,
+    versionNumber,
+    changes,
+    activeChangeIndex,
+  }: {
+    side: string;
+    versionNumber: number;
+    changes: unknown[];
+    activeChangeIndex: number | null;
+  }) => (
+    <div
+      data-testid={`pane-${side}`}
+      data-version={versionNumber}
+      data-changes={changes.length}
+      data-active={String(activeChangeIndex)}
+    />
+  ),
+}));
+
+const version = (
+  versionNumber: number,
+  extractionStatus: ExtractionStatus = ExtractionStatus.Ready,
+): DocumentVersionSummary => ({
+  versionNumber,
+  contentType: 'application/pdf',
+  sizeBytes: 1000,
+  contentHash: `hash-${versionNumber}`,
+  extractionStatus,
+  createdBy: 'u1',
+  createdAt: '2026-07-01T10:00:00Z',
+});
+
+const CHANGES: DiffChange[] = [
+  {
+    type: DiffChangeType.Inserted,
+    fromText: '',
+    toText: 'brand new sentence',
+    fromLocations: [],
+    toLocations: [{ surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.4, height: 0.02 } }],
+  },
+];
+
+function mockData({
+  versions = [version(1), version(2), version(3)],
+  diff = {
+    data: { fromVersion: 2, toVersion: 3, changes: CHANGES },
+    isError: false,
+    error: null,
+  },
+}: {
+  versions?: DocumentVersionSummary[];
+  diff?: unknown;
+} = {}) {
+  vi.mocked(useDocument).mockReturnValue({
+    isPending: false,
+    isError: false,
+    data: { id: 'd1', title: 'Framework agreement', ownerId: 'u1', workflowState: 'IN_REVIEW' },
+  } as never);
+  vi.mocked(useDocumentVersions).mockReturnValue({
+    isPending: false,
+    data: { versions },
+  } as never);
+  vi.mocked(useParticipants).mockReturnValue({
+    data: { participants: [{ principalId: 'u1', displayName: 'Maxim' }] },
+  } as never);
+  vi.mocked(useOriginalPdf).mockReturnValue({ data: undefined } as never);
+  vi.mocked(useRenderedDocument).mockReturnValue({ data: undefined } as never);
+  vi.mocked(usePdfDocument).mockReturnValue({ pdf: null, error: null });
+  vi.mocked(useVersionDiff).mockReturnValue(diff as never);
+}
+
+function renderPage(initialEntry = '/reviews/d1/compare') {
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/reviews/:documentId/compare" element={<VersionComparePage />} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('VersionComparePage', () => {
+  it('defaults the pair to previous ↔ latest extracted version', () => {
+    mockData();
+    renderPage();
+    expect(screen.getByTestId('pane-from')).toHaveAttribute('data-version', '2');
+    expect(screen.getByTestId('pane-to')).toHaveAttribute('data-version', '3');
+  });
+
+  it('takes a valid pair from the URL and skips unextracted versions as defaults', () => {
+    mockData({ versions: [version(1), version(2), version(3, ExtractionStatus.Pending)] });
+    renderPage('/reviews/d1/compare?from=1&to=2');
+    expect(screen.getByTestId('pane-from')).toHaveAttribute('data-version', '1');
+    expect(screen.getByTestId('pane-to')).toHaveAttribute('data-version', '2');
+  });
+
+  it('guards when fewer than two versions are extracted', () => {
+    mockData({ versions: [version(1), version(2, ExtractionStatus.Pending)] });
+    renderPage();
+    expect(screen.getByText(/needs at least two versions/)).toBeInTheDocument();
+    expect(screen.queryByTestId('pane-from')).not.toBeInTheDocument();
+  });
+
+  it('feeds the changes into panes, toolbar count and summary', () => {
+    mockData();
+    renderPage();
+    expect(screen.getByTestId('pane-to')).toHaveAttribute('data-changes', '1');
+    expect(screen.getByText('1 change')).toBeInTheDocument();
+    expect(screen.getByText('brand new sentence')).toBeInTheDocument();
+  });
+
+  it('marks the selected change as active on both panes', () => {
+    mockData();
+    renderPage();
+    fireEvent.click(screen.getByTestId('change-card-0'));
+    expect(screen.getByTestId('pane-from')).toHaveAttribute('data-active', '0');
+    expect(screen.getByTestId('pane-to')).toHaveAttribute('data-active', '0');
+  });
+
+  it('explains a still-pending extraction on the diff error path', () => {
+    mockData({
+      diff: {
+        data: undefined,
+        isError: true,
+        error: {
+          isAxiosError: true,
+          response: { status: 409, data: { code: 'EXTRACTION_PENDING' } },
+        },
+      },
+    });
+    renderPage();
+    expect(screen.getByText(/still being processed/)).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Link as RouterLink, useParams, useSearchParams } from 'react-router-dom';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import { ArrowLeft } from 'lucide-react';
+import { ExtractionStatus } from '../../api/generated';
+import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
+import { useOriginalPdf } from '../../api/hooks/useDocuments';
+import { useRenderedDocument } from '../../api/hooks/useDocuments';
+import { useParticipants } from '../../api/hooks/useReviews';
+import { useVersionDiff, versionDiffErrorCode } from '../../api/hooks/useVersionDiff';
+import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { ChangeSummaryPanel } from '../../components/reviews/diff/ChangeSummaryPanel';
+import { ComparePane } from '../../components/reviews/diff/ComparePane';
+import { CompareToolbar } from '../../components/reviews/diff/CompareToolbar';
+import { useSyncScroll } from '../../components/reviews/diff/useSyncScroll';
+import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
+import { formatDateTime } from '../../utils/formatDate';
+
+/**
+ * The version comparison workspace (issue #252, ADR-0034): two panes render
+ * the compared originals side by side with the server's located changes
+ * painted on them; the right-hand summary lists every change with statistics.
+ * The pair lives in the URL (`?from=1&to=3`) so a comparison is shareable;
+ * invalid or missing parameters normalise to "previous ↔ latest".
+ */
+export function VersionComparePage() {
+  const { documentId = '' } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const documentQuery = useDocument(documentId);
+  const versionsQuery = useDocumentVersions(documentId);
+  const participantsQuery = useParticipants(documentId);
+
+  const versions = versionsQuery.data?.versions ?? [];
+  const readyNumbers = versions
+    .filter((version) => version.extractionStatus === ExtractionStatus.Ready)
+    .map((version) => version.versionNumber)
+    .sort((a, b) => a - b);
+
+  // Resolve the compared pair: URL params when valid, else previous ↔ latest.
+  const paramFrom = Number(searchParams.get('from'));
+  const paramTo = Number(searchParams.get('to'));
+  const to = readyNumbers.includes(paramTo) ? paramTo : readyNumbers.at(-1);
+  const from =
+    readyNumbers.includes(paramFrom) && paramFrom !== to
+      ? paramFrom
+      : readyNumbers.filter((n) => n !== to).at(-1);
+
+  // Keep the URL canonical so a copied link reproduces exactly this view.
+  useEffect(() => {
+    if (from === undefined || to === undefined) return;
+    if (paramFrom !== from || paramTo !== to) {
+      setSearchParams({ from: String(from), to: String(to) }, { replace: true });
+    }
+  }, [from, to, paramFrom, paramTo, setSearchParams]);
+
+  const fromBytes = useOriginalPdf(documentId, from);
+  const toBytes = useOriginalPdf(documentId, to);
+  const fromPdf = usePdfDocument(fromBytes.data);
+  const toPdf = usePdfDocument(toBytes.data);
+  const fromRendered = useRenderedDocument(documentId, from ?? 0, from !== undefined);
+  const toRendered = useRenderedDocument(documentId, to ?? 0, to !== undefined);
+  const diffQuery = useVersionDiff(documentId, from, to);
+
+  const [activeChange, setActiveChange] = useState<number | null>(null);
+  const [syncScroll, setSyncScroll] = useState(true);
+  const fromScrollRef = useRef<HTMLDivElement>(null);
+  const toScrollRef = useRef<HTMLDivElement>(null);
+  useSyncScroll(fromScrollRef, toScrollRef, syncScroll);
+
+  // Selecting a change (card or highlight) brings it into view on both sides.
+  useEffect(() => {
+    if (activeChange === null) return;
+    for (const side of ['from', 'to'] as const) {
+      document
+        .getElementById(`diff-change-${side}-${activeChange}`)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [activeChange]);
+
+  const handleChangePair = (nextFrom: number, nextTo: number) => {
+    setActiveChange(null);
+    setSearchParams({ from: String(nextFrom), to: String(nextTo) });
+  };
+
+  if (documentQuery.isPending || versionsQuery.isPending) {
+    return (
+      <Stack sx={{ alignItems: 'center', py: 8 }}>
+        <CircularProgress />
+      </Stack>
+    );
+  }
+  if (documentQuery.isError || !documentQuery.data) {
+    return (
+      <Alert severity="error">
+        This document does not exist, or you are not a participant of its review.
+      </Alert>
+    );
+  }
+
+  const document_ = documentQuery.data;
+  const participants = participantsQuery.data?.participants ?? [];
+  const uploaderName = (userId: string) =>
+    participants.find((participant) => participant.principalId === userId)?.displayName;
+  const versionMeta = (versionNumber: number | undefined) => {
+    const version = versions.find((v) => v.versionNumber === versionNumber);
+    if (!version) return '';
+    const name = uploaderName(version.createdBy);
+    return `${formatDateTime(version.createdAt)}${name ? ` · ${name}` : ''}`;
+  };
+
+  const changes = diffQuery.data?.changes ?? null;
+  const backHref = `/reviews/${documentId}${to !== undefined ? `?version=${to}` : ''}`;
+
+  return (
+    <Stack spacing={2.5} sx={{ height: { md: '100%' }, minHeight: { md: 480 } }}>
+      <PageHeader
+        title={document_.title}
+        titleAdornment={<Chip size="small" variant="outlined" label="Compare versions" />}
+        action={
+          <Button
+            component={RouterLink}
+            to={backHref}
+            variant="outlined"
+            size="small"
+            startIcon={<ArrowLeft size={15} />}
+          >
+            Back to review
+          </Button>
+        }
+      />
+
+      {from === undefined || to === undefined ? (
+        <Alert severity="info">
+          Comparing needs at least two versions with an extracted text layer. Upload a new version
+          first.
+        </Alert>
+      ) : (
+        <>
+          <CompareToolbar
+            versions={versions}
+            from={from}
+            to={to}
+            onChangePair={handleChangePair}
+            syncScroll={syncScroll}
+            onSyncScrollChange={setSyncScroll}
+            changeCount={changes ? changes.length : null}
+          />
+          {diffQuery.isError && (
+            <Alert severity="error">
+              {versionDiffErrorCode(diffQuery.error) === 'EXTRACTION_PENDING'
+                ? 'One of the versions is still being processed — try again in a moment.'
+                : 'The comparison could not be computed.'}
+            </Alert>
+          )}
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', lg: 'minmax(0,1fr) minmax(0,1fr) 300px' },
+              gap: 2,
+              flex: 1,
+              minHeight: 0,
+            }}
+          >
+            {(
+              [
+                { side: 'from' as const, version: from, pdfState: fromPdf, rendered: fromRendered },
+                { side: 'to' as const, version: to, pdfState: toPdf, rendered: toRendered },
+              ] as const
+            ).map(({ side, version, pdfState, rendered }) => (
+              <Paper
+                key={side}
+                variant="outlined"
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  minHeight: 0,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  height: { xs: 480, lg: 'auto' },
+                }}
+              >
+                <ComparePane
+                  side={side}
+                  versionNumber={version}
+                  metaText={versionMeta(version)}
+                  trailingText={
+                    side === 'to' && changes
+                      ? `${changes.length} ${changes.length === 1 ? 'change' : 'changes'}`
+                      : undefined
+                  }
+                  pdf={pdfState.pdf}
+                  pdfError={pdfState.error}
+                  surfaces={rendered.data?.surfaces}
+                  changes={changes ?? []}
+                  activeChangeIndex={activeChange}
+                  onSelectChange={(index) => setActiveChange(index)}
+                  scrollRef={side === 'from' ? fromScrollRef : toScrollRef}
+                />
+              </Paper>
+            ))}
+            <Paper variant="outlined" sx={{ p: 2, overflow: 'auto', minHeight: 0 }}>
+              {changes === null && !diffQuery.isError ? (
+                <Stack sx={{ alignItems: 'center', py: 4 }}>
+                  <CircularProgress size={22} />
+                </Stack>
+              ) : (
+                <ChangeSummaryPanel
+                  changes={changes ?? []}
+                  activeChangeIndex={activeChange}
+                  onSelectChange={setActiveChange}
+                />
+              )}
+            </Paper>
+          </Box>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -174,7 +174,7 @@ export function VersionComparePage() {
             onChangePair={handleChangePair}
             syncScroll={syncScroll}
             onSyncScrollChange={setSyncScroll}
-            changeCount={changes ? changes.length : null}
+            changes={changes}
             zoom={zoom}
             onZoomChange={setZoom}
           />

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link as RouterLink, useParams, useSearchParams } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -91,9 +91,11 @@ export function VersionComparePage() {
 
   const [activeChange, setActiveChange] = useState<number | null>(null);
   const [syncScroll, setSyncScroll] = useState(true);
-  const fromScrollRef = useRef<HTMLDivElement>(null);
-  const toScrollRef = useRef<HTMLDivElement>(null);
-  useSyncScroll(fromScrollRef, toScrollRef, syncScroll);
+  // Callback refs held in state: the panes mount only after the data guards,
+  // so the sync-scroll listeners must attach when the elements appear.
+  const [fromScrollEl, setFromScrollEl] = useState<HTMLDivElement | null>(null);
+  const [toScrollEl, setToScrollEl] = useState<HTMLDivElement | null>(null);
+  useSyncScroll(fromScrollEl, toScrollEl, syncScroll);
 
   // Selecting a change (card or highlight) brings it into view on both sides.
   useEffect(() => {
@@ -222,7 +224,7 @@ export function VersionComparePage() {
                   changes={changes ?? []}
                   activeChangeIndex={activeChange}
                   onSelectChange={(index) => setActiveChange(index)}
-                  scrollRef={side === 'from' ? fromScrollRef : toScrollRef}
+                  scrollRef={side === 'from' ? setFromScrollEl : setToScrollEl}
                 />
               </Paper>
             ))}

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -91,6 +91,7 @@ export function VersionComparePage() {
 
   const [activeChange, setActiveChange] = useState<number | null>(null);
   const [syncScroll, setSyncScroll] = useState(true);
+  const [zoom, setZoom] = useState(1);
   // Callback refs held in state: the panes mount only after the data guards,
   // so the sync-scroll listeners must attach when the elements appear.
   const [fromScrollEl, setFromScrollEl] = useState<HTMLDivElement | null>(null);
@@ -174,6 +175,8 @@ export function VersionComparePage() {
             syncScroll={syncScroll}
             onSyncScrollChange={setSyncScroll}
             changeCount={changes ? changes.length : null}
+            zoom={zoom}
+            onZoomChange={setZoom}
           />
           {diffQuery.isError && (
             <Alert severity="error">
@@ -225,6 +228,7 @@ export function VersionComparePage() {
                   activeChangeIndex={activeChange}
                   onSelectChange={(index) => setActiveChange(index)}
                   scrollRef={side === 'from' ? setFromScrollEl : setToScrollEl}
+                  zoom={zoom}
                 />
               </Paper>
             ))}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -58,6 +58,11 @@ const DocumentReviewPage = lazy(() =>
   import('../pages/reviews/DocumentReviewPage').then((m) => ({ default: m.DocumentReviewPage })),
 );
 
+// The version comparison shares pdf.js with the review surface (#252).
+const VersionComparePage = lazy(() =>
+  import('../pages/reviews/VersionComparePage').then((m) => ({ default: m.VersionComparePage })),
+);
+
 const lazyFallback = (
   <div style={{ padding: '8px 4px', fontSize: 14, color: '#5E6C7B' }}>Loading…</div>
 );
@@ -93,6 +98,14 @@ export const router = createBrowserRouter([
         element: (
           <Suspense fallback={lazyFallback}>
             <DocumentReviewPage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'reviews/:documentId/compare',
+        element: (
+          <Suspense fallback={lazyFallback}>
+            <VersionComparePage />
           </Suspense>
         ),
       },


### PR DESCRIPTION
Closes #252. Implements the plan posted in the issue (ADR-0034; backend shipped in #249 — this PR is frontend-only).

## What

- **Compare workspace** at `/reviews/:documentId/compare?from&to` (URL as state, shareable): two panes render the compared originals side by side, sticky version headers (badge, date, uploader), fit-width page stacks sharing the viewer's lazy pdf.js rendering.
- **Located change highlights**: the server's `fromLocations`/`toLocations` paint as multiply-blended marker bands on the rendered pages — insertions green, deletions red, in-place changes amber (the prototype's diff colour language, both themes). Deletions/`CHANGED` appear on the baseline pane, insertions/`CHANGED` on the newer pane.
- **Change summary sidebar** (prototype `diff.jsx`): one card per change with type label, excerpt (old → new for `CHANGED`), page; statistics block (±words, change count, touched pages). Card ↔ highlight are linked: selecting either marks both and scrolls both panes to the change.
- **Toolbar**: baseline/compare pickers (unextracted versions and same-pair disabled), swap button, live change count, **shared fit-width zoom** (the triplet extracted into a reusable ZoomControls, both panes re-render crisply and overflow inside their own scroll panes), toggleable proportional **sync scrolling**.
- **States**: fewer than two extracted versions (guard), diff loading, `409 EXTRACTION_PENDING`, empty diff ("identical text content"), pdf render errors.
- **Entry**: compare icon in the viewer toolbar once ≥2 versions are READY; "Back to review" returns to the `to` version.
- **Refactor**: the pdf.js canvas render moved out of `SurfacePage` into a shared `PageCanvas` (lazy render, DPR, cancellation) reused by both surfaces.

Deferred per plan: overlay mode, AI summary (enterprise/SPI), report export, timeline-slider picker.

## Test plan

- [x] Unit: `diffModel` (side routing, grouping, page numbers, stats, excerpts), `useSyncScroll` (proportional follow, echo guard, disabled)
- [x] Component: `DiffHighlightLayer` (per-side painting, geometry, click/active), `ChangeSummaryPanel` (cards, stats, empty state, toggle), `CompareToolbar` (picker disabling, swap, sync toggle), `VersionComparePage` (pair defaults/URL, guards, wiring, 409 path)
- [x] Gates: `tsc`, `eslint`, `prettier`, 339 vitest tests, production build
- [x] Manual visual pass in the running app: side-by-side highlights on a real changed document (payment-term change, added skonto clause, deleted prepayment clause), card↔highlight linking with active state, sync scrolling (fixed here — see second commit), empty diff on an identical pair, URL normalisation, dark mode

🤖 Co-Author: Claude (Fable 5) via Claude Code


