### PR TITLE
perf(core): index the review/diff foreign-key columns (#330)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/review/DocumentReviewSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DocumentReviewSchemaIT.java
@@ -303,7 +303,26 @@ class DocumentReviewSchemaIT extends AbstractIntegrationTest {
         .isInstanceOf(DataIntegrityViolationException.class);
   }
 
+  @Test
+  @DisplayName("the author/actor foreign keys are indexed")
+  void indexesTheAuthorAndActorForeignKeys() {
+    // Postgres does not auto-index FKs; without these, deleting a qnop_user (the RESTRICT check
+    // on annotation/comment author, the audit actor) or joining by author/actor sequentially
+    // scans the table (issue #330).
+    assertThat(indexCount("annotation", "ix_annotation_author")).isEqualTo(1);
+    assertThat(indexCount("comment", "ix_comment_author")).isEqualTo(1);
+    assertThat(indexCount("audit_event", "ix_audit_event_actor")).isEqualTo(1);
+  }
+
   // --- helpers -------------------------------------------------------------
+
+  private Integer indexCount(String tableName, String indexName) {
+    return jdbc.queryForObject(
+        "SELECT count(*) FROM pg_indexes WHERE tablename = ? AND indexname = ?",
+        Integer.class,
+        tableName,
+        indexName);
+  }
 
   private User newUser(String displayName) {
     return users.saveAndFlush(

--- a/qnop-app/src/test/java/io/qnop/review/VersionDiffIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/VersionDiffIT.java
@@ -36,6 +36,7 @@ import io.qnop.testsupport.SeededIntegrationTest;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 /**
@@ -49,6 +50,7 @@ class VersionDiffIT extends SeededIntegrationTest {
   @Autowired private DocumentVersionRepository versions;
   @Autowired private ReviewParticipantRepository participants;
   @Autowired private VersionDiffRepository diffCache;
+  @Autowired private JdbcTemplate jdbc;
 
   /** The jsonb of a one-surface rendered document whose spans are the given lines (ADR-0032). */
   private static String rendered(String... lines) {
@@ -188,5 +190,17 @@ class VersionDiffIT extends SeededIntegrationTest {
     seedVersion(documentId, 1, rendered("alpha"));
 
     mockMvc.perform(diffRequest(documentId, 1, 9, MEMBER_ID)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void indexesTheDocumentForeignKey() {
+    // version_diff.document_id is otherwise an unindexed FK — a document delete (ON DELETE
+    // CASCADE) or a by-document lookup would sequentially scan the cache (issue #330).
+    Integer count =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM pg_indexes WHERE tablename = 'version_diff'"
+                + " AND indexname = 'ix_version_diff_document'",
+            Integer.class);
+    assertThat(count).isEqualTo(1);
   }
 }

--- a/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
@@ -273,6 +273,11 @@ databaseChangeLog:
             tableName: annotation
             columns:
               - column: { name: document_id }
+        - createIndex:
+            indexName: ix_annotation_author
+            tableName: annotation
+            columns:
+              - column: { name: author_id }
         - sql:
             comment: Closed set of annotation outcomes (not expressible in JPA).
             sql: |
@@ -326,6 +331,11 @@ databaseChangeLog:
             tableName: comment
             columns:
               - column: { name: annotation_id }
+        - createIndex:
+            indexName: ix_comment_author
+            tableName: comment
+            columns:
+              - column: { name: author_id }
 
   - changeSet:
       id: 0011-annotation-placement
@@ -443,3 +453,8 @@ databaseChangeLog:
             columns:
               - column: { name: document_id }
               - column: { name: created_at }
+        - createIndex:
+            indexName: ix_audit_event_actor
+            tableName: audit_event
+            columns:
+              - column: { name: actor_id }

--- a/qnop-core/src/main/resources/db/changelog/migrations/0013-version-diff-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0013-version-diff-schema.yaml
@@ -64,3 +64,8 @@ databaseChangeLog:
             tableName: version_diff
             columnNames: from_version_id, to_version_id
             constraintName: ux_version_diff_pair
+        - createIndex:
+            indexName: ix_version_diff_document
+            tableName: version_diff
+            columns:
+              - column: { name: document_id }


### PR DESCRIPTION
## Summary

Implements #374 (review finding #330). Postgres does not auto-index foreign keys, so a user delete (RESTRICT / SET NULL check) or a join on these columns sequentially scanned the table. Adds the four genuinely-missing FK indexes, **folded into their existing changesets** — the app is pre-production and the schema is still being shaped, so no new migration (per the maintainer convention).

| Column | Index | Changelog |
|--------|-------|-----------|
| `annotation.author_id` | `ix_annotation_author` | `0011` |
| `comment.author_id` | `ix_comment_author` | `0011` |
| `audit_event.actor_id` | `ix_audit_event_actor` | `0011` |
| `version_diff.document_id` | `ix_version_diff_document` | `0013` |

### Deliberately not added
`user_setting.user_id` and `version_diff.from_version_id` each are already the **leading column of a composite unique index** (`ux_user_setting_user_key`, `ux_version_diff_pair`), which Postgres uses for the FK check and any lookup — a standalone index would only add write cost and never be chosen.

## Test plan
- [x] `DocumentReviewSchemaIT` asserts `ix_annotation_author` / `ix_comment_author` / `ix_audit_event_actor` exist (`pg_indexes`), mirroring `SettingsSchemaIT`'s FK-index check.
- [x] `VersionDiffIT` asserts `ix_version_diff_document` exists.
- [x] Local gate green: `spotlessApply`, `:qnop-core:build`, `:qnop-app:compileTestJava`, `ArchitectureRulesTest`.
- [ ] CI applies the (modified) changesets against a fresh Postgres via Testcontainers — validates the Liquibase YAML end-to-end.

> Because existing changesets were modified, any already-migrated **dev** database needs a `liquibase clearCheckSums` (or a fresh DB). No production databases exist yet.

Closes #330

🤖 Co-Author: Claude (Opus 4.8) via Claude Code