### PR TITLE
fix(core): dedup only COMMITTED storage rows; re-upload poisoned PENDING keys

### DIFF
--- a/qnop-app/src/test/java/io/qnop/storage/StorageServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/storage/StorageServiceIT.java
@@ -24,10 +24,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.StorageObjectStatus;
 import io.qnop.repository.StorageObjectRepository;
 import io.qnop.service.storage.StagedObject;
 import io.qnop.service.storage.StorageService;
 import io.qnop.spi.storage.StorageContent;
+import io.qnop.spi.storage.StorageProvider;
 import java.io.ByteArrayInputStream;
 import java.security.MessageDigest;
 import java.util.HexFormat;
@@ -46,6 +48,7 @@ class StorageServiceIT extends AbstractIntegrationTest {
 
   @Autowired private StorageService storage;
   @Autowired private StorageObjectRepository repository;
+  @Autowired private StorageProvider provider;
   @Autowired private JdbcTemplate jdbc;
 
   private static byte[] uniqueContent() {
@@ -84,6 +87,26 @@ class StorageServiceIT extends AbstractIntegrationTest {
 
     assertThat(staged.contentHash()).isEqualTo(expected);
     assertThat(staged.key()).isEqualTo("sha256/" + expected.substring(0, 2) + "/" + expected);
+    storage.delete(staged.key());
+  }
+
+  @Test
+  void reStagingHealsAPoisonedPendingRow() {
+    // Reproduce the #289 poisoning: a PENDING registry row whose object is missing (a put that
+    // failed after the row was persisted). Stage, then delete only the object — the row stays.
+    byte[] data = uniqueContent();
+    StagedObject staged = stage(data, "application/pdf");
+    provider.delete(staged.key());
+    assertThat(provider.exists(staged.key())).isFalse();
+    assertThat(repository.findByObjectKey(staged.key()))
+        .hasValueSatisfying(
+            row -> assertThat(row.getStatus()).isEqualTo(StorageObjectStatus.PENDING));
+
+    // Re-staging identical content must re-upload rather than trust the poisoned row.
+    StagedObject restaged = stage(data, "application/pdf");
+
+    assertThat(restaged.key()).isEqualTo(staged.key());
+    assertThat(provider.exists(staged.key())).isTrue();
     storage.delete(staged.key());
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
@@ -72,9 +72,15 @@ public class StorageService {
   }
 
   /**
-   * Buffers the content (to compute its hash and length), uploads it under a content-addressed key,
-   * and records a {@code PENDING} registry row. Idempotent for identical content: an already-known
-   * key is returned without re-uploading (dedup).
+   * Buffers the content (to compute its hash and length), records a {@code PENDING} registry row,
+   * and uploads it under a content-addressed key.
+   *
+   * <p><strong>Dedup is authoritative only for {@code COMMITTED} rows</strong> (issue #289): a
+   * {@code PENDING} row can be <em>poisoned</em> — it is persisted before {@code put}, so a failed
+   * upload leaves a row with no object behind it. On a {@code PENDING} hit (or a lost concurrent
+   * insert race), the object's real existence is checked and it is (re-)uploaded when missing;
+   * {@code put} is idempotent for a content-addressed key + identical bytes, so this self-heals a
+   * failed earlier upload without ever returning a key that points at nothing.
    */
   public StagedObject stage(InputStream content, String contentType) {
     Path buffer = bufferToTempFile(content);
@@ -83,25 +89,38 @@ public class StorageService {
       long size = sizeOf(buffer);
       String key = keyFor(hash);
 
-      if (repository.findByObjectKey(key).isPresent()) {
-        return new StagedObject(key, hash, size); // dedup: content already stored
+      Optional<StorageObject> existing = repository.findByObjectKey(key);
+      if (existing.map(o -> o.getStatus() == StorageObjectStatus.COMMITTED).orElse(false)) {
+        return new StagedObject(key, hash, size); // authoritative dedup: the object is durable
       }
       // Persist the PENDING row (in Spring Data's own transaction) BEFORE the upload, so a crash
       // between the two always leaves a row the reaper can reclaim. A concurrent stage of identical
-      // content may win the unique-key race first — treat that as dedup.
-      try {
-        repository.save(StorageObject.pending(key, hash, contentType, size));
-      } catch (DataIntegrityViolationException e) {
-        return new StagedObject(key, hash, size);
+      // content may win the unique-key race — its row is only PENDING (the object may be missing),
+      // so we still verify-and-(re)upload below rather than trusting it.
+      boolean rowPreexisted = existing.isPresent();
+      if (!rowPreexisted) {
+        try {
+          repository.save(StorageObject.pending(key, hash, contentType, size));
+        } catch (DataIntegrityViolationException e) {
+          rowPreexisted = true;
+        }
       }
-      try (InputStream in = Files.newInputStream(buffer)) {
-        provider.put(key, in, size, contentType);
-      } catch (IOException e) {
-        throw new StorageException("Failed to read buffered upload for " + key, e);
+      // A freshly inserted row always needs the upload; a pre-existing PENDING row (possibly
+      // poisoned, mid-flight, or a race winner's) needs it only when the object is actually absent.
+      if (!rowPreexisted || !provider.exists(key)) {
+        uploadBuffered(buffer, key, size, contentType);
       }
       return new StagedObject(key, hash, size);
     } finally {
       deleteQuietly(buffer);
+    }
+  }
+
+  private void uploadBuffered(Path buffer, String key, long size, String contentType) {
+    try (InputStream in = Files.newInputStream(buffer)) {
+      provider.put(key, in, size, contentType);
+    } catch (IOException e) {
+      throw new StorageException("Failed to read buffered upload for " + key, e);
     }
   }
 

--- a/qnop-core/src/test/java/io/qnop/service/storage/StorageServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/StorageServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.StorageObject;
+import io.qnop.repository.StorageObjectRepository;
+import io.qnop.spi.storage.StorageProvider;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * DB-free unit tests for {@link StorageService#stage} dedup correctness (issue #289): only {@code
+ * COMMITTED} rows are authoritative, and a {@code PENDING} row is (re-)uploaded when the object is
+ * actually missing — so a failed earlier {@code put} can never poison the key.
+ */
+class StorageServiceTest {
+
+  private final StorageProvider provider = mock(StorageProvider.class);
+  private final StorageObjectRepository repository = mock(StorageObjectRepository.class);
+  private final StorageService storage =
+      new StorageService(provider, repository, mock(S3Properties.class));
+
+  private static InputStream content() {
+    return new ByteArrayInputStream("some qnop document bytes".getBytes());
+  }
+
+  private static StorageObject pendingRow() {
+    return StorageObject.pending("k", "h", "application/pdf", 1L);
+  }
+
+  private static StorageObject committedRow() {
+    StorageObject row = pendingRow();
+    row.markCommitted(Instant.now());
+    return row;
+  }
+
+  @Test
+  @DisplayName("a COMMITTED hit dedups without uploading or a HEAD check")
+  void committedRowIsAuthoritativeDedup() {
+    when(repository.findByObjectKey(anyString())).thenReturn(Optional.of(committedRow()));
+
+    storage.stage(content(), "application/pdf");
+
+    verify(provider, never()).put(anyString(), any(), anyLong(), anyString());
+    verify(provider, never()).exists(anyString());
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("a poisoned PENDING hit (object missing) re-uploads — the fix")
+  void pendingRowWithMissingObjectIsReuploaded() {
+    when(repository.findByObjectKey(anyString())).thenReturn(Optional.of(pendingRow()));
+    when(provider.exists(anyString())).thenReturn(false);
+
+    storage.stage(content(), "application/pdf");
+
+    verify(provider).exists(anyString());
+    verify(provider).put(anyString(), any(), anyLong(), eq("application/pdf"));
+    verify(repository, never()).save(any()); // row already exists — not re-inserted
+  }
+
+  @Test
+  @DisplayName("a PENDING hit whose object exists (mid-flight) is not re-uploaded")
+  void pendingRowWithExistingObjectIsNotReuploaded() {
+    when(repository.findByObjectKey(anyString())).thenReturn(Optional.of(pendingRow()));
+    when(provider.exists(anyString())).thenReturn(true);
+
+    storage.stage(content(), "application/pdf");
+
+    verify(provider).exists(anyString());
+    verify(provider, never()).put(anyString(), any(), anyLong(), anyString());
+  }
+
+  @Test
+  @DisplayName("fresh content inserts the row and uploads, with no wasted HEAD check")
+  void freshContentInsertsAndUploads() {
+    when(repository.findByObjectKey(anyString())).thenReturn(Optional.empty());
+
+    storage.stage(content(), "application/pdf");
+
+    verify(repository).save(any(StorageObject.class));
+    verify(provider, never()).exists(anyString());
+    verify(provider).put(anyString(), any(), anyLong(), eq("application/pdf"));
+  }
+
+  @Test
+  @DisplayName("a lost insert race (DataIntegrityViolation) still verify-and-(re)uploads")
+  void concurrentInsertRaceIsVerifiedNotTrusted() {
+    when(repository.findByObjectKey(anyString())).thenReturn(Optional.empty());
+    when(repository.save(any())).thenThrow(new DataIntegrityViolationException("dup key"));
+    when(provider.exists(anyString())).thenReturn(false); // race winner's put had failed too
+
+    storage.stage(content(), "application/pdf");
+
+    verify(provider).exists(anyString());
+    verify(provider, times(1)).put(anyString(), any(), anyLong(), eq("application/pdf"));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #289. `StorageService.stage()` deduplicated on registry-row **presence**
alone. But a `PENDING` row is persisted **before** `provider.put(...)` (so a
crash leaves something for the reaper) — which means a `put` that throws leaves a
**poisoned** `PENDING` row with no object behind it. A later upload of identical
content matched that row, skipped the `put`, and let the caller `commit()`: the
`DocumentVersion` then referenced an object that never existed (extraction failed
permanently, `GET …/original` → 500, and no self-healing, since the reaper
ignores `COMMITTED` rows). Any transient S3 blip during an upload plants a
poisoned row for exactly the content the user immediately retries.

## Fix

- Only `COMMITTED` rows are authoritative dedup hits (fast path, no HEAD).
- On a `PENDING` hit — or a lost concurrent-insert race
  (`DataIntegrityViolationException`, which had the identical blind spot) —
  verify the object's real existence via `provider.exists()` and **(re-)upload
  when it is missing**. `put` is idempotent for a content-addressed key +
  identical bytes, so this self-heals a failed earlier upload.
- A freshly inserted row uploads directly (no wasted HEAD); a `PENDING` row whose
  object *does* exist (mid-flight between stage and commit) is not re-uploaded.

No SPI change — `StorageProvider.exists()` already existed.

## Test plan

- **`StorageServiceTest`** (new, DB-free, Mockito): COMMITTED → no put/exists;
  poisoned PENDING (`exists=false`) → re-put; mid-flight PENDING (`exists=true`) →
  no re-put; fresh content → save+put without exists; DataIntegrityViolation race
  → verify-and-re-put.
- **`StorageServiceIT`** (MinIO, CI): `reStagingHealsAPoisonedPendingRow` — stage,
  delete only the object to poison the PENDING row, re-stage identical content,
  assert the object exists again.
- `spotlessApply` + compile + ArchUnit + `StorageServiceTest` green locally; the
  MinIO IT runs in CI.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code