### PR TITLE
docs(api): document 401 on authenticated review-domain endpoints (#327)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1903,6 +1903,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DocumentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown document, or the caller is not a participant
           content:
@@ -1967,6 +1969,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DocumentVersionListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown document, or the caller is not a participant
           content:
@@ -1996,6 +2000,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RenderedDocumentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown document/version, or the caller is not a participant
           content:
@@ -2047,6 +2053,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnnotationListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown document, or the caller is not a participant
           content:
@@ -2083,6 +2091,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown document/version, or the caller is not a participant
           content:
@@ -2105,6 +2115,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnnotationView'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown annotation, or the caller is not a participant
           content:
@@ -2138,6 +2150,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnnotationView'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '403':
           description: The caller is neither the document owner nor the annotation's author
           content:
@@ -2172,6 +2186,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CommentListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown annotation, or the caller is not a participant
           content:
@@ -2203,6 +2219,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown annotation, or the caller is not a participant
           content:
@@ -2254,6 +2272,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown document/version, or the caller is not a participant
           content:


### PR DESCRIPTION
## Summary

Closes #327. Ten authenticated (`bearerAuth`) review-domain operations omitted the `401` response that the rest of the contract documents. This adds the shared `#/components/responses/Unauthorized` to each, in numeric order beside the existing 4xx entries.

Affected operations:

- `GET /documents/{documentId}`
- `GET /documents/{documentId}/versions`
- `GET /documents/{documentId}/versions/{versionNumber}/rendered`
- `GET /documents/{documentId}/diff`
- `GET|POST /documents/{documentId}/annotations`
- `GET /annotations/{annotationId}`
- `POST /annotations/{annotationId}/decision`
- `GET|POST /annotations/{annotationId}/comments`

Scope note: operations that already document a 401 — including deliberately specific inline ones like login's *Invalid credentials* — are left untouched; this only fills the gaps.

Docs-only: 401 is an error response, so no generated Spring interface or TS client signatures change.

## Test plan

- [x] Parsed the full spec: every `bearerAuth` operation now has a `401` (0 remaining), each referencing the shared component.
- [x] `:qnop-api:qnop-api-endpoint:build` — spec parses, generated Spring interfaces compile.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code