### PR TITLE
fix(ui): replace unsafe viewer casts and non-null assertions (#335)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/architecture/RequestBodyValidationRulesTest.java
+++ b/qnop-app/src/test/java/io/qnop/architecture/RequestBodyValidationRulesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.architecture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameter;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * Guards that every request body on the generated REST contract carries Bean Validation (issue
+ * #346). The controllers implement the openapi-generator {@code spring} interfaces (ADR-0021) and
+ * do not redeclare parameter annotations, so enforcement of the DTO constraints hinges entirely on
+ * the generator emitting {@code @Valid} next to each {@code @RequestBody} — which it does while
+ * {@code useBeanValidation=true} in {@code qnop-api-endpoint}'s generator config. Spring MVC
+ * honours those interface-declared parameter annotations, so a missing {@code @Valid} would
+ * silently stop validating request bodies (a {@code MethodArgumentNotValidException} would never
+ * fire, and the {@code VALIDATION_ERROR} envelope never surface).
+ *
+ * <p>The runtime behaviour is exercised by {@code ErrorEnvelopeIT} (an empty {@code POST
+ * /auth/login} body → 400 {@code VALIDATION_ERROR}); this test is the static counterpart that fails
+ * fast — without a Spring context or a database — if a config or generator change ever drops the
+ * annotation.
+ */
+class RequestBodyValidationRulesTest {
+
+  /** The generated Spring MVC interfaces the controllers implement (ADR-0021). */
+  private static final String ENDPOINT_PACKAGE = "io.qnop.api.v1.endpoint";
+
+  private static final JavaClasses ENDPOINT_APIS =
+      new ClassFileImporter().importPackages(ENDPOINT_PACKAGE);
+
+  @Test
+  void everyRequestBodyParameterIsValidated() {
+    List<String> requestBodies = new ArrayList<>();
+    List<String> unvalidated = new ArrayList<>();
+
+    for (JavaClass api : ENDPOINT_APIS) {
+      for (JavaMethod method : api.getMethods()) {
+        for (JavaParameter parameter : method.getParameters()) {
+          if (!parameter.isAnnotatedWith(RequestBody.class)) {
+            continue;
+          }
+          String location = api.getSimpleName() + "#" + method.getName();
+          requestBodies.add(location);
+          if (!parameter.isAnnotatedWith(Valid.class)) {
+            unvalidated.add(location);
+          }
+        }
+      }
+    }
+
+    // Fail loudly if the scan found nothing — a wrong package or an empty generation
+    // output would otherwise let this rule pass vacuously.
+    assertFalse(
+        requestBodies.isEmpty(),
+        "No @RequestBody parameters found in "
+            + ENDPOINT_PACKAGE
+            + "; the generated endpoint contract is missing from the classpath.");
+
+    assertTrue(
+        unvalidated.isEmpty(),
+        "Every @RequestBody must also be @Valid so request-DTO constraints are enforced (#346). "
+            + "Missing @Valid on: "
+            + unvalidated);
+  }
+}

--- a/qnop-ui/src/api/hooks/useVersionDiff.ts
+++ b/qnop-ui/src/api/hooks/useVersionDiff.ts
@@ -42,11 +42,13 @@ export function useVersionDiff(documentId: string, from?: number, to?: number) {
   return useQuery<VersionDiffResponse>({
     queryKey: versionDiffKeys.pair(documentId, from ?? 0, to ?? 0),
     queryFn: async () => {
-      const response = await documentsApi.getVersionDiff({
-        documentId,
-        from: from as number,
-        to: to as number,
-      });
+      // `enabled: validPair` guarantees both bounds are defined when the query
+      // runs; the guard narrows them to `number` for the request without a cast
+      // and fails loud should that invariant ever break.
+      if (from === undefined || to === undefined) {
+        throw new Error('useVersionDiff: version bounds must be defined when the query runs');
+      }
+      const response = await documentsApi.getVersionDiff({ documentId, from, to });
       return response.data;
     },
     enabled: documentId.length > 0 && validPair,

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.tsx
@@ -33,6 +33,9 @@ import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { highlightBoxesForAnchor } from './anchoring';
 import { SELECTION_MARKER_BG, highlightColorFor } from './markerColors';
 
+/** An annotation whose optional {@link Anchor} is known to be present. */
+type AnchoredAnnotation = AnnotationView & { anchor: Anchor };
+
 interface HighlightLayerProps {
   /** All annotations of the document — the layer picks the ones on this surface. */
   annotations: AnnotationView[];
@@ -95,8 +98,11 @@ export function HighlightLayer({
 }: HighlightLayerProps) {
   const theme = useTheme();
 
+  // The predicate narrows the survivors to a guaranteed-anchored shape, so the
+  // render below reads `annotation.anchor` without a non-null assertion.
   const visible = annotations.filter(
-    (annotation) => annotation.anchor?.region.surfaceIndex === surfaceIndex,
+    (annotation): annotation is AnchoredAnnotation =>
+      annotation.anchor?.region.surfaceIndex === surfaceIndex,
   );
   const pending =
     pendingAnchor && pendingAnchor.region.surfaceIndex === surfaceIndex
@@ -129,7 +135,7 @@ export function HighlightLayer({
   return (
     <Box sx={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
       {visible.map((annotation) => {
-        const anchor = annotation.anchor!;
+        const anchor = annotation.anchor;
         const { kind, boxes } = highlightBoxesForAnchor(anchor, spans);
         const style = styleFor(annotation);
         const active = annotation.id === activeAnnotationId;

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import type { PointerEvent } from 'react';
 import Box from '@mui/material/Box';
 import type { NormalizedBox } from '../../../api/generated';
@@ -54,11 +54,12 @@ export function RegionSelectLayer({
   enabled,
   onRegionSelected,
 }: RegionSelectLayerProps) {
-  const rootRef = useRef<HTMLDivElement>(null);
   const [draft, setDraft] = useState<DraftRect | null>(null);
 
-  const toNormalized = (event: PointerEvent) => {
-    const rect = rootRef.current!.getBoundingClientRect();
+  // `currentTarget` is the surface Box the handlers are bound to — always the
+  // live element during the event, so it needs no ref and no non-null assertion.
+  const toNormalized = (event: PointerEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
     return {
       x: clampUnit((event.clientX - rect.left) / rect.width),
       y: clampUnit((event.clientY - rect.top) / rect.height),
@@ -97,7 +98,6 @@ export function RegionSelectLayer({
 
   return (
     <Box
-      ref={rootRef}
       data-testid={`region-layer-${surfaceIndex}`}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}


### PR DESCRIPTION
Closes #335.

Three spots on the viewer path bypassed the type system with casts / `!`. Each is replaced by a genuine narrowing construct — no behavior change.

## Changes

| File | Before | After |
|------|--------|-------|
| `api/hooks/useVersionDiff.ts` | `from as number`, `to as number` | Runtime guard inside `queryFn` narrows both bounds to `number` (the `enabled: validPair` gate already guarantees them; the guard fails loud if that invariant ever breaks). |
| `components/reviews/viewer/HighlightLayer.tsx` | `annotation.anchor!` | The surface `.filter()` is now a type-guard predicate producing an `AnchoredAnnotation` (`AnnotationView & { anchor: Anchor }`), so the render reads `annotation.anchor` without an assertion. |
| `components/reviews/viewer/RegionSelectLayer.tsx` | `rootRef.current!` | Uses the non-null `event.currentTarget` of the surface `Box` (always the live bound element during the pointer event); the ref is dropped entirely. |

## Test plan

- [x] `tsc -b --noEmit` — clean
- [x] `eslint` on the three files — clean
- [x] `prettier --check` — clean
- [x] `vitest run` viewer suite — 52 passed
- [x] Behavior-preserving: same runtime element/rect and same filtered set; only the type-level machinery changed.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code