### PR TITLE
perf: stream document uploads instead of materializing them in the heap (#361)

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/DocumentUploadController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentUploadController.java
@@ -23,7 +23,9 @@ package io.qnop.web;
 import io.qnop.service.document.DocumentIngestService;
 import io.qnop.service.document.DocumentIngestService.UploadResult;
 import io.qnop.service.document.DocumentValidationException;
+import io.qnop.service.document.UploadSource;
 import java.io.IOException;
+import java.io.InputStream;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
@@ -61,14 +63,16 @@ public class DocumentUploadController {
       @RequestParam("file") MultipartFile file,
       @RequestParam(value = "dueAt", required = false) String dueAt) {
     UploadResult result =
-        ingest.createDocument(CurrentUser.requireUserId(), title, bytesOf(file), parseDueAt(dueAt));
+        ingest.createDocument(
+            CurrentUser.requireUserId(), title, sourceOf(file), parseDueAt(dueAt));
     return ResponseEntity.status(HttpStatus.CREATED).body(DocumentUploadResponse.of(result));
   }
 
   @PostMapping(value = "/{documentId}/versions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<DocumentUploadResponse> addVersion(
       @PathVariable UUID documentId, @RequestParam("file") MultipartFile file) {
-    UploadResult result = ingest.addVersion(CurrentUser.requireUserId(), documentId, bytesOf(file));
+    UploadResult result =
+        ingest.addVersion(CurrentUser.requireUserId(), documentId, sourceOf(file));
     return ResponseEntity.status(HttpStatus.CREATED).body(DocumentUploadResponse.of(result));
   }
 
@@ -84,12 +88,24 @@ public class DocumentUploadController {
     }
   }
 
-  private static byte[] bytesOf(MultipartFile file) {
-    try {
-      return file.getBytes();
-    } catch (IOException e) {
-      throw DocumentValidationException.invalidRequest("upload could not be read");
-    }
+  /**
+   * Adapts the multipart part to the framework-free {@link UploadSource} the ingest service
+   * consumes (issue #361), so the upload streams through without being materialized in the heap and
+   * {@code MultipartFile} never crosses into {@code qnop-core} (ADR-0004). {@code getInputStream}
+   * may be opened more than once (ingest sniffs, then stages).
+   */
+  private static UploadSource sourceOf(MultipartFile file) {
+    return new UploadSource() {
+      @Override
+      public InputStream open() throws IOException {
+        return file.getInputStream();
+      }
+
+      @Override
+      public long declaredSize() {
+        return file.getSize();
+      }
+    };
   }
 
   /** What the SPA needs after an upload: where the version landed and its extraction state. */

--- a/qnop-app/src/test/java/io/qnop/document/DocumentIngestIT.java
+++ b/qnop-app/src/test/java/io/qnop/document/DocumentIngestIT.java
@@ -35,11 +35,15 @@ import io.qnop.entity.User;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.repository.UserRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.job.JobQueuePoller;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -73,6 +77,7 @@ class DocumentIngestIT extends AbstractIntegrationTest {
   @Autowired ReviewParticipantRepository participants;
   @Autowired PasswordEncoder passwordEncoder;
   @Autowired JobQueuePoller poller;
+  @Autowired ApplicationSettingsService settings;
 
   private final List<UUID> createdDocuments = new ArrayList<>();
   private final List<UUID> createdUsers = new ArrayList<>();
@@ -192,6 +197,48 @@ class DocumentIngestIT extends AbstractIntegrationTest {
                 .with(asUser(owner)))
         .andExpect(status().isUnsupportedMediaType())
         .andExpect(jsonPath("$.code").value("UNSUPPORTED_MEDIA_TYPE"));
+  }
+
+  @Test
+  @DisplayName("an empty upload is rejected with 400 and the uniform envelope")
+  void rejectsEmptyUpload() throws Exception {
+    UUID owner = createUser();
+
+    mockMvc
+        .perform(
+            multipart("/api/v1/documents")
+                .file(new MockMultipartFile("file", "empty.pdf", "application/pdf", new byte[0]))
+                .param("title", "Empty")
+                .with(asUser(owner)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @DisplayName("an upload over the configured size cap is rejected with 413 (before staging)")
+  void rejectsOversizeUpload() throws Exception {
+    UUID owner = createUser();
+    int originalCapMb = settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB);
+    try {
+      settings.update(Map.of(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB.getKey(), "1"), null);
+      byte[] tooBig = new byte[2 * 1024 * 1024]; // 2 MB > 1 MB cap
+      System.arraycopy("%PDF-".getBytes(StandardCharsets.US_ASCII), 0, tooBig, 0, 5);
+
+      mockMvc
+          .perform(
+              multipart("/api/v1/documents")
+                  .file(pdfFile(tooBig))
+                  .param("title", "Too big")
+                  .with(asUser(owner)))
+          .andExpect(status().isPayloadTooLarge())
+          .andExpect(jsonPath("$.code").value("PAYLOAD_TOO_LARGE"));
+    } finally {
+      settings.update(
+          Map.of(
+              ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB.getKey(),
+              String.valueOf(originalCapMb)),
+          null);
+    }
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -33,8 +33,10 @@ import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.job.JobService;
 import io.qnop.service.storage.StagedObject;
+import io.qnop.service.storage.StorageQuotaExceededException;
 import io.qnop.service.storage.StorageService;
-import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Comparator;
@@ -104,12 +106,13 @@ public class DocumentIngestService {
    * Creates a new document owned by {@code actor} with the upload as version 1. An optional {@code
    * dueAt} completion deadline (issue #295) must be in the future when set at creation.
    */
-  public UploadResult createDocument(UUID actor, String title, byte[] content, Instant dueAt) {
+  public UploadResult createDocument(UUID actor, String title, UploadSource upload, Instant dueAt) {
     String cleanTitle = requireTitle(title);
     Instant validDueAt = requireFutureOrNull(dueAt);
-    validatePdf(content);
+    long maxBytes = maxUploadBytes();
+    validateUpload(upload, maxBytes);
 
-    StagedObject staged = storage.stage(new ByteArrayInputStream(content), PDF_CONTENT_TYPE);
+    StagedObject staged = stageUpload(upload, maxBytes);
     UploadResult result =
         transactionTemplate.execute(
             status -> {
@@ -127,7 +130,7 @@ public class DocumentIngestService {
   }
 
   /** Appends the upload as the next version of {@code documentId}; owner-only. */
-  public UploadResult addVersion(UUID actor, UUID documentId, byte[] content) {
+  public UploadResult addVersion(UUID actor, UUID documentId, UploadSource upload) {
     Document document =
         documents
             .findById(documentId)
@@ -141,9 +144,10 @@ public class DocumentIngestService {
       }
       throw DocumentValidationException.notOwner("only the owner may upload a new version");
     }
-    validatePdf(content);
+    long maxBytes = maxUploadBytes();
+    validateUpload(upload, maxBytes);
 
-    StagedObject staged = storage.stage(new ByteArrayInputStream(content), PDF_CONTENT_TYPE);
+    StagedObject staged = stageUpload(upload, maxBytes);
     UploadResult result =
         transactionTemplate.execute(
             status -> {
@@ -235,27 +239,48 @@ public class DocumentIngestService {
     return dueAt;
   }
 
-  private void validatePdf(byte[] content) {
-    if (content == null || content.length == 0) {
-      throw DocumentValidationException.invalidRequest("empty upload");
-    }
-    long maxBytes =
-        settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB) * 1024L * 1024L;
-    if (content.length > maxBytes) {
+  private long maxUploadBytes() {
+    return settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB) * 1024L * 1024L;
+  }
+
+  /**
+   * Rejects an upload before it is buffered: a fast early check on the (advisory) declared size,
+   * then a streaming magic-byte sniff of the real type (ADR-0032 §5 — the client-declared MIME is
+   * never trusted). The authoritative size limit is enforced while staging (issue #361).
+   */
+  private void validateUpload(UploadSource upload, long maxBytes) {
+    if (upload.declaredSize() > maxBytes) {
       throw DocumentValidationException.tooLarge("document exceeds " + maxBytes + " bytes");
     }
-    // Sniff the real type from the bytes (ADR-0032 §5); the client-declared MIME is never trusted.
-    if (!hasPdfMagic(content)) {
+    byte[] prefix = new byte[PDF_MAGIC.length];
+    int read;
+    try (InputStream in = upload.open()) {
+      read = in.readNBytes(prefix, 0, prefix.length);
+    } catch (IOException e) {
+      throw DocumentValidationException.invalidRequest("upload could not be read");
+    }
+    if (read == 0) {
+      throw DocumentValidationException.invalidRequest("empty upload");
+    }
+    if (read < PDF_MAGIC.length || !hasPdfMagic(prefix)) {
       throw DocumentValidationException.unsupportedType("only PDF documents are accepted");
     }
   }
 
-  private static boolean hasPdfMagic(byte[] content) {
-    if (content.length < PDF_MAGIC.length) {
-      return false;
+  /** Streams the upload into storage under the authoritative size cap, mapping its errors. */
+  private StagedObject stageUpload(UploadSource upload, long maxBytes) {
+    try (InputStream in = upload.open()) {
+      return storage.stage(in, PDF_CONTENT_TYPE, maxBytes);
+    } catch (StorageQuotaExceededException e) {
+      throw DocumentValidationException.tooLarge("document exceeds " + e.limitBytes() + " bytes");
+    } catch (IOException e) {
+      throw DocumentValidationException.invalidRequest("upload could not be read");
     }
+  }
+
+  private static boolean hasPdfMagic(byte[] prefix) {
     for (int i = 0; i < PDF_MAGIC.length; i++) {
-      if (content[i] != PDF_MAGIC[i]) {
+      if (prefix[i] != PDF_MAGIC[i]) {
         return false;
       }
     }

--- a/qnop-core/src/main/java/io/qnop/service/document/UploadSource.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/UploadSource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.document;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A re-openable, framework-free view of an upload (issue #361). Lets {@link DocumentIngestService}
+ * stream a document without materializing it in the heap, while keeping the web layer's {@code
+ * MultipartFile} out of {@code qnop-core} (ADR-0004). {@link #open()} returns a <em>fresh</em>
+ * stream on each call, so ingest can sniff the magic bytes from one stream and stage the content
+ * from another.
+ */
+public interface UploadSource {
+
+  /** Opens a new stream over the upload's bytes; the caller closes it. */
+  InputStream open() throws IOException;
+
+  /**
+   * The upload's size as declared by the transport (e.g. the multipart part length). Advisory only
+   * — a client may under-report it — so it is used for a fast early rejection; the authoritative
+   * size is measured while staging.
+   */
+  long declaredSize();
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageQuotaExceededException.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageQuotaExceededException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+/**
+ * Thrown by {@link StorageService#stage(java.io.InputStream, String, long)} when the streamed
+ * content exceeds the caller-supplied byte limit (issue #361). Staging aborts <em>before</em>
+ * buffering the whole stream or uploading anything, so an over-limit upload never reaches the
+ * backend. Callers translate this to their own domain error (e.g. HTTP 413).
+ */
+public class StorageQuotaExceededException extends RuntimeException {
+
+  private final long limitBytes;
+
+  public StorageQuotaExceededException(long limitBytes) {
+    super("upload exceeds the maximum of " + limitBytes + " bytes");
+    this.limitBytes = limitBytes;
+  }
+
+  public long limitBytes() {
+    return limitBytes;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
@@ -28,9 +28,9 @@ import io.qnop.spi.storage.StorageException;
 import io.qnop.spi.storage.StorageProvider;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
@@ -83,7 +83,18 @@ public class StorageService {
    * failed earlier upload without ever returning a key that points at nothing.
    */
   public StagedObject stage(InputStream content, String contentType) {
-    Path buffer = bufferToTempFile(content);
+    return stage(content, contentType, Long.MAX_VALUE);
+  }
+
+  /**
+   * As {@link #stage(InputStream, String)}, but aborts with {@link StorageQuotaExceededException}
+   * once the stream exceeds {@code maxBytes} — before the whole stream is buffered and before any
+   * upload (issue #361), so an over-limit upload never touches the backend and never fully lands on
+   * local disk. This is the authoritative size check for content whose declared length cannot be
+   * trusted.
+   */
+  public StagedObject stage(InputStream content, String contentType, long maxBytes) {
+    Path buffer = bufferToTempFile(content, maxBytes);
     try {
       String hash = sha256(buffer);
       long size = sizeOf(buffer);
@@ -170,13 +181,42 @@ public class StorageService {
     return "sha256/" + hash.substring(0, 2) + "/" + hash;
   }
 
-  private static Path bufferToTempFile(InputStream content) {
+  private static Path bufferToTempFile(InputStream content, long maxBytes) {
+    Path temp;
     try {
-      Path temp = Files.createTempFile("qnop-storage-", ".tmp");
-      Files.copy(content, temp, StandardCopyOption.REPLACE_EXISTING);
-      return temp;
+      temp = Files.createTempFile("qnop-storage-", ".tmp");
     } catch (IOException e) {
       throw new StorageException("Failed to buffer upload", e);
+    }
+    try (OutputStream out = Files.newOutputStream(temp)) {
+      copyBounded(content, out, maxBytes);
+      return temp;
+    } catch (StorageQuotaExceededException e) {
+      deleteQuietly(temp); // never keep an over-limit partial on disk
+      throw e;
+    } catch (IOException e) {
+      deleteQuietly(temp);
+      throw new StorageException("Failed to buffer upload", e);
+    }
+  }
+
+  /**
+   * Copies at most {@code maxBytes}; if the stream still has data at that point the content is
+   * over-limit and {@link StorageQuotaExceededException} is thrown before more is read (issue
+   * #361).
+   */
+  private static void copyBounded(InputStream in, OutputStream out, long maxBytes)
+      throws IOException {
+    byte[] buffer = new byte[8192];
+    long remaining = maxBytes;
+    int read;
+    while ((read = in.read(buffer)) != -1) {
+      if (read > remaining) {
+        out.write(buffer, 0, (int) remaining); // fill exactly to the limit, then reject
+        throw new StorageQuotaExceededException(maxBytes);
+      }
+      out.write(buffer, 0, read);
+      remaining -= read;
     }
   }
 

--- a/qnop-core/src/test/java/io/qnop/service/storage/StorageServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/StorageServiceTest.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -65,6 +66,29 @@ class StorageServiceTest {
     StorageObject row = pendingRow();
     row.markCommitted(Instant.now());
     return row;
+  }
+
+  @Test
+  @DisplayName("staging aborts over the byte limit before any upload (issue #361)")
+  void overLimitContentIsRejectedBeforeUpload() {
+    InputStream tenBytes = new ByteArrayInputStream("0123456789".getBytes());
+
+    Assertions.assertThatThrownBy(() -> storage.stage(tenBytes, "application/pdf", 4L))
+        .isInstanceOf(StorageQuotaExceededException.class);
+
+    verify(provider, never()).put(anyString(), any(), anyLong(), anyString());
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("content exactly at the byte limit still stages")
+  void contentAtLimitIsStaged() {
+    when(repository.findByObjectKey(anyString())).thenReturn(Optional.empty());
+    InputStream fourBytes = new ByteArrayInputStream("abcd".getBytes());
+
+    storage.stage(fourBytes, "application/pdf", 4L);
+
+    verify(provider).put(anyString(), any(), anyLong(), eq("application/pdf"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Carved out of #314. The upload path loaded the **entire file into the JVM heap**: `DocumentUploadController` called `MultipartFile.getBytes()` and passed a `byte[]` through `DocumentIngestService`, which wrapped it back into a `ByteArrayInputStream` for staging. A 50 MB+ upload — or several concurrent ones — spiked heap and GC pressure on the request path, even though `StorageService.stage` **already** buffers to a temp file and hashes/sizes incrementally.

### Changes
- **New `UploadSource` abstraction** (`qnop-core`): a framework-free, re-openable view of an upload (`open()` → fresh `InputStream`, `declaredSize()`). The controller adapts `MultipartFile` to it, so `MultipartFile` never crosses into `qnop-core` (ADR-0004) and the bytes are never fully materialized. `open()` may be called twice (ingest sniffs, then stages).
- **`DocumentIngestService`** takes an `UploadSource`: a fast early reject on the *advisory* declared size, a **streaming magic-byte sniff** of the real type (empty → 400, non-PDF → 415), then streams into staging.
- **`StorageService.stage(stream, type, maxBytes)`**: the temp-file copy is now bounded and aborts with `StorageQuotaExceededException` **before** buffering the whole stream or uploading anything — so the size cap stays **authoritative** even if the declared length is under-reported, and no over-limit object ever reaches the backend. The 2-arg overload is preserved (delegates uncapped).

### Why no ADR
Pure implementation refinement within the existing ingest/storage seams (ADR-0032 §5 / ADR-0005/0036); the contract and behaviour are unchanged.

## Test plan
- [x] `StorageServiceTest`: cap rejects before any `put`; content exactly at the limit still stages.
- [x] `DocumentIngestIT`: empty upload → 400; over-cap upload → 413 (setting lowered + restored); existing happy-path / 415 / corrupt-PDF cases unchanged.
- [x] Local gate green: `spotlessApply`, `:qnop-core:build` (incl. `StorageServiceTest`), `:qnop-app:compileTestJava`, `ArchitectureRulesTest`.
- [ ] CI: full ingest ITs (Testcontainers, incl. MinIO) exercise the streamed path end-to-end.

Closes #361

🤖 Co-Author: Claude (Opus 4.x) via Claude Code