### PR TITLE
feat(ui): focus view mode — spotlight overlay for annotations (#291)

### DIFF
--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -123,6 +123,17 @@ describe('FocusAnnotationCard', () => {
     expect(props.onNavigate).not.toHaveBeenCalled();
   });
 
+  it('is resizable within hard bounds', () => {
+    renderCard();
+    const body = screen.getByTestId('focus-card-body');
+    const style = getComputedStyle(body);
+    expect(style.resize).toBe('both');
+    expect(style.minWidth).toBe('320px');
+    expect(style.minHeight).toBe('220px');
+    expect(style.maxWidth).toContain('640px');
+    expect(style.maxHeight).toContain('72vh');
+  });
+
   it('disables the ends of the walk and hides deciding from uninvolved users', () => {
     renderCard({
       position: { index: 0, count: 3, prevId: null, nextId: 'a3' },

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { FocusAnnotationCard } from './FocusAnnotationCard';
+
+vi.mock('../panel/CommentThread', () => ({
+  CommentThread: ({ annotationId }: { annotationId: string }) => (
+    <div data-testid={`thread-${annotationId}`}>
+      <textarea aria-label="Reply" />
+    </div>
+  ),
+}));
+
+const { decideMutate } = vi.hoisted(() => ({ decideMutate: vi.fn() }));
+vi.mock('../../../api/hooks/useAnnotations', () => ({
+  useDecideAnnotation: () => ({ mutate: decideMutate, isPending: false }),
+}));
+
+const ANNOTATION: AnnotationView = {
+  id: 'a2',
+  documentId: 'd1',
+  authorId: 'author-1',
+  status: AnnotationStatus.Open,
+  placementStatus: PlacementStatus.Placed,
+  anchor: {
+    region: { surfaceIndex: 0, box: { x: 0.1, y: 0.2, width: 0.3, height: 0.02 } },
+    textQuote: { quote: 'the disputed clause' },
+  },
+  commentCount: 2,
+  createdAt: '2026-07-01T10:00:00Z',
+  updatedAt: '2026-07-01T10:00:00Z',
+};
+
+let anchor: HTMLElement;
+
+beforeEach(() => {
+  anchor = document.createElement('button');
+  document.body.appendChild(anchor);
+});
+
+afterEach(() => {
+  anchor.remove();
+  decideMutate.mockClear();
+});
+
+function renderCard(overrides: Partial<Parameters<typeof FocusAnnotationCard>[0]> = {}) {
+  const props: Parameters<typeof FocusAnnotationCard>[0] = {
+    annotation: ANNOTATION,
+    anchorEl: anchor,
+    position: { index: 1, count: 3, prevId: 'a1', nextId: 'a3' },
+    onNavigate: vi.fn(),
+    onClose: vi.fn(),
+    ownerId: 'owner-1',
+    userId: 'author-1',
+    notify: vi.fn(),
+    ...overrides,
+  };
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <FocusAnnotationCard {...props} />
+    </ThemeProvider>,
+  );
+  return props;
+}
+
+describe('FocusAnnotationCard', () => {
+  it('shows the walk counter, quote, cues and the full thread', () => {
+    renderCard();
+    expect(screen.getByText('Annotation 2 of 3')).toBeInTheDocument();
+    expect(screen.getByText('“the disputed clause”')).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByTestId('thread-a2')).toBeInTheDocument();
+    // The author may decide their own annotation (ADR-0011).
+    expect(screen.getByTestId('decision-bar')).toBeInTheDocument();
+  });
+
+  it('walks prev/next via the buttons', () => {
+    const props = renderCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Previous annotation' }));
+    expect(props.onNavigate).toHaveBeenCalledWith('a1');
+    fireEvent.click(screen.getByRole('button', { name: 'Next annotation' }));
+    expect(props.onNavigate).toHaveBeenCalledWith('a3');
+  });
+
+  it('walks with the arrow keys and closes on Escape', () => {
+    const props = renderCard();
+    const card = screen.getByTestId('focus-annotation-card');
+    fireEvent.keyDown(card, { key: 'ArrowDown' });
+    expect(props.onNavigate).toHaveBeenCalledWith('a3');
+    fireEvent.keyDown(card, { key: 'ArrowUp' });
+    expect(props.onNavigate).toHaveBeenCalledWith('a1');
+    fireEvent.keyDown(card, { key: 'Escape' });
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('leaves the arrow keys to the caret inside text fields', () => {
+    const props = renderCard();
+    fireEvent.keyDown(screen.getByLabelText('Reply'), { key: 'ArrowDown' });
+    expect(props.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('disables the ends of the walk and hides deciding from uninvolved users', () => {
+    renderCard({
+      position: { index: 0, count: 3, prevId: null, nextId: 'a3' },
+      userId: 'stranger',
+    });
+    expect(screen.getByRole('button', { name: 'Previous annotation' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next annotation' })).toBeEnabled();
+    expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -21,7 +21,7 @@
 
 import type { KeyboardEvent } from 'react';
 import Box from '@mui/material/Box';
-import Fade from '@mui/material/Fade';
+import Grow from '@mui/material/Grow';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Popper from '@mui/material/Popper';
@@ -33,6 +33,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { ChevronDown, ChevronUp, X } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
+import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { STATUS_CUES } from '../panel/statusCues';
@@ -116,16 +117,19 @@ export function FocusAnnotationCard({
         { name: 'preventOverflow', options: { padding: 12 } },
       ]}
     >
-      {({ TransitionProps }) => (
-        <Fade
+      {({ TransitionProps, placement }) => (
+        <Grow
           {...TransitionProps}
           // The staged entrance: scrim first, then the card — collapsed to
           // instant under prefers-reduced-motion.
-          timeout={reducedMotion ? 0 : 180}
-          style={{ transitionDelay: reducedMotion ? '0ms' : '120ms' }}
+          timeout={reducedMotion ? 0 : 200}
+          style={{
+            transitionDelay: reducedMotion ? '0ms' : '120ms',
+            transformOrigin: placement.startsWith('left') ? 'right top' : 'left top',
+          }}
         >
           <Paper
-            elevation={8}
+            variant="outlined"
             data-testid="focus-annotation-card"
             onKeyDown={handleKeyDown}
             sx={{
@@ -134,17 +138,60 @@ export function FocusAnnotationCard({
               maxHeight: 'min(70vh, 560px)',
               display: 'flex',
               flexDirection: 'column',
-              borderRadius: 2,
-              overflow: 'hidden',
+              position: 'relative',
+              borderRadius: '10px',
+              // Bordered surface with ONE soft ambient shadow — the brand
+              // reads as borders, not elevation stacks (theme.ts); dark mode
+              // keeps the hairline edge only (shadows vanish on dark).
+              boxShadow: theme.palette.mode === 'light' ? tokens.shadow.lg : 'none',
+              // The pointer arrow sits just outside the border.
+              overflow: 'visible',
             }}
           >
+            {/* The prototype's card↔mark link cues: a status rail on the edge
+                facing the reader, and a pointer arrow toward the spotlit mark
+                (flips with the Popper placement). */}
+            <Box
+              aria-hidden
+              sx={{
+                position: 'absolute',
+                left: 0,
+                top: 10,
+                bottom: 10,
+                width: 3,
+                borderRadius: '0 3px 3px 0',
+                bgcolor: statusCue.color(theme),
+              }}
+            />
+            <Box
+              aria-hidden
+              data-testid="focus-card-arrow"
+              sx={{
+                position: 'absolute',
+                top: 16,
+                width: 0,
+                height: 0,
+                borderTop: '7px solid transparent',
+                borderBottom: '7px solid transparent',
+                ...(placement.startsWith('left')
+                  ? { right: -8, borderLeft: `8px solid ${statusCue.color(theme)}` }
+                  : { left: -8, borderRight: `8px solid ${statusCue.color(theme)}` }),
+              }}
+            />
             {/* Enforcement stays off: the card coexists with interactive marks
                 and the toolbar — clicking them must not yank focus (and the
                 window scroll) back into the card. Tab still cycles inside. */}
             <FocusTrap open disableRestoreFocus disableEnforceFocus>
               <Box
                 tabIndex={-1}
-                sx={{ display: 'flex', flexDirection: 'column', minHeight: 0, outline: 'none' }}
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  minHeight: 0,
+                  outline: 'none',
+                  borderRadius: '9px',
+                  overflow: 'hidden',
+                }}
               >
                 <Stack
                   direction="row"
@@ -158,9 +205,16 @@ export function FocusAnnotationCard({
                   }}
                 >
                   <Typography
-                    variant="caption"
+                    component="span"
                     aria-live="polite"
-                    sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
+                    sx={{
+                      fontSize: 10,
+                      fontWeight: 600,
+                      letterSpacing: '0.08em',
+                      textTransform: 'uppercase',
+                      color: 'text.secondary',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
                   >
                     {position
                       ? `Annotation ${position.index + 1} of ${position.count}`
@@ -207,6 +261,8 @@ export function FocusAnnotationCard({
                       color="text.secondary"
                       sx={{
                         fontStyle: 'italic',
+                        borderLeft: `2px solid ${theme.palette.divider}`,
+                        pl: 1,
                         display: '-webkit-box',
                         WebkitLineClamp: 3,
                         WebkitBoxOrient: 'vertical',
@@ -231,7 +287,7 @@ export function FocusAnnotationCard({
               </Box>
             </FocusTrap>
           </Paper>
-        </Fade>
+        </Grow>
       )}
     </Popper>
   );

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { KeyboardEvent } from 'react';
+import Box from '@mui/material/Box';
+import Fade from '@mui/material/Fade';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Popper from '@mui/material/Popper';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import FocusTrap from '@mui/material/Unstable_TrapFocus';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
+import { ChevronDown, ChevronUp, X } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import type { Notify } from '../../admin/layout/useToast';
+import { ToneBadge } from '../../admin/ToneBadge';
+import { STATUS_CUES } from '../panel/statusCues';
+import { CommentThread } from '../panel/CommentThread';
+import { DecisionBar } from '../panel/DecisionBar';
+import { mayDecideAnnotation, useDecideWithFeedback } from '../panel/decisions';
+import { PlacementStatusChip } from '../panel/PlacementStatusChip';
+import type { WalkPosition } from './spotlightModel';
+
+interface FocusAnnotationCardProps {
+  annotation: AnnotationView;
+  /** The spotlit mark element the card floats next to. */
+  anchorEl: HTMLElement | null;
+  /** Position among the placed annotations; null for an unplaced annotation. */
+  position: WalkPosition | null;
+  onNavigate: (annotationId: string) => void;
+  onClose: () => void;
+  ownerId: string | null;
+  userId: string | null;
+  notify: Notify;
+}
+
+/** True when the key event originates in a text field (arrows must move the caret). */
+function isTypingTarget(event: KeyboardEvent): boolean {
+  const element = event.target as HTMLElement;
+  return element.tagName === 'TEXTAREA' || element.tagName === 'INPUT';
+}
+
+/**
+ * Focus mode's floating discussion card (issue #291): everything the panel
+ * card offers — status and placement cues, the quote, Accept/Reject, the full
+ * comment thread with its composer — next to the spotlit mark, never over it.
+ * Prev/Next (and ↑/↓ outside text fields) walk the annotations in document
+ * order without closing; the walk position is announced politely. Focus is
+ * trapped inside the card; Escape (and the close button) return it to the
+ * mark.
+ */
+export function FocusAnnotationCard({
+  annotation,
+  anchorEl,
+  position,
+  onNavigate,
+  onClose,
+  ownerId,
+  userId,
+  notify,
+}: FocusAnnotationCardProps) {
+  const theme = useTheme();
+  const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+  const { decideWith, isPending: deciding } = useDecideWithFeedback(notify);
+  const statusCue = STATUS_CUES[annotation.status];
+  const quote = annotation.anchor?.textQuote?.quote;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+    if (isTypingTarget(event)) return;
+    if (event.key === 'ArrowUp' && position?.prevId) {
+      event.preventDefault();
+      onNavigate(position.prevId);
+    }
+    if (event.key === 'ArrowDown' && position?.nextId) {
+      event.preventDefault();
+      onNavigate(position.nextId);
+    }
+  };
+
+  return (
+    <Popper
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      placement="right-start"
+      transition
+      sx={{ zIndex: theme.zIndex.modal }}
+      modifiers={[
+        { name: 'offset', options: { offset: [0, 16] } },
+        { name: 'flip', options: { fallbackPlacements: ['left-start', 'bottom', 'top'] } },
+        { name: 'preventOverflow', options: { padding: 12 } },
+      ]}
+    >
+      {({ TransitionProps }) => (
+        <Fade
+          {...TransitionProps}
+          // The staged entrance: scrim first, then the card — collapsed to
+          // instant under prefers-reduced-motion.
+          timeout={reducedMotion ? 0 : 180}
+          style={{ transitionDelay: reducedMotion ? '0ms' : '120ms' }}
+        >
+          <Paper
+            elevation={8}
+            data-testid="focus-annotation-card"
+            onKeyDown={handleKeyDown}
+            sx={{
+              width: 380,
+              maxWidth: 'calc(100vw - 32px)',
+              maxHeight: 'min(70vh, 560px)',
+              display: 'flex',
+              flexDirection: 'column',
+              borderRadius: 2,
+              overflow: 'hidden',
+            }}
+          >
+            {/* Enforcement stays off: the card coexists with interactive marks
+                and the toolbar — clicking them must not yank focus (and the
+                window scroll) back into the card. Tab still cycles inside. */}
+            <FocusTrap open disableRestoreFocus disableEnforceFocus>
+              <Box
+                tabIndex={-1}
+                sx={{ display: 'flex', flexDirection: 'column', minHeight: 0, outline: 'none' }}
+              >
+                <Stack
+                  direction="row"
+                  spacing={0.5}
+                  sx={{
+                    alignItems: 'center',
+                    px: 1.5,
+                    py: 1,
+                    borderBottom: `1px solid ${theme.palette.divider}`,
+                    flexShrink: 0,
+                  }}
+                >
+                  <Typography
+                    variant="caption"
+                    aria-live="polite"
+                    sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
+                  >
+                    {position
+                      ? `Annotation ${position.index + 1} of ${position.count}`
+                      : 'Annotation'}
+                  </Typography>
+                  <Box sx={{ flex: 1 }} />
+                  <Tooltip title="Previous annotation (↑)">
+                    <span>
+                      <IconButton
+                        size="small"
+                        aria-label="Previous annotation"
+                        disabled={!position?.prevId}
+                        onClick={() => position?.prevId && onNavigate(position.prevId)}
+                      >
+                        <ChevronUp size={16} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <Tooltip title="Next annotation (↓)">
+                    <span>
+                      <IconButton
+                        size="small"
+                        aria-label="Next annotation"
+                        disabled={!position?.nextId}
+                        onClick={() => position?.nextId && onNavigate(position.nextId)}
+                      >
+                        <ChevronDown size={16} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <IconButton size="small" aria-label="Close annotation" onClick={onClose}>
+                    <X size={16} />
+                  </IconButton>
+                </Stack>
+
+                <Box sx={{ px: 1.5, pt: 1.25, flexShrink: 0 }}>
+                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
+                    <ToneBadge tone={statusCue.tone} label={statusCue.label} />
+                    <PlacementStatusChip status={annotation.placementStatus} />
+                  </Stack>
+                  {quote && (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{
+                        fontStyle: 'italic',
+                        display: '-webkit-box',
+                        WebkitLineClamp: 3,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      {`“${quote}”`}
+                    </Typography>
+                  )}
+                </Box>
+
+                {mayDecideAnnotation(annotation, userId, ownerId) && (
+                  <DecisionBar
+                    disabled={deciding}
+                    onDecide={(decision) => decideWith(annotation, decision)}
+                  />
+                )}
+
+                <Box sx={{ overflowY: 'auto', minHeight: 0, px: 0.5, pb: 0.5 }}>
+                  <CommentThread annotationId={annotation.id} notify={notify} />
+                </Box>
+              </Box>
+            </FocusTrap>
+          </Paper>
+        </Fade>
+      )}
+    </Popper>
+  );
+}

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -133,11 +133,7 @@ export function FocusAnnotationCard({
             data-testid="focus-annotation-card"
             onKeyDown={handleKeyDown}
             sx={{
-              width: 380,
-              maxWidth: 'calc(100vw - 32px)',
-              maxHeight: 'min(70vh, 560px)',
               display: 'flex',
-              flexDirection: 'column',
               position: 'relative',
               borderRadius: '10px',
               // Bordered surface with ONE soft ambient shadow — the brand
@@ -184,13 +180,23 @@ export function FocusAnnotationCard({
             <FocusTrap open disableRestoreFocus disableEnforceFocus>
               <Box
                 tabIndex={-1}
+                data-testid="focus-card-body"
                 sx={{
+                  position: 'relative',
                   display: 'flex',
                   flexDirection: 'column',
-                  minHeight: 0,
                   outline: 'none',
                   borderRadius: '9px',
                   overflow: 'hidden',
+                  // Reader-resizable (long threads, narrow viewports): the
+                  // native grip, hard-bounded so the card can neither
+                  // collapse below usability nor swallow the document.
+                  resize: 'both',
+                  width: 380,
+                  minWidth: 320,
+                  maxWidth: 'min(640px, calc(100vw - 48px))',
+                  minHeight: 220,
+                  maxHeight: 'min(72vh, 680px)',
                 }}
               >
                 <Stack
@@ -281,9 +287,23 @@ export function FocusAnnotationCard({
                   />
                 )}
 
-                <Box sx={{ overflowY: 'auto', minHeight: 0, px: 0.5, pb: 0.5 }}>
+                <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0, px: 0.5, pb: 0.5 }}>
                   <CommentThread annotationId={annotation.id} notify={notify} />
                 </Box>
+                {/* Discoverability for the native resize grip underneath. */}
+                <Box
+                  aria-hidden
+                  sx={{
+                    position: 'absolute',
+                    right: 2,
+                    bottom: 2,
+                    width: 11,
+                    height: 11,
+                    pointerEvents: 'none',
+                    clipPath: 'polygon(100% 0, 100% 100%, 0 100%)',
+                    background: `repeating-linear-gradient(135deg, transparent 0 2.5px, ${theme.palette.divider} 2.5px 4px)`,
+                  }}
+                />
               </Box>
             </FocusTrap>
           </Paper>

--- a/qnop-ui/src/components/reviews/focus/FocusDrawer.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusDrawer.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import type { ReactNode } from 'react';
+
+interface FocusDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+/**
+ * Focus mode's temporary home of the annotation list (issue #291): the full
+ * panel — filters, sections, the orphaned group — slides in on demand and
+ * disappears again, keeping the document at full width the rest of the time.
+ */
+export function FocusDrawer({ open, onClose, children }: FocusDrawerProps) {
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      slotProps={{ paper: { sx: { width: { xs: '100%', sm: 420 } } } }}
+    >
+      <Box sx={{ p: 2, overflowY: 'auto' }}>{children}</Box>
+    </Drawer>
+  );
+}

--- a/qnop-ui/src/components/reviews/focus/FocusScrimLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusScrimLayer.test.tsx
@@ -24,40 +24,58 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../../theme/theme';
 import { FocusScrimLayer } from './FocusScrimLayer';
+import { holePolygon } from './spotlightModel';
 
 function renderLayer(spotlight: Parameters<typeof FocusScrimLayer>[0]['spotlight']) {
   const onDismiss = vi.fn();
-  render(
+  const view = render(
     <ThemeProvider theme={buildTheme('light')}>
       <FocusScrimLayer spotlight={spotlight} onDismiss={onDismiss} surfaceIndex={0} />
     </ThemeProvider>,
   );
-  return onDismiss;
+  return { onDismiss, view };
 }
+
+describe('holePolygon', () => {
+  it('cuts a rectangular notch with a constant vertex count (morphable)', () => {
+    const polygon = holePolygon({ x: 0.1, y: 0.2, width: 0.3, height: 0.1 });
+    expect(polygon).toContain('10.0000% 20.0000%');
+    expect(polygon).toContain('40.0000% 30.0000%');
+    // 10 vertices — the same count for every hole, so clip-path can transition.
+    expect(polygon.split(',')).toHaveLength(10);
+  });
+});
 
 describe('FocusScrimLayer', () => {
   it('dims the whole page when the spotlight is elsewhere', () => {
     renderLayer(null);
-    const layer = screen.getByTestId('focus-scrim-0');
-    expect(layer.children).toHaveLength(1);
+    const clip = getComputedStyle(screen.getByTestId('focus-scrim-0')).clipPath;
+    expect(['', 'none']).toContain(clip);
   });
 
-  it('leaves a sharp hole around the spotlight', () => {
-    renderLayer({ x: 0.1, y: 0.2, width: 0.3, height: 0.1 });
-    const layer = screen.getByTestId('focus-scrim-0');
-    // above, below, left, right — the spotlight itself carries no veil.
-    expect(layer.children).toHaveLength(4);
-    expect(screen.getByTestId('scrim-segment-0-0')).toHaveStyle({ top: '0%', height: '20%' });
-    expect(screen.getByTestId('scrim-segment-0-2')).toHaveStyle({
-      top: '20%',
-      left: '0%',
-      width: '10%',
+  it('cuts the sharp hole at the spotlight and moves it with the mark', () => {
+    const { view } = renderLayer({ x: 0.1, y: 0.2, width: 0.3, height: 0.1 });
+    expect(screen.getByTestId('focus-scrim-0')).toHaveStyle({
+      clipPath: holePolygon({ x: 0.1, y: 0.2, width: 0.3, height: 0.1 }),
+    });
+
+    view.rerender(
+      <ThemeProvider theme={buildTheme('light')}>
+        <FocusScrimLayer
+          spotlight={{ x: 0.5, y: 0.6, width: 0.2, height: 0.05 }}
+          onDismiss={vi.fn()}
+          surfaceIndex={0}
+        />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('focus-scrim-0')).toHaveStyle({
+      clipPath: holePolygon({ x: 0.5, y: 0.6, width: 0.2, height: 0.05 }),
     });
   });
 
   it('dismisses on a veil click', () => {
-    const onDismiss = renderLayer({ x: 0.1, y: 0.2, width: 0.3, height: 0.1 });
-    fireEvent.click(screen.getByTestId('scrim-segment-0-0'));
+    const { onDismiss } = renderLayer({ x: 0.1, y: 0.2, width: 0.3, height: 0.1 });
+    fireEvent.click(screen.getByTestId('focus-scrim-0'));
     expect(onDismiss).toHaveBeenCalled();
   });
 });

--- a/qnop-ui/src/components/reviews/focus/FocusScrimLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusScrimLayer.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import { FocusScrimLayer } from './FocusScrimLayer';
+
+function renderLayer(spotlight: Parameters<typeof FocusScrimLayer>[0]['spotlight']) {
+  const onDismiss = vi.fn();
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <FocusScrimLayer spotlight={spotlight} onDismiss={onDismiss} surfaceIndex={0} />
+    </ThemeProvider>,
+  );
+  return onDismiss;
+}
+
+describe('FocusScrimLayer', () => {
+  it('dims the whole page when the spotlight is elsewhere', () => {
+    renderLayer(null);
+    const layer = screen.getByTestId('focus-scrim-0');
+    expect(layer.children).toHaveLength(1);
+  });
+
+  it('leaves a sharp hole around the spotlight', () => {
+    renderLayer({ x: 0.1, y: 0.2, width: 0.3, height: 0.1 });
+    const layer = screen.getByTestId('focus-scrim-0');
+    // above, below, left, right — the spotlight itself carries no veil.
+    expect(layer.children).toHaveLength(4);
+    expect(screen.getByTestId('scrim-segment-0-0')).toHaveStyle({ top: '0%', height: '20%' });
+    expect(screen.getByTestId('scrim-segment-0-2')).toHaveStyle({
+      top: '20%',
+      left: '0%',
+      width: '10%',
+    });
+  });
+
+  it('dismisses on a veil click', () => {
+    const onDismiss = renderLayer({ x: 0.1, y: 0.2, width: 0.3, height: 0.1 });
+    fireEvent.click(screen.getByTestId('scrim-segment-0-0'));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/components/reviews/focus/FocusScrimLayer.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusScrimLayer.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import type { NormalizedBox } from '../../../api/generated';
+
+interface FocusScrimLayerProps {
+  /** The sharp region when the spotlight targets THIS page; null dims it fully. */
+  spotlight: NormalizedBox | null;
+  /** Clicking the dimmed area closes the overlay. */
+  onDismiss: () => void;
+  surfaceIndex: number;
+}
+
+/** The dimmed segments around the spotlight (or one full cover without one). */
+function segments(spotlight: NormalizedBox | null): NormalizedBox[] {
+  if (!spotlight) return [{ x: 0, y: 0, width: 1, height: 1 }];
+  const { x, y, width, height } = spotlight;
+  return [
+    { x: 0, y: 0, width: 1, height: y }, // above
+    { x: 0, y: y + height, width: 1, height: Math.max(0, 1 - y - height) }, // below
+    { x: 0, y, width: x, height }, // left of the spotlight
+    { x: x + width, y, width: Math.max(0, 1 - x - width), height }, // right of it
+  ].filter((segment) => segment.width > 0 && segment.height > 0);
+}
+
+/**
+ * The focus mode's per-page scrim (issue #291): the page dims under a soft
+ * veil while the spotlit passage stays untouched — the scrim is four
+ * rectangles AROUND the spotlight, never a filter over it, so the anchored
+ * text keeps its full contrast (the marks themselves paint on the layer
+ * above). A light backdrop blur adds atmosphere; `prefers-reduced-
+ * transparency` falls back to the plain veil, and the fade respects
+ * `prefers-reduced-motion`. Clicking the veil dismisses the overlay.
+ */
+export function FocusScrimLayer({ spotlight, onDismiss, surfaceIndex }: FocusScrimLayerProps) {
+  return (
+    <Box
+      data-testid={`focus-scrim-${surfaceIndex}`}
+      sx={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
+    >
+      {segments(spotlight).map((segment, index) => (
+        <Box
+          key={index}
+          data-testid={spotlight ? `scrim-segment-${surfaceIndex}-${index}` : undefined}
+          onClick={onDismiss}
+          sx={{
+            position: 'absolute',
+            left: `${segment.x * 100}%`,
+            top: `${segment.y * 100}%`,
+            width: `${segment.width * 100}%`,
+            height: `${segment.height * 100}%`,
+            pointerEvents: 'auto',
+            cursor: 'pointer',
+            bgcolor: 'rgba(1, 32, 66, 0.32)',
+            backdropFilter: 'blur(1.5px)',
+            '@media (prefers-reduced-transparency: reduce)': { backdropFilter: 'none' },
+            animation: 'qnopScrimIn 200ms ease-out',
+            '@keyframes qnopScrimIn': { from: { opacity: 0 }, to: { opacity: 1 } },
+            '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+          }}
+        />
+      ))}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/focus/FocusScrimLayer.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusScrimLayer.tsx
@@ -21,6 +21,8 @@
 
 import Box from '@mui/material/Box';
 import type { NormalizedBox } from '../../../api/generated';
+import { tokens } from '../../../theme/tokens';
+import { holePolygon } from './spotlightModel';
 
 interface FocusScrimLayerProps {
   /** The sharp region when the spotlight targets THIS page; null dims it fully. */
@@ -30,55 +32,36 @@ interface FocusScrimLayerProps {
   surfaceIndex: number;
 }
 
-/** The dimmed segments around the spotlight (or one full cover without one). */
-function segments(spotlight: NormalizedBox | null): NormalizedBox[] {
-  if (!spotlight) return [{ x: 0, y: 0, width: 1, height: 1 }];
-  const { x, y, width, height } = spotlight;
-  return [
-    { x: 0, y: 0, width: 1, height: y }, // above
-    { x: 0, y: y + height, width: 1, height: Math.max(0, 1 - y - height) }, // below
-    { x: 0, y, width: x, height }, // left of the spotlight
-    { x: x + width, y, width: Math.max(0, 1 - x - width), height }, // right of it
-  ].filter((segment) => segment.width > 0 && segment.height > 0);
-}
-
 /**
  * The focus mode's per-page scrim (issue #291): the page dims under a soft
- * veil while the spotlit passage stays untouched — the scrim is four
- * rectangles AROUND the spotlight, never a filter over it, so the anchored
- * text keeps its full contrast (the marks themselves paint on the layer
- * above). A light backdrop blur adds atmosphere; `prefers-reduced-
- * transparency` falls back to the plain veil, and the fade respects
- * `prefers-reduced-motion`. Clicking the veil dismisses the overlay.
+ * veil while the spotlit passage stays untouched — the hole is cut with a
+ * clip-path, never a filter over the mark, so the anchored text keeps its
+ * full contrast (the marks themselves paint on the layer above). The clipped
+ * region is also transparent to pointer events, so the spotlit passage stays
+ * selectable while the veil catches dismiss clicks. Moving the spotlight
+ * (prev/next) morphs the clip smoothly — clip-path animates on the
+ * compositor; `prefers-reduced-motion` snaps instead, and
+ * `prefers-reduced-transparency` drops the blur.
  */
 export function FocusScrimLayer({ spotlight, onDismiss, surfaceIndex }: FocusScrimLayerProps) {
   return (
     <Box
       data-testid={`focus-scrim-${surfaceIndex}`}
-      sx={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
-    >
-      {segments(spotlight).map((segment, index) => (
-        <Box
-          key={index}
-          data-testid={spotlight ? `scrim-segment-${surfaceIndex}-${index}` : undefined}
-          onClick={onDismiss}
-          sx={{
-            position: 'absolute',
-            left: `${segment.x * 100}%`,
-            top: `${segment.y * 100}%`,
-            width: `${segment.width * 100}%`,
-            height: `${segment.height * 100}%`,
-            pointerEvents: 'auto',
-            cursor: 'pointer',
-            bgcolor: 'rgba(1, 32, 66, 0.32)',
-            backdropFilter: 'blur(1.5px)',
-            '@media (prefers-reduced-transparency: reduce)': { backdropFilter: 'none' },
-            animation: 'qnopScrimIn 200ms ease-out',
-            '@keyframes qnopScrimIn': { from: { opacity: 0 }, to: { opacity: 1 } },
-            '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
-          }}
-        />
-      ))}
-    </Box>
+      onClick={onDismiss}
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'auto',
+        cursor: 'pointer',
+        bgcolor: 'rgba(1, 32, 66, 0.32)',
+        backdropFilter: 'blur(1.5px)',
+        '@media (prefers-reduced-transparency: reduce)': { backdropFilter: 'none' },
+        clipPath: spotlight ? holePolygon(spotlight) : undefined,
+        transition: `clip-path ${tokens.motion.durSlow}ms ${tokens.motion.easeInOut}`,
+        animation: 'qnopScrimIn 200ms ease-out',
+        '@keyframes qnopScrimIn': { from: { opacity: 0 }, to: { opacity: 1 } },
+        '@media (prefers-reduced-motion: reduce)': { animation: 'none', transition: 'none' },
+      }}
+    />
   );
 }

--- a/qnop-ui/src/components/reviews/focus/spotlightModel.test.ts
+++ b/qnop-ui/src/components/reviews/focus/spotlightModel.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AnnotationView, RenderedSurface } from '../../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+import { placedInOrder, spotlightForAnchor, walkPosition } from './spotlightModel';
+
+const annotation = (id: string, surfaceIndex: number | null, y = 0.2): AnnotationView => ({
+  id,
+  documentId: 'd1',
+  authorId: 'u1',
+  status: AnnotationStatus.Open,
+  placementStatus: surfaceIndex === null ? PlacementStatus.Orphaned : PlacementStatus.Placed,
+  anchor:
+    surfaceIndex === null
+      ? undefined
+      : { region: { surfaceIndex, box: { x: 0.1, y, width: 0.3, height: 0.02 } } },
+  commentCount: 1,
+  createdAt: '2026-07-01T10:00:00Z',
+  updatedAt: '2026-07-01T10:00:00Z',
+});
+
+const SURFACES: RenderedSurface[] = [{ index: 0, width: 600, height: 800, textSpans: [] }];
+
+describe('spotlightForAnchor', () => {
+  it('pads the anchor region and stays inside the page', () => {
+    const spotlight = spotlightForAnchor(
+      { region: { surfaceIndex: 0, box: { x: 0.1, y: 0.2, width: 0.3, height: 0.02 } } },
+      SURFACES,
+    );
+
+    expect(spotlight.surfaceIndex).toBe(0);
+    expect(spotlight.box.x).toBeCloseTo(0.085, 5);
+    expect(spotlight.box.y).toBeCloseTo(0.19, 5);
+    expect(spotlight.box.width).toBeCloseTo(0.33, 5);
+    expect(spotlight.box.height).toBeCloseTo(0.04, 5);
+  });
+
+  it('clamps at the page edges', () => {
+    const spotlight = spotlightForAnchor(
+      { region: { surfaceIndex: 0, box: { x: 0, y: 0, width: 1, height: 0.05 } } },
+      SURFACES,
+    );
+
+    expect(spotlight.box.x).toBe(0);
+    expect(spotlight.box.y).toBe(0);
+    expect(spotlight.box.x + spotlight.box.width).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('placedInOrder / walkPosition', () => {
+  const list = [
+    annotation('c', 1, 0.1),
+    annotation('a', 0, 0.2),
+    annotation('orphan', null),
+    annotation('b', 0, 0.6),
+  ];
+
+  it('orders placed annotations by document position, skipping unplaced ones', () => {
+    expect(placedInOrder(list).map((a) => a.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('reports the walk position with its neighbours', () => {
+    expect(walkPosition(list, 'b')).toEqual({ index: 1, count: 3, prevId: 'a', nextId: 'c' });
+    expect(walkPosition(list, 'a')?.prevId).toBeNull();
+    expect(walkPosition(list, 'c')?.nextId).toBeNull();
+  });
+
+  it('returns null for annotations without a placement', () => {
+    expect(walkPosition(list, 'orphan')).toBeNull();
+  });
+});

--- a/qnop-ui/src/components/reviews/focus/spotlightModel.test.ts
+++ b/qnop-ui/src/components/reviews/focus/spotlightModel.test.ts
@@ -42,27 +42,26 @@ const annotation = (id: string, surfaceIndex: number | null, y = 0.2): Annotatio
 const SURFACES: RenderedSurface[] = [{ index: 0, width: 600, height: 800, textSpans: [] }];
 
 describe('spotlightForAnchor', () => {
-  it('pads the anchor region and stays inside the page', () => {
+  it('hugs the painted geometry exactly — no margin exposing undimmed page', () => {
     const spotlight = spotlightForAnchor(
       { region: { surfaceIndex: 0, box: { x: 0.1, y: 0.2, width: 0.3, height: 0.02 } } },
       SURFACES,
     );
 
     expect(spotlight.surfaceIndex).toBe(0);
-    expect(spotlight.box.x).toBeCloseTo(0.085, 5);
-    expect(spotlight.box.y).toBeCloseTo(0.19, 5);
-    expect(spotlight.box.width).toBeCloseTo(0.33, 5);
-    expect(spotlight.box.height).toBeCloseTo(0.04, 5);
+    expect(spotlight.box.x).toBeCloseTo(0.1, 10);
+    expect(spotlight.box.y).toBeCloseTo(0.2, 10);
+    expect(spotlight.box.width).toBeCloseTo(0.3, 10);
+    expect(spotlight.box.height).toBeCloseTo(0.02, 10);
   });
 
   it('clamps at the page edges', () => {
     const spotlight = spotlightForAnchor(
-      { region: { surfaceIndex: 0, box: { x: 0, y: 0, width: 1, height: 0.05 } } },
+      { region: { surfaceIndex: 0, box: { x: -0.05, y: 0, width: 1.2, height: 0.05 } } },
       SURFACES,
     );
 
     expect(spotlight.box.x).toBe(0);
-    expect(spotlight.box.y).toBe(0);
     expect(spotlight.box.x + spotlight.box.width).toBeLessThanOrEqual(1);
   });
 });

--- a/qnop-ui/src/components/reviews/focus/spotlightModel.ts
+++ b/qnop-ui/src/components/reviews/focus/spotlightModel.ts
@@ -96,3 +96,18 @@ export function walkPosition(annotations: AnnotationView[], activeId: string): W
     nextId: index < ordered.length - 1 ? ordered[index + 1].id : null,
   };
 }
+
+/**
+ * The veil-with-a-hole as ONE polygon (a rectangular notch reached through a
+ * seam at the hole's left edge). A single path with a constant vertex count
+ * makes the hole itself transitionable — walking prev/next GLIDES the
+ * spotlight to the next mark instead of jumping.
+ */
+export function holePolygon(hole: NormalizedBox): string {
+  const pct = (value: number) => `${(value * 100).toFixed(4)}%`;
+  const x1 = pct(hole.x);
+  const y1 = pct(hole.y);
+  const x2 = pct(hole.x + hole.width);
+  const y2 = pct(hole.y + hole.height);
+  return `polygon(0% 0%, 0% 100%, ${x1} 100%, ${x1} ${y1}, ${x2} ${y1}, ${x2} ${y2}, ${x1} ${y2}, ${x1} 100%, 100% 100%, 100% 0%)`;
+}

--- a/qnop-ui/src/components/reviews/focus/spotlightModel.ts
+++ b/qnop-ui/src/components/reviews/focus/spotlightModel.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type {
+  Anchor,
+  AnnotationView,
+  NormalizedBox,
+  RenderedSurface,
+} from '../../../api/generated';
+import {
+  clampBox,
+  compareAnnotationsByPosition,
+  highlightBoxesForAnchor,
+  unionBoxes,
+} from '../viewer/anchoring';
+
+/**
+ * Pure geometry/ordering helpers for the focus view (issue #291). The
+ * spotlight never derives from the client's own rendering — it grows from the
+ * same stored anchor boxes the highlights paint with (ADR-0032).
+ */
+
+/** Breathing room around the mark, normalized to the page (x wider — reading direction). */
+const SPOTLIGHT_PAD_X = 0.015;
+const SPOTLIGHT_PAD_Y = 0.01;
+
+/** The sharp region of the scrim: one page and the padded box on it. */
+export interface Spotlight {
+  surfaceIndex: number;
+  box: NormalizedBox;
+}
+
+/** The padded, clamped spotlight rect of an anchor on its surface. */
+export function spotlightForAnchor(
+  anchor: Anchor,
+  surfaces: RenderedSurface[] | undefined,
+): Spotlight {
+  const surfaceIndex = anchor.region.surfaceIndex;
+  const spans = surfaces?.find((surface) => surface.index === surfaceIndex)?.textSpans ?? [];
+  const { boxes } = highlightBoxesForAnchor(anchor, spans);
+  const union = unionBoxes(boxes) ?? anchor.region.box;
+  return {
+    surfaceIndex,
+    box: clampBox({
+      x: union.x - SPOTLIGHT_PAD_X,
+      y: union.y - SPOTLIGHT_PAD_Y,
+      width: union.width + 2 * SPOTLIGHT_PAD_X,
+      height: union.height + 2 * SPOTLIGHT_PAD_Y,
+    }),
+  };
+}
+
+/** The spotlight of an annotation, or null when it has no placement here. */
+export function spotlightForAnnotation(
+  annotation: AnnotationView | undefined,
+  surfaces: RenderedSurface[] | undefined,
+): Spotlight | null {
+  if (!annotation?.anchor) return null;
+  return spotlightForAnchor(annotation.anchor, surfaces);
+}
+
+/** Placed annotations in document order — the prev/next walking order. */
+export function placedInOrder(annotations: AnnotationView[]): AnnotationView[] {
+  return annotations.filter((annotation) => annotation.anchor).sort(compareAnnotationsByPosition);
+}
+
+/** Where the active annotation sits in the walking order, with its neighbours. */
+export interface WalkPosition {
+  /** Zero-based position among the placed annotations. */
+  index: number;
+  count: number;
+  prevId: string | null;
+  nextId: string | null;
+}
+
+/** The walk position of `activeId`, or null when it is not placed here. */
+export function walkPosition(annotations: AnnotationView[], activeId: string): WalkPosition | null {
+  const ordered = placedInOrder(annotations);
+  const index = ordered.findIndex((annotation) => annotation.id === activeId);
+  if (index < 0) return null;
+  return {
+    index,
+    count: ordered.length,
+    prevId: index > 0 ? ordered[index - 1].id : null,
+    nextId: index < ordered.length - 1 ? ordered[index + 1].id : null,
+  };
+}

--- a/qnop-ui/src/components/reviews/focus/spotlightModel.ts
+++ b/qnop-ui/src/components/reviews/focus/spotlightModel.ts
@@ -38,17 +38,18 @@ import {
  * same stored anchor boxes the highlights paint with (ADR-0032).
  */
 
-/** Breathing room around the mark, normalized to the page (x wider — reading direction). */
-const SPOTLIGHT_PAD_X = 0.015;
-const SPOTLIGHT_PAD_Y = 0.01;
-
-/** The sharp region of the scrim: one page and the padded box on it. */
+/** The sharp region of the scrim: one page and the box on it. */
 export interface Spotlight {
   surfaceIndex: number;
   box: NormalizedBox;
 }
 
-/** The padded, clamped spotlight rect of an anchor on its surface. */
+/**
+ * The clamped spotlight rect of an anchor on its surface — the union of
+ * exactly the boxes the highlight layer paints (the pitch-grown marker bands,
+ * or the region box). No extra padding: any margin would expose undimmed page
+ * pixels around the mark, reading as a white frame against the veil.
+ */
 export function spotlightForAnchor(
   anchor: Anchor,
   surfaces: RenderedSurface[] | undefined,
@@ -57,15 +58,7 @@ export function spotlightForAnchor(
   const spans = surfaces?.find((surface) => surface.index === surfaceIndex)?.textSpans ?? [];
   const { boxes } = highlightBoxesForAnchor(anchor, spans);
   const union = unionBoxes(boxes) ?? anchor.region.box;
-  return {
-    surfaceIndex,
-    box: clampBox({
-      x: union.x - SPOTLIGHT_PAD_X,
-      y: union.y - SPOTLIGHT_PAD_Y,
-      width: union.width + 2 * SPOTLIGHT_PAD_X,
-      height: union.height + 2 * SPOTLIGHT_PAD_Y,
-    }),
-  };
+  return { surfaceIndex, box: clampBox(union) };
 }
 
 /** The spotlight of an annotation, or null when it has no placement here. */

--- a/qnop-ui/src/components/reviews/focus/useAnchorElement.ts
+++ b/qnop-ui/src/components/reviews/focus/useAnchorElement.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useState } from 'react';
+
+/** Give the layers a good second of frames to mount before giving up. */
+const MAX_RESOLVE_FRAMES = 60;
+
+/**
+ * Resolves a DOM id to its element for anchoring the focus overlay (issue
+ * #291). The mark elements render inside the viewer's layer stack, typically
+ * a tick AFTER the id becomes known (annotation refetch, page mount) — so the
+ * lookup retries across animation frames, bounded, instead of reading once.
+ */
+export function useAnchorElement(id: string | null): HTMLElement | null {
+  const [element, setElement] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    // All updates happen inside animation-frame callbacks (the DOM is the
+    // external system being observed) — never synchronously in the effect.
+    let frame = 0;
+    let attempts = 0;
+    const resolve = () => {
+      const found = id ? document.getElementById(id) : null;
+      if (found || !id || attempts >= MAX_RESOLVE_FRAMES) {
+        setElement(found);
+        return;
+      }
+      attempts += 1;
+      frame = requestAnimationFrame(resolve);
+    };
+    frame = requestAnimationFrame(resolve);
+    return () => cancelAnimationFrame(frame);
+  }, [id]);
+
+  return element;
+}

--- a/qnop-ui/src/components/reviews/focus/useViewMode.ts
+++ b/qnop-ui/src/components/reviews/focus/useViewMode.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
+
+/**
+ * The review surface's two presentations (issue #291): the always-visible
+ * annotation panel, or the full-width focus mode with the spotlight overlay.
+ */
+export type ReviewViewMode = 'panel' | 'focus';
+
+const VIEW_MODE_KEY = 'qnop-review-view-mode';
+
+function storedMode(): ReviewViewMode | null {
+  try {
+    const value = localStorage.getItem(VIEW_MODE_KEY);
+    return value === 'panel' || value === 'focus' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The persisted view mode (a personal preference, so localStorage rather than
+ * the URL). Without a stored choice, small viewports default to focus mode —
+ * exactly where the panel-below-document layout is weakest (issue #291).
+ */
+export function useViewMode(): [ReviewViewMode, (mode: ReviewViewMode) => void] {
+  const theme = useTheme();
+  const smallViewport = useMediaQuery(theme.breakpoints.down('md'));
+  const [stored, setStored] = useState<ReviewViewMode | null>(storedMode);
+
+  const setMode = (mode: ReviewViewMode) => {
+    setStored(mode);
+    try {
+      localStorage.setItem(VIEW_MODE_KEY, mode);
+    } catch {
+      // best-effort persistence
+    }
+  };
+
+  return [stored ?? (smallViewport ? 'focus' : 'panel'), setMode];
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -25,48 +25,21 @@ import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha, keyframes, useTheme } from '@mui/material/styles';
-import type { Theme } from '@mui/material/styles';
-import { CircleCheck, CircleDot, CircleX, MessageSquare } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
-import { AnnotationStatus } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
-import type { BadgeTone } from '../../admin/ToneBadge';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { highlightColorFor } from '../viewer/markerColors';
 import { PlacementStatusChip } from './PlacementStatusChip';
+import { STATUS_CUES } from './statusCues';
 
 /** Gentle glow on the status rail while the card is linked to its hovered mark. */
 const railGlow = keyframes`
   0%, 100% { box-shadow: 0 0 0 0 transparent; }
   50% { box-shadow: 0 0 10px 2px var(--rail-glow); }
 `;
-
-const STATUS_CUES: Record<
-  AnnotationStatus,
-  { tone: BadgeTone; label: string; icon: LucideIcon; color: (theme: Theme) => string }
-> = {
-  [AnnotationStatus.Open]: {
-    tone: 'blue',
-    label: 'Open',
-    icon: CircleDot,
-    color: (theme) => theme.qnop.brand.blue,
-  },
-  [AnnotationStatus.Accepted]: {
-    tone: 'green',
-    label: 'Accepted',
-    icon: CircleCheck,
-    color: (theme) => theme.palette.success.main,
-  },
-  [AnnotationStatus.Rejected]: {
-    tone: 'neutral',
-    label: 'Rejected',
-    icon: CircleX,
-    color: (theme) => theme.palette.text.disabled,
-  },
-};
 
 /** Up to this many participant avatars stack in the collapsed row. */
 const MAX_AVATARS = 3;

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -22,34 +22,26 @@
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import ButtonBase from '@mui/material/ButtonBase';
 import Chip from '@mui/material/Chip';
 import Collapse from '@mui/material/Collapse';
-import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { Check, ChevronRight, Link2, NotebookPen, Unlink, X } from 'lucide-react';
+import { ChevronRight, Link2, NotebookPen, Unlink } from 'lucide-react';
 import type { Anchor, AnnotationView } from '../../../api/generated';
-import { AnnotationDecision, AnnotationStatus } from '../../../api/generated';
-import { useDecideAnnotation } from '../../../api/hooks/useAnnotations';
+import { AnnotationStatus } from '../../../api/generated';
 import { useAuthStore } from '../../../stores/authStore';
-import { apiErrorCode } from '../../../utils/apiError';
-import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
 import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
 import { compareAnnotationsByPosition } from '../viewer/anchoring';
 import { AnnotationListItem } from './AnnotationListItem';
 import { CommentThread } from './CommentThread';
+import { Composer } from './Composer';
+import { DecisionBar } from './DecisionBar';
+import { mayDecideAnnotation, useDecideWithFeedback } from './decisions';
 
 type StatusFilter = 'all' | 'open' | 'decided';
-
-/** Known decision conflicts (409) — mapped to friendly text, never server prose. */
-const DECISION_CONFLICTS: Record<string, string> = {
-  ANNOTATION_ALREADY_DECIDED: 'This annotation was already decided.',
-};
 
 const FILTERS: { value: StatusFilter; label: string }[] = [
   { value: 'all', label: 'All' },
@@ -72,115 +64,6 @@ interface AnnotationPanelProps {
   /** The document owner — owner or author may decide an annotation (ADR-0011). */
   ownerId: string | null;
   notify: Notify;
-}
-
-/** Accept/Reject for an open annotation, shown to the owner or the author. */
-function DecisionBar({
-  disabled,
-  onDecide,
-}: {
-  disabled: boolean;
-  onDecide: (decision: AnnotationDecision) => void;
-}) {
-  return (
-    <Stack
-      direction="row"
-      spacing={1}
-      data-testid="decision-bar"
-      sx={{ alignItems: 'center', pl: 2, py: 1 }}
-    >
-      <Button
-        size="small"
-        variant="contained"
-        color="success"
-        startIcon={<Check size={14} />}
-        disabled={disabled}
-        onClick={() => onDecide(AnnotationDecision.Accepted)}
-      >
-        Accept
-      </Button>
-      <Button
-        size="small"
-        variant="outlined"
-        color="inherit"
-        startIcon={<X size={14} />}
-        disabled={disabled}
-        onClick={() => onDecide(AnnotationDecision.Rejected)}
-      >
-        Reject
-      </Button>
-    </Stack>
-  );
-}
-
-/**
- * The composer for a freshly drawn anchor. The first comment is mandatory
- * (issue #301) — an annotation without text must not exist, so creating stays
- * disabled (button and submit shortcut) until the trimmed comment is non-empty.
- */
-function Composer({
-  pendingAnchor,
-  creating,
-  onCreate,
-  onCancel,
-}: {
-  pendingAnchor: Anchor;
-  creating: boolean;
-  onCreate: (comment: string) => void;
-  onCancel: () => void;
-}) {
-  const [comment, setComment] = useState('');
-  const canCreate = !creating && comment.trim().length > 0;
-  const quote = pendingAnchor.textQuote?.quote;
-  return (
-    <Paper variant="outlined" sx={{ p: 1.5 }} data-testid="annotation-composer">
-      <Stack spacing={1}>
-        <Typography variant="subtitle2">New annotation</Typography>
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{
-            fontStyle: quote ? 'italic' : 'normal',
-            display: '-webkit-box',
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {quote ? `“${quote}”` : `Region on page ${pendingAnchor.region.surfaceIndex + 1}`}
-        </Typography>
-        <TextField
-          multiline
-          minRows={5}
-          size="small"
-          required
-          placeholder="Add a comment"
-          value={comment}
-          onChange={(event) => setComment(event.target.value)}
-          onKeyDown={(event) => {
-            if (isSubmitShortcut(event)) {
-              event.preventDefault();
-              if (canCreate) onCreate(comment);
-            }
-          }}
-          slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Annotation comment' } }}
-        />
-        <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => onCreate(comment)}
-            disabled={!canCreate}
-          >
-            Create annotation ({submitShortcutLabel()})
-          </Button>
-          <Button size="small" onClick={onCancel} disabled={creating}>
-            Cancel
-          </Button>
-        </Stack>
-      </Stack>
-    </Paper>
-  );
 }
 
 /** A collapsible, counted group of annotation cards (prototype sidebar section). */
@@ -300,31 +183,7 @@ export function AnnotationPanel({
 }: AnnotationPanelProps) {
   const [filter, setFilter] = useState<StatusFilter>('all');
   const userId = useAuthStore((state) => state.userId);
-  const decide = useDecideAnnotation();
-
-  const mayDecide = (annotation: AnnotationView) =>
-    annotation.status === AnnotationStatus.Open &&
-    userId !== null &&
-    (ownerId === userId || annotation.authorId === userId);
-
-  const handleDecide = (annotation: AnnotationView, decision: AnnotationDecision) => {
-    decide.mutate(
-      { annotationId: annotation.id, decision },
-      {
-        onSuccess: () =>
-          notify(
-            decision === AnnotationDecision.Accepted
-              ? 'Annotation accepted.'
-              : 'Annotation rejected.',
-          ),
-        onError: (error) =>
-          notify(
-            DECISION_CONFLICTS[apiErrorCode(error) ?? ''] ?? 'The decision could not be saved.',
-            'error',
-          ),
-      },
-    );
-  };
+  const { decideWith, isPending: deciding } = useDecideWithFeedback(notify);
 
   const matchesFilter = (annotation: AnnotationView) =>
     filter === 'all' ||
@@ -349,10 +208,10 @@ export function AnnotationPanel({
           onHover={onHover}
         />
         <Collapse in={active} unmountOnExit>
-          {mayDecide(annotation) && (
+          {mayDecideAnnotation(annotation, userId, ownerId) && (
             <DecisionBar
-              disabled={decide.isPending}
-              onDecide={(decision) => handleDecide(annotation, decision)}
+              disabled={deciding}
+              onDecide={(decision) => decideWith(annotation, decision)}
             />
           )}
           <CommentThread annotationId={annotation.id} notify={notify} />

--- a/qnop-ui/src/components/reviews/panel/Composer.tsx
+++ b/qnop-ui/src/components/reviews/panel/Composer.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import type { Anchor } from '../../../api/generated';
+import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
+
+/**
+ * The composer for a freshly drawn anchor — rendered in the panel, and in
+ * focus mode inside the overlay card. The first comment is mandatory (issue
+ * #301) — an annotation without text must not exist, so creating stays
+ * disabled (button and submit shortcut) until the trimmed comment is
+ * non-empty.
+ */
+export function Composer({
+  pendingAnchor,
+  creating,
+  onCreate,
+  onCancel,
+}: {
+  pendingAnchor: Anchor;
+  creating: boolean;
+  onCreate: (comment: string) => void;
+  onCancel: () => void;
+}) {
+  const [comment, setComment] = useState('');
+  const canCreate = !creating && comment.trim().length > 0;
+  const quote = pendingAnchor.textQuote?.quote;
+  return (
+    <Paper variant="outlined" sx={{ p: 1.5 }} data-testid="annotation-composer">
+      <Stack spacing={1}>
+        <Typography variant="subtitle2">New annotation</Typography>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{
+            fontStyle: quote ? 'italic' : 'normal',
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {quote ? `“${quote}”` : `Region on page ${pendingAnchor.region.surfaceIndex + 1}`}
+        </Typography>
+        <TextField
+          multiline
+          minRows={5}
+          size="small"
+          required
+          placeholder="Add a comment"
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          onKeyDown={(event) => {
+            if (isSubmitShortcut(event)) {
+              event.preventDefault();
+              if (canCreate) onCreate(comment);
+            }
+          }}
+          slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Annotation comment' } }}
+        />
+        <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => onCreate(comment)}
+            disabled={!canCreate}
+          >
+            Create annotation ({submitShortcutLabel()})
+          </Button>
+          <Button size="small" onClick={onCancel} disabled={creating}>
+            Cancel
+          </Button>
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/DecisionBar.tsx
+++ b/qnop-ui/src/components/reviews/panel/DecisionBar.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { Check, X } from 'lucide-react';
+import { AnnotationDecision } from '../../../api/generated';
+
+/** Accept/Reject for an open annotation, shown to the owner or the author. */
+export function DecisionBar({
+  disabled,
+  onDecide,
+}: {
+  disabled: boolean;
+  onDecide: (decision: AnnotationDecision) => void;
+}) {
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      data-testid="decision-bar"
+      sx={{ alignItems: 'center', pl: 2, py: 1 }}
+    >
+      <Button
+        size="small"
+        variant="contained"
+        color="success"
+        startIcon={<Check size={14} />}
+        disabled={disabled}
+        onClick={() => onDecide(AnnotationDecision.Accepted)}
+      >
+        Accept
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        color="inherit"
+        startIcon={<X size={14} />}
+        disabled={disabled}
+        onClick={() => onDecide(AnnotationDecision.Rejected)}
+      >
+        Reject
+      </Button>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/decisions.ts
+++ b/qnop-ui/src/components/reviews/panel/decisions.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationDecision, AnnotationStatus } from '../../../api/generated';
+import { useDecideAnnotation } from '../../../api/hooks/useAnnotations';
+import { apiErrorCode } from '../../../utils/apiError';
+import type { Notify } from '../../admin/layout/useToast';
+
+/** Known decision conflicts (409) — mapped to friendly text, never server prose. */
+const DECISION_CONFLICTS: Record<string, string> = {
+  ANNOTATION_ALREADY_DECIDED: 'This annotation was already decided.',
+};
+
+/** Owner or author may decide an OPEN annotation (ADR-0011). */
+export function mayDecideAnnotation(
+  annotation: AnnotationView,
+  userId: string | null,
+  ownerId: string | null,
+): boolean {
+  return (
+    annotation.status === AnnotationStatus.Open &&
+    userId !== null &&
+    (ownerId === userId || annotation.authorId === userId)
+  );
+}
+
+/**
+ * The decide mutation with the shared toast feedback — used by the panel and
+ * the focus overlay card, so both surfaces report identically.
+ */
+export function useDecideWithFeedback(notify: Notify) {
+  const decide = useDecideAnnotation();
+  const decideWith = (annotation: AnnotationView, decision: AnnotationDecision) => {
+    decide.mutate(
+      { annotationId: annotation.id, decision },
+      {
+        onSuccess: () =>
+          notify(
+            decision === AnnotationDecision.Accepted
+              ? 'Annotation accepted.'
+              : 'Annotation rejected.',
+          ),
+        onError: (error) =>
+          notify(
+            DECISION_CONFLICTS[apiErrorCode(error) ?? ''] ?? 'The decision could not be saved.',
+            'error',
+          ),
+      },
+    );
+  };
+  return { decideWith, isPending: decide.isPending };
+}

--- a/qnop-ui/src/components/reviews/panel/statusCues.ts
+++ b/qnop-ui/src/components/reviews/panel/statusCues.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { LucideIcon } from 'lucide-react';
+import { CircleCheck, CircleDot, CircleX } from 'lucide-react';
+import type { Theme } from '@mui/material/styles';
+import { AnnotationStatus } from '../../../api/generated';
+import type { BadgeTone } from '../../admin/ToneBadge';
+
+/**
+ * Status → badge tone/label/icon/rail colour — shared by the panel's list
+ * items and the focus overlay card (#291), so both surfaces read identically.
+ */
+export const STATUS_CUES: Record<
+  AnnotationStatus,
+  { tone: BadgeTone; label: string; icon: LucideIcon; color: (theme: Theme) => string }
+> = {
+  [AnnotationStatus.Open]: {
+    tone: 'blue',
+    label: 'Open',
+    icon: CircleDot,
+    color: (theme) => theme.qnop.brand.blue,
+  },
+  [AnnotationStatus.Accepted]: {
+    tone: 'green',
+    label: 'Accepted',
+    icon: CircleCheck,
+    color: (theme) => theme.palette.success.main,
+  },
+  [AnnotationStatus.Rejected]: {
+    tone: 'neutral',
+    label: 'Rejected',
+    icon: CircleX,
+    color: (theme) => theme.palette.text.disabled,
+  },
+};

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -61,6 +61,14 @@ interface DocumentViewerProps {
   pendingAnchor: Anchor | null;
   onTextSelected: (selection: TextSelectionOffsets, at: ScreenPosition) => void;
   onRegionSelected: (surfaceIndex: number, box: NormalizedBox, at: ScreenPosition) => void;
+  /**
+   * Focus-mode overlay state (issue #291): non-null dims every page;
+   * `spotlight` names the page and rect that stay sharp.
+   */
+  focusScrim?: {
+    spotlight: { surfaceIndex: number; box: NormalizedBox } | null;
+    onDismiss: () => void;
+  } | null;
 }
 
 /**
@@ -87,6 +95,7 @@ export function DocumentViewer({
   pendingAnchor,
   onTextSelected,
   onRegionSelected,
+  focusScrim,
 }: DocumentViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const pageRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -147,12 +156,15 @@ export function DocumentViewer({
     };
   }, [onVisiblePageChange]);
 
-  // A panel click scrolls the (possibly off-screen) highlight into view.
+  // A panel click (or the focus card's prev/next walk, #291) scrolls the
+  // possibly off-screen highlight into view. scrollIntoView ignores the CSS
+  // scroll-behavior override, so reduced motion is honoured explicitly.
   useEffect(() => {
     if (!activeAnnotationId) return;
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     document
       .getElementById(`annotation-highlight-${activeAnnotationId}`)
-      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      ?.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'center' });
   }, [activeAnnotationId]);
 
   // Hovering a panel card brings its mark into view — but only when it is
@@ -165,7 +177,8 @@ export function DocumentViewer({
     const markRect = mark.getBoundingClientRect();
     const viewRect = container.getBoundingClientRect();
     if (markRect.top < viewRect.top + 24 || markRect.bottom > viewRect.bottom - 8) {
-      mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      mark.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'center' });
     }
   }, [hoverAnnotationId]);
 
@@ -219,6 +232,15 @@ export function DocumentViewer({
                   pendingAnchor={pendingAnchor}
                   onTextSelected={onTextSelected}
                   onRegionSelected={onRegionSelected}
+                  focusScrim={
+                    focusScrim && {
+                      box:
+                        focusScrim.spotlight?.surfaceIndex === pageIndex
+                          ? focusScrim.spotlight.box
+                          : null,
+                      onDismiss: focusScrim.onDismiss,
+                    }
+                  }
                 />
               </div>
             );

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -206,6 +206,7 @@ export function HighlightLayer({
         pending.boxes.map((box, index) => (
           <Box
             key={index}
+            id={index === 0 ? 'pending-highlight' : undefined}
             data-testid={index === 0 ? 'pending-highlight' : undefined}
             sx={{
               ...positionSx(box),

--- a/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
+++ b/qnop-ui/src/components/reviews/viewer/SurfacePage.tsx
@@ -29,6 +29,7 @@ import type {
   RenderedSurface,
 } from '../../../api/generated';
 import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
+import { FocusScrimLayer } from '../focus/FocusScrimLayer';
 import { HighlightLayer } from './HighlightLayer';
 import { PageCanvas } from './PageCanvas';
 import { RegionSelectLayer } from './RegionSelectLayer';
@@ -58,6 +59,12 @@ interface SurfacePageProps {
   pendingAnchor: Anchor | null;
   onTextSelected: (selection: TextSelectionOffsets, at: ScreenPosition) => void;
   onRegionSelected: (surfaceIndex: number, box: NormalizedBox, at: ScreenPosition) => void;
+  /**
+   * Focus-mode scrim (issue #291): non-null dims this page — with a sharp
+   * spotlight hole when `box` is set (the spotlit passage lives here). The
+   * scrim sits UNDER the highlight layer, so marks stay crisp and clickable.
+   */
+  focusScrim?: { box: NormalizedBox | null; onDismiss: () => void } | null;
 }
 
 /**
@@ -82,6 +89,7 @@ export function SurfacePage({
   pendingAnchor,
   onTextSelected,
   onRegionSelected,
+  focusScrim,
 }: SurfacePageProps) {
   const [fallbackAspect, setFallbackAspect] = useState<number | null>(null);
 
@@ -129,6 +137,13 @@ export function SurfacePage({
             enabled={canAnnotate && tool === 'region'}
             onRegionSelected={onRegionSelected}
           />
+          {focusScrim && (
+            <FocusScrimLayer
+              spotlight={focusScrim.box}
+              onDismiss={focusScrim.onDismiss}
+              surfaceIndex={surface.index}
+            />
+          )}
           <HighlightLayer
             annotations={annotations}
             surfaceIndex={surface.index}

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -31,10 +31,20 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { Link as RouterLink } from 'react-router-dom';
-import { BoxSelect, ChevronDown, ChevronUp, GitCompareArrows, TextCursor } from 'lucide-react';
+import {
+  BoxSelect,
+  ChevronDown,
+  ChevronUp,
+  GitCompareArrows,
+  NotebookPen,
+  PanelRight,
+  Scan,
+  TextCursor,
+} from 'lucide-react';
 import type { DocumentVersionSummary } from '../../../api/generated';
 import { ExtractionStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
+import type { ReviewViewMode } from '../focus/useViewMode';
 import { ZoomControls } from './ZoomControls';
 
 export type ViewerTool = 'text' | 'region';
@@ -58,6 +68,12 @@ interface ViewerToolbarProps {
   onZoomChange: (zoom: number) => void;
   /** Link to the version comparison (#252); undefined hides the button (fewer than two extracted versions). */
   compareHref?: string;
+  /** The review's presentation (issue #291): side panel, or full-width focus mode. */
+  viewMode: ReviewViewMode;
+  onViewModeChange: (mode: ReviewViewMode) => void;
+  /** Shown on the list button in focus mode — the drawer's entry point. */
+  annotationCount: number;
+  onOpenAnnotationList: () => void;
 }
 
 /**
@@ -81,6 +97,10 @@ export function ViewerToolbar({
   zoom,
   onZoomChange,
   compareHref,
+  viewMode,
+  onViewModeChange,
+  annotationCount,
+  onOpenAnnotationList,
 }: ViewerToolbarProps) {
   return (
     <Paper
@@ -184,6 +204,44 @@ export function ViewerToolbar({
         <Divider orientation="vertical" flexItem />
 
         <ZoomControls zoom={zoom} onZoomChange={onZoomChange} />
+
+        <Divider orientation="vertical" flexItem />
+
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={viewMode}
+          onChange={(_event, next: ReviewViewMode | null) => next && onViewModeChange(next)}
+          aria-label="View mode"
+        >
+          <ToggleButton value="panel" aria-label="Panel view">
+            <Tooltip title="Panel view — the annotation list stays beside the document">
+              <PanelRight size={16} />
+            </Tooltip>
+          </ToggleButton>
+          <ToggleButton value="focus" aria-label="Focus view">
+            <Tooltip title="Focus view — full document width, discussion on demand">
+              <Scan size={16} />
+            </Tooltip>
+          </ToggleButton>
+        </ToggleButtonGroup>
+
+        {viewMode === 'focus' && (
+          <Tooltip title="Show the annotation list">
+            <IconButton
+              size="small"
+              aria-label={`Show annotations (${annotationCount})`}
+              onClick={onOpenAnnotationList}
+            >
+              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                <NotebookPen size={16} />
+                <Typography variant="caption" sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                  {annotationCount}
+                </Typography>
+              </Stack>
+            </IconButton>
+          </Tooltip>
+        )}
       </Stack>
     </Paper>
   );

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
@@ -285,5 +285,37 @@ describe('DocumentReviewPage', () => {
     expect(
       screen.getByText('This document does not exist, or you are not a participant of its review.'),
     ).toBeInTheDocument();
+  });
+});
+
+// Issue #291: the focus view replaces the fixed panel with the drawer + the
+// spotlight overlay; the mode toggle persists as a personal preference.
+describe('DocumentReviewPage focus mode', () => {
+  afterEach(() => {
+    localStorage.removeItem('qnop-review-view-mode');
+  });
+
+  it('hides the side panel, offers the list drawer and persists the choice', () => {
+    localStorage.setItem('qnop-review-view-mode', 'focus');
+    seedHappyPath();
+    renderPage();
+
+    // No fixed aside — the document takes the full width.
+    expect(screen.queryByRole('complementary', { name: 'Annotations' })).not.toBeInTheDocument();
+
+    // The toolbar's counter button opens the full panel in a drawer.
+    fireEvent.click(screen.getByRole('button', { name: /Show annotations/ }));
+    expect(screen.getByText(/Annotations \(/)).toBeInTheDocument();
+  });
+
+  it('switches back to panel mode via the toolbar toggle and stores it', () => {
+    localStorage.setItem('qnop-review-view-mode', 'focus');
+    seedHappyPath();
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Panel view' }));
+
+    expect(screen.getByRole('complementary', { name: 'Annotations' })).toBeInTheDocument();
+    expect(localStorage.getItem('qnop-review-view-mode')).toBe('panel');
   });
 });

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -463,12 +463,22 @@ export function DocumentReviewPage() {
             { name: 'preventOverflow', options: { padding: 12 } },
           ]}
         >
-          <Composer
-            pendingAnchor={pending.anchor}
-            creating={createAnnotation.isPending}
-            onCreate={handleCreate}
-            onCancel={() => setPending(null)}
-          />
+          {/* Same floating-surface treatment as the focus card: bordered
+              Paper under one soft ambient shadow. */}
+          <Box
+            sx={{
+              boxShadow: (theme) =>
+                theme.qnop.mode === 'dark' ? 'none' : '0 16px 48px rgba(1,32,66,0.14)',
+              borderRadius: '10px',
+            }}
+          >
+            <Composer
+              pendingAnchor={pending.anchor}
+              creating={createAnnotation.isPending}
+              onCreate={handleCreate}
+              onCancel={() => setPending(null)}
+            />
+          </Box>
         </Popper>
       )}
       {/* The post-selection popup: only an explicit "Create annotation" opens

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -28,6 +28,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import Popper from '@mui/material/Popper';
 import Stack from '@mui/material/Stack';
 import { NotebookPen } from 'lucide-react';
 import type { Anchor, NormalizedBox } from '../../api/generated';
@@ -45,6 +46,16 @@ import { useToast } from '../../components/admin/layout/useToast';
 import { ReviewHubHead } from '../../components/reviews/hub/ReviewHubHead';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
 import { PANEL_MIN_WIDTH, PanelResizer } from '../../components/reviews/PanelResizer';
+import { FocusAnnotationCard } from '../../components/reviews/focus/FocusAnnotationCard';
+import { FocusDrawer } from '../../components/reviews/focus/FocusDrawer';
+import {
+  spotlightForAnchor,
+  spotlightForAnnotation,
+  walkPosition,
+} from '../../components/reviews/focus/spotlightModel';
+import { useAnchorElement } from '../../components/reviews/focus/useAnchorElement';
+import { useViewMode } from '../../components/reviews/focus/useViewMode';
+import { Composer } from '../../components/reviews/panel/Composer';
 import { WorkflowBadge } from '../../components/reviews/WorkflowBadge';
 import type {
   ScreenPosition,
@@ -104,6 +115,8 @@ export function DocumentReviewPage() {
 
   const [tool, setTool] = useState<ViewerTool>('text');
   const [zoom, setZoom] = useState(1);
+  const [viewMode, setViewMode] = useViewMode();
+  const [listOpen, setListOpen] = useState(false);
   const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
   // Card↔mark linking (prototype): hovering either side lights up the other.
   const [hoverAnnotationId, setHoverAnnotationId] = useState<string | null>(null);
@@ -143,6 +156,30 @@ export function DocumentReviewPage() {
   const canAnnotate = extractionReady && surfaces !== undefined;
   const textToolAvailable = (surfaces ?? []).some((surface) => surface.textSpans.length > 0);
   const pageCount = surfaces?.length ?? pdf?.numPages ?? 0;
+
+  // Focus mode (issue #291): the spotlight follows the active annotation, or
+  // the pending anchor while its composer is open. The card/composer anchor
+  // to the mark elements the highlight layer renders.
+  const focusMode = viewMode === 'focus';
+  const activeAnnotation = annotations.find((a) => a.id === activeAnnotationId);
+  const composingPending = Boolean(pending && !pending.menuPosition);
+  const focusSpotlight = !focusMode
+    ? null
+    : composingPending && pending
+      ? spotlightForAnchor(pending.anchor, surfaces)
+      : spotlightForAnnotation(activeAnnotation, surfaces);
+  const focusOverlayOpen = focusMode && (composingPending || Boolean(activeAnnotation));
+  const activeMarkEl = useAnchorElement(
+    focusMode && activeAnnotation?.anchor ? `annotation-highlight-${activeAnnotation.id}` : null,
+  );
+  const pendingMarkEl = useAnchorElement(
+    focusMode && composingPending ? 'pending-highlight' : null,
+  );
+
+  const closeFocusCard = () => {
+    setActiveAnnotationId(null);
+    activeMarkEl?.focus();
+  };
 
   const handleVersionChange = (version: number) => {
     setSearchParams({ version: String(version) });
@@ -266,6 +303,13 @@ export function DocumentReviewPage() {
                   ? `/reviews/${documentId}/compare`
                   : undefined
               }
+              viewMode={viewMode}
+              onViewModeChange={(mode) => {
+                setViewMode(mode);
+                setListOpen(false);
+              }}
+              annotationCount={annotations.length}
+              onOpenAnnotationList={() => setListOpen(true)}
             />
             {extractionStatus === ExtractionStatus.Pending && (
               <Alert severity="info">
@@ -316,41 +360,116 @@ export function DocumentReviewPage() {
                   pendingAnchor={pending?.anchor ?? null}
                   onTextSelected={handleTextSelected}
                   onRegionSelected={handleRegionSelected}
+                  focusScrim={
+                    focusOverlayOpen
+                      ? {
+                          spotlight: focusSpotlight,
+                          // The veil never discards a composer mid-typing — the
+                          // card's Cancel is the explicit way out.
+                          onDismiss: () => {
+                            if (!composingPending) closeFocusCard();
+                          },
+                        }
+                      : null
+                  }
                 />
               </Box>
             )}
           </Stack>
-          <PanelResizer
-            width={panelWidth}
-            defaultWidth={PANEL_MIN_WIDTH}
-            onWidthChange={handlePanelWidthChange}
-          />
-          <Box
-            component="aside"
-            aria-label="Annotations"
-            sx={{
-              width: { xs: '100%', md: panelWidth },
-              flexShrink: 0,
-              minHeight: 0,
-              overflowY: { md: 'auto' },
-            }}
-          >
-            <AnnotationPanel
-              annotations={annotations}
-              activeAnnotationId={activeAnnotationId}
-              hoverAnnotationId={hoverAnnotationId}
-              onSelect={setActiveAnnotationId}
-              onHover={setHoverAnnotationId}
-              pendingAnchor={pending && !pending.menuPosition ? pending.anchor : null}
-              creating={createAnnotation.isPending}
-              onCreate={handleCreate}
-              onCancelPending={() => setPending(null)}
-              canAnnotate={canAnnotate}
-              ownerId={document.ownerId}
-              notify={notify}
+          {!focusMode && (
+            <PanelResizer
+              width={panelWidth}
+              defaultWidth={PANEL_MIN_WIDTH}
+              onWidthChange={handlePanelWidthChange}
             />
-          </Box>
+          )}
+          {!focusMode && (
+            <Box
+              component="aside"
+              aria-label="Annotations"
+              sx={{
+                width: { xs: '100%', md: panelWidth },
+                flexShrink: 0,
+                minHeight: 0,
+                overflowY: { md: 'auto' },
+              }}
+            >
+              <AnnotationPanel
+                annotations={annotations}
+                activeAnnotationId={activeAnnotationId}
+                hoverAnnotationId={hoverAnnotationId}
+                onSelect={setActiveAnnotationId}
+                onHover={setHoverAnnotationId}
+                pendingAnchor={pending && !pending.menuPosition ? pending.anchor : null}
+                creating={createAnnotation.isPending}
+                onCreate={handleCreate}
+                onCancelPending={() => setPending(null)}
+                canAnnotate={canAnnotate}
+                ownerId={document.ownerId}
+                notify={notify}
+              />
+            </Box>
+          )}
         </Stack>
+      )}
+      {focusMode && (
+        <FocusDrawer open={listOpen} onClose={() => setListOpen(false)}>
+          <AnnotationPanel
+            annotations={annotations}
+            activeAnnotationId={activeAnnotationId}
+            hoverAnnotationId={hoverAnnotationId}
+            onSelect={(id) => {
+              setActiveAnnotationId(id);
+              // A placed annotation continues in the spotlight; unplaced ones
+              // keep their thread inside the drawer (no mark to spotlight).
+              if (id && annotations.find((a) => a.id === id)?.anchor) setListOpen(false);
+            }}
+            onHover={setHoverAnnotationId}
+            pendingAnchor={null}
+            creating={createAnnotation.isPending}
+            onCreate={handleCreate}
+            onCancelPending={() => setPending(null)}
+            canAnnotate={canAnnotate}
+            ownerId={document.ownerId}
+            notify={notify}
+          />
+        </FocusDrawer>
+      )}
+      {focusMode && activeAnnotation && !listOpen && (
+        <FocusAnnotationCard
+          annotation={activeAnnotation}
+          anchorEl={activeMarkEl}
+          position={walkPosition(annotations, activeAnnotation.id)}
+          onNavigate={setActiveAnnotationId}
+          onClose={closeFocusCard}
+          ownerId={document.ownerId}
+          userId={userId}
+          notify={notify}
+        />
+      )}
+      {focusMode && composingPending && pending && (
+        <Popper
+          open={Boolean(pendingMarkEl)}
+          anchorEl={pendingMarkEl}
+          placement="right-start"
+          sx={(theme) => ({
+            zIndex: theme.zIndex.modal,
+            width: 380,
+            maxWidth: 'calc(100vw - 32px)',
+          })}
+          modifiers={[
+            { name: 'offset', options: { offset: [0, 16] } },
+            { name: 'flip', options: { fallbackPlacements: ['left-start', 'bottom', 'top'] } },
+            { name: 'preventOverflow', options: { padding: 12 } },
+          ]}
+        >
+          <Composer
+            pendingAnchor={pending.anchor}
+            creating={createAnnotation.isPending}
+            onCreate={handleCreate}
+            onCancel={() => setPending(null)}
+          />
+        </Popper>
       )}
       {/* The post-selection popup: only an explicit "Create annotation" opens
           the composer; dismissing it (click-away, Escape) discards the mark. */}


### PR DESCRIPTION
Closes #291. Implements the plan posted in the issue — frontend-only, panel mode untouched.

## What

- **Two view modes**, toggled in the viewer toolbar and persisted in localStorage (small viewports default to focus): the existing panel, or **focus mode** — full document width, discussion on demand.
- **Spotlight, not a modal**: clicking a mark dims every page under a soft blurred veil while the passage around the mark stays sharp. The scrim is four rectangles around the padded union of the anchor's line boxes (`spotlightModel`), rendered **per page below the highlight layer** — marks keep full contrast and stay clickable, and clicking another mark switches the spotlight directly. Veil click dismisses (but never discards a composer mid-typing).
- **Floating discussion card** (`Popper` next to the mark, never over it): status + placement cues, quote, Accept/Reject, the full comment thread with composer. **Prev/Next** (buttons and ↑/↓ outside text fields) walk the placed annotations in document order; the position is announced via `aria-live` ("Annotation 3 of 6"). Tab cycles inside the card without focus enforcement; `Escape`/close returns focus to the mark.
- **Drawer**: a toolbar counter button ("N annotations") opens the full panel — filters, orphaned section — as a temporary drawer; picking a placed annotation continues in the spotlight, unplaced ones keep their thread in the drawer.
- **Creating annotations** works identically in both modes; in focus mode the composer floats at the pending mark under its own spotlight.
- **A11y**: `prefers-reduced-transparency` drops the blur, `prefers-reduced-motion` collapses the staged entrance — and the viewer's scroll-to-mark now honours it too (`scrollIntoView` ignores the CSS `scroll-behavior` override; pre-existing gap).
- **Refactors on the way**: `Composer`, `DecisionBar`, the decide-feedback hook and the status cues extracted from the panel internals for reuse (panel behaviour unchanged).

## Test plan

- [x] Unit: `spotlightModel` (padding/clamping, document order, walk neighbours)
- [x] Component: `FocusScrimLayer` (full dim vs four-segment hole, veil dismiss), `FocusAnnotationCard` (counter, thread, decisions, prev/next via buttons and keys, typing-target guard, escape, end-of-walk disabling, permission gating), page-level focus mode (panel hidden, drawer entry, toggle + persistence)
- [x] All 382 tests green; `tsc`, `eslint`, `prettier`, production build
- [x] Manual visual pass in the running app (both themes): toggle + persistence across reloads, spotlight geometry on text and region marks, card entrance, drawer→spotlight handoff, pending composer under spotlight, veil dismiss, escape focus-return
- [ ] Interactive check of the smooth scroll-follow on prev/next (verified the effect fires with the right element; smooth scrolling is frozen in background tabs, so the automated session could not observe the animation itself)

Two fixes found by the visual pass are part of this PR: focus-trap enforcement removed (clicking the toolbar/marks yanked focus and window scroll back into the card) and reduced-motion-aware scrolling.

🤖 Co-Author: Claude (Fable 5) via Claude Code