### PR TITLE
fix(core): guard getInteger against missing/blank setting values (#340)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingsService.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingsService.java
@@ -106,11 +106,30 @@ public class ApplicationSettingsService {
   }
 
   public int getInteger(ApplicationSettingKey key) {
-    return Integer.parseInt(snapshot.get().get(key).trim());
+    return parseIntSetting(key.getKey(), snapshot.get().get(key));
   }
 
   public boolean getBoolean(ApplicationSettingKey key) {
     return Boolean.parseBoolean(snapshot.get().get(key));
+  }
+
+  /**
+   * Parses an integer setting, failing with a clear, key-named message instead of an opaque {@link
+   * NullPointerException}/{@link NumberFormatException} when the value is absent, blank or
+   * non-numeric (issue #340). A null/blank value here means the key has no usable value (no row and
+   * no numeric default) — a configuration error the caller cannot recover from.
+   */
+  static int parseIntSetting(String keyName, String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalStateException(
+          "Setting '" + keyName + "' has no value to read as an integer.");
+    }
+    try {
+      return Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      throw new IllegalStateException(
+          "Setting '" + keyName + "' is not a valid integer: '" + value + "'.", e);
+    }
   }
 
   /** All settings with their (redacted) current values, for the admin API. */

--- a/qnop-core/src/test/java/io/qnop/service/ApplicationSettingsServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/ApplicationSettingsServiceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ApplicationSettingsService#parseIntSetting(String, String)} — the
+ * null/blank guard added for issue #340 so a missing or malformed integer setting fails with a
+ * clear, key-named message instead of an opaque NPE / NumberFormatException.
+ */
+class ApplicationSettingsServiceTest {
+
+  @Test
+  void parsesAValidInteger() {
+    assertThat(ApplicationSettingsService.parseIntSetting("upload.max_file_size_mb", "25"))
+        .isEqualTo(25);
+  }
+
+  @Test
+  void trimsSurroundingWhitespace() {
+    assertThat(ApplicationSettingsService.parseIntSetting("smtp.port", "  587 ")).isEqualTo(587);
+  }
+
+  @Test
+  void rejectsNullWithAKeyNamedMessage() {
+    assertThatThrownBy(() -> ApplicationSettingsService.parseIntSetting("smtp.port", null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("smtp.port")
+        .hasNoCause();
+  }
+
+  @Test
+  void rejectsBlank() {
+    assertThatThrownBy(() -> ApplicationSettingsService.parseIntSetting("smtp.port", "   "))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("smtp.port");
+  }
+
+  @Test
+  void rejectsNonNumericWithTheOriginalNumberFormatExceptionAsCause() {
+    assertThatThrownBy(
+            () -> ApplicationSettingsService.parseIntSetting("smtp.port", "not-a-number"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("smtp.port")
+        .hasMessageContaining("not-a-number")
+        .hasCauseInstanceOf(NumberFormatException.class);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #340. `ApplicationSettingsService.getInteger()` did `Integer.parseInt(snapshot.get().get(key).trim())` with no guard, so a setting with no row **and** no numeric default (or a blank value) threw an opaque `NullPointerException` / `NumberFormatException` that never named the offending key.

It now parses through a small guard, `parseIntSetting`, which throws a clear, key-named `IllegalStateException` for null, blank or non-numeric values — keeping the original `NumberFormatException` as the cause for the non-numeric case.

Scope: only `getInteger` is affected. `getBoolean(null)` already yields `false`, and `getString` returns the raw (possibly null) value by contract, so neither is touched.

## Test plan
- [x] New `ApplicationSettingsServiceTest` (pure unit, DB-free) covers: valid value, surrounding whitespace, null, blank, and non-numeric (asserts the `NumberFormatException` cause and the key in the message).
- [x] Local: `spotlessApply`, `:qnop-core:test` green.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code