### PR TITLE
fix(ui): keep the review viewer polling after a new-version upload (#300)

### DIFF
--- a/qnop-ui/src/api/hooks/useDocuments.test.tsx
+++ b/qnop-ui/src/api/hooks/useDocuments.test.tsx
@@ -20,8 +20,8 @@
  */
 
 import type { ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { RenderedDocumentResponse } from '../generated';
 import { ExtractionStatus } from '../generated';
@@ -89,6 +89,101 @@ describe('useDocumentVersions', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(documentsApi.listDocumentVersions).toHaveBeenCalledWith({ documentId: DOC_ID });
     expect(result.current.data?.versions).toHaveLength(1);
+  });
+
+  // Regression for issue #300: right after a new-version upload the cached list may
+  // not contain the watched version yet. Polling must run BOTH while the version is
+  // missing from the list AND while it is PENDING — otherwise the viewer sticks on
+  // "Processing document…" until a manual reload.
+  describe('extraction polling (issue #300)', () => {
+    const v1Ready = { versionNumber: 1, extractionStatus: ExtractionStatus.Ready };
+    const v2Pending = { versionNumber: 2, extractionStatus: ExtractionStatus.Pending };
+    const v2Ready = { versionNumber: 2, extractionStatus: ExtractionStatus.Ready };
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('polls while the watched version is missing, then while PENDING, and stops on READY', async () => {
+      vi.useFakeTimers();
+      const responses = [
+        { versions: [v1Ready] }, // stale list — v2 uploaded but not refetched yet
+        { versions: [v1Ready, v2Pending] }, // v2 appears, extraction running
+        { versions: [v1Ready, v2Ready] }, // extraction finished
+      ];
+      let call = 0;
+      vi.mocked(documentsApi.listDocumentVersions).mockImplementation(
+        async () =>
+          ({ data: responses[Math.min(call++, responses.length - 1)] }) as Awaited<
+            ReturnType<typeof documentsApi.listDocumentVersions>
+          >,
+      );
+
+      const { result } = renderHook(() => useDocumentVersions(DOC_ID, 2), { wrapper });
+
+      // Initial fetch resolves with the stale list (v2 missing).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(documentsApi.listDocumentVersions).toHaveBeenCalledTimes(1);
+
+      // The watched version is absent → the list is stale → a poll tick must fire.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+      expect(documentsApi.listDocumentVersions).toHaveBeenCalledTimes(2);
+
+      // v2 is PENDING → keep polling until READY.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+      expect(documentsApi.listDocumentVersions).toHaveBeenCalledTimes(3);
+      expect(result.current.data?.versions).toContainEqual(v2Ready);
+
+      // READY → polling stops.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+      expect(documentsApi.listDocumentVersions).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not poll without a watched version', async () => {
+      vi.useFakeTimers();
+      vi.mocked(documentsApi.listDocumentVersions).mockResolvedValue({
+        data: { versions: [v1Ready] },
+      } as Awaited<ReturnType<typeof documentsApi.listDocumentVersions>>);
+
+      renderHook(() => useDocumentVersions(DOC_ID, undefined), { wrapper });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+      expect(documentsApi.listDocumentVersions).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not poll forever for an out-of-range version (stale/tampered URL)', async () => {
+      vi.useFakeTimers();
+      // Only v1 exists; a URL asking for v999 must not keep the list polling —
+      // that version is more than one above the max and can never appear.
+      vi.mocked(documentsApi.listDocumentVersions).mockResolvedValue({
+        data: { versions: [v1Ready] },
+      } as Awaited<ReturnType<typeof documentsApi.listDocumentVersions>>);
+
+      renderHook(() => useDocumentVersions(DOC_ID, 999), { wrapper });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(documentsApi.listDocumentVersions).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+      expect(documentsApi.listDocumentVersions).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/qnop-ui/src/api/hooks/useDocuments.ts
+++ b/qnop-ui/src/api/hooks/useDocuments.ts
@@ -53,9 +53,12 @@ export function useDocument(documentId: string) {
 }
 
 /**
- * The document's version list, oldest first. While the given version's server-side
- * extraction (ADR-0032) is still PENDING the list is re-polled, so the viewer
- * flips to annotatable as soon as the rendered representation is READY.
+ * The document's version list, oldest first. The list is re-polled while the
+ * watched version's server-side extraction (ADR-0032) is still PENDING — and
+ * also while the watched version is missing from the cached list entirely
+ * (right after a new-version upload the list may still be stale, issue #300) —
+ * so the viewer flips to annotatable as soon as the rendered representation is
+ * READY, without a manual reload or a window-focus refetch.
  */
 export function useDocumentVersions(documentId: string, watchVersion?: number) {
   return useQuery<DocumentVersionListResponse>({
@@ -66,8 +69,18 @@ export function useDocumentVersions(documentId: string, watchVersion?: number) {
     },
     refetchInterval: (query) => {
       if (!watchVersion) return false;
-      const watched = query.state.data?.versions.find((v) => v.versionNumber === watchVersion);
-      return watched?.extractionStatus === ExtractionStatus.Pending ? EXTRACTION_POLL_MS : false;
+      const versions = query.state.data?.versions;
+      const watched = versions?.find((v) => v.versionNumber === watchVersion);
+      if (!watched) {
+        // A watched version the cached list does not know yet means the list is
+        // stale — poll until it appears. Bound this to the plausibly-next
+        // version (one above the current max): an out-of-range version (a stale
+        // or tampered `?version=` URL) never arrives, so it must not poll
+        // forever.
+        const maxKnown = versions?.reduce((max, v) => Math.max(max, v.versionNumber), 0) ?? 0;
+        return watchVersion <= maxKnown + 1 ? EXTRACTION_POLL_MS : false;
+      }
+      return watched.extractionStatus === ExtractionStatus.Pending ? EXTRACTION_POLL_MS : false;
     },
   });
 }

--- a/qnop-ui/src/api/hooks/useReviews.test.tsx
+++ b/qnop-ui/src/api/hooks/useReviews.test.tsx
@@ -40,6 +40,7 @@ import {
   useUploadVersion,
   useWorkflow,
 } from './useReviews';
+import { documentKeys } from './useDocuments';
 import { axiosInstance, documentsApi, principalsApi, reviewWorkflowApi } from '../config';
 
 vi.mock('../config', () => ({
@@ -196,5 +197,32 @@ describe('uploads', () => {
     await result.current.mutateAsync({ file });
 
     expect(vi.mocked(axiosInstance.post).mock.calls[0][0]).toBe(`/documents/${DOC_ID}/versions`);
+  });
+
+  // Regression for issue #300: the review page derives the effective version from
+  // detail.latestVersionNumber; a stale value right after the upload made the page
+  // watch the OLD version (polling off) and stick on "Processing document…". The
+  // upload response is authoritative, so the cache must be bumped synchronously.
+  it('bumps the cached latestVersionNumber from the upload response', async () => {
+    vi.mocked(axiosInstance.post).mockResolvedValue({
+      data: { documentId: DOC_ID, versionNumber: 2, extractionStatus: 'PENDING' },
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(documentKeys.detail(DOC_ID), {
+      id: DOC_ID,
+      title: 'Contract',
+      latestVersionNumber: 1,
+    });
+    const clientWrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useUploadVersion(DOC_ID), { wrapper: clientWrapper });
+    await result.current.mutateAsync({ file: new File(['%PDF'], 'v2.pdf') });
+
+    expect(
+      (queryClient.getQueryData(documentKeys.detail(DOC_ID)) as { latestVersionNumber: number })
+        .latestVersionNumber,
+    ).toBe(2);
   });
 });

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -22,6 +22,7 @@
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   DocumentListResponse,
+  DocumentResponse,
   ParticipantCreateRequest,
   ParticipantListResponse,
   PrincipalListResponse,
@@ -225,7 +226,20 @@ export function useUploadVersion(documentId: string) {
       );
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
+      // The upload response is authoritative about the new version number. Bump the
+      // cached document detail synchronously so the review page immediately resolves
+      // and watches the new version (its extraction polling then runs) instead of
+      // falling back to the stale latestVersionNumber until the refetch below lands
+      // (issue #300). The versions list itself converges via invalidation + polling.
+      queryClient.setQueryData<DocumentResponse>(documentKeys.detail(documentId), (detail) =>
+        detail
+          ? {
+              ...detail,
+              latestVersionNumber: Math.max(detail.latestVersionNumber, result.versionNumber),
+            }
+          : detail,
+      );
       queryClient.invalidateQueries({ queryKey: documentKeys.all });
       queryClient.invalidateQueries({ queryKey: reviewKeys.all });
     },

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -27,6 +27,7 @@ import type { AnnotationView, RenderedSurface } from '../../api/generated';
 import { AnnotationStatus, ExtractionStatus, PlacementStatus } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { DocumentReviewPage } from './DocumentReviewPage';
+import { resolveEffectiveVersion } from './resolveEffectiveVersion';
 import {
   useDocument,
   useDocumentVersions,
@@ -183,6 +184,36 @@ function renderPage() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+// Issue #300: the effective version must honor the URL as soon as ANY loaded
+// source (document detail or the version list) knows it — a stale
+// latestVersionNumber right after an upload must not push the page back onto
+// the old version (which would switch extraction polling off).
+describe('resolveEffectiveVersion', () => {
+  it('uses the requested version when the detail already knows it', () => {
+    expect(resolveEffectiveVersion(2, 2, [1, 2])).toBe(2);
+  });
+
+  it('uses the requested version when only the version list knows it (stale detail)', () => {
+    expect(resolveEffectiveVersion(2, 1, [1, 2])).toBe(2);
+  });
+
+  it('uses the requested version when only the detail knows it (stale list)', () => {
+    expect(resolveEffectiveVersion(2, 2, [1])).toBe(2);
+  });
+
+  it('falls back to the highest known version when the requested one is unknown', () => {
+    expect(resolveEffectiveVersion(9, 2, [1, 2])).toBe(2);
+  });
+
+  it('falls back to the latest without a requested version', () => {
+    expect(resolveEffectiveVersion(NaN, 3, [1, 2, 3])).toBe(3);
+  });
+
+  it('is undefined while nothing is known yet', () => {
+    expect(resolveEffectiveVersion(2, 0, [])).toBeUndefined();
+  });
 });
 
 describe('DocumentReviewPage', () => {

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -57,6 +57,7 @@ import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
 import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
 import { useAuthStore } from '../../stores/authStore';
+import { resolveEffectiveVersion } from './resolveEffectiveVersion';
 
 const PANEL_WIDTH_KEY = 'qnop-review-panel-width';
 
@@ -76,14 +77,19 @@ export function DocumentReviewPage() {
   const documentQuery = useDocument(documentId);
   const latestVersion = documentQuery.data?.latestVersionNumber ?? 0;
   const requestedVersion = Number(searchParams.get('version'));
-  const versionNumber =
-    requestedVersion >= 1 && requestedVersion <= latestVersion
-      ? requestedVersion
-      : latestVersion >= 1
-        ? latestVersion
-        : undefined;
 
-  const versionsQuery = useDocumentVersions(documentId, versionNumber);
+  // Watch the URL's version even when the cached list does not know it yet —
+  // right after an upload the list is briefly stale, and useDocumentVersions
+  // polls until the watched version appears and its extraction settles (#300).
+  const versionsQuery = useDocumentVersions(
+    documentId,
+    requestedVersion >= 1 ? requestedVersion : latestVersion >= 1 ? latestVersion : undefined,
+  );
+  const versionNumber = resolveEffectiveVersion(
+    requestedVersion,
+    latestVersion,
+    versionsQuery.data?.versions.map((version) => version.versionNumber) ?? [],
+  );
   const versionSummary = versionsQuery.data?.versions.find(
     (version) => version.versionNumber === versionNumber,
   );

--- a/qnop-ui/src/pages/reviews/resolveEffectiveVersion.ts
+++ b/qnop-ui/src/pages/reviews/resolveEffectiveVersion.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Resolves the version to show: the requested one when any loaded source (the
+ * document detail's `latestVersionNumber` or the version list itself) already
+ * knows it, otherwise the highest known version. Clamping against BOTH sources
+ * closes the stale-detail window right after a new-version upload, where the
+ * URL says `?version=2` but the cached detail still reports 1 (issue #300).
+ */
+export function resolveEffectiveVersion(
+  requestedVersion: number,
+  latestFromDetail: number,
+  knownVersionNumbers: number[],
+): number | undefined {
+  const maxKnown = Math.max(latestFromDetail, ...knownVersionNumbers, 0);
+  if (requestedVersion >= 1 && requestedVersion <= maxKnown) return requestedVersion;
+  return maxKnown >= 1 ? maxKnown : undefined;
+}


### PR DESCRIPTION
## Summary

Fixes #300. After uploading a new version via the review head's **New version** button (`?version=2` navigation), the viewer stuck on *"The document is being processed…"* for seconds — indefinitely in a headless session — although extraction was already `READY`; only a manual reload recovered.

**Root cause.** The review page derived the watched version from the document detail's `latestVersionNumber`, which lags the `?version=` navigation right after the upload. The page then watched the old, already-`READY` version, so `useDocumentVersions`' extraction poll switched off and the banner never flipped — the versions cache meanwhile held a transient `PENDING` snapshot that nothing refreshed.

## Changes

Three complementary layers close the race:

- **`DocumentReviewPage.tsx`** — watch the requested URL version directly (not clamped to the stale latest), so polling arms for the new version immediately. The *displayed* version is resolved separately.
- **`resolveEffectiveVersion.ts`** (new) — resolve the shown version against **both** the detail's `latestVersionNumber` and the version list, so a stale detail can't push the page back onto the old version.
- **`useDocuments.ts`** — poll the version list while the watched version is `PENDING` **or not yet present**, bounded to the plausibly-next version so a stale/tampered `?version=` URL can't poll forever.
- **`useReviews.ts`** — optimistically bump the cached `latestVersionNumber` from the authoritative upload response, so the page resolves the new version synchronously.

## Test plan

- [x] `pnpm test:run` — **367 passed**, incl. new coverage: fake-timer polling (missing → PENDING → READY → stop), the out-of-range-version bound, the `resolveEffectiveVersion` table, and the upload cache-bump regression.
- [x] `pnpm typecheck` — clean (API client regenerated).
- [x] `pnpm lint` — clean.
- [ ] Manual: upload a new version in a running review and confirm the viewer flips to the annotatable text layer within a couple of seconds without a reload.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code