### PR TITLE
docs(api): reference the 429 response on rate-limited endpoints (#347)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1284,11 +1284,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '429':
-          description: Too many registration attempts
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/TooManyRequests'
   /auth/verify-email:
     get:
       tags:
@@ -1338,11 +1334,7 @@ paths:
         '204':
           description: Request accepted (no content; outcome intentionally not disclosed)
         '429':
-          description: Too many reset requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/TooManyRequests'
   /auth/reset-password:
     post:
       tags:
@@ -1439,6 +1431,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /auth/logout:
     post:
       tags:
@@ -1505,6 +1499,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /users/me:
     get:
       tags:


### PR DESCRIPTION
## Summary

Closes #347. The shared `TooManyRequests` (429) response component was referenced only by `/auth/login`, so the other rate-limited auth operations under-documented their throttling. This attaches it to **every** rate-limited endpoint (the five Bucket4j filters, ADR-0027).

| Endpoint | Before | After |
|---|---|---|
| `/auth/login` | `$ref TooManyRequests` | unchanged |
| `/auth/refresh` | *(no 429)* | `$ref TooManyRequests` |
| `/auth/change-password` | *(no 429)* | `$ref TooManyRequests` |
| `/auth/register` | inline 429 (no `Retry-After`) | `$ref TooManyRequests` |
| `/auth/forgot-password` | inline 429 (no `Retry-After`) | `$ref TooManyRequests` |

Using the shared component (over the ad-hoc inline blocks) also documents the `Retry-After` header the filters actually emit, and gives one consistent 429 contract.

Docs-only: 429 is an error response, so no generated Spring interface or TS client signatures change.

## Test plan

- [x] `:qnop-api:qnop-api-endpoint:build` — spec parses, generated Spring interfaces compile.
- [x] `pnpm generate:api` + `pnpm typecheck` — TS client regenerates, clean.
- [x] Verified all five rate-limited operations now reference `#/components/responses/TooManyRequests` and no inline 429 remains.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code