### PR TITLE
refactor: handle xlink:href explicitly in the SVG sanitizer (#338)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/branding/SvgSanitizer.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/SvgSanitizer.java
@@ -147,10 +147,11 @@ public final class SvgSanitizer {
         toRemove.add(attribute);
       } else if (name.equals("style")) {
         toRemove.add(attribute);
-      } else if (name.equals("href")) {
+      } else if (isHrefAttribute(attribute, name)) {
         String value = attribute.getValue() == null ? "" : attribute.getValue().trim();
         if (!value.startsWith("#")) {
-          toRemove.add(attribute); // only local fragment references survive
+          // Only a local #fragment survives — covers href and the legacy xlink:href alike.
+          toRemove.add(attribute);
         }
       }
     }
@@ -173,6 +174,23 @@ public final class SvgSanitizer {
         element.removeChild(child); // drops <script>, <foreignObject>, <style>, <image>, …
       }
     }
+  }
+
+  /**
+   * Whether {@code attribute} is a hyperlink reference whose target must be restricted to a local
+   * {@code #fragment} (issue #338): {@code href} in any namespace — including the legacy {@code
+   * xlink:href} (SVG 1.1) that {@code <use>} still relies on. Matched explicitly so the
+   * classification never depends on how the parser resolved the {@code xlink} prefix: the local
+   * name {@code href} (namespace-aware parsing yields this for {@code xlink:href}), plus a fallback
+   * on a qualified name ending in {@code :href} for a prefixed name the parser did not split. Other
+   * XLink attributes ({@code xlink:title}, {@code xlink:show}, …) are deliberately not treated as
+   * links.
+   *
+   * @param localName the attribute's already-lowercased local name
+   */
+  private static boolean isHrefAttribute(Attr attribute, String localName) {
+    return localName.equals("href")
+        || attribute.getNodeName().toLowerCase(Locale.ROOT).endsWith(":href");
   }
 
   private static String localName(Node node) {

--- a/qnop-core/src/test/java/io/qnop/service/branding/SvgSanitizerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/branding/SvgSanitizerTest.java
@@ -67,6 +67,24 @@ class SvgSanitizerTest {
   }
 
   @Test
+  void stripsExternalXlinkHrefButKeepsTheAllowlistedElement() {
+    // The <use> element is allowlisted, so its xlink:href must be neutralized by the href logic
+    // itself (not by element removal): an external target is dropped, a #fragment survives (#338).
+    String out =
+        sanitize(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\""
+                + " xmlns:xlink=\"http://www.w3.org/1999/xlink\" viewBox=\"0 0 10 10\">"
+                + "<use xlink:href=\"https://evil.example/x.svg#i\"/>"
+                + "<use href=\"https://evil.example/y.svg#j\"/>"
+                + "<use xlink:href=\"#safe\"/>"
+                + "</svg>");
+
+    assertFalse(out.toLowerCase(java.util.Locale.ROOT).contains("evil.example"), out);
+    assertTrue(out.contains("#safe"), out); // the local fragment reference survives
+    assertTrue(out.contains("<use"), out); // the allowlisted element itself is kept
+  }
+
+  @Test
   void rejectsDoctypeToBlockXxe() {
     String xxe =
         "<?xml version=\"1.0\"?>"


### PR DESCRIPTION
## Summary

LOW security-review finding #338. `xlink:href` was **already** restricted to local `#fragment` targets — the namespace-aware parser gives it the local name `href`, so the existing `equals("href")` check matched it. This PR makes that handling **explicit** for clarity and future-proofing, and closes a latent edge case.

- Extracted an `isHrefAttribute()` helper that documents *why* `href` and the legacy `xlink:href` (SVG 1.1, still used by `<use>`) are treated as link references.
- Closed the edge: if the parser ever left a prefixed name unsplit, `localName()` falls back to the qualified name (`xlink:href`), which `equals("href")` would have **missed**. The helper now also matches any qualified name ending in `:href`.
- Deliberately does **not** treat other XLink attributes (`xlink:title`, `xlink:show`, …) as links.

No behavioural change for well-formed input; the element allowlist and XXE hardening are untouched.

## Test plan
- [x] New `stripsExternalXlinkHrefButKeepsTheAllowlistedElement`: an external `xlink:href` **and** `href` on the allowlisted `<use>` are neutralized by the href logic itself (not element removal), while a `#fragment` survives and the element is kept.
- [x] Existing sanitizer tests (script/handler stripping, DOCTYPE/XXE rejection, depth limit) unchanged and green.
- [x] Local gate green: `spotlessApply`, `:qnop-core:build` (incl. `SvgSanitizerTest`), `:qnop-app:compileTestJava`, `ArchitectureRulesTest`.

Closes #338

🤖 Co-Author: Claude (Opus 4.x) via Claude Code