### PR TITLE
feat: annotations and decisions on the latest version only (#306)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2099,6 +2099,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: >-
+            The addressed version is not the latest (`VERSION_READ_ONLY`,
+            issue #306) — annotations are created on the newest version only;
+            older versions are a read-only record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /annotations/{annotationId}:
     parameters:
       - $ref: '#/components/parameters/AnnotationIdParam'

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -225,6 +225,33 @@ class AnnotationApiIT extends SeededIntegrationTest {
   }
 
   @Test
+  void createsOnlyOnTheLatestVersion() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    versions.save(
+        new DocumentVersion(
+            documentId, 2, "sha256/bb/cafebabe", "cafebabe", "application/pdf", 2345L, MEMBER_ID));
+
+    // Older versions are a read-only record (issue #306).
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"versionNumber\":1,\"anchor\":" + ANCHOR + ",\"comment\":\"too late\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("VERSION_READ_ONLY"));
+
+    // The latest version keeps accepting annotations.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"versionNumber\":2,\"anchor\":" + ANCHOR + ",\"comment\":\"on latest\"}"))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
   void rejectsAnAnnotationWithoutAComment() throws Exception {
     UUID documentId = seedDocumentWithVersion();
 

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentValidationException.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentValidationException.java
@@ -70,6 +70,11 @@ public class DocumentValidationException extends RuntimeException {
     return new DocumentValidationException(400, "VALIDATION_ERROR", detail);
   }
 
+  /** Mutating review activity happens on the LATEST version only (issue #306). */
+  public static DocumentValidationException versionReadOnly(String detail) {
+    return new DocumentValidationException(409, "VERSION_READ_ONLY", detail);
+  }
+
   /** The rendered representation is not (yet) available: extraction pending or failed. */
   public static DocumentValidationException renderingUnavailable(String code, String detail) {
     return new DocumentValidationException(409, code, detail);

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -104,7 +104,10 @@ public class AnnotationService {
 
   /**
    * Creates an annotation on {@code versionNumber}, placed immediately, seeded with its mandatory
-   * first comment — an annotation without text must not exist (issue #301).
+   * first comment — an annotation without text must not exist (issue #301). Only the LATEST version
+   * accepts new annotations (issue #306) — older versions are a read-only record; the guard answers
+   * 409 {@code VERSION_READ_ONLY} so a client racing a concurrent re-upload gets a stable, mappable
+   * signal.
    */
   @Transactional
   public AnnotationView create(
@@ -123,6 +126,16 @@ public class AnnotationService {
             .findByDocumentIdAndVersionNumber(documentId, versionNumber)
             .orElseThrow(
                 () -> DocumentValidationException.notFound("no such version: " + versionNumber));
+    int latest =
+        versions
+            .findTopByDocumentIdOrderByVersionNumberDesc(documentId)
+            .map(DocumentVersion::getVersionNumber)
+            .orElse(versionNumber);
+    if (versionNumber != latest) {
+      throw DocumentValidationException.versionReadOnly(
+          "annotations are created on the latest version (v%d), not v%d"
+              .formatted(latest, versionNumber));
+    }
 
     // saveAndFlush so the @CreationTimestamp / @UpdateTimestamp are populated on the returned
     // entity (they are only set when the INSERT is flushed) before the view is built.

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -143,4 +143,10 @@ describe('FocusAnnotationCard', () => {
     expect(screen.getByRole('button', { name: 'Next annotation' })).toBeEnabled();
     expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
   });
+
+  it('suppresses deciding on a read-only (older) version (#306)', () => {
+    renderCard({ readOnly: true });
+    expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('thread-a2')).toBeInTheDocument();
+  });
 });

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -54,6 +54,8 @@ interface FocusAnnotationCardProps {
   ownerId: string | null;
   userId: string | null;
   notify: Notify;
+  /** True while an OLDER version is viewed (#306): thread readable, nothing writable. */
+  readOnly?: boolean;
 }
 
 /** True when the key event originates in a text field (arrows must move the caret). */
@@ -80,6 +82,7 @@ export function FocusAnnotationCard({
   ownerId,
   userId,
   notify,
+  readOnly = false,
 }: FocusAnnotationCardProps) {
   const theme = useTheme();
   const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
@@ -280,7 +283,7 @@ export function FocusAnnotationCard({
                   )}
                 </Box>
 
-                {mayDecideAnnotation(annotation, userId, ownerId) && (
+                {!readOnly && mayDecideAnnotation(annotation, userId, ownerId) && (
                   <DecisionBar
                     disabled={deciding}
                     onDecide={(decision) => decideWith(annotation, decision)}
@@ -288,7 +291,7 @@ export function FocusAnnotationCard({
                 )}
 
                 <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0, px: 0.5, pb: 0.5 }}>
-                  <CommentThread annotationId={annotation.id} notify={notify} />
+                  <CommentThread annotationId={annotation.id} notify={notify} readOnly={readOnly} />
                 </Box>
                 {/* Discoverability for the native resize grip underneath. */}
                 <Box

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -257,4 +257,11 @@ describe('AnnotationPanel', () => {
     fireEvent.keyDown(field, { key: 'Enter', altKey: true });
     expect(props.onCreate).toHaveBeenCalledTimes(2);
   });
+
+  it('suppresses deciding on a read-only (older) version (#306)', () => {
+    useAuthStore.setState({ userId: 'owner-1' });
+    renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1', readOnly: true });
+    expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('thread-a1')).toBeInTheDocument();
+  });
 });

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -64,6 +64,8 @@ interface AnnotationPanelProps {
   /** The document owner — owner or author may decide an annotation (ADR-0011). */
   ownerId: string | null;
   notify: Notify;
+  /** True while an OLDER version is viewed (#306): threads readable, nothing writable. */
+  readOnly?: boolean;
 }
 
 /** A collapsible, counted group of annotation cards (prototype sidebar section). */
@@ -180,6 +182,7 @@ export function AnnotationPanel({
   canAnnotate,
   ownerId,
   notify,
+  readOnly = false,
 }: AnnotationPanelProps) {
   const [filter, setFilter] = useState<StatusFilter>('all');
   const userId = useAuthStore((state) => state.userId);
@@ -208,13 +211,13 @@ export function AnnotationPanel({
           onHover={onHover}
         />
         <Collapse in={active} unmountOnExit>
-          {mayDecideAnnotation(annotation, userId, ownerId) && (
+          {!readOnly && mayDecideAnnotation(annotation, userId, ownerId) && (
             <DecisionBar
               disabled={deciding}
               onDecide={(decision) => decideWith(annotation, decision)}
             />
           )}
-          <CommentThread annotationId={annotation.id} notify={notify} />
+          <CommentThread annotationId={annotation.id} notify={notify} readOnly={readOnly} />
         </Collapse>
       </Stack>
     );

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -34,10 +34,10 @@ vi.mock('../../../api/hooks/useComments', () => ({
 
 const addMutate = vi.fn();
 
-function renderThread() {
+function renderThread(readOnly = false) {
   return render(
     <ThemeProvider theme={buildTheme('light')}>
-      <CommentThread annotationId="a1" notify={vi.fn()} />
+      <CommentThread annotationId="a1" notify={vi.fn()} readOnly={readOnly} />
     </ThemeProvider>,
   );
 }
@@ -114,5 +114,15 @@ describe('CommentThread', () => {
     fireEvent.click(button);
 
     expect(addMutate).toHaveBeenCalledWith('Needs a stronger clause', expect.anything());
+  });
+
+  it('hides the reply composer on a read-only (older) version (#306)', () => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: { comments: [] },
+    } as unknown as ReturnType<typeof useComments>);
+    renderThread(true);
+    expect(screen.queryByLabelText('Add a comment')).not.toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -42,6 +42,8 @@ const LINE_LEFT = AVATAR_SIZE / 2 - 1;
 interface CommentThreadProps {
   annotationId: string;
   notify: Notify;
+  /** Hides the reply composer — older versions are a read-only record (#306). */
+  readOnly?: boolean;
 }
 
 const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
@@ -57,7 +59,7 @@ const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
  * of the annotation API yet, so authorship is shown relative to the signed-in
  * user.
  */
-export function CommentThread({ annotationId, notify }: CommentThreadProps) {
+export function CommentThread({ annotationId, notify, readOnly = false }: CommentThreadProps) {
   const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
   const displayName = useAuthStore((state) => state.displayName);
@@ -144,48 +146,52 @@ export function CommentThread({ annotationId, notify }: CommentThreadProps) {
             No comments yet. Start the discussion.
           </Typography>
         )}
-        {/* Composer continues the thread rail with the signed-in user's avatar. */}
-        <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
-          <Box sx={{ position: 'relative', zIndex: 1, pt: 0.5 }}>
-            <UserAvatar name={displayName ?? 'You'} size={AVATAR_SIZE} imageUrl={avatarUrl} />
-          </Box>
-          <TextField
-            multiline
-            minRows={3}
-            size="small"
-            fullWidth
-            placeholder="Add a comment"
-            value={draft}
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={(event) => {
-              if (isSubmitShortcut(event)) {
-                event.preventDefault();
-                submit();
-              }
-            }}
-            slotProps={{
-              htmlInput: { maxLength: 20000, 'aria-label': 'Add a comment' },
-              input: {
-                sx: { borderRadius: 1, bgcolor: 'background.paper' },
-                endAdornment: (
-                  <Tooltip title={`Send (${submitShortcutLabel()})`}>
-                    <span style={{ alignSelf: 'flex-end' }}>
-                      <IconButton
-                        size="small"
-                        aria-label="Comment"
-                        color="primary"
-                        onClick={submit}
-                        disabled={!draft.trim() || addComment.isPending}
-                      >
-                        <SendHorizontal size={16} />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                ),
-              },
-            }}
-          />
-        </Stack>
+        {/* Composer continues the thread rail with the signed-in user's avatar.
+            Hidden on read-only (older) versions — the same thread stays
+            writable when the annotation is opened on the latest version. */}
+        {!readOnly && (
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+            <Box sx={{ position: 'relative', zIndex: 1, pt: 0.5 }}>
+              <UserAvatar name={displayName ?? 'You'} size={AVATAR_SIZE} imageUrl={avatarUrl} />
+            </Box>
+            <TextField
+              multiline
+              minRows={3}
+              size="small"
+              fullWidth
+              placeholder="Add a comment"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (isSubmitShortcut(event)) {
+                  event.preventDefault();
+                  submit();
+                }
+              }}
+              slotProps={{
+                htmlInput: { maxLength: 20000, 'aria-label': 'Add a comment' },
+                input: {
+                  sx: { borderRadius: 1, bgcolor: 'background.paper' },
+                  endAdornment: (
+                    <Tooltip title={`Send (${submitShortcutLabel()})`}>
+                      <span style={{ alignSelf: 'flex-end' }}>
+                        <IconButton
+                          size="small"
+                          aria-label="Comment"
+                          color="primary"
+                          onClick={submit}
+                          disabled={!draft.trim() || addComment.isPending}
+                        >
+                          <SendHorizontal size={16} />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  ),
+                },
+              }}
+            />
+          </Stack>
+        )}
       </Stack>
     </Box>
   );

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../api/hooks/useDocuments';
 import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotations';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
+import { useAuthStore } from '../../stores/authStore';
 
 vi.mock('../../api/hooks/useDocuments', () => ({
   useDocument: vi.fn(),
@@ -336,5 +337,33 @@ describe('DocumentReviewPage on an older version', () => {
     seedHappyPath();
     renderPage();
     expect(screen.queryByTestId('read-only-banner')).not.toBeInTheDocument();
+  });
+
+  // The page must pass readOnly down to the panel — the decision bar and the
+  // reply composer of an expanded thread are gated there, not in the page.
+  describe('expanded thread', () => {
+    afterEach(() => {
+      useAuthStore.setState({ userId: null });
+    });
+
+    it('is read-only on an older version', () => {
+      seedHappyPath();
+      useAuthStore.setState({ userId: 'u1' });
+      renderPage('/reviews/doc-1?version=1');
+
+      fireEvent.click(screen.getByTestId('annotation-item-a1'));
+      expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Add a comment')).not.toBeInTheDocument();
+    });
+
+    it('stays writable on the latest version', () => {
+      seedHappyPath();
+      useAuthStore.setState({ userId: 'u1' });
+      renderPage('/reviews/doc-1?version=2');
+
+      fireEvent.click(screen.getByTestId('annotation-item-a1'));
+      expect(screen.getByTestId('decision-bar')).toBeInTheDocument();
+      expect(screen.getByLabelText('Add a comment')).toBeInTheDocument();
+    });
   });
 });

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -170,10 +170,10 @@ function seedHappyPath(extractionStatus: ExtractionStatus = ExtractionStatus.Rea
   } as unknown as ReturnType<typeof useCreateAnnotation>);
 }
 
-function renderPage() {
+function renderPage(initialEntry = '/reviews/doc-1') {
   render(
     <ThemeProvider theme={buildTheme('light')}>
-      <MemoryRouter initialEntries={['/reviews/doc-1']}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route path="/reviews/:documentId" element={<DocumentReviewPage />} />
         </Routes>
@@ -317,5 +317,24 @@ describe('DocumentReviewPage focus mode', () => {
 
     expect(screen.getByRole('complementary', { name: 'Annotations' })).toBeInTheDocument();
     expect(localStorage.getItem('qnop-review-view-mode')).toBe('panel');
+  });
+});
+
+// Issue #306: mutating review activity is latest-only — older versions read as
+// an archive: banner + jump, annotation tools off, threads read-only.
+describe('DocumentReviewPage on an older version', () => {
+  it('shows the read-only banner with a jump to the latest version', () => {
+    seedHappyPath();
+    renderPage('/reviews/doc-1?version=1');
+
+    expect(screen.getByTestId('read-only-banner')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Go to v2' }));
+    expect(screen.queryByTestId('read-only-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows no banner on the latest version', () => {
+    seedHappyPath();
+    renderPage();
+    expect(screen.queryByTestId('read-only-banner')).not.toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -457,6 +457,7 @@ export function DocumentReviewPage() {
                   canAnnotate={canAnnotate}
                   ownerId={document.ownerId}
                   notify={notify}
+                  readOnly={!isLatestVersion}
                 />
               </ErrorBoundary>
             </Box>
@@ -489,6 +490,7 @@ export function DocumentReviewPage() {
               canAnnotate={canAnnotate}
               ownerId={document.ownerId}
               notify={notify}
+              readOnly={!isLatestVersion}
             />
           </ErrorBoundary>
         </FocusDrawer>

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -23,6 +23,7 @@ import { useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -70,6 +71,7 @@ import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
 import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
 import { useAuthStore } from '../../stores/authStore';
+import { apiErrorCode } from '../../utils/apiError';
 import { resolveEffectiveVersion } from './resolveEffectiveVersion';
 
 const PANEL_WIDTH_KEY = 'qnop-review-panel-width';
@@ -155,7 +157,15 @@ export function DocumentReviewPage() {
     () => annotationsQuery.data?.annotations ?? [],
     [annotationsQuery.data],
   );
-  const canAnnotate = extractionReady && surfaces !== undefined;
+  // The latest version across BOTH sources (the detail can be stale right
+  // after an upload, #300); mutating review activity is latest-only (#306).
+  const knownVersionNumbers = versionsQuery.data?.versions.map((v) => v.versionNumber) ?? [];
+  const knownLatest = Math.max(
+    latestVersion,
+    ...(knownVersionNumbers.length ? knownVersionNumbers : [0]),
+  );
+  const isLatestVersion = versionNumber !== undefined && versionNumber === knownLatest;
+  const canAnnotate = extractionReady && surfaces !== undefined && isLatestVersion;
   const textToolAvailable = (surfaces ?? []).some((surface) => surface.textSpans.length > 0);
   const pageCount = surfaces?.length ?? pdf?.numPages ?? 0;
 
@@ -222,7 +232,13 @@ export function DocumentReviewPage() {
           setActiveAnnotationId(created.id);
           notify('Annotation created.');
         },
-        onError: () => notify('Could not create the annotation.', 'error'),
+        onError: (error) =>
+          notify(
+            apiErrorCode(error) === 'VERSION_READ_ONLY'
+              ? 'A newer version was uploaded in the meantime — annotations go on the latest version.'
+              : 'Could not create the annotation.',
+            'error',
+          ),
       },
     );
   };
@@ -313,6 +329,23 @@ export function DocumentReviewPage() {
               annotationCount={annotations.length}
               onOpenAnnotationList={() => setListOpen(true)}
             />
+            {!isLatestVersion && versionNumber !== undefined && (
+              <Alert
+                severity="info"
+                data-testid="read-only-banner"
+                action={
+                  <Button
+                    color="inherit"
+                    size="small"
+                    onClick={() => handleVersionChange(knownLatest)}
+                  >
+                    Go to v{knownLatest}
+                  </Button>
+                }
+              >
+                You are viewing an older version — reading only. Annotate on v{knownLatest}.
+              </Alert>
+            )}
             {extractionStatus === ExtractionStatus.Pending && (
               <Alert severity="info">
                 The document is being processed — annotating becomes available once the text layer
@@ -470,6 +503,7 @@ export function DocumentReviewPage() {
           ownerId={document.ownerId}
           userId={userId}
           notify={notify}
+          readOnly={!isLatestVersion}
         />
       )}
       {focusMode && composingPending && pending && (


### PR DESCRIPTION
Closes #306. Implements the plan confirmed in chat.

## What

Older versions become a **read-only record**; all mutating review activity happens on the latest version:

- **Backend (hard rule):** `AnnotationService.create` rejects any non-latest `versionNumber` with **409 `VERSION_READ_ONLY`** (new `DocumentValidationException.versionReadOnly`, documented on the contract's create endpoint). This is also the stable answer for the upload race — a client annotating while someone re-uploads gets a mappable signal instead of silently writing to a stale version.
- **UI:** the review page derives the latest version across BOTH sources (document detail can be stale right after an upload, #300). On an older version it
  - shows a read-only banner with a **one-click jump** to the latest version,
  - disables the text/region tools (no new marks),
  - hides the reply composers and suppresses **Accept/Reject** — consistently across the **panel, the focus overlay card and the drawer** via one `readOnly` prop through the shared pieces (`CommentThread`, `DecisionBar` gating).
- The `VERSION_READ_ONLY` race maps to a friendly toast; the composer text survives the error.
- **Deliberate semantics** (as decided in #306): threads are annotation-scoped — the same thread stays writable when the annotation is opened on the latest version; annotations **orphaned on the latest version stay discussable and decidable** (the rule keys on the *viewed* version, not the placement).

## Test plan

- [x] `AnnotationApiIT`: create on v1 with v2 present → 409 + `VERSION_READ_ONLY`; create on the latest → 201; full review/document IT suites green
- [x] UI: page banner + jump (older vs latest), `CommentThread` read-only, panel and focus card suppress deciding while threads stay readable — 411 tests green
- [x] Gates: `./gradlew build` (Spotless/ArchUnit), `tsc`, `eslint`, `prettier`
- [x] Manual visual pass (older version in panel + focus mode, jump button, race toast) — done 2026-07-04; it caught a missing `readOnly` wire into both `AnnotationPanel` instances, fixed in d4de16d with page-level regression tests

🤖 Co-Author: Claude (Fable 5) via Claude Code
