### PR TITLE
fix: validate the S3 storage key format before use (#337)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/storage/StorageServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/storage/StorageServiceIT.java
@@ -134,7 +134,9 @@ class StorageServiceIT extends AbstractIntegrationTest {
 
   @Test
   void getMissingKeyReturnsEmpty() {
-    assertThat(storage.get("sha256/zz/" + UUID.randomUUID())).isEmpty();
+    // A well-formed content-addressed key (issue #337) for content that was never staged: the
+    // all-zero SHA-256, so the shard matches its prefix and the read is a clean miss, not a reject.
+    assertThat(storage.get("sha256/00/" + "0".repeat(64))).isEmpty();
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3StorageProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3StorageProvider.java
@@ -25,6 +25,8 @@ import io.qnop.spi.storage.StorageException;
 import io.qnop.spi.storage.StorageProvider;
 import java.io.InputStream;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -42,6 +44,15 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
  */
 public class S3StorageProvider implements StorageProvider {
 
+  /**
+   * The content-addressed key shape this adapter accepts: {@code sha256/<2-hex-shard>/<64-hex>}, as
+   * minted by {@code StorageService.keyFor}. Every entry point rejects anything else before it
+   * reaches S3 (issue #337) — defense-in-depth so a malformed or injected key (traversal segments,
+   * a foreign prefix, a truncated hash) can never address an object, even though object stores
+   * treat keys as opaque flat strings.
+   */
+  private static final Pattern KEY_PATTERN = Pattern.compile("sha256/([0-9a-f]{2})/([0-9a-f]{64})");
+
   private final S3Client s3;
   private final String bucket;
 
@@ -52,6 +63,7 @@ public class S3StorageProvider implements StorageProvider {
 
   @Override
   public void put(String key, InputStream content, long contentLength, String contentType) {
+    requireValidKey(key);
     try {
       s3.putObject(
           PutObjectRequest.builder().bucket(bucket).key(key).contentType(contentType).build(),
@@ -63,6 +75,7 @@ public class S3StorageProvider implements StorageProvider {
 
   @Override
   public Optional<StorageContent> get(String key) {
+    requireValidKey(key);
     try {
       ResponseInputStream<GetObjectResponse> stream =
           s3.getObject(GetObjectRequest.builder().bucket(bucket).key(key).build());
@@ -78,6 +91,7 @@ public class S3StorageProvider implements StorageProvider {
 
   @Override
   public boolean exists(String key) {
+    requireValidKey(key);
     try {
       s3.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
       return true;
@@ -94,6 +108,7 @@ public class S3StorageProvider implements StorageProvider {
 
   @Override
   public boolean delete(String key) {
+    requireValidKey(key);
     if (!exists(key)) {
       return false;
     }
@@ -102,6 +117,18 @@ public class S3StorageProvider implements StorageProvider {
       return true;
     } catch (S3Exception e) {
       throw new StorageException("Failed to delete object " + key, e);
+    }
+  }
+
+  /**
+   * Fails an operation whose key is not a canonical content-addressed key (issue #337). The message
+   * deliberately does not echo the rejected key, so a crafted value can neither poison logs nor
+   * leak back to a caller.
+   */
+  private static void requireValidKey(String key) {
+    Matcher matcher = key == null ? null : KEY_PATTERN.matcher(key);
+    if (matcher == null || !matcher.matches() || !matcher.group(2).startsWith(matcher.group(1))) {
+      throw new StorageException("Rejected storage key with an unexpected format");
     }
   }
 }

--- a/qnop-core/src/test/java/io/qnop/service/storage/S3StorageProviderTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/S3StorageProviderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.qnop.spi.storage.StorageException;
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+
+/**
+ * Key-format defense-in-depth (issue #337): every entry point must reject anything that is not a
+ * canonical {@code sha256/<2-hex>/<64-hex>} key <em>before</em> it reaches S3. {@code @ValueSource}
+ * needs compile-time constants, so the 64-hex body is spelled out via {@link #Z64}.
+ */
+class S3StorageProviderTest {
+
+  private static final String Z64 =
+      "0000000000000000000000000000000000000000000000000000000000000000";
+  private static final String VALID_KEY = "sha256/00/" + Z64; // shard '00' matches the hash prefix
+
+  private final S3Client s3 = mock(S3Client.class);
+  private final S3StorageProvider provider = new S3StorageProvider(s3, "qnop");
+
+  @ParameterizedTest(name = "rejects [{0}]")
+  @NullSource
+  @ValueSource(
+      strings = {
+        "", // empty
+        "foo/bar", // foreign scheme
+        "sha256/aa/deadbeef", // hash too short
+        "sha256/zz/" + Z64, // non-hex shard
+        "sha256/AA/" + Z64, // uppercase shard
+        "sha256/aa/../../etc/passwd", // traversal segments
+        "sha256/ab/" + Z64, // shard does not match the hash prefix (ab vs 00)
+        "sha256/00/" + Z64 + "/extra", // trailing segment
+        "../sha256/00/" + Z64, // leading traversal
+      })
+  @DisplayName("get rejects a malformed key before any S3 call")
+  void getRejectsMalformedKey(String key) {
+    assertThatThrownBy(() -> provider.get(key)).isInstanceOf(StorageException.class);
+    verifyNoInteractions(s3);
+  }
+
+  @ParameterizedTest(name = "rejects [{0}]")
+  @NullSource
+  @ValueSource(strings = {"sha256/aa/short", "sha256/ab/" + Z64})
+  @DisplayName("put rejects a malformed key before any S3 call")
+  void putRejectsMalformedKey(String key) {
+    assertThatThrownBy(
+            () ->
+                provider.put(key, new ByteArrayInputStream(new byte[] {1}), 1L, "application/pdf"))
+        .isInstanceOf(StorageException.class);
+    verifyNoInteractions(s3);
+  }
+
+  @ParameterizedTest(name = "rejects [{0}]")
+  @NullSource
+  @ValueSource(strings = {"nope", "sha256/aa/short"})
+  @DisplayName("exists and delete reject a malformed key before any S3 call")
+  void existsAndDeleteRejectMalformedKey(String key) {
+    assertThatThrownBy(() -> provider.exists(key)).isInstanceOf(StorageException.class);
+    assertThatThrownBy(() -> provider.delete(key)).isInstanceOf(StorageException.class);
+    verifyNoInteractions(s3);
+  }
+
+  @Test
+  @DisplayName("a canonical key passes validation and reaches S3")
+  void validKeyReachesS3() {
+    when(s3.headObject(any(HeadObjectRequest.class)))
+        .thenReturn(HeadObjectResponse.builder().build());
+
+    assertThat(provider.exists(VALID_KEY)).isTrue();
+
+    verify(s3).headObject(any(HeadObjectRequest.class));
+  }
+}


### PR DESCRIPTION
Closes #337.

## Problem

`S3StorageProvider` passed the key straight into `put`/`get`/`exists`/`delete` with no format check. Object stores treat keys as opaque flat strings, so there is no classic filesystem traversal — but an unvalidated key is still a defense-in-depth gap: a bug or an injected value could address a foreign prefix or a malformed object.

## Fix

Enforce the canonical content-addressed shape minted by `StorageService.keyFor` — `sha256/<2-hex-shard>/<64-hex>`, with the shard required to equal the hash prefix — at **every** entry point. Anything else is rejected with a `StorageException` **before** any S3 call.

- Placed in the provider (the last hop before the S3 sink) because it is qnop's own Community adapter, not a generic third-party client — true defense-in-depth closest to the sink.
- The rejection message deliberately **does not echo** the offending key, so a crafted value can neither poison logs nor leak back to a caller.

## Changes

- `S3StorageProvider`: `KEY_PATTERN` + `requireValidKey(...)` guard on all four operations.
- **new** `S3StorageProviderTest`: null, empty, foreign prefix, short hash, non-hex shard, uppercase shard, traversal segments (`../`), shard≠prefix, trailing segment, leading traversal — each rejected with **no** S3 interaction; a canonical key still reaches S3.
- `StorageServiceIT.getMissingKeyReturnsEmpty`: switched from `sha256/zz/<uuid>` (which conflated *malformed* with *missing*) to a well-formed-but-never-staged key (the all-zero hash), so a miss stays a clean miss.

## Test plan

- [x] `spotlessApply` + `:qnop-core:compileJava` — clean
- [x] `:qnop-core:test --tests io.qnop.service.storage.*` — pass (incl. new `S3StorageProviderTest`)
- [x] `:qnop-app:test --tests io.qnop.architecture.*` (ArchUnit layering) — pass
- [x] `StorageServiceIT` (real MinIO round-trip, CI/Testcontainers) exercises the guard with genuine content-addressed keys; the missing-key case now uses a well-formed key.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code