### PR TITLE
fix: explicit servlet + HTTP client timeouts (#342)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,20 @@ QNOP_S3_AUTO_CREATE_BUCKET=true
 # service can return its clean 413.
 # QNOP_UPLOAD_MULTIPART_LIMIT_MB=55
 
+# --- Timeouts (issue #342) ---
+# All optional; sensible defaults apply. Durations accept e.g. 5s, 500ms, PT2S.
+# Inbound (servlet):
+# QNOP_HTTP_CONNECTION_TIMEOUT=20s
+# QNOP_HTTP_KEEP_ALIVE_TIMEOUT=20s
+# QNOP_HTTP_REQUEST_TIMEOUT=30s
+# Outbound HTTP (GitHub email fetch; also bounds OIDC discovery / JWK fetch):
+# QNOP_HTTP_CLIENT_OUTBOUND_CONNECT_TIMEOUT=5s
+# QNOP_HTTP_CLIENT_OUTBOUND_READ_TIMEOUT=15s
+# Outgoing mail (SMTP transport):
+# QNOP_HTTP_CLIENT_SMTP_CONNECT_TIMEOUT=10s
+# QNOP_HTTP_CLIENT_SMTP_READ_TIMEOUT=30s
+# QNOP_HTTP_CLIENT_SMTP_WRITE_TIMEOUT=30s
+
 # --- Security & crypto (issue #10) ---
 # The server FAILS TO START with these placeholders (they trip @ValidSecret).
 # Set strong, unique values (>= 32 chars) for local `bootRun`; in production these

--- a/qnop-app/src/main/java/io/qnop/bootstrap/HttpUrlConnectionTimeoutConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/HttpUrlConnectionTimeoutConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import io.qnop.service.http.HttpClientProperties;
+import java.time.Duration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Applies the configurable outbound timeouts (issue #342) to the JDK {@code HttpURLConnection}
+ * defaults, as a bound for outbound calls made over the legacy client that carries no timeout of
+ * its own — notably Spring Security's OIDC issuer discovery ({@code ClientRegistrations}) and
+ * JWK-set fetching, which build a default {@code RestTemplate}. Runs at context initialization,
+ * well before any (user-triggered) OIDC discovery or login. An operator-supplied {@code
+ * -Dsun.net.client.default*Timeout} always wins. Clients qnop constructs itself (S3, SMTP, the
+ * GitHub {@code RestClient}) carry their own timeouts and are unaffected.
+ */
+@Configuration(proxyBeanMethods = false)
+class HttpUrlConnectionTimeoutConfiguration {
+
+  HttpUrlConnectionTimeoutConfiguration(HttpClientProperties properties) {
+    apply(properties.outboundConnectTimeout(), properties.outboundReadTimeout());
+  }
+
+  static void apply(Duration connectTimeout, Duration readTimeout) {
+    setIfAbsent("sun.net.client.defaultConnectTimeout", connectTimeout);
+    setIfAbsent("sun.net.client.defaultReadTimeout", readTimeout);
+  }
+
+  private static void setIfAbsent(String key, Duration value) {
+    if (System.getProperty(key) == null) {
+      System.setProperty(key, Long.toString(value.toMillis()));
+    }
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
@@ -21,6 +21,7 @@
 package io.qnop.bootstrap;
 
 import io.qnop.security.QnopProperties;
+import io.qnop.service.http.HttpClientProperties;
 import io.qnop.web.security.ratelimit.RateLimitProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -38,34 +39,17 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * sibling packages, so they are registered explicitly (the data model arrived with issue #11).
  */
 @SpringBootApplication(scanBasePackages = "io.qnop")
-@EnableConfigurationProperties({QnopProperties.class, RateLimitProperties.class})
+@EnableConfigurationProperties({
+  QnopProperties.class,
+  RateLimitProperties.class,
+  HttpClientProperties.class
+})
 @EntityScan("io.qnop.entity")
 @EnableJpaRepositories("io.qnop.repository")
 @EnableScheduling
 public class QnopApplication {
 
   public static void main(String[] args) {
-    applyDefaultHttpUrlConnectionTimeouts();
     SpringApplication.run(QnopApplication.class, args);
-  }
-
-  /**
-   * Bounds the JDK {@code HttpURLConnection} defaults (issue #342) as a safety net for outbound
-   * calls made over the legacy client that carries no timeout of its own — notably Spring
-   * Security's OIDC issuer discovery ({@code ClientRegistrations}) and JWK-set fetching, which
-   * build a default {@code RestTemplate}. Set only when the operator has not already supplied a
-   * value via {@code -Dsun.net.client.default*Timeout}, so an explicit override always wins.
-   * Clients we construct ourselves (S3, SMTP, the GitHub {@code RestClient}) carry their own
-   * timeouts and are unaffected.
-   */
-  static void applyDefaultHttpUrlConnectionTimeouts() {
-    setPropertyIfAbsent("sun.net.client.defaultConnectTimeout", "5000");
-    setPropertyIfAbsent("sun.net.client.defaultReadTimeout", "15000");
-  }
-
-  private static void setPropertyIfAbsent(String key, String value) {
-    if (System.getProperty(key) == null) {
-      System.setProperty(key, value);
-    }
   }
 }

--- a/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
@@ -45,6 +45,27 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class QnopApplication {
 
   public static void main(String[] args) {
+    applyDefaultHttpUrlConnectionTimeouts();
     SpringApplication.run(QnopApplication.class, args);
+  }
+
+  /**
+   * Bounds the JDK {@code HttpURLConnection} defaults (issue #342) as a safety net for outbound
+   * calls made over the legacy client that carries no timeout of its own — notably Spring
+   * Security's OIDC issuer discovery ({@code ClientRegistrations}) and JWK-set fetching, which
+   * build a default {@code RestTemplate}. Set only when the operator has not already supplied a
+   * value via {@code -Dsun.net.client.default*Timeout}, so an explicit override always wins.
+   * Clients we construct ourselves (S3, SMTP, the GitHub {@code RestClient}) carry their own
+   * timeouts and are unaffected.
+   */
+  static void applyDefaultHttpUrlConnectionTimeouts() {
+    setPropertyIfAbsent("sun.net.client.defaultConnectTimeout", "5000");
+    setPropertyIfAbsent("sun.net.client.defaultReadTimeout", "15000");
+  }
+
+  private static void setPropertyIfAbsent(String key, String value) {
+    if (System.getProperty(key) == null) {
+      System.setProperty(key, value);
+    }
   }
 }

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -75,6 +75,16 @@ qnop:
       frontend-base-url: ${QNOP_AUTH_OIDC_FRONTEND_BASE_URL:}
   cors:
     allowed-origins: ${QNOP_CORS_ALLOWED_ORIGINS:http://localhost:5173}
+  # Outbound HTTP timeouts (issue #342). `outbound-*` bound the GitHub email fetch
+  # (OIDC login) and, as JDK HttpURLConnection defaults, the OIDC issuer discovery
+  # and JWK-set fetches; `smtp-*` bound the outgoing-mail transport. All are
+  # durations (e.g. 5s, 500ms, PT2S) and overridable via the QNOP_HTTP_CLIENT_* env.
+  http-client:
+    outbound-connect-timeout: ${QNOP_HTTP_CLIENT_OUTBOUND_CONNECT_TIMEOUT:5s}
+    outbound-read-timeout: ${QNOP_HTTP_CLIENT_OUTBOUND_READ_TIMEOUT:15s}
+    smtp-connect-timeout: ${QNOP_HTTP_CLIENT_SMTP_CONNECT_TIMEOUT:10s}
+    smtp-read-timeout: ${QNOP_HTTP_CLIENT_SMTP_READ_TIMEOUT:30s}
+    smtp-write-timeout: ${QNOP_HTTP_CLIENT_SMTP_WRITE_TIMEOUT:30s}
   # Object storage for binary documents (issue #243, ADR-0005). Defaults target the
   # docker-compose MinIO; leave `endpoint` blank to target real AWS S3 (SaaS). The
   # access/secret keys are storage credentials, not crypto secrets, so short local

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -30,6 +30,19 @@ spring:
       # uploads stream to a temp file, not the heap, so a generous ceiling is safe.
       max-file-size: ${QNOP_UPLOAD_MULTIPART_LIMIT_MB:55}MB
       max-request-size: ${QNOP_UPLOAD_MULTIPART_LIMIT_MB:55}MB
+  mvc:
+    async:
+      # Cap async request handling so a stalled async dispatch cannot pin request
+      # resources indefinitely (issue #342).
+      request-timeout: ${QNOP_HTTP_REQUEST_TIMEOUT:30s}
+
+# Inbound request timeouts (issue #342): bound how long the connector waits on a
+# slow/stalled client so a worker thread is never held open forever.
+server:
+  tomcat:
+    connection-timeout: ${QNOP_HTTP_CONNECTION_TIMEOUT:20s}
+    # Reap idle keep-alive connections rather than holding a thread per socket.
+    keep-alive-timeout: ${QNOP_HTTP_KEEP_ALIVE_TIMEOUT:20s}
 
 management:
   endpoints:

--- a/qnop-app/src/test/java/io/qnop/bootstrap/HttpUrlConnectionTimeoutConfigurationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/HttpUrlConnectionTimeoutConfigurationTest.java
@@ -22,6 +22,7 @@ package io.qnop.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
@@ -29,8 +30,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/** The JDK HttpURLConnection timeout backstop for OIDC discovery / JWK fetching (issue #342). */
-class QnopApplicationTest {
+/**
+ * The configurable JDK HttpURLConnection timeout backstop for OIDC discovery / JWK fetching (issue
+ * #342).
+ */
+class HttpUrlConnectionTimeoutConfigurationTest {
 
   private static final String CONNECT = "sun.net.client.defaultConnectTimeout";
   private static final String READ = "sun.net.client.defaultReadTimeout";
@@ -55,12 +59,12 @@ class QnopApplicationTest {
   }
 
   @Test
-  @DisplayName("sets finite HttpURLConnection connect/read timeouts when unset")
-  void setsDefaultsWhenUnset() {
-    QnopApplication.applyDefaultHttpUrlConnectionTimeouts();
+  @DisplayName("applies the configured connect/read timeouts (in millis) when unset")
+  void appliesConfiguredValuesWhenUnset() {
+    HttpUrlConnectionTimeoutConfiguration.apply(Duration.ofSeconds(7), Duration.ofSeconds(21));
 
-    assertThat(System.getProperty(CONNECT)).isEqualTo("5000");
-    assertThat(System.getProperty(READ)).isEqualTo("15000");
+    assertThat(System.getProperty(CONNECT)).isEqualTo("7000");
+    assertThat(System.getProperty(READ)).isEqualTo("21000");
   }
 
   @Test
@@ -69,7 +73,7 @@ class QnopApplicationTest {
     System.setProperty(CONNECT, "1234");
     System.setProperty(READ, "9999");
 
-    QnopApplication.applyDefaultHttpUrlConnectionTimeouts();
+    HttpUrlConnectionTimeoutConfiguration.apply(Duration.ofSeconds(7), Duration.ofSeconds(21));
 
     assertThat(System.getProperty(CONNECT)).isEqualTo("1234");
     assertThat(System.getProperty(READ)).isEqualTo("9999");

--- a/qnop-app/src/test/java/io/qnop/bootstrap/QnopApplicationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/QnopApplicationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** The JDK HttpURLConnection timeout backstop for OIDC discovery / JWK fetching (issue #342). */
+class QnopApplicationTest {
+
+  private static final String CONNECT = "sun.net.client.defaultConnectTimeout";
+  private static final String READ = "sun.net.client.defaultReadTimeout";
+
+  private final Map<String, Optional<String>> saved =
+      Map.of(
+          CONNECT, Optional.ofNullable(System.getProperty(CONNECT)),
+          READ, Optional.ofNullable(System.getProperty(READ)));
+
+  @BeforeEach
+  void clear() {
+    System.clearProperty(CONNECT);
+    System.clearProperty(READ);
+  }
+
+  @AfterEach
+  void restore() {
+    saved.forEach(
+        (key, value) ->
+            value.ifPresentOrElse(
+                v -> System.setProperty(key, v), () -> System.clearProperty(key)));
+  }
+
+  @Test
+  @DisplayName("sets finite HttpURLConnection connect/read timeouts when unset")
+  void setsDefaultsWhenUnset() {
+    QnopApplication.applyDefaultHttpUrlConnectionTimeouts();
+
+    assertThat(System.getProperty(CONNECT)).isEqualTo("5000");
+    assertThat(System.getProperty(READ)).isEqualTo("15000");
+  }
+
+  @Test
+  @DisplayName("never overrides an operator-supplied -D value")
+  void respectsOperatorOverride() {
+    System.setProperty(CONNECT, "1234");
+    System.setProperty(READ, "9999");
+
+    QnopApplication.applyDefaultHttpUrlConnectionTimeouts();
+
+    assertThat(System.getProperty(CONNECT)).isEqualTo("1234");
+    assertThat(System.getProperty(READ)).isEqualTo("9999");
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/http/HttpClientProperties.java
+++ b/qnop-core/src/main/java/io/qnop/service/http/HttpClientProperties.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.http;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configurable timeouts for the outbound HTTP paths (issue #342), so a slow or hung dependency can
+ * never pin a thread indefinitely. Every value is overridable via {@code qnop.http-client.*} (or
+ * the matching {@code QNOP_HTTP_CLIENT_*} environment variable); the defaults below apply only when
+ * a value is not supplied.
+ *
+ * <ul>
+ *   <li>{@code outbound*} — the connect/read timeouts for HTTP clients qnop makes calls through:
+ *       the GitHub email fetch (OIDC login) and, applied as JDK {@code HttpURLConnection} defaults,
+ *       the Spring Security OIDC issuer-discovery and JWK-set fetches.
+ *   <li>{@code smtp*} — the SMTP transport connect/read/write timeouts for outgoing mail.
+ * </ul>
+ *
+ * @param outboundConnectTimeout TCP-connect ceiling for outbound HTTP (default 5s)
+ * @param outboundReadTimeout response-read ceiling for outbound HTTP (default 15s)
+ * @param smtpConnectTimeout SMTP connect ceiling (default 10s)
+ * @param smtpReadTimeout SMTP read ceiling (default 30s)
+ * @param smtpWriteTimeout SMTP write ceiling (default 30s)
+ */
+@ConfigurationProperties(prefix = "qnop.http-client")
+public record HttpClientProperties(
+    Duration outboundConnectTimeout,
+    Duration outboundReadTimeout,
+    Duration smtpConnectTimeout,
+    Duration smtpReadTimeout,
+    Duration smtpWriteTimeout) {
+
+  public HttpClientProperties {
+    outboundConnectTimeout = orDefault(outboundConnectTimeout, Duration.ofSeconds(5));
+    outboundReadTimeout = orDefault(outboundReadTimeout, Duration.ofSeconds(15));
+    smtpConnectTimeout = orDefault(smtpConnectTimeout, Duration.ofSeconds(10));
+    smtpReadTimeout = orDefault(smtpReadTimeout, Duration.ofSeconds(30));
+    smtpWriteTimeout = orDefault(smtpWriteTimeout, Duration.ofSeconds(30));
+  }
+
+  private static Duration orDefault(Duration value, Duration fallback) {
+    return value == null ? fallback : value;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailSenderProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailSenderProvider.java
@@ -48,6 +48,14 @@ public class MailSenderProvider implements SettingsChangeListener {
 
   private static final Logger log = LoggerFactory.getLogger(MailSenderProvider.class);
 
+  // Explicit SMTP transport timeouts (issue #342): without them a hung or slow
+  // mail server pins the sending thread indefinitely. Values are milliseconds, as
+  // Jakarta Mail expects. Generous but finite — mail is best-effort and never on a
+  // request's critical path.
+  private static final String SMTP_CONNECT_TIMEOUT_MS = "10000";
+  private static final String SMTP_READ_TIMEOUT_MS = "30000";
+  private static final String SMTP_WRITE_TIMEOUT_MS = "30000";
+
   // Only the keys that shape the JavaMailSender transport invalidate the cache.
   // smtp.from / smtp.from_name are read per-send from the snapshot (see MailService),
   // not baked into the sender, so changing them must not drop the cached transport.
@@ -131,6 +139,10 @@ public class MailSenderProvider implements SettingsChangeListener {
     Properties props = sender.getJavaMailProperties();
     props.put("mail.transport.protocol", "smtp");
     props.put("mail.smtp.auth", String.valueOf(authenticated));
+    // Bound connect/read/write so a stalled SMTP peer cannot hang the sender (#342).
+    props.put("mail.smtp.connectiontimeout", SMTP_CONNECT_TIMEOUT_MS);
+    props.put("mail.smtp.timeout", SMTP_READ_TIMEOUT_MS);
+    props.put("mail.smtp.writetimeout", SMTP_WRITE_TIMEOUT_MS);
     applyEncryption(props, settings.getString(ApplicationSettingKey.SMTP_ENCRYPTION));
     return sender;
   }

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailSenderProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailSenderProvider.java
@@ -23,6 +23,8 @@ package io.qnop.service.mail;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.SettingsChangeListener;
+import io.qnop.service.http.HttpClientProperties;
+import java.time.Duration;
 import java.util.EnumSet;
 import java.util.Properties;
 import java.util.Set;
@@ -48,14 +50,6 @@ public class MailSenderProvider implements SettingsChangeListener {
 
   private static final Logger log = LoggerFactory.getLogger(MailSenderProvider.class);
 
-  // Explicit SMTP transport timeouts (issue #342): without them a hung or slow
-  // mail server pins the sending thread indefinitely. Values are milliseconds, as
-  // Jakarta Mail expects. Generous but finite — mail is best-effort and never on a
-  // request's critical path.
-  private static final String SMTP_CONNECT_TIMEOUT_MS = "10000";
-  private static final String SMTP_READ_TIMEOUT_MS = "30000";
-  private static final String SMTP_WRITE_TIMEOUT_MS = "30000";
-
   // Only the keys that shape the JavaMailSender transport invalidate the cache.
   // smtp.from / smtp.from_name are read per-send from the snapshot (see MailService),
   // not baked into the sender, so changing them must not drop the cached transport.
@@ -69,13 +63,16 @@ public class MailSenderProvider implements SettingsChangeListener {
           ApplicationSettingKey.SMTP_ENCRYPTION);
 
   private final ApplicationSettingsService settings;
+  private final HttpClientProperties httpClientProperties;
   private final AtomicReference<JavaMailSender> cached = new AtomicReference<>();
 
   // @Lazy breaks the construction cycle: ApplicationSettingsService injects the
   // List<SettingsChangeListener> (which includes this bean), while this bean
   // needs the settings service. A lazy proxy defers resolution until first use.
-  public MailSenderProvider(@Lazy ApplicationSettingsService settings) {
+  public MailSenderProvider(
+      @Lazy ApplicationSettingsService settings, HttpClientProperties httpClientProperties) {
     this.settings = settings;
+    this.httpClientProperties = httpClientProperties;
   }
 
   /**
@@ -139,10 +136,11 @@ public class MailSenderProvider implements SettingsChangeListener {
     Properties props = sender.getJavaMailProperties();
     props.put("mail.transport.protocol", "smtp");
     props.put("mail.smtp.auth", String.valueOf(authenticated));
-    // Bound connect/read/write so a stalled SMTP peer cannot hang the sender (#342).
-    props.put("mail.smtp.connectiontimeout", SMTP_CONNECT_TIMEOUT_MS);
-    props.put("mail.smtp.timeout", SMTP_READ_TIMEOUT_MS);
-    props.put("mail.smtp.writetimeout", SMTP_WRITE_TIMEOUT_MS);
+    // Bound connect/read/write so a stalled SMTP peer cannot hang the sender (#342);
+    // ceilings come from the configurable qnop.http-client.smtp-* durations.
+    props.put("mail.smtp.connectiontimeout", millis(httpClientProperties.smtpConnectTimeout()));
+    props.put("mail.smtp.timeout", millis(httpClientProperties.smtpReadTimeout()));
+    props.put("mail.smtp.writetimeout", millis(httpClientProperties.smtpWriteTimeout()));
     applyEncryption(props, settings.getString(ApplicationSettingKey.SMTP_ENCRYPTION));
     return sender;
   }
@@ -176,5 +174,10 @@ public class MailSenderProvider implements SettingsChangeListener {
   private static void requireStartTls(Properties props) {
     props.put("mail.smtp.starttls.enable", "true");
     props.put("mail.smtp.starttls.required", "true");
+  }
+
+  /** Jakarta Mail expects the timeouts as millisecond strings. */
+  private static String millis(Duration duration) {
+    return Long.toString(duration.toMillis());
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/oidc/GitHubEmailFetcher.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/GitHubEmailFetcher.java
@@ -20,8 +20,8 @@
  */
 package io.qnop.service.oidc;
 
+import io.qnop.service.http.HttpClientProperties;
 import java.net.http.HttpClient;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -45,19 +45,21 @@ public class GitHubEmailFetcher {
       new ParameterizedTypeReference<>() {};
   private static final Logger log = LoggerFactory.getLogger(GitHubEmailFetcher.class);
 
+  private final RestClient restClient;
+
   // Bound the outbound call (issue #342): RestClient.create() uses the JDK HTTP
   // client with no default timeout, so a slow/hung GitHub response would pin the
-  // login thread. Finite connect + read timeouts keep the OIDC login responsive.
-  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
-  private static final Duration READ_TIMEOUT = Duration.ofSeconds(15);
+  // login thread. The configurable connect + read timeouts keep OIDC login responsive.
+  public GitHubEmailFetcher(HttpClientProperties httpClientProperties) {
+    this.restClient =
+        RestClient.builder().requestFactory(timedFactory(httpClientProperties)).build();
+  }
 
-  private final RestClient restClient = RestClient.builder().requestFactory(timedFactory()).build();
-
-  private static JdkClientHttpRequestFactory timedFactory() {
+  private static JdkClientHttpRequestFactory timedFactory(HttpClientProperties properties) {
     JdkClientHttpRequestFactory factory =
         new JdkClientHttpRequestFactory(
-            HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build());
-    factory.setReadTimeout(READ_TIMEOUT);
+            HttpClient.newBuilder().connectTimeout(properties.outboundConnectTimeout()).build());
+    factory.setReadTimeout(properties.outboundReadTimeout());
     return factory;
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/oidc/GitHubEmailFetcher.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/GitHubEmailFetcher.java
@@ -20,11 +20,14 @@
  */
 package io.qnop.service.oidc;
 
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -42,7 +45,21 @@ public class GitHubEmailFetcher {
       new ParameterizedTypeReference<>() {};
   private static final Logger log = LoggerFactory.getLogger(GitHubEmailFetcher.class);
 
-  private final RestClient restClient = RestClient.create();
+  // Bound the outbound call (issue #342): RestClient.create() uses the JDK HTTP
+  // client with no default timeout, so a slow/hung GitHub response would pin the
+  // login thread. Finite connect + read timeouts keep the OIDC login responsive.
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(15);
+
+  private final RestClient restClient = RestClient.builder().requestFactory(timedFactory()).build();
+
+  private static JdkClientHttpRequestFactory timedFactory() {
+    JdkClientHttpRequestFactory factory =
+        new JdkClientHttpRequestFactory(
+            HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build());
+    factory.setReadTimeout(READ_TIMEOUT);
+    return factory;
+  }
 
   /** The primary verified email for the token's user, or {@code null} if none is available. */
   public String fetchPrimaryEmail(String accessToken) {

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailSenderProviderTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailSenderProviderTest.java
@@ -126,6 +126,18 @@ class MailSenderProviderTest {
   }
 
   @Test
+  @DisplayName("the transport carries explicit connect/read/write timeouts (issue #342)")
+  void transportHasTimeouts() {
+    configureSmtp();
+
+    Properties props = propsOf(provider.current());
+
+    assertThat(props.getProperty("mail.smtp.connectiontimeout")).isEqualTo("10000");
+    assertThat(props.getProperty("mail.smtp.timeout")).isEqualTo("30000");
+    assertThat(props.getProperty("mail.smtp.writetimeout")).isEqualTo("30000");
+  }
+
+  @Test
   @DisplayName("encryption=none leaves the connection plaintext")
   void encryptionNone() {
     configureSmtp("none");

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailSenderProviderTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailSenderProviderTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.http.HttpClientProperties;
+import java.time.Duration;
 import java.util.EnumSet;
 import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +48,11 @@ class MailSenderProviderTest {
 
   @BeforeEach
   void setUp() {
-    provider = new MailSenderProvider(settings);
+    // Explicit non-default timeouts prove the transport picks them up from config.
+    HttpClientProperties httpClient =
+        new HttpClientProperties(
+            null, null, Duration.ofSeconds(8), Duration.ofSeconds(24), Duration.ofSeconds(42));
+    provider = new MailSenderProvider(settings, httpClient);
   }
 
   private void configureSmtp() {
@@ -126,15 +132,15 @@ class MailSenderProviderTest {
   }
 
   @Test
-  @DisplayName("the transport carries explicit connect/read/write timeouts (issue #342)")
+  @DisplayName("the transport carries the configured connect/read/write timeouts (issue #342)")
   void transportHasTimeouts() {
     configureSmtp();
 
     Properties props = propsOf(provider.current());
 
-    assertThat(props.getProperty("mail.smtp.connectiontimeout")).isEqualTo("10000");
-    assertThat(props.getProperty("mail.smtp.timeout")).isEqualTo("30000");
-    assertThat(props.getProperty("mail.smtp.writetimeout")).isEqualTo("30000");
+    assertThat(props.getProperty("mail.smtp.connectiontimeout")).isEqualTo("8000");
+    assertThat(props.getProperty("mail.smtp.timeout")).isEqualTo("24000");
+    assertThat(props.getProperty("mail.smtp.writetimeout")).isEqualTo("42000");
   }
 
   @Test


### PR DESCRIPTION
## Summary

No explicit request/outbound-HTTP timeouts were configured, so a slow or hung dependency could tie up threads indefinitely (issue #342, LOW). This bounds every request and outbound path.

## Changes
- **Inbound / servlet** (`application.yml`): `server.tomcat.connection-timeout` (20s) + `keep-alive-timeout` (20s) and `spring.mvc.async.request-timeout` (30s) — all env-tunable (`QNOP_HTTP_*`).
- **SMTP** (`MailSenderProvider`): explicit `mail.smtp.connectiontimeout` / `timeout` / `writetimeout` (10s / 30s / 30s) so a stalled mail server can't hang the sender thread.
- **GitHub email fetch** (OIDC login, `GitHubEmailFetcher`): `RestClient.create()` used the JDK HTTP client with **no** default timeout; it now uses a `JdkClientHttpRequestFactory` with finite connect (5s) + read (15s) timeouts.
- **OIDC issuer discovery + JWK-set fetch**: these go through Spring Security's default `RestTemplate` over `HttpURLConnection`, which has no timeout hook. Set the `sun.net.client.default*Timeout` JDK defaults in `main()` as a backstop — **only** when the operator hasn't already supplied a value via `-D`, so an explicit override always wins.

**Already covered:** S3 is bounded by `apiCallTimeout` + `apiCallAttemptTimeout` (#314), so no change there.

## Notes
Boot 4.1 has no `spring.http.client.*` timeout property, so the outbound-client timeouts are set in code (Spring Framework's `JdkClientHttpRequestFactory`, no new dependency).

## Test plan
- [x] New unit tests: SMTP transport carries the timeout properties; the `main()` backstop sets finite defaults and never overrides an operator `-D`.
- [x] Local: `spotlessCheck`, ArchUnit, `:qnop-core:test`, targeted app tests all green.
- [ ] CI green (incl. the docker-compose smoke, which boots the image and drives the OIDC discovery/login path).

Closes #342

🤖 Co-Author: Claude (Opus 4.x) via Claude Code