### PR TITLE
perf: batch placements and comment counts in annotation list (#313)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/repository/AnnotationCommentCount.java
+++ b/qnop-core/src/main/java/io/qnop/repository/AnnotationCommentCount.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/** Comment-thread size per annotation, for the annotation list (avoids an N+1). Issue #313. */
+public record AnnotationCommentCount(UUID annotationId, long count) {}

--- a/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
@@ -21,9 +21,12 @@
 package io.qnop.repository;
 
 import io.qnop.entity.Comment;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Data access for annotation comment threads (issue #244, ADR-0011). */
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
@@ -33,4 +36,14 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
   /** The size of an annotation's thread (issue #247). */
   long countByAnnotationId(UUID annotationId);
+
+  /**
+   * Thread sizes for a set of annotations in one aggregation (issue #313) — annotations with no
+   * comments are simply absent from the result, so the caller defaults them to 0.
+   */
+  @Query(
+      "SELECT new io.qnop.repository.AnnotationCommentCount(c.annotationId, COUNT(c))"
+          + " FROM Comment c WHERE c.annotationId IN :annotationIds GROUP BY c.annotationId")
+  List<AnnotationCommentCount> countByAnnotationIdIn(
+      @Param("annotationIds") Collection<UUID> annotationIds);
 }

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -20,12 +20,15 @@
  */
 package io.qnop.service.review;
 
+import static java.util.stream.Collectors.toMap;
+
 import io.qnop.entity.Annotation;
 import io.qnop.entity.AnnotationPlacement;
 import io.qnop.entity.AnnotationStatus;
 import io.qnop.entity.AuditEvent;
 import io.qnop.entity.Comment;
 import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.AnnotationCommentCount;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.AuditEventRepository;
@@ -35,6 +38,7 @@ import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.document.DocumentValidationException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -158,17 +162,21 @@ public class AnnotationService {
                 .findByDocumentIdAndVersionNumber(documentId, versionNumber)
                 .map(DocumentVersion::getId)
                 .orElse(null);
-    return annotations.findByDocumentId(documentId).stream()
+    List<Annotation> documentAnnotations = annotations.findByDocumentId(documentId);
+    // Batch the placements and comment counts (issue #313): one query each instead of 2N.
+    Map<UUID, AnnotationPlacement> placementByAnnotation =
+        versionId == null
+            ? Map.of()
+            : placements.findByDocumentVersionId(versionId).stream()
+                .collect(toMap(AnnotationPlacement::getAnnotationId, placement -> placement));
+    Map<UUID, Integer> threadSizeByAnnotation = threadSizes(documentAnnotations);
+    return documentAnnotations.stream()
         .map(
-            annotation -> {
-              AnnotationPlacement placement =
-                  versionId == null
-                      ? null
-                      : placements
-                          .findByAnnotationIdAndDocumentVersionId(annotation.getId(), versionId)
-                          .orElse(null);
-              return view(annotation, placement, threadSize(annotation.getId()));
-            })
+            annotation ->
+                view(
+                    annotation,
+                    placementByAnnotation.get(annotation.getId()),
+                    threadSizeByAnnotation.getOrDefault(annotation.getId(), 0)))
         .filter(view -> placementStatus == null || placementStatus.equals(view.placementStatus()))
         .toList();
   }
@@ -219,6 +227,16 @@ public class AnnotationService {
 
   private int threadSize(UUID annotationId) {
     return (int) comments.countByAnnotationId(annotationId);
+  }
+
+  /** Thread sizes for a batch of annotations in a single aggregation (issue #313). */
+  private Map<UUID, Integer> threadSizes(List<Annotation> forAnnotations) {
+    if (forAnnotations.isEmpty()) {
+      return Map.of();
+    }
+    List<UUID> ids = forAnnotations.stream().map(Annotation::getId).toList();
+    return comments.countByAnnotationIdIn(ids).stream()
+        .collect(toMap(AnnotationCommentCount::annotationId, count -> (int) count.count()));
   }
 
   private static AnnotationView view(


### PR DESCRIPTION
## Summary

`AnnotationService.list` (HIGH review finding #313) issued, **per annotation**, a placement lookup (`findByAnnotationIdAndDocumentVersionId`) plus a comment count (`countByAnnotationId`) — ~1+2N queries (≈41 for 20 annotations, hundreds across a page) and the dominant DB load during document viewing.

Now:
- placements for the requested version load in a single `findByDocumentVersionId` query, keyed into a `Map<annotationId, placement>`;
- thread sizes load as one grouped aggregation `CommentRepository.countByAnnotationIdIn` returning the new `AnnotationCommentCount` projection.

The per-annotation view is assembled in memory — **3 queries total** regardless of annotation count. Annotations with no comments are absent from the aggregation and default to 0.

## Test plan

- [x] Behaviour unchanged — the annotation list / placement-status filter is covered by `AnnotationApiIT`.
- [x] Local gate green: `spotlessApply`, `:qnop-core:build`, `:qnop-app:compileTestJava`, `ArchitectureRulesTest`.
- [ ] CI: full IT suite (Testcontainers).

Closes #313

🤖 Co-Author: Claude (Opus 4.x) via Claude Code