### PR TITLE
refactor: split JobEnqueuer out of JobService to break the handler cycle (#318)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionWriter.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionWriter.java
@@ -26,11 +26,10 @@ import io.qnop.entity.ExtractionStatus;
 import io.qnop.entity.PlacementStatus;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
-import io.qnop.service.job.JobService;
+import io.qnop.service.job.JobEnqueuer;
 import io.qnop.service.review.ReanchorJobHandler;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,14 +50,16 @@ class DocumentExtractionWriter {
 
   private final DocumentVersionRepository versions;
   private final AnnotationPlacementRepository placements;
-  // ObjectProvider breaks the constructor cycle: JobService injects every JobHandler, and the
-  // extraction path needs JobService back to enqueue the follow-up re-anchoring job (issue #248).
-  private final ObjectProvider<JobService> jobs;
+  // The narrow write-side queue bean, injected directly (no ObjectProvider): depending on
+  // JobEnqueuer rather than the full JobService keeps the extraction path from closing the
+  // dispatch↔handler cycle, so the follow-up re-anchoring job (issue #248) enqueues without any
+  // lazy indirection (issue #318).
+  private final JobEnqueuer jobs;
 
   DocumentExtractionWriter(
       DocumentVersionRepository versions,
       AnnotationPlacementRepository placements,
-      ObjectProvider<JobService> jobs) {
+      JobEnqueuer jobs) {
     this.versions = versions;
     this.placements = placements;
     this.jobs = jobs;
@@ -80,8 +81,7 @@ class DocumentExtractionWriter {
     if (!placements
         .findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING)
         .isEmpty()) {
-      jobs.getObject()
-          .enqueue(ReanchorJobHandler.TYPE, DocumentIngestService.extractionPayload(versionId));
+      jobs.enqueue(ReanchorJobHandler.TYPE, DocumentIngestService.extractionPayload(versionId));
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/job/JobEnqueuer.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobEnqueuer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import io.qnop.entity.Job;
+import io.qnop.repository.JobRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The write side of the durable job queue: appends a job in the caller's transaction (outbox,
+ * ADR-0033). Split out of {@link JobService} to break the dispatch↔handler cycle (issue #318) —
+ * {@code JobService} injects every {@link JobHandler}, yet a handler's write phase needs to enqueue
+ * a follow-up job. Depending on this narrow bean (its only collaborator is {@link JobRepository})
+ * instead of the full {@code JobService} means a handler no longer has a path back to the
+ * dispatcher that injected it, so no lazy {@code ObjectProvider} indirection is needed.
+ */
+@Service
+public class JobEnqueuer {
+
+  /** Attempts a job is retried before it is parked {@code FAILED} (matches the queue's backoff). */
+  static final int DEFAULT_MAX_ATTEMPTS = 5;
+
+  private final JobRepository repository;
+
+  public JobEnqueuer(JobRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Enqueues a job to run as soon as the poller picks it up. Runs in the caller's transaction
+   * (outbox): the job and the triggering write commit together, or neither does.
+   */
+  @Transactional
+  public UUID enqueue(String type, String payload) {
+    Job job = new Job(type, payload, DEFAULT_MAX_ATTEMPTS, Instant.now());
+    return repository.save(job).getId();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/job/JobService.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobService.java
@@ -57,30 +57,31 @@ public class JobService {
   private static final Logger log = LoggerFactory.getLogger(JobService.class);
 
   static final int POLL_BATCH = 20;
-  static final int DEFAULT_MAX_ATTEMPTS = 5;
   static final Duration BACKOFF_BASE = Duration.ofSeconds(10);
   static final Duration BACKOFF_CAP = Duration.ofMinutes(10);
   static final Duration STALE_AFTER = Duration.ofMinutes(5);
   private static final int MAX_ERROR_LENGTH = 2000;
 
   private final JobRepository repository;
+  private final JobEnqueuer enqueuer;
   private final Map<String, JobHandler> handlers;
 
-  public JobService(JobRepository repository, List<JobHandler> handlers) {
+  public JobService(JobRepository repository, JobEnqueuer enqueuer, List<JobHandler> handlers) {
     this.repository = repository;
+    this.enqueuer = enqueuer;
     this.handlers =
         handlers.stream()
             .collect(Collectors.toUnmodifiableMap(JobHandler::type, Function.identity()));
   }
 
   /**
-   * Enqueues a job to run as soon as the poller picks it up. Runs in the caller's transaction
-   * (outbox): the job and the triggering write commit together, or neither does.
+   * Enqueues a job to run as soon as the poller picks it up. Delegates to {@link JobEnqueuer} — the
+   * narrow write-side bean handlers depend on to avoid the dispatch↔handler cycle (issue #318) —
+   * while remaining the queue's public facade for callers that already hold a {@code JobService}.
+   * Runs in the caller's transaction (outbox): the job and the triggering write commit together.
    */
-  @Transactional
   public UUID enqueue(String type, String payload) {
-    Job job = new Job(type, payload, DEFAULT_MAX_ATTEMPTS, Instant.now());
-    return repository.save(job).getId();
+    return enqueuer.enqueue(type, payload);
   }
 
   /** Claims a batch of due jobs (flips them to {@code RUNNING}) and returns their ids. */

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
@@ -31,7 +31,7 @@ import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
-import io.qnop.service.job.JobService;
+import io.qnop.service.job.JobEnqueuer;
 import io.qnop.service.storage.StorageService;
 import io.qnop.spi.extract.DocumentExtractor;
 import io.qnop.spi.extract.ExtractionException;
@@ -48,7 +48,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 
 /** Unit tests for {@link DocumentExtractionJobHandler}'s failure policy and idempotency (#245). */
 class DocumentExtractionJobHandlerTest {
@@ -57,9 +56,7 @@ class DocumentExtractionJobHandlerTest {
   private final StorageService storage = mock(StorageService.class);
   private final AnnotationPlacementRepository placements =
       mock(AnnotationPlacementRepository.class);
-
-  @SuppressWarnings("unchecked")
-  private final ObjectProvider<JobService> jobs = mock(ObjectProvider.class);
+  private final JobEnqueuer jobs = mock(JobEnqueuer.class);
 
   private final UUID versionId = UUID.randomUUID();
   private DocumentVersion version;

--- a/qnop-core/src/test/java/io/qnop/service/job/JobEnqueuerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/job/JobEnqueuerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.Job;
+import io.qnop.entity.JobStatus;
+import io.qnop.repository.JobRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/** Unit tests for the outbox write side of the job queue (issue #318, ADR-0033). */
+class JobEnqueuerTest {
+
+  private final JobRepository repository = mock(JobRepository.class);
+  private final JobEnqueuer enqueuer = new JobEnqueuer(repository);
+
+  @Test
+  @DisplayName("enqueue saves a PENDING job carrying the type, payload and default attempts")
+  void enqueuePersistsAPendingJob() {
+    ArgumentCaptor<Job> saved = ArgumentCaptor.forClass(Job.class);
+    when(repository.save(any(Job.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    enqueuer.enqueue("document.reanchor", "{\"versionId\":\"x\"}");
+
+    verify(repository).save(saved.capture());
+    Job job = saved.getValue();
+    assertThat(job.getType()).isEqualTo("document.reanchor");
+    assertThat(job.getPayload()).isEqualTo("{\"versionId\":\"x\"}");
+    assertThat(job.getStatus()).isEqualTo(JobStatus.PENDING);
+    assertThat(job.getMaxAttempts()).isEqualTo(JobEnqueuer.DEFAULT_MAX_ATTEMPTS);
+  }
+}


### PR DESCRIPTION
Closes #318.

## Problem

`JobService` injects every `JobHandler` (to dispatch a job to its handler by type), yet a handler's write phase — `DocumentExtractionWriter` — needs to **enqueue** a follow-up re-anchoring job. That closes a constructor cycle:

```
JobService ──(List<JobHandler>)──▶ DocumentExtractionJobHandler ──▶ DocumentExtractionWriter ──▶ JobService
```

It was only held together by a fragile lazy `ObjectProvider<JobService>` in the writer (`jobs.getObject().enqueue(...)`).

## Fix — Interface Segregation via a narrow enqueue bean

Extract the outbox write side into a new **`JobEnqueuer`** `@Service` whose only collaborator is `JobRepository`. Since it has no dependency on handlers, nothing that depends on it can reach back to `JobService`:

- `DocumentExtractionWriter` now injects `JobEnqueuer` **directly** — no `ObjectProvider`, no lazy lookup. The cycle is structurally gone.
- `JobService` keeps `enqueue` as the queue's public **facade**, delegating to `JobEnqueuer`, so external callers (`DocumentIngestService`, `JobQueuePoller`, `JobQueueIT`) are untouched.
- Outbox semantics preserved: `enqueue` still runs in the caller's transaction (`@Transactional` REQUIRED joins the caller), so a job and its triggering write still commit together.

This is the issue's "registry/post-processing" spirit, realized as the smallest change that removes the lazy binding while keeping every existing collaborator working — and keeps the codebase's constructor-injection / immutable-bean grain (no post-construct mutable registry).

## Changes

- **new** `JobEnqueuer` (`@Service`, `JobRepository` only) + `JobEnqueuerTest`
- `JobService`: `enqueue` delegates to `JobEnqueuer`; `DEFAULT_MAX_ATTEMPTS` moves to `JobEnqueuer`; constructor gains the `JobEnqueuer` collaborator
- `DocumentExtractionWriter`: `ObjectProvider<JobService>` → `JobEnqueuer` (direct)
- `DocumentExtractionJobHandlerTest`: mock `JobEnqueuer` instead of `ObjectProvider<JobService>`

## Test plan

- [x] `spotlessApply` + `:qnop-core:compileJava` — clean
- [x] `:qnop-core:test` job + `DocumentExtractionJobHandlerTest` — pass (incl. new `JobEnqueuerTest`)
- [x] `:qnop-app:test --tests io.qnop.architecture.*` (ArchUnit layering) — pass
- [x] Cycle regression guard: the full Spring context in every `@SpringBootTest` IT (e.g. `JobQueueIT`, `DocumentIngestIT`, `ReanchoringIT`) now wires **without** the `ObjectProvider` workaround — Boot 4 forbids circular references, so a re-introduced cycle would fail context startup in CI.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code