### PR TITLE
fix: give the viewer text layer an accessible label (#341)

### DIFF
--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -83,6 +83,12 @@ function renderLayer({ enabled = true } = {}) {
 }
 
 describe('TextSpanLayer', () => {
+  it('exposes an accessible label naming the page (issue #341)', () => {
+    renderLayer();
+
+    expect(layerAt()).toHaveAttribute('aria-label', 'Selectable document text, page 1');
+  });
+
   it('selects glyph-true via charAdvances — never the uniform grid', () => {
     const onTextSelected = renderLayer();
     const layer = layerAt();

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -137,6 +137,10 @@ export function TextSpanLayer({
     <Box
       ref={rootRef}
       data-testid={`text-layer-${surfaceIndex}`}
+      // Names the otherwise-generic selection surface for assistive tech (issue #341):
+      // the printed glyphs live in the canvas below, so this layer needs its own label.
+      role="group"
+      aria-label={`Selectable document text, page ${surfaceIndex + 1}`}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}


### PR DESCRIPTION
## Summary

LOW accessibility finding #341. `TextSpanLayer` — the pointer-driven text-selection surface in the document viewer — was an unlabeled generic `<div>`, so a screen reader announced nothing for it. The layer has no intrinsic text of its own: the printed glyphs live in the `<canvas>` beneath it (`PageCanvas`), which already carries `aria-label="Page N"`.

- Added `role="group"` + a page-scoped `aria-label` (`Selectable document text, page N`) to the layer root, so assistive tech names the region.
- Plain-string label, matching the existing convention (`PageCanvas` uses `Page ${pageIndex + 1}`); the UI has no i18n layer for these.

## Test plan
- [x] New `TextSpanLayer.test.tsx` case asserts `aria-label="Selectable document text, page 1"`.
- [x] `vitest run` on the file — 8/8 pass (existing selection tests unchanged).
- [x] `tsc -b --noEmit` and `eslint` on the changed files — clean.

Closes #341

🤖 Co-Author: Claude (Opus 4.x) via Claude Code