### PR TITLE
perf: run extraction I/O outside the DB transaction and stream large PDFs (#314)

### DIFF
--- a/docs/adr/0033-durable-async-job-execution-on-postgres.md
+++ b/docs/adr/0033-durable-async-job-execution-on-postgres.md
@@ -37,3 +37,10 @@ These are **data-critical**: losing a re-anchoring job would leave annotations s
 - **Spring `@Async` + thread pool.** Rejected: in-memory; a crash/restart mid-job loses the work and strands annotations `PENDING` permanently — unacceptable for re-anchoring.
 - **Redis / RabbitMQ / Kafka queue.** Rejected for now: pulls a broker into the On-Prem story early, against ADR-0013; Postgres-backed queues are well-proven at this scale (`FOR UPDATE SKIP LOCKED`).
 - **Spring Batch / Quartz.** Rejected: heavier than needed; we want a small, explicit, idempotent job table, not a scheduling framework.
+
+## Amendment (2026-07-04, issue #314)
+
+One refinement to the execution model; it refines, not reverses, the decision above.
+
+- **The job runner no longer holds a transaction across the handler.** The original `runOne` was `@Transactional`, so *handler effects and the `DONE` write committed atomically*. That was tidy but made the extraction handler pin a pooled DB connection for the entire S3 fetch + PDF parse (seconds); under concurrent uploads that exhausts the pool. `runOne` is now **non-transactional**: the handler runs with **no ambient transaction**, does its slow I/O connection-free, and owns the transaction around *its own* writes (the extraction handler's `READY`/`FAILED` writes moved into a small `DocumentExtractionWriter` bean so the `@Transactional` boundary is a real proxy call; the re-anchoring handler's `handle` is now itself `@Transactional`). `DONE` is then marked in a separate short transaction.
+- **The outbox guarantee is unchanged, and safety now rests entirely on idempotency.** The extraction→re-anchor enqueue still shares the `READY` write's transaction (outbox intact). What changes is that handler-effects and `DONE` are no longer one atomic unit — a crash in the gap re-runs the job, and the pre-existing, already-mandatory **idempotency** contract (a replay observing the terminal state is a no-op) covers that window. This trades a strong-but-costly atomicity for a brief connection hold, keeping the durability the data-criticality demands.

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
@@ -20,15 +20,10 @@
  */
 package io.qnop.service.document;
 
-import io.qnop.entity.AnnotationPlacement;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
-import io.qnop.entity.PlacementStatus;
-import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobHandler;
-import io.qnop.service.job.JobService;
-import io.qnop.service.review.ReanchorJobHandler;
 import io.qnop.service.storage.StorageService;
 import io.qnop.spi.extract.DocumentExtractor;
 import io.qnop.spi.extract.ExtractionException;
@@ -39,7 +34,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
@@ -51,6 +45,12 @@ import tools.jackson.databind.json.JsonMapper;
  * original from object storage, finds the {@link DocumentExtractor} for its content type, and
  * attaches the resulting {@link RenderedDocument} as jsonb — flipping the version's extraction
  * status to READY, or FAILED when the content itself is unprocessable.
+ *
+ * <p><strong>Transaction shape (issue #314).</strong> The slow work — the S3 fetch and PDF parsing
+ * — runs here with <em>no</em> DB transaction held (the job runner no longer wraps the handler, see
+ * ADR-0033). Only the resulting DB writes are transactional, and they live in {@link
+ * DocumentExtractionWriter} so the {@code @Transactional} boundary is a real proxy call. A network
+ * hang or a 50 MB parse therefore no longer pins a pooled connection.
  *
  * <p><strong>Failure policy:</strong> {@link ExtractionException} (corrupt/encrypted content) and a
  * missing extractor are <em>permanent</em> — the handler marks the version FAILED and completes, so
@@ -72,22 +72,17 @@ public class DocumentExtractionJobHandler implements JobHandler {
   private final DocumentVersionRepository versions;
   private final StorageService storage;
   private final List<DocumentExtractor> extractors;
-  private final AnnotationPlacementRepository placements;
-  // ObjectProvider breaks the constructor cycle: JobService injects every JobHandler, and this
-  // handler needs JobService back to enqueue the follow-up re-anchoring job (issue #248).
-  private final ObjectProvider<JobService> jobs;
+  private final DocumentExtractionWriter writer;
 
   public DocumentExtractionJobHandler(
       DocumentVersionRepository versions,
       StorageService storage,
       List<DocumentExtractor> extractors,
-      AnnotationPlacementRepository placements,
-      ObjectProvider<JobService> jobs) {
+      DocumentExtractionWriter writer) {
     this.versions = versions;
     this.storage = storage;
     this.extractors = extractors;
-    this.placements = placements;
-    this.jobs = jobs;
+    this.writer = writer;
   }
 
   @Override
@@ -116,12 +111,13 @@ public class DocumentExtractionJobHandler implements JobHandler {
           "No DocumentExtractor supports {} — marking version {} FAILED.",
           version.getContentType(),
           versionId);
-      version.markExtractionFailed();
-      versions.save(version);
-      failPendingPlacements(version);
+      writer.failPermanently(versionId);
       return;
     }
 
+    // The fetch + parse run with no DB transaction held (issue #314); only the write phase below
+    // opens a short transaction.
+    String renderedJson;
     try (StorageContent content =
         storage
             .get(version.getStorageKey())
@@ -130,47 +126,17 @@ public class DocumentExtractionJobHandler implements JobHandler {
                     new IllegalStateException( // retryable: the object should exist post-commit
                         "stored object missing for version " + versionId))) {
       RenderedDocument rendered = extractor.get().extract(content.stream());
-      version.attachRenderedDocument(MAPPER.writeValueAsString(rendered));
-      versions.save(version);
-      enqueueReanchoringIfPending(version);
+      renderedJson = MAPPER.writeValueAsString(rendered);
     } catch (ExtractionException e) {
       log.warn("Extraction of version {} failed permanently: {}", versionId, e.getMessage());
-      version.markExtractionFailed();
-      versions.save(version);
-      failPendingPlacements(version);
+      writer.failPermanently(versionId);
+      return;
     } catch (JacksonException e) {
       // Serializing our own SPI records can only fail on a code bug; add context and let the
       // queue's retry/FAILED policy surface it.
       throw new IllegalStateException("Failed to serialize rendered document", e);
     }
-  }
-
-  /**
-   * Chains the re-anchoring job (issue #248) once the text layer is READY — in the same transaction
-   * as the READY write (outbox, ADR-0033). Skipped when the version has no pending placements (v1
-   * uploads, documents without open annotations).
-   */
-  private void enqueueReanchoringIfPending(DocumentVersion version) {
-    if (!placements
-        .findByDocumentVersionIdAndStatus(version.getId(), PlacementStatus.PENDING)
-        .isEmpty()) {
-      jobs.getObject()
-          .enqueue(
-              ReanchorJobHandler.TYPE, DocumentIngestService.extractionPayload(version.getId()));
-    }
-  }
-
-  /**
-   * A version whose extraction failed permanently can never be re-anchored against: its pending
-   * placements become FAILED (deterministic on replay — they are only ever PENDING before this).
-   */
-  private void failPendingPlacements(DocumentVersion version) {
-    List<AnnotationPlacement> pending =
-        placements.findByDocumentVersionIdAndStatus(version.getId(), PlacementStatus.PENDING);
-    for (AnnotationPlacement placement : pending) {
-      placement.markFailed();
-      placements.save(placement);
-    }
+    writer.attachRenderedAndChain(versionId, renderedJson);
   }
 
   private static UUID parseVersionId(String payload) {

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionWriter.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionWriter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.document;
+
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ExtractionStatus;
+import io.qnop.entity.PlacementStatus;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.job.JobService;
+import io.qnop.service.review.ReanchorJobHandler;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The short, transactional write phase of document extraction (issue #314). Split out of {@link
+ * DocumentExtractionJobHandler} so the S3 fetch and PDF parsing run with <em>no</em> DB transaction
+ * held: the handler does the I/O, then calls one of these methods, each of which opens a brief
+ * transaction just for the DB writes. Being a separate bean is what makes the
+ * {@code @Transactional} boundary real — a self-invoked annotated method would bypass the proxy.
+ *
+ * <p>Every method re-loads the version by id and re-checks its status, so it is idempotent
+ * (ADR-0033): a replay after a crash observes the already-terminal state and is a no-op. The
+ * reanchor enqueue shares the READY write's transaction (the outbox, ADR-0033) so the follow-up job
+ * can never be lost.
+ */
+@Component
+class DocumentExtractionWriter {
+
+  private final DocumentVersionRepository versions;
+  private final AnnotationPlacementRepository placements;
+  // ObjectProvider breaks the constructor cycle: JobService injects every JobHandler, and the
+  // extraction path needs JobService back to enqueue the follow-up re-anchoring job (issue #248).
+  private final ObjectProvider<JobService> jobs;
+
+  DocumentExtractionWriter(
+      DocumentVersionRepository versions,
+      AnnotationPlacementRepository placements,
+      ObjectProvider<JobService> jobs) {
+    this.versions = versions;
+    this.placements = placements;
+    this.jobs = jobs;
+  }
+
+  /**
+   * Attaches the rendered representation, flips the version to READY, and — atomically, in the same
+   * transaction (outbox) — enqueues re-anchoring when the version has pending placements. A version
+   * that is already READY (a replay) is a no-op.
+   */
+  @Transactional
+  public void attachRenderedAndChain(UUID versionId, String renderedJson) {
+    DocumentVersion version = versions.findById(versionId).orElse(null);
+    if (version == null || version.getExtractionStatus() == ExtractionStatus.READY) {
+      return; // idempotent: deleted or already processed
+    }
+    version.attachRenderedDocument(renderedJson);
+    versions.save(version);
+    if (!placements
+        .findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING)
+        .isEmpty()) {
+      jobs.getObject()
+          .enqueue(ReanchorJobHandler.TYPE, DocumentIngestService.extractionPayload(versionId));
+    }
+  }
+
+  /**
+   * Marks the version FAILED permanently (unprocessable content or no extractor) and fails its
+   * pending placements — they can never be re-anchored against a version with no text layer. A
+   * version already FAILED (a replay) is a no-op.
+   */
+  @Transactional
+  public void failPermanently(UUID versionId) {
+    DocumentVersion version = versions.findById(versionId).orElse(null);
+    if (version == null || version.getExtractionStatus() == ExtractionStatus.FAILED) {
+      return; // idempotent: deleted or already failed
+    }
+    version.markExtractionFailed();
+    versions.save(version);
+    List<AnnotationPlacement> pending =
+        placements.findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING);
+    for (AnnotationPlacement placement : pending) {
+      placement.markFailed();
+      placements.save(placement);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/document/PdfBoxDocumentExtractor.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/PdfBoxDocumentExtractor.java
@@ -28,10 +28,14 @@ import io.qnop.spi.extract.Surface;
 import io.qnop.spi.extract.TextSpan;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.text.PDFTextStripper;
@@ -65,14 +69,11 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
 
   @Override
   public RenderedDocument extract(InputStream content) throws ExtractionException {
-    final byte[] bytes;
-    try {
-      bytes = content.readAllBytes();
-    } catch (IOException e) {
-      // Failing to read the caller-supplied stream is an I/O problem, not bad content: retryable.
-      throw new IllegalStateException("Failed to read PDF content", e);
-    }
-    try (PDDocument document = Loader.loadPDF(bytes)) {
+    // Spool to a temp file and let PDFBox page from disk (issue #314): loadPDF(byte[]) after
+    // readAllBytes held a 50 MB+ PDF fully in the heap; RandomAccessReadBufferedFile reads on
+    // demand, bounding memory to PDFBox's own buffers.
+    Path spooled = spoolToTempFile(content);
+    try (PDDocument document = Loader.loadPDF(new RandomAccessReadBufferedFile(spooled.toFile()))) {
       if (document.isEncrypted()) {
         throw new ExtractionException("Encrypted PDFs are not supported");
       }
@@ -87,6 +88,34 @@ public class PdfBoxDocumentExtractor implements DocumentExtractor {
     } catch (IOException e) {
       // PDFBox signals unparseable/corrupt input as IOException: the content is bad — permanent.
       throw new ExtractionException("Unreadable PDF: " + e.getMessage(), e);
+    } finally {
+      try {
+        Files.deleteIfExists(spooled);
+      } catch (IOException e) {
+        // Best-effort cleanup; the OS temp dir is swept eventually and a leak is not actionable.
+      }
+    }
+  }
+
+  private static Path spoolToTempFile(InputStream content) {
+    Path spooled;
+    try {
+      spooled = Files.createTempFile("qnop-pdf-", ".pdf");
+    } catch (IOException e) {
+      // A local-disk failure is an environment problem, not bad content: retryable.
+      throw new IllegalStateException("Failed to allocate a temp file for PDF extraction", e);
+    }
+    try (OutputStream out = Files.newOutputStream(spooled)) {
+      content.transferTo(out);
+      return spooled;
+    } catch (IOException e) {
+      try {
+        Files.deleteIfExists(spooled);
+      } catch (IOException suppressed) {
+        e.addSuppressed(suppressed);
+      }
+      // Failing to read the caller-supplied stream is an I/O problem, not bad content: retryable.
+      throw new IllegalStateException("Failed to buffer PDF content", e);
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/job/JobService.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobService.java
@@ -42,6 +42,14 @@ import org.springframework.transaction.annotation.Transactional;
  * (not self-invoked) so a handler failure rolls back its own effects without losing the failure
  * bookkeep, and so {@link #reapStale} can recover jobs stranded {@code RUNNING} by a crash.
  * Handlers are dispatched by {@code Job.type} and must be idempotent.
+ *
+ * <p><strong>Handler transactions (issue #314).</strong> {@link #runOne} deliberately runs the
+ * handler <em>without</em> an ambient transaction, so a handler doing slow I/O (an S3 fetch, a PDF
+ * parse) never pins a pooled DB connection for its whole duration. Each handler owns the
+ * transaction around its own writes, and the terminal {@code DONE} write is a separate short
+ * transaction. Handler-effects and {@code DONE} are therefore no longer one atomic unit — the
+ * mandatory idempotency (a re-run after a crash between the two is a no-op) is what keeps this
+ * safe.
  */
 @Service
 public class JobService {
@@ -82,11 +90,13 @@ public class JobService {
   }
 
   /**
-   * Runs one claimed job: dispatches its handler and marks it {@code DONE}. Handler effects and the
-   * {@code DONE} write are one transaction; a throwing handler rolls both back, and the caller
-   * records the failure separately. The {@code RUNNING} guard makes a re-run a no-op (idempotency).
+   * Runs one claimed job: dispatches its handler, then marks it {@code DONE}. Intentionally
+   * <em>not</em> {@code @Transactional} (issue #314) — the handler must be free to do slow I/O
+   * without holding a DB connection, so it owns the transaction around its own writes and this
+   * method marks {@code DONE} in a separate short transaction (via the repository). A throwing
+   * handler propagates to the caller, which records the failure; the {@code RUNNING} guard plus
+   * handler idempotency make a re-run a no-op.
    */
-  @Transactional
   public void runOne(UUID id) {
     Job job = repository.findById(id).orElse(null);
     if (job == null || job.getStatus() != JobStatus.RUNNING) {

--- a/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -73,7 +74,11 @@ public class ReanchorJobHandler implements JobHandler {
     return TYPE;
   }
 
+  // Its own transaction now that the job runner is non-transactional (issue #314): the
+  // per-placement
+  // writes still commit all-or-nothing, and it holds no external I/O so the connection is brief.
   @Override
+  @Transactional
   public void handle(String payload) {
     UUID versionId = parseVersionId(payload);
     Optional<DocumentVersion> found = versions.findById(versionId);

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3Configuration.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3Configuration.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -47,6 +48,12 @@ public class S3Configuration {
         S3Client.builder()
             .region(Region.of(properties.region()))
             .forcePathStyle(properties.pathStyleAccess())
+            // Bound every call so a hung storage op cannot pin a worker indefinitely (issue #314).
+            .overrideConfiguration(
+                ClientOverrideConfiguration.builder()
+                    .apiCallTimeout(properties.apiCallTimeout())
+                    .apiCallAttemptTimeout(properties.apiCallAttemptTimeout())
+                    .build())
             .credentialsProvider(
                 StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(properties.accessKey(), properties.secretKey())));

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3Properties.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3Properties.java
@@ -43,6 +43,10 @@ import org.springframework.validation.annotation.Validated;
  *     dev / tests against an empty MinIO — real S3 buckets are pre-provisioned)
  * @param reaperGracePeriod how long an uploaded-but-uncommitted object is kept before the orphan
  *     reaper deletes it (default 1h)
+ * @param apiCallTimeout hard ceiling on a whole S3 call including retries (default 60s); bounds a
+ *     hung extraction/serving job so it cannot pin a worker indefinitely (issue #314)
+ * @param apiCallAttemptTimeout ceiling on a single HTTP attempt before the SDK retries it (default
+ *     20s)
  */
 @ConfigurationProperties(prefix = "qnop.s3")
 @Validated
@@ -54,7 +58,9 @@ public record S3Properties(
     @NotBlank String secretKey,
     Boolean pathStyleAccess,
     Boolean autoCreateBucket,
-    Duration reaperGracePeriod) {
+    Duration reaperGracePeriod,
+    Duration apiCallTimeout,
+    Duration apiCallAttemptTimeout) {
 
   public S3Properties {
     endpoint = (endpoint == null || endpoint.isBlank()) ? null : endpoint.trim();
@@ -62,5 +68,8 @@ public record S3Properties(
     pathStyleAccess = pathStyleAccess == null ? Boolean.TRUE : pathStyleAccess;
     autoCreateBucket = autoCreateBucket == null ? Boolean.FALSE : autoCreateBucket;
     reaperGracePeriod = reaperGracePeriod == null ? Duration.ofHours(1) : reaperGracePeriod;
+    apiCallTimeout = apiCallTimeout == null ? Duration.ofSeconds(60) : apiCallTimeout;
+    apiCallAttemptTimeout =
+        apiCallAttemptTimeout == null ? Duration.ofSeconds(20) : apiCallAttemptTimeout;
   }
 }

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
@@ -72,8 +72,10 @@ class DocumentExtractionJobHandlerTest {
   }
 
   private DocumentExtractionJobHandler handler(DocumentExtractor... extractors) {
-    return new DocumentExtractionJobHandler(
-        versions, storage, List.of(extractors), placements, jobs);
+    // The write phase lives in DocumentExtractionWriter (issue #314); in this unit test it runs
+    // directly (no Spring proxy), over the same mocked repositories.
+    DocumentExtractionWriter writer = new DocumentExtractionWriter(versions, placements, jobs);
+    return new DocumentExtractionJobHandler(versions, storage, List.of(extractors), writer);
   }
 
   private static String payload(UUID versionId) {


### PR DESCRIPTION
## Summary

HIGH review finding #314: the extraction job held a DB transaction across its S3 fetch and PDF parse (seconds) — concurrent uploads could exhaust the connection pool — and read the whole PDF into the heap via `readAllBytes()`, risking OOM on 50 MB+ files.

### Transaction boundary (the HIGH)
- **`JobService.runOne` is no longer `@Transactional`.** The handler runs with no ambient transaction, does its slow I/O connection-free, and owns the transaction around its own writes; `DONE` is marked in a separate short transaction. Handler-effects and `DONE` are no longer one atomic unit — the already-mandatory **idempotency** (a replay observing the terminal state is a no-op) covers the crash gap.
- The extraction `READY`/`FAILED` writes and the **outbox reanchor enqueue** move into a new `DocumentExtractionWriter` `@Transactional` bean, so the boundary is a real proxy call, not a self-invocation. **The outbox guarantee is preserved.**
- `ReanchorJobHandler.handle` becomes `@Transactional` (it previously relied on the runner's ambient tx); it holds no external I/O, so its connection stays brief.
- **ADR-0033 amended** to record the shift and its idempotency rationale.

### Heap + hardening
- `PdfBoxDocumentExtractor` spools the stream to a temp file and parses via `RandomAccessReadBufferedFile`, so PDFBox pages from disk instead of holding the whole document in the heap. Temp file is deleted in `finally`.
- `S3Client` gets `apiCallTimeout` (60s) and `apiCallAttemptTimeout` (20s) — `qnop.s3.*` configurable — so a hung storage op cannot pin a worker indefinitely.

### Scoped out
The upload-materialization MEDIUM (`MultipartFile.getBytes`) is a larger cascading `byte[]→InputStream` refactor through `DocumentIngestService` and is tracked in **#361**.

## Test plan

- [x] `DocumentExtractionJobHandlerTest` updated for the writer split (failure policy + idempotency preserved).
- [x] Local gate green: `spotlessApply`, `:qnop-core:build` (unit tests incl. extractor / reanchor / job-backoff), `:qnop-app:compileTestJava`, `ArchitectureRulesTest`.
- [ ] CI: full IT suite (Testcontainers) exercises the ingest→extraction→reanchor pipeline end-to-end (`DocumentIngestIT`, smoke pipeline #308) under the new transaction shape.

Closes #314

🤖 Co-Author: Claude (Opus 4.x) via Claude Code