### PR TITLE
test(app): guard @Valid on every generated request body (#346)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/architecture/RequestBodyValidationRulesTest.java
+++ b/qnop-app/src/test/java/io/qnop/architecture/RequestBodyValidationRulesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.architecture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameter;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * Guards that every request body on the generated REST contract carries Bean Validation (issue
+ * #346). The controllers implement the openapi-generator {@code spring} interfaces (ADR-0021) and
+ * do not redeclare parameter annotations, so enforcement of the DTO constraints hinges entirely on
+ * the generator emitting {@code @Valid} next to each {@code @RequestBody} — which it does while
+ * {@code useBeanValidation=true} in {@code qnop-api-endpoint}'s generator config. Spring MVC
+ * honours those interface-declared parameter annotations, so a missing {@code @Valid} would
+ * silently stop validating request bodies (a {@code MethodArgumentNotValidException} would never
+ * fire, and the {@code VALIDATION_ERROR} envelope never surface).
+ *
+ * <p>The runtime behaviour is exercised by {@code ErrorEnvelopeIT} (an empty {@code POST
+ * /auth/login} body → 400 {@code VALIDATION_ERROR}); this test is the static counterpart that fails
+ * fast — without a Spring context or a database — if a config or generator change ever drops the
+ * annotation.
+ */
+class RequestBodyValidationRulesTest {
+
+  /** The generated Spring MVC interfaces the controllers implement (ADR-0021). */
+  private static final String ENDPOINT_PACKAGE = "io.qnop.api.v1.endpoint";
+
+  private static final JavaClasses ENDPOINT_APIS =
+      new ClassFileImporter().importPackages(ENDPOINT_PACKAGE);
+
+  @Test
+  void everyRequestBodyParameterIsValidated() {
+    List<String> requestBodies = new ArrayList<>();
+    List<String> unvalidated = new ArrayList<>();
+
+    for (JavaClass api : ENDPOINT_APIS) {
+      for (JavaMethod method : api.getMethods()) {
+        for (JavaParameter parameter : method.getParameters()) {
+          if (!parameter.isAnnotatedWith(RequestBody.class)) {
+            continue;
+          }
+          String location = api.getSimpleName() + "#" + method.getName();
+          requestBodies.add(location);
+          if (!parameter.isAnnotatedWith(Valid.class)) {
+            unvalidated.add(location);
+          }
+        }
+      }
+    }
+
+    // Fail loudly if the scan found nothing — a wrong package or an empty generation
+    // output would otherwise let this rule pass vacuously.
+    assertFalse(
+        requestBodies.isEmpty(),
+        "No @RequestBody parameters found in "
+            + ENDPOINT_PACKAGE
+            + "; the generated endpoint contract is missing from the classpath.");
+
+    assertTrue(
+        unvalidated.isEmpty(),
+        "Every @RequestBody must also be @Valid so request-DTO constraints are enforced (#346). "
+            + "Missing @Valid on: "
+            + unvalidated);
+  }
+}


### PR DESCRIPTION
## Summary

Addresses #346. The review flagged that `@Valid` on request bodies "is not evident" so DTO constraints "may not be enforced." Investigation shows enforcement **already works** — but invisibly, and with no guardrail against silent regression, which this PR adds.

### Why it already works
- The openapi-generator `spring` interfaces (ADR-0021) emit `@Valid @RequestBody` — the module's generator config sets `useBeanValidation=true`.
- Every controller `implements` its generated `*Api` interface (no hand-written `@RequestBody` bypasses it), and Spring MVC (Boot 4 / Spring 6.1+) honours parameter annotations declared on interface methods.
- Runtime proof already in the suite: `ErrorEnvelopeIT.bodyValidationReturns400Envelope()` POSTs an empty `{}` to `/auth/login` and asserts **400 `VALIDATION_ERROR`** (empty body → `@NotNull` → `MethodArgumentNotValidException` → the handled envelope). `SeededPasswordResetIT` covers a `@Size` body constraint likewise.

### The gap this closes
Because the `@Valid` lives only on generated code and the controllers never restate it, a future generator/config change could drop it and disable request-body validation **with no compile error and no obvious signal**. This adds a static guard — an ArchUnit scan of `io.qnop.api.v1.endpoint` asserting every `@RequestBody` parameter is also `@Valid` (and that the scan is non-empty, so it can't pass vacuously). It runs without a Spring context or database.

No production change is needed: the annotation is present and enforced; this locks it in.

## Test plan

- [x] `./gradlew :qnop-app:test --tests "io.qnop.architecture.RequestBodyValidationRulesTest"` — passes (12 request bodies found, all `@Valid`).
- [x] `./gradlew :qnop-app:spotlessCheck` — clean.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code