### PR TITLE
fix(ui): error boundaries around viewer/panel + lazy routes (#331)

### DIFF
--- a/qnop-ui/src/components/errors/BoundaryFallback.tsx
+++ b/qnop-ui/src/components/errors/BoundaryFallback.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { RotateCcw, TriangleAlert } from 'lucide-react';
+
+interface BoundaryFallbackProps {
+  /** Retry callback from the enclosing {@link ErrorBoundary}. */
+  onRetry: () => void;
+  /** Short label for what failed, e.g. "The document viewer". */
+  title?: string;
+  /** Compact variant for a small pane (viewer/panel); default is roomier. */
+  dense?: boolean;
+}
+
+/**
+ * The default scoped fallback for an {@link ErrorBoundary} (issue #331): an
+ * in-brand "something went wrong" card with a retry, sized to the pane it
+ * replaces rather than taking over the page.
+ */
+export function BoundaryFallback({
+  onRetry,
+  title = 'Something went wrong',
+  dense = false,
+}: BoundaryFallbackProps) {
+  return (
+    <Paper
+      variant="outlined"
+      role="alert"
+      sx={{
+        display: 'grid',
+        placeItems: 'center',
+        textAlign: 'center',
+        p: dense ? 3 : 5,
+        minHeight: dense ? 160 : 240,
+        height: '100%',
+      }}
+    >
+      <Stack spacing={1.25} sx={{ alignItems: 'center', maxWidth: 360 }}>
+        <Box sx={{ color: 'error.main', display: 'flex' }}>
+          <TriangleAlert size={dense ? 24 : 32} aria-hidden />
+        </Box>
+        <Typography variant={dense ? 'subtitle2' : 'h6'} component="p">
+          {title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          This part of the page ran into an unexpected error. You can try again, or reload the page
+          if it keeps happening.
+        </Typography>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<RotateCcw size={15} />}
+          onClick={onRetry}
+          sx={{ mt: 0.5 }}
+        >
+          Try again
+        </Button>
+      </Stack>
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/errors/ErrorBoundary.test.tsx
+++ b/qnop-ui/src/components/errors/ErrorBoundary.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { BoundaryFallback } from './BoundaryFallback';
+import { ErrorBoundary } from './ErrorBoundary';
+
+// A component whose throwing is controlled by a module flag, so a retry can
+// re-render it into a working state.
+let shouldThrow = true;
+function MaybeBomb() {
+  if (shouldThrow) {
+    throw new Error('kaboom');
+  }
+  return <div>recovered content</div>;
+}
+
+function Bomb(): never {
+  throw new Error('kaboom');
+}
+
+function withTheme(node: ReactNode) {
+  return <ThemeProvider theme={buildTheme('light')}>{node}</ThemeProvider>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    shouldThrow = true;
+    // React logs caught render errors to console.error; keep the test output clean.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when nothing throws', () => {
+    render(
+      <ErrorBoundary fallback={<div>fallback</div>}>
+        <div>healthy child</div>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('healthy child')).toBeInTheDocument();
+    expect(screen.queryByText('fallback')).not.toBeInTheDocument();
+  });
+
+  it('renders the fallback when a descendant throws', () => {
+    render(
+      <ErrorBoundary fallback={<div>caught it</div>}>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('caught it')).toBeInTheDocument();
+  });
+
+  it('reports the caught error through onError', () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary fallback={<div>fallback</div>} onError={onError}>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('recovers when the fallback retry is invoked', () => {
+    render(
+      <ErrorBoundary fallback={(_error, reset) => <button onClick={reset}>retry</button>}>
+        <MaybeBomb />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole('button', { name: 'retry' })).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+
+    expect(screen.getByText('recovered content')).toBeInTheDocument();
+  });
+
+  it('clears the error when resetKeys change', () => {
+    function Scene({ resetKey, boom }: { resetKey: number; boom: boolean }) {
+      return (
+        <ErrorBoundary resetKeys={[resetKey]} fallback={<div>fallback</div>}>
+          {boom ? <Bomb /> : <div>ok now</div>}
+        </ErrorBoundary>
+      );
+    }
+
+    const { rerender } = render(<Scene resetKey={1} boom />);
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+
+    rerender(<Scene resetKey={2} boom={false} />);
+    expect(screen.getByText('ok now')).toBeInTheDocument();
+  });
+
+  it('uses BoundaryFallback as a retryable, in-brand default', () => {
+    render(
+      withTheme(
+        <ErrorBoundary fallback={(_error, reset) => <BoundaryFallback onRetry={reset} />}>
+          <Bomb />
+        </ErrorBoundary>,
+      ),
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/errors/ErrorBoundary.tsx
+++ b/qnop-ui/src/components/errors/ErrorBoundary.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * What to render when a descendant throws. Either a static node, or a render
+   * function that receives the error and a `reset` callback to retry.
+   */
+  fallback: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+  /**
+   * When any value in this array changes between renders, the boundary clears its
+   * error and re-renders its children — e.g. navigating to a different document.
+   */
+  resetKeys?: readonly unknown[];
+  /** Optional hook for reporting; called once per caught error. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * A React error boundary (issue #331). A throw in a descendant — a crashing
+ * viewer, annotation panel, or a lazy chunk that fails to load — is caught here
+ * and rendered as a scoped fallback instead of unmounting the whole page. React
+ * has no functional equivalent, so this stays a class component. Pair one above
+ * every {@code Suspense} boundary so both the loading and the failure states are
+ * handled.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Surface the crash for diagnosis rather than swallowing it silently; a real
+    // error reporter can be wired through `onError` later.
+    console.error('Unhandled error caught by ErrorBoundary:', error, info.componentStack);
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (this.state.error !== null && this.resetKeysChanged(prevProps.resetKeys)) {
+      this.reset();
+    }
+  }
+
+  private resetKeysChanged(previous: readonly unknown[] | undefined): boolean {
+    const next = this.props.resetKeys;
+    if (previous === undefined || next === undefined) {
+      return previous !== next;
+    }
+    return (
+      previous.length !== next.length || previous.some((value, i) => !Object.is(value, next[i]))
+    );
+  }
+
+  private reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error === null) {
+      return this.props.children;
+    }
+    const { fallback } = this.props;
+    return typeof fallback === 'function' ? fallback(error, this.reset) : fallback;
+  }
+}

--- a/qnop-ui/src/components/errors/LazyBoundary.tsx
+++ b/qnop-ui/src/components/errors/LazyBoundary.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Suspense, type ReactNode } from 'react';
+import { BoundaryFallback } from './BoundaryFallback';
+import { ErrorBoundary } from './ErrorBoundary';
+
+// Plain inline styling so the placeholder needs no theme while a chunk loads.
+const loadingFallback = (
+  <div style={{ padding: '8px 4px', fontSize: 14, color: '#5E6C7B' }}>Loading…</div>
+);
+
+/**
+ * Wraps a lazily-loaded route in an {@link ErrorBoundary} above a {@link Suspense}
+ * (issue #331): the Suspense shows the loading placeholder while the chunk loads,
+ * and the boundary catches both a chunk that fails to load and any render crash in
+ * the loaded page — surfacing a retryable fallback instead of a blank screen.
+ */
+export function LazyBoundary({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary fallback={(_error, reset) => <BoundaryFallback onRetry={reset} />}>
+      <Suspense fallback={loadingFallback}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -43,6 +43,8 @@ import {
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
+import { BoundaryFallback } from '../../components/errors/BoundaryFallback';
+import { ErrorBoundary } from '../../components/errors/ErrorBoundary';
 import { ReviewHubHead } from '../../components/reviews/hub/ReviewHubHead';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
 import { PANEL_MIN_WIDTH, PanelResizer } from '../../components/reviews/PanelResizer';
@@ -341,38 +343,47 @@ export function DocumentReviewPage() {
                   bgcolor: (theme) => theme.qnop.surface2,
                 }}
               >
-                <DocumentViewer
-                  ref={viewerRef}
-                  pdf={pdf}
-                  surfaces={surfaces}
-                  zoom={zoom}
-                  annotations={annotations}
-                  activeAnnotationId={activeAnnotationId}
-                  hoverAnnotationId={hoverAnnotationId}
-                  onSelectAnnotation={(id) => {
-                    setActiveAnnotationId(id);
-                    setPending(null);
-                  }}
-                  onHoverAnnotation={setHoverAnnotationId}
-                  onVisiblePageChange={setCurrentPage}
-                  tool={tool}
-                  canAnnotate={canAnnotate}
-                  pendingAnchor={pending?.anchor ?? null}
-                  onTextSelected={handleTextSelected}
-                  onRegionSelected={handleRegionSelected}
-                  focusScrim={
-                    focusOverlayOpen
-                      ? {
-                          spotlight: focusSpotlight,
-                          // The veil never discards a composer mid-typing — the
-                          // card's Cancel is the explicit way out.
-                          onDismiss: () => {
-                            if (!composingPending) closeFocusCard();
-                          },
-                        }
-                      : null
-                  }
-                />
+                {/* A crash in the pdf.js viewer must not take down the panel or the
+                    page — scope it and let the reviewer retry (issue #331). */}
+                <ErrorBoundary
+                  resetKeys={[versionNumber, pdf]}
+                  fallback={(_error, reset) => (
+                    <BoundaryFallback title="The document viewer failed" onRetry={reset} />
+                  )}
+                >
+                  <DocumentViewer
+                    ref={viewerRef}
+                    pdf={pdf}
+                    surfaces={surfaces}
+                    zoom={zoom}
+                    annotations={annotations}
+                    activeAnnotationId={activeAnnotationId}
+                    hoverAnnotationId={hoverAnnotationId}
+                    onSelectAnnotation={(id) => {
+                      setActiveAnnotationId(id);
+                      setPending(null);
+                    }}
+                    onHoverAnnotation={setHoverAnnotationId}
+                    onVisiblePageChange={setCurrentPage}
+                    tool={tool}
+                    canAnnotate={canAnnotate}
+                    pendingAnchor={pending?.anchor ?? null}
+                    onTextSelected={handleTextSelected}
+                    onRegionSelected={handleRegionSelected}
+                    focusScrim={
+                      focusOverlayOpen
+                        ? {
+                            spotlight: focusSpotlight,
+                            // The veil never discards a composer mid-typing — the
+                            // card's Cancel is the explicit way out.
+                            onDismiss: () => {
+                              if (!composingPending) closeFocusCard();
+                            },
+                          }
+                        : null
+                    }
+                  />
+                </ErrorBoundary>
               </Box>
             )}
           </Stack>
@@ -394,45 +405,59 @@ export function DocumentReviewPage() {
                 overflowY: { md: 'auto' },
               }}
             >
-              <AnnotationPanel
-                annotations={annotations}
-                activeAnnotationId={activeAnnotationId}
-                hoverAnnotationId={hoverAnnotationId}
-                onSelect={setActiveAnnotationId}
-                onHover={setHoverAnnotationId}
-                pendingAnchor={pending && !pending.menuPosition ? pending.anchor : null}
-                creating={createAnnotation.isPending}
-                onCreate={handleCreate}
-                onCancelPending={() => setPending(null)}
-                canAnnotate={canAnnotate}
-                ownerId={document.ownerId}
-                notify={notify}
-              />
+              <ErrorBoundary
+                resetKeys={[versionNumber]}
+                fallback={(_error, reset) => (
+                  <BoundaryFallback title="The annotations panel failed" onRetry={reset} dense />
+                )}
+              >
+                <AnnotationPanel
+                  annotations={annotations}
+                  activeAnnotationId={activeAnnotationId}
+                  hoverAnnotationId={hoverAnnotationId}
+                  onSelect={setActiveAnnotationId}
+                  onHover={setHoverAnnotationId}
+                  pendingAnchor={pending && !pending.menuPosition ? pending.anchor : null}
+                  creating={createAnnotation.isPending}
+                  onCreate={handleCreate}
+                  onCancelPending={() => setPending(null)}
+                  canAnnotate={canAnnotate}
+                  ownerId={document.ownerId}
+                  notify={notify}
+                />
+              </ErrorBoundary>
             </Box>
           )}
         </Stack>
       )}
       {focusMode && (
         <FocusDrawer open={listOpen} onClose={() => setListOpen(false)}>
-          <AnnotationPanel
-            annotations={annotations}
-            activeAnnotationId={activeAnnotationId}
-            hoverAnnotationId={hoverAnnotationId}
-            onSelect={(id) => {
-              setActiveAnnotationId(id);
-              // A placed annotation continues in the spotlight; unplaced ones
-              // keep their thread inside the drawer (no mark to spotlight).
-              if (id && annotations.find((a) => a.id === id)?.anchor) setListOpen(false);
-            }}
-            onHover={setHoverAnnotationId}
-            pendingAnchor={null}
-            creating={createAnnotation.isPending}
-            onCreate={handleCreate}
-            onCancelPending={() => setPending(null)}
-            canAnnotate={canAnnotate}
-            ownerId={document.ownerId}
-            notify={notify}
-          />
+          <ErrorBoundary
+            resetKeys={[versionNumber]}
+            fallback={(_error, reset) => (
+              <BoundaryFallback title="The annotations panel failed" onRetry={reset} dense />
+            )}
+          >
+            <AnnotationPanel
+              annotations={annotations}
+              activeAnnotationId={activeAnnotationId}
+              hoverAnnotationId={hoverAnnotationId}
+              onSelect={(id) => {
+                setActiveAnnotationId(id);
+                // A placed annotation continues in the spotlight; unplaced ones
+                // keep their thread inside the drawer (no mark to spotlight).
+                if (id && annotations.find((a) => a.id === id)?.anchor) setListOpen(false);
+              }}
+              onHover={setHoverAnnotationId}
+              pendingAnchor={null}
+              creating={createAnnotation.isPending}
+              onCreate={handleCreate}
+              onCancelPending={() => setPending(null)}
+              canAnnotate={canAnnotate}
+              ownerId={document.ownerId}
+              notify={notify}
+            />
+          </ErrorBoundary>
         </FocusDrawer>
       )}
       {focusMode && activeAnnotation && !listOpen && (

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -19,10 +19,11 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { lazy, Suspense } from 'react';
+import { lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import { ShieldCheck } from 'lucide-react';
 import { AppShell } from '../components/shell/AppShell';
+import { LazyBoundary } from '../components/errors/LazyBoundary';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { ProtectedRoute } from '../components/auth/ProtectedRoute';
 import { RoleRoute } from '../components/auth/RoleRoute';
@@ -63,10 +64,6 @@ const VersionComparePage = lazy(() =>
   import('../pages/reviews/VersionComparePage').then((m) => ({ default: m.VersionComparePage })),
 );
 
-const lazyFallback = (
-  <div style={{ padding: '8px 4px', fontSize: 14, color: '#5E6C7B' }}>Loading…</div>
-);
-
 /**
  * Central route table. Public routes (login, errors) sit outside the shell;
  * everything under the shell requires authentication. Surfaces whose screens
@@ -96,17 +93,17 @@ export const router = createBrowserRouter([
       {
         path: 'reviews/:documentId',
         element: (
-          <Suspense fallback={lazyFallback}>
+          <LazyBoundary>
             <DocumentReviewPage />
-          </Suspense>
+          </LazyBoundary>
         ),
       },
       {
         path: 'reviews/:documentId/compare',
         element: (
-          <Suspense fallback={lazyFallback}>
+          <LazyBoundary>
             <VersionComparePage />
-          </Suspense>
+          </LazyBoundary>
         ),
       },
       {
@@ -181,9 +178,9 @@ export const router = createBrowserRouter([
         path: 'admin/mail-templates/:key',
         element: (
           <AdminRoute>
-            <Suspense fallback={lazyFallback}>
+            <LazyBoundary>
               <MailTemplateEditPage />
-            </Suspense>
+            </LazyBoundary>
           </AdminRoute>
         ),
       },


### PR DESCRIPTION
## Summary

A throw in `DocumentViewer` / `AnnotationPanel`, or a lazily-loaded route chunk that fails to load, crashed the **whole page** (blank screen) instead of a scoped fallback — the review surface has no error boundaries above its Suspense boundaries (issue #331, MEDIUM).

## Changes
- **`ErrorBoundary`** — a class component (React 19 has no functional equivalent) with `resetKeys` (auto-clear when e.g. the document changes), a `reset` retry callback, and an `onError` reporting hook. Logs the caught error rather than swallowing it.
- **`BoundaryFallback`** — a shared, in-brand "something went wrong" card (`role="alert"`, amber icon, **Try again**), with a `dense` variant for small panes.
- **`LazyBoundary`** — pairs an `ErrorBoundary` above a `Suspense`, so both the loading state and a chunk-load/render failure are handled. The router now wraps its three lazy routes (review surface, version compare, mail-template editor) with it instead of bare `<Suspense>`.
- **`DocumentReviewPage`** — the pdf.js viewer and both annotation panels (desktop + focus drawer) are each wrapped in a scoped boundary that resets on version/pdf change, so a crash in one pane no longer takes down the header or the other pane.

## Test plan
- [x] New `ErrorBoundary.test.tsx` (6 cases): renders children; catches a throw → fallback; `onError` fires; retry recovers; `resetKeys` change recovers; default `BoundaryFallback` is a retryable alert.
- [x] Local: `tsc -b`, `eslint`, `prettier --check` clean; **406 vitest tests pass**; production `vite build` green.

Closes #331

🤖 Co-Author: Claude (Opus 4.x) via Claude Code