### PR TITLE
test: extend smoke test to cover object storage + review pipeline (#308)

### DIFF
--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# Test-deployment stack for the CI smoke tests (issues #207, #225): a standalone
-# PostgreSQL, the qnop server built from the repo Dockerfile, and a Keycloak
-# identity provider for the OIDC login smoke test. This is NOT a production or
-# local-dev stack — the QNOP_AUTH_* values below are throwaway test secrets that
-# intentionally match the encryption key/salt used to produce testdata/db/seed.sql,
-# so the seeded rows (e.g. the OIDC client secret) stay decryptable. MinIO is
-# omitted: object storage is not consumed yet.
+# Test-deployment stack for the CI smoke tests (issues #207, #225, #308): a
+# standalone PostgreSQL, a MinIO object store, the qnop server built from the repo
+# Dockerfile, and a Keycloak identity provider for the OIDC login smoke test. This
+# is NOT a production or local-dev stack — the QNOP_AUTH_* values below are
+# throwaway test secrets that intentionally match the encryption key/salt used to
+# produce testdata/db/seed.sql, so the seeded rows (e.g. the OIDC client secret)
+# stay decryptable. MinIO backs the document-ingest smoke (#308): the server writes
+# uploads there, the scheduled extraction job reads them back, and the smoke asserts
+# the rendered representation and byte-identical original.
 #
 # Usage:  docker compose -f docker-compose.smoke.yml up -d --build
 #         bash scripts/smoke-test.sh
@@ -26,6 +28,21 @@ services:
       timeout: 5s
       retries: 20
 
+  # Object storage for binary documents (issue #243, ADR-0005). The app writes
+  # uploads here and the extraction job reads them back; `auto-create-bucket` on
+  # the app side provisions the bucket on first use, so no init job is needed.
+  minio:
+    image: minio/minio:latest@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: qnop
+      MINIO_ROOT_PASSWORD: qnop_secret
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
   app:
     build:
       context: .
@@ -33,12 +50,23 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      minio:
+        condition: service_healthy
     environment:
       QNOP_DB_HOST: postgres
       QNOP_DB_PORT: '5432'
       QNOP_DB_NAME: qnop
       QNOP_DB_USERNAME: qnop
       QNOP_DB_PASSWORD: qnop
+      # Object storage (issue #308): point at the MinIO service and let the app
+      # create the bucket on first use — the deployed ingest → extraction → serve
+      # path runs against real S3-compatible storage in the smoke.
+      QNOP_S3_ENDPOINT: http://minio:9000
+      QNOP_S3_BUCKET: qnop-documents
+      QNOP_S3_ACCESS_KEY: qnop
+      QNOP_S3_SECRET_KEY: qnop_secret
+      QNOP_S3_PATH_STYLE_ACCESS: 'true'
+      QNOP_S3_AUTO_CREATE_BUCKET: 'true'
       # Test-only secrets — must match testdata/db/seed.sql's encryption inputs.
       QNOP_AUTH_JWT_SECRET: integration-test-jwt-secret-0123456789
       QNOP_AUTH_ENCRYPTION_KEY: integration-test-encryption-key-0123456789

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,28 +1,49 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# Smoke test (issue #207): waits for the deployed qnop server to become healthy,
-# seeds the shared fixtures from testdata/, and exercises the base functionality
-# over real HTTP. Fails fast (non-zero exit) on the first deviation.
+# Smoke test (issues #207, #308): waits for the deployed qnop server to become
+# healthy, seeds the shared fixtures from testdata/, and exercises the shipped
+# surface over real HTTP against the built container image — base auth/admin, the
+# full document-ingest pipeline through real MinIO + the scheduled extraction job,
+# the review lifecycle (due date, overview, workflow), and auth session rotation.
+# Fails fast (non-zero exit) on the first deviation.
 #
 # Run from the repo root, with the stack already up:
 #   docker compose -f docker-compose.smoke.yml up -d --build
 #   bash scripts/smoke-test.sh
+#
+# Needs bash, curl, jq, cmp and GNU date on PATH.
 set -euo pipefail
 
 BASE_URL="${SMOKE_BASE_URL:-http://localhost:8080}"
 COMPOSE_FILE="${SMOKE_COMPOSE_FILE:-docker-compose.smoke.yml}"
 CLEAN_FILE="testdata/db/clean.sql"
 SEED_FILE="testdata/db/seed.sql"
+SAMPLE_PDF="testdata/documents/sample.pdf"
 SEED_USER="admin"
 SEED_PASS="Test-Pass-1234!"
 HEALTH_RETRIES=60
 HEALTH_DELAY=5
+EXTRACT_RETRIES=30
+EXTRACT_DELAY=5
+
+WORKDIR="$(mktemp -d)"
+COOKIES="${WORKDIR}/cookies.txt"
+trap 'rm -rf "${WORKDIR}"' EXIT
 
 log() { echo "[smoke] $*"; }
 fail() {
   echo "[smoke] FAIL: $*" >&2
   exit 1
+}
+
+# Authenticated helpers — the access token is set once login succeeds.
+TOKEN=""
+aget() { curl -sf "${BASE_URL}$1" -H "Authorization: Bearer ${TOKEN}"; }
+acode() {
+  # method path -> prints the HTTP status of an authenticated request (no -f)
+  curl -s -o /dev/null -w '%{http_code}' -X "$1" "${BASE_URL}$2" \
+    -H "Authorization: Bearer ${TOKEN}"
 }
 
 # 1) Readiness — covers the container boot, DB connectivity and Liquibase.
@@ -55,30 +76,128 @@ code="$(curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/api/v1/config")"
 [ "$code" = "200" ] || fail "GET /api/v1/config -> HTTP $code (expected 200)"
 log "GET /api/v1/config -> 200"
 
-# 4) Login as the seeded admin (covers seeded data + bcrypt + JWT issuance).
-token="$(
-  curl -sf -X POST "${BASE_URL}/api/v1/auth/login" \
-    -H 'Content-Type: application/json' \
-    -d "{\"usernameOrEmail\":\"${SEED_USER}\",\"password\":\"${SEED_PASS}\"}" |
-    jq -r '.accessToken'
-)"
-[ -n "$token" ] && [ "$token" != "null" ] || fail "login did not return an access token"
-log "POST /api/v1/auth/login -> access token issued"
+# 4) An unauthenticated call to a protected endpoint is rejected (security gate).
+code="$(curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/api/v1/users/me")"
+[ "$code" = "401" ] || fail "unauthenticated GET /api/v1/users/me -> HTTP $code (expected 401)"
+log "unauthenticated GET /api/v1/users/me -> 401"
 
-# 5) Authenticated admin query of the seeded users.
-total="$(
-  curl -sf "${BASE_URL}/api/v1/admin/users" -H "Authorization: Bearer ${token}" |
-    jq -r '.total'
+# 5) Login as the seeded admin (covers seeded data + bcrypt + JWT issuance). The
+#    rotating refresh token comes back as the HttpOnly qnop_refresh cookie, kept
+#    in a jar so the session-rotation checks below can replay it.
+login_json="$(
+  curl -sf -c "$COOKIES" -X POST "${BASE_URL}/api/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"usernameOrEmail\":\"${SEED_USER}\",\"password\":\"${SEED_PASS}\"}"
 )"
+TOKEN="$(echo "$login_json" | jq -r '.accessToken')"
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || fail "login did not return an access token"
+grep -q 'qnop_refresh' "$COOKIES" || fail "login did not set the qnop_refresh cookie"
+log "POST /api/v1/auth/login -> access token + refresh cookie"
+
+# 6) Authenticated admin query of the seeded users.
+total="$(aget /api/v1/admin/users | jq -r '.total')"
 [ "$total" -ge 8 ] 2>/dev/null || fail "GET /api/v1/admin/users total=${total} (expected >= 8 seeded users)"
 log "GET /api/v1/admin/users -> total=${total}"
 
-# 6) Current-user principal resolves from the JWT.
-role="$(
-  curl -sf "${BASE_URL}/api/v1/users/me" -H "Authorization: Bearer ${token}" |
-    jq -r '.role'
-)"
+# 7) Current-user principal resolves from the JWT.
+role="$(aget /api/v1/users/me | jq -r '.role')"
 [ "$role" = "ADMIN" ] || fail "GET /api/v1/users/me role=${role} (expected ADMIN)"
 log "GET /api/v1/users/me -> role=${role}"
+
+# 8) Admin + user read surfaces (settings service, teams, per-user settings).
+code="$(acode GET /api/v1/admin/settings)"
+[ "$code" = "200" ] || fail "GET /api/v1/admin/settings -> HTTP $code (expected 200)"
+code="$(acode GET /api/v1/admin/teams)"
+[ "$code" = "200" ] || fail "GET /api/v1/admin/teams -> HTTP $code (expected 200)"
+code="$(acode GET /api/v1/users/me/settings)"
+[ "$code" = "200" ] || fail "GET /api/v1/users/me/settings -> HTTP $code (expected 200)"
+log "GET admin/settings, admin/teams, users/me/settings -> 200"
+
+# 9) Document ingest through real object storage (#243, #308). Upload the sample
+#    PDF with a future due date (#295); the server stages it in MinIO and enqueues
+#    the extraction job in one transaction.
+due_at="$(date -u -d '+30 days' '+%Y-%m-%dT%H:%M:%SZ')"
+upload_json="$(
+  curl -sf -X POST "${BASE_URL}/api/v1/documents" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -F "title=Smoke Review" \
+    -F "dueAt=${due_at}" \
+    -F "file=@${SAMPLE_PDF};type=application/pdf"
+)"
+doc_id="$(echo "$upload_json" | jq -r '.documentId')"
+[ -n "$doc_id" ] && [ "$doc_id" != "null" ] || fail "upload did not return a documentId"
+[ "$(echo "$upload_json" | jq -r '.versionNumber')" = "1" ] || fail "first upload was not version 1"
+log "POST /api/v1/documents -> document ${doc_id} v1 (stored in MinIO)"
+
+# 10) The scheduled extraction job (real MinIO read + PDFBox) flips v1 to READY.
+extraction=""
+for i in $(seq 1 "$EXTRACT_RETRIES"); do
+  extraction="$(aget "/api/v1/documents/${doc_id}/versions" | jq -r '.versions[0].extractionStatus')"
+  [ "$extraction" = "READY" ] && break
+  [ "$extraction" = "FAILED" ] && fail "extraction FAILED for the uploaded document"
+  if [ "$i" -eq "$EXTRACT_RETRIES" ]; then
+    fail "extraction did not reach READY within $((EXTRACT_RETRIES * EXTRACT_DELAY))s (last=${extraction})"
+  fi
+  sleep "$EXTRACT_DELAY"
+done
+log "extraction READY after the scheduled job ran"
+
+# 11) The rendered representation parses from stored JSON and carries the text.
+rendered="$(aget "/api/v1/documents/${doc_id}/versions/1/rendered")"
+surfaces="$(echo "$rendered" | jq -r '.surfaces | length')"
+[ "$surfaces" = "1" ] || fail "rendered document has ${surfaces} surfaces (expected 1)"
+text="$(echo "$rendered" | jq -r '[.surfaces[0].textSpans[].text] | join("")')"
+echo "$text" | grep -q "QNOP" || fail "rendered text '${text}' does not contain the fixture text"
+log "GET .../rendered -> 1 surface, text '${text}'"
+
+# 12) The original binary streams back byte-identical from object storage.
+curl -sf "${BASE_URL}/api/v1/documents/${doc_id}/versions/1/original" \
+  -H "Authorization: Bearer ${TOKEN}" -o "${WORKDIR}/original.pdf"
+cmp -s "${WORKDIR}/original.pdf" "$SAMPLE_PDF" ||
+  fail "streamed original is not byte-identical to the uploaded PDF"
+log "GET .../original -> byte-identical to the upload"
+
+# 13) Review due date set-at-create is visible, and the owner can clear it (#295).
+due_seen="$(aget "/api/v1/documents/${doc_id}" | jq -r '.dueAt')"
+[ "$due_seen" != "null" ] && [ -n "$due_seen" ] || fail "created document has no dueAt (expected the set value)"
+curl -sf -X PATCH "${BASE_URL}/api/v1/documents/${doc_id}" \
+  -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
+  -d '{"dueAt":null}' >/dev/null
+due_cleared="$(aget "/api/v1/documents/${doc_id}" | jq -r '.dueAt')"
+[ "$due_cleared" = "null" ] || fail "PATCH did not clear dueAt (still ${due_cleared})"
+log "due date set-at-create then cleared via PATCH"
+
+# 14) The document appears in the caller's overview.
+seen="$(aget "/api/v1/documents" | jq -r --arg id "$doc_id" '[.items[].id] | index($id)')"
+[ "$seen" != "null" ] || fail "uploaded document is missing from GET /api/v1/documents"
+log "GET /api/v1/documents -> lists the uploaded document"
+
+# 15) Workflow: the offered Draft -> In review transition is authoritative.
+transitions="$(aget "/api/v1/documents/${doc_id}/workflow" | jq -r '.allowedTransitions | join(",")')"
+echo "$transitions" | grep -q "IN_REVIEW" || fail "IN_REVIEW not offered from Draft (got: ${transitions})"
+curl -sf -X POST "${BASE_URL}/api/v1/documents/${doc_id}/workflow" \
+  -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
+  -d '{"targetState":"IN_REVIEW"}' >/dev/null
+state="$(aget "/api/v1/documents/${doc_id}" | jq -r '.workflowState')"
+[ "$state" = "IN_REVIEW" ] || fail "workflow state is ${state} after transition (expected IN_REVIEW)"
+log "POST .../workflow -> Draft to In review"
+
+# 16) Annotations list resolves against the READY version (empty is fine).
+code="$(acode GET "/api/v1/documents/${doc_id}/annotations?version=1")"
+[ "$code" = "200" ] || fail "GET .../annotations?version=1 -> HTTP $code (expected 200)"
+log "GET .../annotations?version=1 -> 200"
+
+# 17) Auth session rotation: the refresh cookie mints a fresh access token, and
+#     after logout it is revoked (rotation + revocation, ADR-0026).
+refresh_json="$(curl -sf -b "$COOKIES" -c "$COOKIES" -X POST "${BASE_URL}/api/v1/auth/refresh")"
+new_token="$(echo "$refresh_json" | jq -r '.accessToken')"
+[ -n "$new_token" ] && [ "$new_token" != "null" ] || fail "refresh did not return an access token"
+log "POST /api/v1/auth/refresh -> rotated access token"
+
+code="$(curl -s -o /dev/null -w '%{http_code}' -b "$COOKIES" -X POST "${BASE_URL}/api/v1/auth/logout")"
+[ "$code" = "204" ] || fail "POST /api/v1/auth/logout -> HTTP $code (expected 204)"
+code="$(curl -s -o /dev/null -w '%{http_code}' -b "$COOKIES" -X POST "${BASE_URL}/api/v1/auth/refresh")"
+[ "$code" = "401" ] || fail "refresh after logout -> HTTP $code (expected 401 — token revoked)"
+log "logout revokes the refresh family (replay -> 401)"
 
 log "ALL SMOKE CHECKS PASSED"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -191,12 +191,23 @@ log "GET .../annotations?version=1 -> 200"
 #     after logout it is revoked (rotation + revocation, ADR-0026). /auth/refresh
 #     and /auth/logout are CSRF-protected by a double-submit cookie token (#175):
 #     the server sets a (non-HttpOnly) XSRF-TOKEN cookie that must be echoed back
-#     as the X-XSRF-TOKEN header, so we read it from the jar for each call.
-xsrf() { awk '$6=="XSRF-TOKEN"{v=$7} END{print v}' "$COOKIES"; }
-[ -n "$(xsrf)" ] || fail "login did not set the XSRF-TOKEN cookie"
+#     as the X-XSRF-TOKEN header. Prime it from a response's Set-Cookie header
+#     (into the jar via -c), with a jar fallback, so the cookie and header match.
+csrf_hdrs="$(
+  curl -sf -D - -o /dev/null -b "$COOKIES" -c "$COOKIES" \
+    -H "Authorization: Bearer ${TOKEN}" "${BASE_URL}/api/v1/users/me"
+)"
+XSRF="$(printf '%s' "$csrf_hdrs" | tr -d '\r' |
+  sed -n 's/^[Ss]et-[Cc]ookie: *XSRF-TOKEN=\([^;]*\).*/\1/p' | tail -1)"
+[ -n "$XSRF" ] || XSRF="$(awk '$6=="XSRF-TOKEN"{v=$7} END{print v}' "$COOKIES")"
+if [ -z "$XSRF" ]; then
+  echo "[smoke] cookie jar contents:" >&2
+  cat "$COOKIES" >&2
+  fail "no XSRF-TOKEN cookie was issued (double-submit CSRF token, #175)"
+fi
 
 refresh_json="$(
-  curl -sf -b "$COOKIES" -c "$COOKIES" -H "X-XSRF-TOKEN: $(xsrf)" \
+  curl -sf -b "$COOKIES" -c "$COOKIES" -H "X-XSRF-TOKEN: ${XSRF}" \
     -X POST "${BASE_URL}/api/v1/auth/refresh"
 )"
 new_token="$(echo "$refresh_json" | jq -r '.accessToken')"
@@ -205,7 +216,7 @@ log "POST /api/v1/auth/refresh -> rotated access token"
 
 code="$(
   curl -s -o /dev/null -w '%{http_code}' -b "$COOKIES" -c "$COOKIES" \
-    -H "X-XSRF-TOKEN: $(xsrf)" -X POST "${BASE_URL}/api/v1/auth/logout"
+    -H "X-XSRF-TOKEN: ${XSRF}" -X POST "${BASE_URL}/api/v1/auth/logout"
 )"
 [ "$code" = "204" ] || fail "POST /api/v1/auth/logout -> HTTP $code (expected 204)"
 
@@ -213,7 +224,7 @@ code="$(
 # check and must be rejected as unauthorized rather than blocked earlier.
 code="$(
   curl -s -o /dev/null -w '%{http_code}' -b "$COOKIES" \
-    -H "X-XSRF-TOKEN: $(xsrf)" -X POST "${BASE_URL}/api/v1/auth/refresh"
+    -H "X-XSRF-TOKEN: ${XSRF}" -X POST "${BASE_URL}/api/v1/auth/refresh"
 )"
 [ "$code" = "401" ] || fail "refresh after logout -> HTTP $code (expected 401 — token revoked)"
 log "logout revokes the refresh family (replay -> 401)"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -188,15 +188,33 @@ code="$(acode GET "/api/v1/documents/${doc_id}/annotations?version=1")"
 log "GET .../annotations?version=1 -> 200"
 
 # 17) Auth session rotation: the refresh cookie mints a fresh access token, and
-#     after logout it is revoked (rotation + revocation, ADR-0026).
-refresh_json="$(curl -sf -b "$COOKIES" -c "$COOKIES" -X POST "${BASE_URL}/api/v1/auth/refresh")"
+#     after logout it is revoked (rotation + revocation, ADR-0026). /auth/refresh
+#     and /auth/logout are CSRF-protected by a double-submit cookie token (#175):
+#     the server sets a (non-HttpOnly) XSRF-TOKEN cookie that must be echoed back
+#     as the X-XSRF-TOKEN header, so we read it from the jar for each call.
+xsrf() { awk '$6=="XSRF-TOKEN"{v=$7} END{print v}' "$COOKIES"; }
+[ -n "$(xsrf)" ] || fail "login did not set the XSRF-TOKEN cookie"
+
+refresh_json="$(
+  curl -sf -b "$COOKIES" -c "$COOKIES" -H "X-XSRF-TOKEN: $(xsrf)" \
+    -X POST "${BASE_URL}/api/v1/auth/refresh"
+)"
 new_token="$(echo "$refresh_json" | jq -r '.accessToken')"
 [ -n "$new_token" ] && [ "$new_token" != "null" ] || fail "refresh did not return an access token"
 log "POST /api/v1/auth/refresh -> rotated access token"
 
-code="$(curl -s -o /dev/null -w '%{http_code}' -b "$COOKIES" -X POST "${BASE_URL}/api/v1/auth/logout")"
+code="$(
+  curl -s -o /dev/null -w '%{http_code}' -b "$COOKIES" -c "$COOKIES" \
+    -H "X-XSRF-TOKEN: $(xsrf)" -X POST "${BASE_URL}/api/v1/auth/logout"
+)"
 [ "$code" = "204" ] || fail "POST /api/v1/auth/logout -> HTTP $code (expected 204)"
-code="$(curl -s -o /dev/null -w '%{http_code}' -b "$COOKIES" -X POST "${BASE_URL}/api/v1/auth/refresh")"
+
+# Replay the (revoked) family — CSRF still satisfied, so this reaches the auth
+# check and must be rejected as unauthorized rather than blocked earlier.
+code="$(
+  curl -s -o /dev/null -w '%{http_code}' -b "$COOKIES" \
+    -H "X-XSRF-TOKEN: $(xsrf)" -X POST "${BASE_URL}/api/v1/auth/refresh"
+)"
 [ "$code" = "401" ] || fail "refresh after logout -> HTTP $code (expected 401 — token revoked)"
 log "logout revokes the refresh family (replay -> 401)"
 

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -23,13 +23,21 @@ Path svg = TestData.path("branding/logomark.svg");
 
 ```
 testdata/
-└── branding/                 # branding upload fixtures (issue #106)
-    ├── logo-light.png        # valid 320×96 RGBA PNG — "TEST LOGO" wordmark (navy text)
-    ├── logo-dark.png         # valid 320×96 RGBA PNG — "TEST LOGO" wordmark (white text), for "replace"
-    ├── logomark.svg          # valid, clean SVG — "T" mark
-    ├── unsafe.svg            # hostile SVG (script + onload + javascript: link) for sanitization
-    └── not-an-image.txt      # plain text — must be rejected as an unsupported type (415)
+├── branding/                 # branding upload fixtures (issue #106)
+│   ├── logo-light.png        # valid 320×96 RGBA PNG — "TEST LOGO" wordmark (navy text)
+│   ├── logo-dark.png         # valid 320×96 RGBA PNG — "TEST LOGO" wordmark (white text), for "replace"
+│   ├── logomark.svg          # valid, clean SVG — "T" mark
+│   ├── unsafe.svg            # hostile SVG (script + onload + javascript: link) for sanitization
+│   └── not-an-image.txt      # plain text — must be rejected as an unsupported type (415)
+├── db/                       # deterministic SQL fixtures (issue #163)
+│   ├── clean.sql             # wipes the seeded tables to a known-empty slate
+│   └── seed.sql              # the shared seeded dataset (users, team, OIDC provider)
+└── documents/                # review document payloads (issue #308)
+    └── sample.pdf            # minimal valid single-page PDF, text "QNOP SMOKE TEST"
 ```
 
-Add new fixture families as sibling directories (e.g. `db/` seed scripts,
-`documents/` review payloads) as the suites that need them land.
+The `documents/sample.pdf` fixture backs the ingest smoke test: it is uploaded,
+the extraction job renders it, and the smoke asserts the extracted text — so it
+must stay a real, PDFBox-parsable PDF with extractable text.
+
+Add new fixture families as sibling directories as the suites that need them land.

--- a/testdata/documents/sample.pdf
+++ b/testdata/documents/sample.pdf
@@ -1,0 +1,34 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 47 >>
+stream
+BT /F1 24 Tf 72 700 Td (QNOP SMOKE TEST) Tj ET
+
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000344 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+414
+%%EOF


### PR DESCRIPTION
## Summary

The CI smoke test asserted only a thin base slice (health, config, admin login, `GET /admin/users`, `GET /users/me`). The entire **document-review + object-storage** subsystem shipped since (#243–#252, #295) and had **no** smoke coverage — and `docker-compose.smoke.yml` even omitted MinIO, so real S3 wiring, the scheduled extraction job and PDFBox extraction never ran against the built image. This closes that gap.

## Changes
- **Stack:** add a **MinIO** service to `docker-compose.smoke.yml`; wire the app's `QNOP_S3_*` env with `auto-create-bucket`. `app` now `depends_on` MinIO healthy.
- **Fixture:** `testdata/documents/sample.pdf` — a minimal valid single-page PDF (text `QNOP SMOKE TEST`), **verified to parse with the app's own `PdfBoxDocumentExtractor`** before committing.
- **Script (`scripts/smoke-test.sh`):** new stages over real HTTP against the deployed image —
  - unauthenticated `GET /users/me` → **401** (security gate);
  - admin `settings` / `teams` and per-user `settings` reads → 200;
  - **ingest pipeline:** upload the PDF (with a future `dueAt`) → poll versions until extraction is **READY** (real MinIO read + PDFBox via the scheduled poller) → fetch the **rendered** representation and assert the extracted text → stream the **original** back and assert it is **byte-identical**;
  - **review lifecycle:** due date set-at-create then cleared via `PATCH` (#295); overview lists the document; **Draft → In review** workflow transition; annotations list;
  - **auth sessions:** refresh-token **rotation**, then **logout** revokes the family (replay → 401).
- **Docs:** `testdata/README.md` documents the new `documents/` and `db/` fixture families.

## Assessment (why this is the right coverage)
The IT suite (#163) already covers behavioural branches with Testcontainers and a manual `poller.poll()`. The smoke test's distinct value is proving the *deployed container* works end-to-end against real infra — object storage, the auto-scheduled job, bucket creation, the rendered-JSON contract, and cookie-based session rotation — none of which the ITs exercise. Kept fast and deterministic (bounded ~150s extraction poll, fail-fast).

## Test plan
- [x] `bash -n scripts/smoke-test.sh`; compose YAML sane; fixture validated by `PdfBoxDocumentExtractor` + `file` (PDF 1.4, 1 page).
- [ ] CI **Smoke (docker-compose deploy + testdata)** green — the only place this runs (no local Docker).

Closes #308

🤖 Co-Author: Claude (Opus 4.x) via Claude Code