### PR TITLE
fix(core): cap PDF page count to bound extraction DoS (issue #322)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/document/PdfBoxDocumentExtractor.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/PdfBoxDocumentExtractor.java
@@ -58,6 +58,14 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
 
   static final String PDF_CONTENT_TYPE = "application/pdf";
 
+  /**
+   * Upper bound on pages a single document may carry (issue #322). Per-page extraction is CPU- and
+   * heap-bound, so a crafted PDF with an enormous page count is a denial-of-service vector; a
+   * document beyond this cap is rejected as unprocessable rather than extracted. Generous for real
+   * legal/compliance documents while bounding the abuse case.
+   */
+  static final int MAX_PAGES = 2_000;
+
   @Override
   public boolean supports(String contentType) {
     return PDF_CONTENT_TYPE.equalsIgnoreCase(contentType);
@@ -76,8 +84,15 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
       if (document.isEncrypted()) {
         throw new ExtractionException("Encrypted PDFs are not supported");
       }
-      List<Surface> surfaces = new ArrayList<>(document.getNumberOfPages());
-      for (int pageIndex = 0; pageIndex < document.getNumberOfPages(); pageIndex++) {
+      int pageCount = document.getNumberOfPages();
+      if (pageCount > MAX_PAGES) {
+        // Reject before the CPU/heap-bound per-page loop: a crafted huge page count is a DoS
+        // vector, not a document to review (issue #322).
+        throw new ExtractionException(
+            "PDF has " + pageCount + " pages, exceeding the " + MAX_PAGES + "-page limit");
+      }
+      List<Surface> surfaces = new ArrayList<>(pageCount);
+      for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
         surfaces.add(extractSurface(document, pageIndex));
       }
       if (surfaces.isEmpty()) {

--- a/qnop-core/src/test/java/io/qnop/service/document/PdfBoxDocumentExtractorTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/PdfBoxDocumentExtractorTest.java
@@ -126,6 +126,28 @@ class PdfBoxDocumentExtractorTest {
   }
 
   @Test
+  @DisplayName("a PDF beyond the page limit is rejected before extraction (DoS guard, issue #322)")
+  void overSizedPageCountIsRejected() throws Exception {
+    byte[] tooManyPages = blankPdf(PdfBoxDocumentExtractor.MAX_PAGES + 1);
+
+    assertThatThrownBy(() -> extractor.extract(new ByteArrayInputStream(tooManyPages)))
+        .isInstanceOf(ExtractionException.class)
+        .hasMessageContaining(String.valueOf(PdfBoxDocumentExtractor.MAX_PAGES));
+  }
+
+  /** A PDF with {@code pages} empty pages (no content streams — cheap to build past the cap). */
+  private static byte[] blankPdf(int pages) throws IOException {
+    try (PDDocument document = new PDDocument()) {
+      for (int i = 0; i < pages; i++) {
+        document.addPage(new PDPage(PDRectangle.LETTER));
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      document.save(out);
+      return out.toByteArray();
+    }
+  }
+
+  @Test
   @DisplayName("spans carry glyph-true, non-decreasing per-character right edges (#290)")
   void spansCarryCharAdvances() throws Exception {
     byte[] pdf = pdf("Wim mi Wim"); // proportional font: W wide, i narrow


### PR DESCRIPTION
## Summary

Fixes #322. A crafted PDF with an enormous page count could exhaust CPU/heap in
`PdfBoxDocumentExtractor`'s per-page loop. Enforce a **`MAX_PAGES` (2000)** cap
checked **right after load, before the loop**: a document beyond it is rejected
as a permanent `ExtractionException`, so the extraction job ends `FAILED` (not
retried) instead of tying up a worker. 2000 is generous for real
legal/compliance documents while bounding the abuse case.

## Test plan

- New `overSizedPageCountIsRejected`: a PDF with `MAX_PAGES + 1` empty pages
  raises `ExtractionException` (message names the limit). Empty pages keep the
  test cheap — rejection happens before any per-page work.
- `spotlessApply` + `PdfBoxDocumentExtractorTest` + compile + ArchUnit green locally.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code