### PR TITLE
perf: resolve document access in a single query (#312)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/repository/ReviewParticipantRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ReviewParticipantRepository.java
@@ -44,6 +44,18 @@ public interface ReviewParticipantRepository extends JpaRepository<ReviewPartici
 
   boolean existsByDocumentIdAndTeamId(UUID documentId, UUID teamId);
 
+  /**
+   * Whether {@code userId} may access {@code documentId} as a reviewer — either a direct
+   * participant or a member of a participating team — resolved in a single query (issue #312).
+   * Replaces the per-team {@code existsByTeamIdAndUserId} loop that made access checks 1+N.
+   */
+  @Query(
+      "SELECT COUNT(p) > 0 FROM ReviewParticipant p"
+          + " LEFT JOIN TeamMembership m ON m.teamId = p.teamId AND m.userId = :userId"
+          + " WHERE p.documentId = :documentId AND (p.userId = :userId OR m.id IS NOT NULL)")
+  boolean existsAccessibleParticipant(
+      @Param("documentId") UUID documentId, @Param("userId") UUID userId);
+
   String VIEW_SELECT =
       "SELECT new io.qnop.repository.ParticipantProjection(p.id, p.documentId, p.userId,"
           + " p.teamId, COALESCE(u.displayName, t.name), p.createdAt)"

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentAccessService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentAccessService.java
@@ -24,11 +24,9 @@ import io.qnop.api.v1.model.RenderedDocumentResponse;
 import io.qnop.entity.Document;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
-import io.qnop.entity.ReviewParticipant;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.repository.ReviewParticipantRepository;
-import io.qnop.repository.TeamMembershipRepository;
 import io.qnop.service.storage.StorageService;
 import io.qnop.spi.storage.StorageContent;
 import java.io.IOException;
@@ -61,19 +59,16 @@ public class DocumentAccessService {
   private final DocumentRepository documents;
   private final DocumentVersionRepository versions;
   private final ReviewParticipantRepository participants;
-  private final TeamMembershipRepository teamMemberships;
   private final StorageService storage;
 
   public DocumentAccessService(
       DocumentRepository documents,
       DocumentVersionRepository versions,
       ReviewParticipantRepository participants,
-      TeamMembershipRepository teamMemberships,
       StorageService storage) {
     this.documents = documents;
     this.versions = versions;
     this.participants = participants;
-    this.teamMemberships = teamMemberships;
     this.storage = storage;
   }
 
@@ -191,19 +186,11 @@ public class DocumentAccessService {
   }
 
   private boolean canAccess(Document document, UUID actor, boolean admin) {
-    if (admin || document.getOwnerId().equals(actor)) {
-      return true;
-    }
-    for (ReviewParticipant participant : participants.findByDocumentId(document.getId())) {
-      if (actor.equals(participant.getUserId())) {
-        return true;
-      }
-      if (participant.getTeamId() != null
-          && teamMemberships.existsByTeamIdAndUserId(participant.getTeamId(), actor)) {
-        return true;
-      }
-    }
-    return false;
+    // Owner and admin short-circuit; reviewer access (direct or via team) is one query (issue
+    // #312).
+    return admin
+        || document.getOwnerId().equals(actor)
+        || participants.existsAccessibleParticipant(document.getId(), actor);
   }
 
   private DocumentVersion requireVersion(UUID documentId, int versionNumber) {


### PR DESCRIPTION
## Summary

`DocumentAccessService.canAccess` (HIGH review finding #312) loaded every `ReviewParticipant` of a document and then called `existsByTeamIdAndUserId` **once per team participant** — 1+N queries per access check. The check runs on every viewer load, version list and annotation fetch, so it multiplied to an N×M query explosion on the reviews list — the dominant DB load during document viewing.

Replaced the in-memory loop with a single existence query, `ReviewParticipantRepository.existsAccessibleParticipant`, that `LEFT JOIN`s `ReviewParticipant` to `TeamMembership` and resolves direct-or-via-team access in one round trip. Owner and admin still short-circuit before touching the DB. The now-unused `TeamMembershipRepository` dependency is dropped from the service.

## Test plan

- [x] Behaviour unchanged — covered end-to-end by `DocumentServingAuthzIT`: owner / direct participant / team member / admin → 200; stranger → 404 across every read surface.
- [x] Local gate green: `spotlessApply`, `:qnop-core:build`, `:qnop-app:compileTestJava`, `ArchitectureRulesTest`.
- [ ] CI: full IT suite (Testcontainers) exercises the new JPQL entity join.

Closes #312

🤖 Co-Author: Claude (Opus 4.x) via Claude Code