### PR TITLE
fix(core): lock the document during workflow transitions (issue #324)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -21,16 +21,29 @@
 package io.qnop.repository;
 
 import io.qnop.entity.Document;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 /** Data access for review aggregate roots (issue #244, ADR-0011). */
 public interface DocumentRepository extends JpaRepository<Document, UUID> {
+
+  /**
+   * Loads a document under a {@code PESSIMISTIC_WRITE} row lock (issue #324): serializes the
+   * operations that must observe a consistent pending-placement / READY-version picture against the
+   * workflow transition — the finalize guard and a concurrent new-version upload — so a transition
+   * cannot commit on a stale count. Must be called inside a transaction.
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT d FROM Document d WHERE d.id = :id")
+  Optional<Document> findByIdForUpdate(@Param("id") UUID id);
 
   /** Documents owned by the given user. */
   List<Document> findByOwnerId(UUID ownerId);

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -147,6 +147,10 @@ public class DocumentIngestService {
     UploadResult result =
         transactionTemplate.execute(
             status -> {
+              // Take the same pessimistic lock the workflow transition uses (issue #324): seeding a
+              // new version's PENDING placements must serialize with a concurrent finalize, so
+              // finalize can never observe a stale (pre-upload) pending-placement count.
+              documents.findByIdForUpdate(documentId);
               int next =
                   versions
                           .findTopByDocumentIdOrderByVersionNumberDesc(documentId)

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -43,8 +43,10 @@ import org.springframework.transaction.annotation.Transactional;
  * Drives the review workflow (issue #246, ADR-0011): loads the document, feeds the DB-free {@link
  * ReviewWorkflowMachine} choke-point with the guard facts, persists the outcome and appends an
  * {@link AuditEvent} per transition. Authorization is owner-only for state changes (ADR-0011: the
- * owner drives the workflow and decides annotations); concurrent transitions are serialized by the
- * {@code @Version} optimistic lock on {@link Document} (ADR-0030).
+ * owner drives the workflow and decides annotations). State-changing paths load the document under
+ * a pessimistic write lock ({@link DocumentRepository#findByIdForUpdate}), so the finalize-guard
+ * counts and the state write are atomic against a concurrent transition or a new-version upload
+ * that would change the pending-placement picture (issue #324).
  */
 @Service
 public class ReviewWorkflowService {
@@ -93,7 +95,7 @@ public class ReviewWorkflowService {
    */
   @Transactional
   public WorkflowStatus transition(UUID documentId, String targetRaw, UUID actorId) {
-    Document document = load(documentId);
+    Document document = loadForUpdate(documentId);
     requireOwner(document, actorId);
     WorkflowState target =
         WorkflowState.fromString(targetRaw)
@@ -121,7 +123,7 @@ public class ReviewWorkflowService {
         annotations
             .findById(annotationId)
             .orElseThrow(() -> new AnnotationNotFoundException(annotationId));
-    Document document = load(annotation.getDocumentId());
+    Document document = loadForUpdate(annotation.getDocumentId());
     if (!document.getOwnerId().equals(actorId) && !annotation.getAuthorId().equals(actorId)) {
       throw new AnnotationDecisionForbiddenException();
     }
@@ -176,6 +178,18 @@ public class ReviewWorkflowService {
   private Document load(UUID documentId) {
     return documents
         .findById(documentId)
+        .orElseThrow(() -> new DocumentNotFoundException(documentId));
+  }
+
+  /**
+   * Loads the document under a pessimistic write lock for a state-changing path (issue #324), so
+   * the finalize-guard counts and the state write happen atomically relative to a concurrent
+   * transition or a new-version upload (which also takes this lock before seeding pending
+   * placements).
+   */
+  private Document loadForUpdate(UUID documentId) {
+    return documents
+        .findByIdForUpdate(documentId)
         .orElseThrow(() -> new DocumentNotFoundException(documentId));
   }
 

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceLockTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceLockTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.AnnotationStatus;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.Document;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that every state-changing workflow path loads the document under the pessimistic write
+ * lock (issue #324) — {@code findByIdForUpdate}, not the plain {@code findById} — so the finalize
+ * guard's counts and the state write are serialized against concurrent transitions and uploads. The
+ * database enforces the actual mutual exclusion; this test locks in the mechanism.
+ */
+class ReviewWorkflowServiceLockTest {
+
+  private final DocumentRepository documents = mock(DocumentRepository.class);
+  private final DocumentVersionRepository versions = mock(DocumentVersionRepository.class);
+  private final AnnotationRepository annotations = mock(AnnotationRepository.class);
+  private final AnnotationPlacementRepository placements =
+      mock(AnnotationPlacementRepository.class);
+  private final AuditEventRepository auditEvents = mock(AuditEventRepository.class);
+
+  private final ReviewWorkflowService service =
+      new ReviewWorkflowService(documents, versions, annotations, placements, auditEvents);
+
+  private final UUID documentId = UUID.randomUUID();
+  private final UUID owner = UUID.randomUUID();
+
+  @Test
+  @DisplayName("a workflow transition loads the document under the write lock")
+  void transitionAcquiresTheWriteLock() {
+    Document document = new Document(owner, "Locked review"); // DRAFT, owned by the actor
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(document));
+
+    service.transition(documentId, WorkflowState.CANCELLED.name(), owner);
+
+    verify(documents).findByIdForUpdate(documentId);
+    verify(documents, never()).findById(any());
+    assertThat(document.getWorkflowState()).isEqualTo(WorkflowState.CANCELLED.name());
+    verify(auditEvents).save(any());
+  }
+
+  @Test
+  @DisplayName("reading the status uses the unlocked read path")
+  void statusUsesUnlockedRead() {
+    Document document = new Document(owner, "Readable review");
+    when(documents.findById(documentId)).thenReturn(Optional.of(document));
+
+    service.status(documentId);
+
+    verify(documents).findById(documentId);
+    verify(documents, never()).findByIdForUpdate(any());
+    verify(auditEvents, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("deciding an annotation loads its document under the write lock")
+  void decideAnnotationAcquiresTheWriteLock() {
+    Annotation annotation = new Annotation(documentId, owner);
+    Document document = new Document(owner, "Decided review");
+    when(annotations.findById(any())).thenReturn(Optional.of(annotation));
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(document));
+
+    service.decideAnnotation(UUID.randomUUID(), AnnotationStatus.REJECTED, owner);
+
+    verify(documents).findByIdForUpdate(documentId);
+    verify(documents, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("the machine still guards transitions loaded under the lock")
+  void lockedTransitionStillHonoursGuards() {
+    Document inReview = new Document(owner, "Guarded review");
+    inReview.setWorkflowState(WorkflowState.IN_REVIEW);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(inReview));
+    when(annotations.countByDocumentIdAndStatus(any(), any())).thenReturn(1L); // an open annotation
+
+    assertThatThrownBy(() -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner))
+        .isInstanceOf(WorkflowTransitionException.class)
+        .hasMessageContaining("open");
+    verify(documents).findByIdForUpdate(documentId);
+    // guard denied → no state change persisted, but the lock was still taken
+    assertThat(inReview.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
+    verify(auditEvents, never()).save(any(AuditEvent.class));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #324. The finalize guard read the open-annotation / pending-placement /
READY-version facts and then wrote the new state within one transaction, but
nothing held a lock covering both. A concurrent transition — or a new-version
upload seeding fresh `PENDING` placements — could slip between the guard read and
the state write, letting a review finalize on a stale count.

Load the document under a **`PESSIMISTIC_WRITE`** lock on every state-changing path:

- `DocumentRepository.findByIdForUpdate` (`@Lock(PESSIMISTIC_WRITE)`).
- `ReviewWorkflowService.transition` and `decideAnnotation` load via it; `status()`
  keeps the unlocked read.
- `DocumentIngestService.addVersion` takes the **same** lock before seeding a new
  version's `PENDING` placements — so "adding pending work" and "finalizing"
  serialize on the one document row (single row lock ⇒ no lock-ordering deadlock).

## Test plan

- New `ReviewWorkflowServiceLockTest` (unit): the write paths load via
  `findByIdForUpdate` (never plain `findById`), `status()` uses the unlocked read,
  and the guard still denies under the lock. The database enforces the actual
  mutual exclusion.
- `spotlessApply` + workflow unit tests + compile + ArchUnit green locally; ITs in CI.

## Note

> ⚠️ **Stacked on #323** (`fix/issue-323-finalize-ready-guard`) — both touch the
> same guard/transition path. Merge #323 first; this PR's base will retarget to
> `main` automatically once #323 lands. The diff shown here is #324-only.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code