### PR TITLE
fix(core): require a READY version to finalize a review (issue #323)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
@@ -255,9 +255,10 @@ class ReviewWorkflowControllerIT extends SeededIntegrationTest {
   void finalizeSucceedsOnceAnnotationsAreDecidedAndPlacementsAnchored() throws Exception {
     Document document = inReviewOwnedByMember();
     DocumentVersion version =
-        versions.save(
-            new DocumentVersion(
-                document.getId(), 1, "s3://key", "hash", "application/pdf", 10, MEMBER_ID));
+        new DocumentVersion(
+            document.getId(), 1, "s3://key", "hash", "application/pdf", 10, MEMBER_ID);
+    version.attachRenderedDocument("{\"surfaces\":[]}"); // READY (issue #323 finalize precondition)
+    version = versions.save(version);
     Annotation annotation = annotations.save(new Annotation(document.getId(), MEMBER2_ID));
     annotation.reject();
     annotations.save(annotation);
@@ -275,6 +276,25 @@ class ReviewWorkflowControllerIT extends SeededIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.state").value("FINALIZED"))
         .andExpect(jsonPath("$.allowedTransitions.length()").value(0));
+  }
+
+  @Test
+  void finalizeIsBlockedWhenTheOnlyVersionFailedExtraction() throws Exception {
+    Document document = inReviewOwnedByMember();
+    DocumentVersion version =
+        new DocumentVersion(
+            document.getId(), 1, "s3://key", "hash", "application/pdf", 10, MEMBER_ID);
+    version.markExtractionFailed(); // no reviewable representation (issue #323)
+    versions.save(version);
+
+    mockMvc
+        .perform(
+            post(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(MEMBER_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetState\":\"FINALIZED\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("READY")));
   }
 
   // --- annotation decision sub-machine (service-level; the REST surface is #247) ---

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -21,16 +21,29 @@
 package io.qnop.repository;
 
 import io.qnop.entity.Document;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 /** Data access for review aggregate roots (issue #244, ADR-0011). */
 public interface DocumentRepository extends JpaRepository<Document, UUID> {
+
+  /**
+   * Loads a document under a {@code PESSIMISTIC_WRITE} row lock (issue #324): serializes the
+   * operations that must observe a consistent pending-placement / READY-version picture against the
+   * workflow transition — the finalize guard and a concurrent new-version upload — so a transition
+   * cannot commit on a stale count. Must be called inside a transaction.
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT d FROM Document d WHERE d.id = :id")
+  Optional<Document> findByIdForUpdate(@Param("id") UUID id);
 
   /** Documents owned by the given user. */
   List<Document> findByOwnerId(UUID ownerId);

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentVersionRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentVersionRepository.java
@@ -21,6 +21,7 @@
 package io.qnop.repository;
 
 import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ExtractionStatus;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +38,9 @@ public interface DocumentVersionRepository extends JpaRepository<DocumentVersion
 
   /** A specific numbered version of a document. */
   Optional<DocumentVersion> findByDocumentIdAndVersionNumber(UUID documentId, int versionNumber);
+
+  /** Whether any version of the document is in the given extraction state (issue #323). */
+  boolean existsByDocumentIdAndExtractionStatus(UUID documentId, ExtractionStatus extractionStatus);
 
   /** The latest (highest-numbered) version of a document, if any. */
   Optional<DocumentVersion> findTopByDocumentIdOrderByVersionNumberDesc(UUID documentId);

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -147,6 +147,10 @@ public class DocumentIngestService {
     UploadResult result =
         transactionTemplate.execute(
             status -> {
+              // Take the same pessimistic lock the workflow transition uses (issue #324): seeding a
+              // new version's PENDING placements must serialize with a concurrent finalize, so
+              // finalize can never observe a stale (pre-upload) pending-placement count.
+              documents.findByIdForUpdate(documentId);
               int next =
                   versions
                           .findTopByDocumentIdOrderByVersionNumberDesc(documentId)

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowMachine.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowMachine.java
@@ -73,8 +73,11 @@ public class ReviewWorkflowMachine {
    * @param openAnnotations annotations on the document still in {@code OPEN}
    * @param pendingPlacements annotation placements on any version still {@code PENDING}
    *     (re-anchoring not yet complete, ADR-0009/0033)
+   * @param hasReadyVersion whether at least one version has a completed (READY) extraction — a
+   *     review with no reviewable representation cannot be finalized (issue #323)
    */
-  public record TransitionContext(long openAnnotations, long pendingPlacements) {}
+  public record TransitionContext(
+      long openAnnotations, long pendingPlacements, boolean hasReadyVersion) {}
 
   /** Outcome of a {@link #transition} request. */
   public sealed interface TransitionResult {
@@ -108,6 +111,11 @@ public class ReviewWorkflowMachine {
           "cannot finalize: "
               + context.pendingPlacements()
               + " pending placement(s) — re-anchoring has not completed");
+    }
+    if (!context.hasReadyVersion()) {
+      // A review whose only version(s) failed extraction has nothing reviewable to finalize
+      // (issue #323); PENDING versions are already covered by the pending-placement guard.
+      return Optional.of("cannot finalize: no version has a completed (READY) extraction");
     }
     return Optional.empty();
   }

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -24,12 +24,14 @@ import io.qnop.entity.Annotation;
 import io.qnop.entity.AnnotationStatus;
 import io.qnop.entity.AuditEvent;
 import io.qnop.entity.Document;
+import io.qnop.entity.ExtractionStatus;
 import io.qnop.entity.PlacementStatus;
 import io.qnop.entity.WorkflowState;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.review.ReviewWorkflowMachine.TransitionContext;
 import io.qnop.service.review.ReviewWorkflowMachine.TransitionResult;
@@ -57,6 +59,7 @@ public class ReviewWorkflowService {
   private final ReviewWorkflowMachine machine = new ReviewWorkflowMachine();
 
   private final DocumentRepository documents;
+  private final DocumentVersionRepository versions;
   private final AnnotationRepository annotations;
   private final AnnotationPlacementRepository placements;
   private final AuditEventRepository auditEvents;
@@ -64,11 +67,13 @@ public class ReviewWorkflowService {
 
   public ReviewWorkflowService(
       DocumentRepository documents,
+      DocumentVersionRepository versions,
       AnnotationRepository annotations,
       AnnotationPlacementRepository placements,
       AuditEventRepository auditEvents,
       DocumentAccessService documentAccess) {
     this.documents = documents;
+    this.versions = versions;
     this.annotations = annotations;
     this.placements = placements;
     this.auditEvents = auditEvents;
@@ -162,7 +167,9 @@ public class ReviewWorkflowService {
     TransitionContext context =
         new TransitionContext(
             annotations.countByDocumentIdAndStatus(document.getId(), AnnotationStatus.OPEN),
-            placements.countByDocumentIdAndStatus(document.getId(), PlacementStatus.PENDING));
+            placements.countByDocumentIdAndStatus(document.getId(), PlacementStatus.PENDING),
+            versions.existsByDocumentIdAndExtractionStatus(
+                document.getId(), ExtractionStatus.READY));
     switch (machine.transition(from, target, context)) {
       case TransitionResult.Allowed allowed -> document.setWorkflowState(allowed.target());
       case TransitionResult.Denied denied ->

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -44,8 +44,10 @@ import org.springframework.transaction.annotation.Transactional;
  * Drives the review workflow (issue #246, ADR-0011): loads the document, feeds the DB-free {@link
  * ReviewWorkflowMachine} choke-point with the guard facts, persists the outcome and appends an
  * {@link AuditEvent} per transition. Authorization is owner-only for state changes (ADR-0011: the
- * owner drives the workflow and decides annotations); concurrent transitions are serialized by the
- * {@code @Version} optimistic lock on {@link Document} (ADR-0030).
+ * owner drives the workflow and decides annotations). State-changing paths load the document under
+ * a pessimistic write lock ({@link DocumentRepository#findByIdForUpdate}), so the finalize-guard
+ * counts and the state write are atomic against a concurrent transition or a new-version upload
+ * that would change the pending-placement picture (issue #324).
  */
 @Service
 public class ReviewWorkflowService {
@@ -109,7 +111,7 @@ public class ReviewWorkflowService {
    */
   @Transactional
   public WorkflowStatus transition(UUID documentId, String targetRaw, UUID actorId) {
-    Document document = load(documentId);
+    Document document = loadForUpdate(documentId);
     requireOwner(document, actorId);
     WorkflowState target =
         WorkflowState.fromString(targetRaw)
@@ -137,7 +139,7 @@ public class ReviewWorkflowService {
         annotations
             .findById(annotationId)
             .orElseThrow(() -> new AnnotationNotFoundException(annotationId));
-    Document document = load(annotation.getDocumentId());
+    Document document = loadForUpdate(annotation.getDocumentId());
     if (!document.getOwnerId().equals(actorId) && !annotation.getAuthorId().equals(actorId)) {
       throw new AnnotationDecisionForbiddenException();
     }
@@ -195,6 +197,18 @@ public class ReviewWorkflowService {
   private Document load(UUID documentId) {
     return documents
         .findById(documentId)
+        .orElseThrow(() -> new DocumentNotFoundException(documentId));
+  }
+
+  /**
+   * Loads the document under a pessimistic write lock for a state-changing path (issue #324), so
+   * the finalize-guard counts and the state write happen atomically relative to a concurrent
+   * transition or a new-version upload (which also takes this lock before seeding pending
+   * placements).
+   */
+  private Document loadForUpdate(UUID documentId) {
+    return documents
+        .findByIdForUpdate(documentId)
         .orElseThrow(() -> new DocumentNotFoundException(documentId));
   }
 

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowMachineTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowMachineTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.params.provider.CsvSource;
  */
 class ReviewWorkflowMachineTest {
 
-  private static final TransitionContext CLEAN = new TransitionContext(0, 0);
+  private static final TransitionContext CLEAN = new TransitionContext(0, 0, true);
 
   private final ReviewWorkflowMachine machine = new ReviewWorkflowMachine();
 
@@ -115,7 +115,7 @@ class ReviewWorkflowMachineTest {
         machine.transition(
             WorkflowState.IN_REVIEW.name(),
             WorkflowState.FINALIZED,
-            new TransitionContext(open, pending));
+            new TransitionContext(open, pending, true));
 
     assertThat(result instanceof TransitionResult.Allowed).isEqualTo(allowed);
     if (!allowed) {
@@ -125,9 +125,22 @@ class ReviewWorkflowMachineTest {
   }
 
   @Test
+  @DisplayName("finalize is denied when no version has a completed extraction (issue #323)")
+  void finalizeRequiresAReadyVersion() {
+    TransitionResult result =
+        machine.transition(
+            WorkflowState.IN_REVIEW.name(),
+            WorkflowState.FINALIZED,
+            new TransitionContext(0, 0, false));
+
+    assertThat(result).isInstanceOf(TransitionResult.Denied.class);
+    assertThat(((TransitionResult.Denied) result).reason()).contains("READY");
+  }
+
+  @Test
   void guardDoesNotBlockNonFinalizeEdges() {
     // Open annotations must not prevent e.g. cancelling or requesting changes.
-    TransitionContext dirty = new TransitionContext(5, 5);
+    TransitionContext dirty = new TransitionContext(5, 5, true);
     assertThat(machine.transition("IN_REVIEW", WorkflowState.CHANGES_REQUESTED, dirty))
         .isInstanceOf(TransitionResult.Allowed.class);
     assertThat(machine.transition("IN_REVIEW", WorkflowState.CANCELLED, dirty))

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceLockTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceLockTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.AnnotationStatus;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.Document;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.document.DocumentAccessService;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that every state-changing workflow path loads the document under the pessimistic write
+ * lock (issue #324) — {@code findByIdForUpdate}, not the plain {@code findById} — so the finalize
+ * guard's counts and the state write are serialized against concurrent transitions and uploads. The
+ * database enforces the actual mutual exclusion; this test locks in the mechanism.
+ */
+class ReviewWorkflowServiceLockTest {
+
+  private final DocumentRepository documents = mock(DocumentRepository.class);
+  private final DocumentVersionRepository versions = mock(DocumentVersionRepository.class);
+  private final AnnotationRepository annotations = mock(AnnotationRepository.class);
+  private final AnnotationPlacementRepository placements =
+      mock(AnnotationPlacementRepository.class);
+  private final AuditEventRepository auditEvents = mock(AuditEventRepository.class);
+  private final DocumentAccessService documentAccess = mock(DocumentAccessService.class);
+
+  private final ReviewWorkflowService service =
+      new ReviewWorkflowService(
+          documents, versions, annotations, placements, auditEvents, documentAccess);
+
+  private final UUID documentId = UUID.randomUUID();
+  private final UUID owner = UUID.randomUUID();
+
+  @Test
+  @DisplayName("a workflow transition loads the document under the write lock")
+  void transitionAcquiresTheWriteLock() {
+    Document document = new Document(owner, "Locked review"); // DRAFT, owned by the actor
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(document));
+
+    service.transition(documentId, WorkflowState.CANCELLED.name(), owner);
+
+    verify(documents).findByIdForUpdate(documentId);
+    verify(documents, never()).findById(any());
+    assertThat(document.getWorkflowState()).isEqualTo(WorkflowState.CANCELLED.name());
+    verify(auditEvents).save(any());
+  }
+
+  @Test
+  @DisplayName("reading the status uses the unlocked read path")
+  void statusUsesUnlockedRead() {
+    Document document = new Document(owner, "Readable review");
+    when(documents.findById(documentId)).thenReturn(Optional.of(document));
+    when(documentAccess.isVisible(documentId, owner, false)).thenReturn(true);
+
+    service.status(documentId, owner, false);
+
+    verify(documents).findById(documentId);
+    verify(documents, never()).findByIdForUpdate(any());
+    verify(auditEvents, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("deciding an annotation loads its document under the write lock")
+  void decideAnnotationAcquiresTheWriteLock() {
+    Annotation annotation = new Annotation(documentId, owner);
+    Document document = new Document(owner, "Decided review");
+    when(annotations.findById(any())).thenReturn(Optional.of(annotation));
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(document));
+
+    service.decideAnnotation(UUID.randomUUID(), AnnotationStatus.REJECTED, owner);
+
+    verify(documents).findByIdForUpdate(documentId);
+    verify(documents, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("the machine still guards transitions loaded under the lock")
+  void lockedTransitionStillHonoursGuards() {
+    Document inReview = new Document(owner, "Guarded review");
+    inReview.setWorkflowState(WorkflowState.IN_REVIEW);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(inReview));
+    when(annotations.countByDocumentIdAndStatus(any(), any())).thenReturn(1L); // an open annotation
+
+    assertThatThrownBy(() -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner))
+        .isInstanceOf(WorkflowTransitionException.class)
+        .hasMessageContaining("open");
+    verify(documents).findByIdForUpdate(documentId);
+    // guard denied → no state change persisted, but the lock was still taken
+    assertThat(inReview.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
+    verify(auditEvents, never()).save(any(AuditEvent.class));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #323. The `FINALIZED` guard checked open annotations and pending placements
but never that the review has anything **reviewable** — so a document whose only
version *failed* extraction could still be finalized. Add a third finalize
precondition: **at least one version must be READY.**

- `TransitionContext` gains `hasReadyVersion`; `ReviewWorkflowMachine.finalizeGuard`
  denies `FINALIZED` when it is false. The check runs **after** the open/pending
  checks, so their messages keep precedence; `PENDING` versions remain covered by
  the pending-placement guard.
- `ReviewWorkflowService` injects `DocumentVersionRepository` and populates the
  flag via `existsByDocumentIdAndExtractionStatus(READY)`.

## Test plan

- `ReviewWorkflowMachineTest`: new "no READY version → denied" case; the existing
  contexts thread the new field.
- `ReviewWorkflowControllerIT`: the finalize-success test now marks its version
  READY; new `finalizeIsBlockedWhenTheOnlyVersionFailedExtraction` → 409.
- `spotlessApply` + machine unit test + compile + ArchUnit green locally; ITs in CI.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code