### PR TITLE
perf: index the review/diff foreign-key columns (#330)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/review/DocumentReviewSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DocumentReviewSchemaIT.java
@@ -303,6 +303,26 @@ class DocumentReviewSchemaIT extends AbstractIntegrationTest {
         .isInstanceOf(DataIntegrityViolationException.class);
   }
 
+  @Test
+  @DisplayName("the user-referencing FK columns are indexed (issue #330)")
+  void indexesTheUserForeignKeys() {
+    // Postgres does not auto-index FKs; without these, a user delete (RESTRICT check) or an
+    // author/actor join sequentially scans the table.
+    assertThat(indexExists("annotation", "ix_annotation_author")).isTrue();
+    assertThat(indexExists("comment", "ix_comment_author")).isTrue();
+    assertThat(indexExists("audit_event", "ix_audit_event_actor")).isTrue();
+  }
+
+  private boolean indexExists(String tableName, String indexName) {
+    Integer count =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM pg_indexes WHERE tablename = ? AND indexname = ?",
+            Integer.class,
+            tableName,
+            indexName);
+    return count != null && count == 1;
+  }
+
   // --- helpers -------------------------------------------------------------
 
   private User newUser(String displayName) {

--- a/qnop-app/src/test/java/io/qnop/review/VersionDiffIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/VersionDiffIT.java
@@ -36,6 +36,7 @@ import io.qnop.testsupport.SeededIntegrationTest;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 /**
@@ -49,6 +50,19 @@ class VersionDiffIT extends SeededIntegrationTest {
   @Autowired private DocumentVersionRepository versions;
   @Autowired private ReviewParticipantRepository participants;
   @Autowired private VersionDiffRepository diffCache;
+  @Autowired private JdbcTemplate jdbc;
+
+  @Test
+  void indexesTheDocumentForeignKey() {
+    // Postgres does not auto-index FKs; document_id must be indexed for the CASCADE and lookups
+    // (issue #330). from_version_id is already covered by ux_version_diff_pair's leading column.
+    Integer count =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM pg_indexes WHERE tablename = 'version_diff'"
+                + " AND indexname = 'ix_version_diff_document'",
+            Integer.class);
+    assertThat(count).isEqualTo(1);
+  }
 
   /** The jsonb of a one-surface rendered document whose spans are the given lines (ADR-0032). */
   private static String rendered(String... lines) {

--- a/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
@@ -273,6 +273,11 @@ databaseChangeLog:
             tableName: annotation
             columns:
               - column: { name: document_id }
+        - createIndex:
+            indexName: ix_annotation_author
+            tableName: annotation
+            columns:
+              - column: { name: author_id }
         - sql:
             comment: Closed set of annotation outcomes (not expressible in JPA).
             sql: |
@@ -326,6 +331,11 @@ databaseChangeLog:
             tableName: comment
             columns:
               - column: { name: annotation_id }
+        - createIndex:
+            indexName: ix_comment_author
+            tableName: comment
+            columns:
+              - column: { name: author_id }
 
   - changeSet:
       id: 0011-annotation-placement
@@ -443,3 +453,8 @@ databaseChangeLog:
             columns:
               - column: { name: document_id }
               - column: { name: created_at }
+        - createIndex:
+            indexName: ix_audit_event_actor
+            tableName: audit_event
+            columns:
+              - column: { name: actor_id }

--- a/qnop-core/src/main/resources/db/changelog/migrations/0013-version-diff-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0013-version-diff-schema.yaml
@@ -64,3 +64,10 @@ databaseChangeLog:
             tableName: version_diff
             columnNames: from_version_id, to_version_id
             constraintName: ux_version_diff_pair
+        # FK index for the document_id CASCADE and document-scoped lookups (issue #330).
+        # (from_version_id is already covered by the leftmost prefix of ux_version_diff_pair.)
+        - createIndex:
+            indexName: ix_version_diff_document
+            tableName: version_diff
+            columns:
+              - column: { name: document_id }


### PR DESCRIPTION
## Summary

MEDIUM review finding #330. Postgres does not auto-index foreign keys, so a user delete (RESTRICT / SET NULL check) or a join on these columns sequentially scanned the table. Adds the four genuinely-missing FK indexes, **folded into their existing changesets** — the app is pre-production and the schema is still being shaped, so no new migration (per the maintainer convention).

| Column | Index | Changelog |
|--------|-------|-----------|
| `annotation.author_id` | `ix_annotation_author` | `0011` |
| `comment.author_id` | `ix_comment_author` | `0011` |
| `audit_event.actor_id` | `ix_audit_event_actor` | `0011` |
| `version_diff.document_id` | `ix_version_diff_document` | `0013` |

## Deviation from the issue: `user_setting.user_id` not added

The issue also listed `user_setting.user_id`, but the existing composite unique index `ux_user_setting_user_key (user_id, setting_key)` **already indexes `user_id` as its leading column** — Postgres uses it for the FK `CASCADE` and any `user_id` lookup, so a standalone index would be redundant (extra write cost, never chosen over the composite). For the same reason `version_diff.from_version_id` is left uncovered-by-a-standalone-index: it is the leading column of `ux_version_diff_pair`.

If you'd prefer the explicit single-column index on `user_setting.user_id` anyway (e.g. for consistency), I can add it — say the word.

## Test plan
- [x] `DocumentReviewSchemaIT` asserts `ix_annotation_author` / `ix_comment_author` / `ix_audit_event_actor` exist (pg_indexes), mirroring the existing `SettingsSchemaIT` FK-index check.
- [x] `VersionDiffIT` asserts `ix_version_diff_document` exists.
- [x] Local gate green: `spotlessApply`, `:qnop-core:build`, `:qnop-app:compileTestJava`, `ArchitectureRulesTest`.
- [ ] CI applies the (modified) changesets against a fresh Postgres via Testcontainers — validates the Liquibase YAML end-to-end.

> Note: because existing changesets were modified, any already-migrated **dev** database needs a `liquibase clearCheckSums` (or a fresh DB). No production databases exist yet.

Closes #330

🤖 Co-Author: Claude (Opus 4.x) via Claude Code