### PR TITLE
fix(api): use the framework ObjectMapper in AnnotationController (#329)

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -39,7 +39,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Annotations, comment threads and per-version placements (issue #247, ADR-0009/0011), implementing
@@ -51,13 +50,19 @@ import tools.jackson.databind.json.JsonMapper;
 @RestController
 public class AnnotationController implements AnnotationsApi {
 
-  // Jackson 3 (tools.jackson), matching the stack the document pipeline (de)serializes jsonb with.
-  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
-
   private final AnnotationService annotations;
 
-  public AnnotationController(AnnotationService annotations) {
+  /**
+   * The framework-configured Jackson 3 mapper (issue #329): reusing Boot's MVC {@link ObjectMapper}
+   * — rather than a hand-built one — keeps the jsonb anchor round-trip byte-for-byte consistent
+   * with the HTTP (de)serialization of the same published models and inherits Boot's lenient
+   * defaults (e.g. tolerating unknown properties on a stored anchor).
+   */
+  private final ObjectMapper mapper;
+
+  public AnnotationController(AnnotationService annotations, ObjectMapper mapper) {
     this.annotations = annotations;
+    this.mapper = mapper;
   }
 
   @Override
@@ -69,7 +74,7 @@ public class AnnotationController implements AnnotationsApi {
             request.getVersionNumber(),
             CurrentUser.requireUserId(),
             CurrentUser.isAdmin(),
-            MAPPER.writeValueAsString(request.getAnchor()),
+            mapper.writeValueAsString(request.getAnchor()),
             request.getComment());
     return ResponseEntity.status(HttpStatus.CREATED).body(toDto(view));
   }
@@ -125,7 +130,7 @@ public class AnnotationController implements AnnotationsApi {
         .authorId(view.authorId())
         .status(AnnotationStatus.fromValue(view.status()))
         .anchor(
-            view.anchorJson() == null ? null : MAPPER.readValue(view.anchorJson(), Anchor.class))
+            view.anchorJson() == null ? null : mapper.readValue(view.anchorJson(), Anchor.class))
         .placementStatus(
             view.placementStatus() == null
                 ? null


### PR DESCRIPTION
Closes #329.

`AnnotationController` hand-built a `JsonMapper.builder().build()` to (de)serialize the jsonb anchor — the very `Anchor` model Spring MVC also serializes over HTTP. A bare Jackson 3 mapper carries different defaults than Boot's MVC mapper (notably `FAIL_ON_UNKNOWN_PROPERTIES=true`), so a stored anchor that gained a field could throw on read while the same model round-trips fine everywhere else in the HTTP layer.

## Change

- Inject Boot's framework-configured `tools.jackson.databind.ObjectMapper` (constructor injection) instead of a hand-rolled static mapper.
- The anchor round-trip is now byte-for-byte consistent with the HTTP (de)serialization of the same published models and inherits Boot's lenient, forward-compatible defaults.
- The `writeValueAsString` / `readValue` calls are otherwise unchanged; no manual mapper is constructed.

Jackson 2→3: confirmed — the injected bean is the Jackson 3 (`tools.jackson`) mapper Boot 4 uses for MVC; the code already imported `tools.jackson` and Jackson 3's `JacksonException` is unchecked, so no `throws` plumbing is needed.

## Test plan

- [x] `spotlessApply` + `:qnop-app:compileJava` — clean (pre-existing unrelated `serial` warning only)
- [x] `:qnop-app:test --tests io.qnop.architecture.*` (ArchUnit layering) — pass
- [x] Regression coverage: the existing **`AnnotationApiIT`** anchor round-trip (create → jsonb placement → GET/list, asserting `$.anchor.region.*`) now exercises the injected mapper end-to-end in CI. If the injected bean were missing or misconfigured, the Spring context / round-trip would fail.

_Scoped to `AnnotationController` per the issue. The `qnop-core` service classes that hand-build a mapper for internal jsonb (surfaces, re-anchoring) are deliberately out of scope — they must not couple to the web MVC mapper._

🤖 Co-Author: Claude (Opus 4.8) via Claude Code