### PR TITLE
fix: authorize workflow status reads and drop entity leak from web (#311, #315)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1619,6 +1619,8 @@ paths:
         transition list is empty for terminal states and for states this
         edition's state machine does not manage.
       operationId: getDocumentWorkflow
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: The current workflow status.
@@ -1648,6 +1650,8 @@ paths:
         annotations and zero PENDING placements (re-anchoring complete) — or
         when the current or target state is not managed by this edition.
       operationId: transitionDocumentWorkflow
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:

--- a/qnop-app/src/main/java/io/qnop/web/ReviewWorkflowController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ReviewWorkflowController.java
@@ -23,7 +23,6 @@ package io.qnop.web;
 import io.qnop.api.v1.endpoint.ReviewWorkflowApi;
 import io.qnop.api.v1.model.WorkflowStatus;
 import io.qnop.api.v1.model.WorkflowTransitionRequest;
-import io.qnop.entity.WorkflowState;
 import io.qnop.service.review.ReviewWorkflowService;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -46,7 +45,8 @@ public class ReviewWorkflowController implements ReviewWorkflowApi {
 
   @Override
   public ResponseEntity<WorkflowStatus> getDocumentWorkflow(UUID documentId) {
-    return ResponseEntity.ok(toDto(workflow.status(documentId)));
+    UUID actor = CurrentUser.requireUserId();
+    return ResponseEntity.ok(toDto(workflow.status(documentId, actor, CurrentUser.isAdmin())));
   }
 
   @Override
@@ -60,6 +60,6 @@ public class ReviewWorkflowController implements ReviewWorkflowApi {
   private static WorkflowStatus toDto(ReviewWorkflowService.WorkflowStatus status) {
     return new WorkflowStatus()
         .state(status.state())
-        .allowedTransitions(status.allowedTransitions().stream().map(WorkflowState::name).toList());
+        .allowedTransitions(status.allowedTransitions());
   }
 }

--- a/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
@@ -32,12 +32,14 @@ import io.qnop.entity.AnnotationStatus;
 import io.qnop.entity.AuditEvent;
 import io.qnop.entity.Document;
 import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
 import io.qnop.entity.WorkflowState;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.service.review.ReviewWorkflowService;
 import io.qnop.testsupport.SeededIntegrationTest;
 import java.util.UUID;
@@ -59,6 +61,7 @@ class ReviewWorkflowControllerIT extends SeededIntegrationTest {
   @Autowired AnnotationRepository annotations;
   @Autowired AnnotationPlacementRepository placements;
   @Autowired AuditEventRepository auditEvents;
+  @Autowired ReviewParticipantRepository participants;
   @Autowired ReviewWorkflowService workflow;
 
   private Document draftOwnedByMember() {
@@ -78,16 +81,54 @@ class ReviewWorkflowControllerIT extends SeededIntegrationTest {
   // --- GET ---------------------------------------------------------------------
 
   @Test
-  void getReturnsStateAndStructurallyAllowedTransitions() throws Exception {
+  void ownerReadsStateAndStructurallyAllowedTransitions() throws Exception {
     Document document = draftOwnedByMember();
+
+    mockMvc
+        .perform(
+            get(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.state").value("DRAFT"))
+        .andExpect(jsonPath("$.allowedTransitions.length()").value(2));
+  }
+
+  @Test
+  void participantMayReadTheWorkflow() throws Exception {
+    Document document = draftOwnedByMember();
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
 
     mockMvc
         .perform(
             get(workflowPath(document.getId()))
                 .header("Authorization", "Bearer " + token(MEMBER2_ID)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.state").value("DRAFT"))
-        .andExpect(jsonPath("$.allowedTransitions.length()").value(2));
+        .andExpect(jsonPath("$.state").value("DRAFT"));
+  }
+
+  @Test
+  void adminMayReadTheWorkflow() throws Exception {
+    Document document = draftOwnedByMember();
+
+    mockMvc
+        .perform(
+            get(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(ADMIN_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.state").value("DRAFT"));
+  }
+
+  @Test
+  void nonParticipantGetIsRejectedWith404() throws Exception {
+    // A visible-to-nobody document must not leak its existence (issue #311): 404, not 403.
+    Document document = draftOwnedByMember();
+
+    mockMvc
+        .perform(
+            get(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(MEMBER2_ID)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOCUMENT_NOT_FOUND"));
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -30,6 +30,7 @@ import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
+import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.review.ReviewWorkflowMachine.TransitionContext;
 import io.qnop.service.review.ReviewWorkflowMachine.TransitionResult;
 import java.util.List;
@@ -59,25 +60,40 @@ public class ReviewWorkflowService {
   private final AnnotationRepository annotations;
   private final AnnotationPlacementRepository placements;
   private final AuditEventRepository auditEvents;
+  private final DocumentAccessService documentAccess;
 
   public ReviewWorkflowService(
       DocumentRepository documents,
       AnnotationRepository annotations,
       AnnotationPlacementRepository placements,
-      AuditEventRepository auditEvents) {
+      AuditEventRepository auditEvents,
+      DocumentAccessService documentAccess) {
     this.documents = documents;
     this.annotations = annotations;
     this.placements = placements;
     this.auditEvents = auditEvents;
+    this.documentAccess = documentAccess;
   }
 
-  /** The workflow view of a document: its raw state and the structurally reachable targets. */
-  public record WorkflowStatus(String state, List<WorkflowState> allowedTransitions) {}
+  /**
+   * The workflow view of a document: its raw state and the structurally reachable target states as
+   * their names (kept as strings so the web layer maps them without depending on the entity enum,
+   * ADR-0004, issue #315).
+   */
+  public record WorkflowStatus(String state, List<String> allowedTransitions) {}
 
-  /** The current workflow status of a document (any authenticated principal may read it). */
+  /**
+   * The current workflow status of a document, readable by anyone who may see the document — its
+   * owner, a review participant (directly or via team), or an admin (issue #311). A non-participant
+   * gets a 404 (never a 403) so document ids stay non-enumerable, matching {@link
+   * DocumentAccessService}.
+   */
   @Transactional(readOnly = true)
-  public WorkflowStatus status(UUID documentId) {
+  public WorkflowStatus status(UUID documentId, UUID actorId, boolean admin) {
     Document document = load(documentId);
+    if (!documentAccess.isVisible(documentId, actorId, admin)) {
+      throw new DocumentNotFoundException(documentId);
+    }
     return statusOf(document);
   }
 
@@ -163,7 +179,10 @@ public class ReviewWorkflowService {
 
   private WorkflowStatus statusOf(Document document) {
     return new WorkflowStatus(
-        document.getWorkflowState(), machine.allowedTransitions(document.getWorkflowState()));
+        document.getWorkflowState(),
+        machine.allowedTransitions(document.getWorkflowState()).stream()
+            .map(WorkflowState::name)
+            .toList());
   }
 
   private Document load(UUID documentId) {


### PR DESCRIPTION
## Summary

Two HIGH backend findings from the ultimate code review, both touching `ReviewWorkflowController` + `ReviewWorkflowService`, so they land together.

**#311 — missing read authorization on `GET /documents/{documentId}/workflow`.**
The endpoint returned a document's workflow state and structural transitions to *any* authenticated principal, with no visibility check, and the operation had no `security` requirement in the OpenAPI contract. `ReviewWorkflowService.status(...)` now takes the actor + admin flag and delegates visibility to `DocumentAccessService.isVisible` — owner, participant (direct or via team), or admin may read; everyone else gets a **404 (never 403)**, matching the non-enumerable-id policy used across the document endpoints. Both workflow operations now declare `security: - bearerAuth: []`.

**#315 — entity enum leaked into the web layer (ADR-0004).**
The `WorkflowStatus` service record exposed `List<WorkflowState>` (the JPA entity enum), forcing the controller to import `io.qnop.entity.WorkflowState` and map enum→name. The record now returns `List<String>`; the enum→string conversion moves into the service, and the controller drops the entity import.

## Test plan

- [x] `ReviewWorkflowControllerIT`: owner / participant / admin read → 200; non-participant → 404 `DOCUMENT_NOT_FOUND`; unknown document → 404 (new + updated cases).
- [x] Local gate green: `spotlessApply`, `:qnop-core:build`, `:qnop-app:compileTestJava`, `ArchitectureRulesTest`.
- [ ] CI: full IT suite (Testcontainers) + client generation.

Closes #311
Closes #315

🤖 Co-Author: Claude (Opus 4.x) via Claude Code