### PR TITLE
refactor: typed job-payload (de)serialization via a shared codec (#319)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
@@ -24,6 +24,8 @@ import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobHandler;
+import io.qnop.service.job.JobPayload;
+import io.qnop.service.job.JobPayloadCodec;
 import io.qnop.service.storage.StorageService;
 import io.qnop.spi.extract.DocumentExtractor;
 import io.qnop.spi.extract.ExtractionException;
@@ -36,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import tools.jackson.core.JacksonException;
-import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -92,7 +93,8 @@ public class DocumentExtractionJobHandler implements JobHandler {
 
   @Override
   public void handle(String payload) {
-    UUID versionId = parseVersionId(payload);
+    UUID versionId =
+        JobPayloadCodec.deserialize(payload, JobPayload.DocumentVersionRef.class).versionId();
     Optional<DocumentVersion> found = versions.findById(versionId);
     if (found.isEmpty()) {
       log.info("Extraction skipped: version {} no longer exists.", versionId);
@@ -137,16 +139,5 @@ public class DocumentExtractionJobHandler implements JobHandler {
       throw new IllegalStateException("Failed to serialize rendered document", e);
     }
     writer.attachRenderedAndChain(versionId, renderedJson);
-  }
-
-  private static UUID parseVersionId(String payload) {
-    try {
-      JsonNode node = MAPPER.readTree(payload);
-      return UUID.fromString(node.get("versionId").asText());
-    } catch (JacksonException | NullPointerException | IllegalArgumentException e) {
-      // A malformed payload can only come from a code bug; retrying cannot fix it, but failing
-      // loudly (job FAILED after max attempts) surfaces it instead of silently dropping work.
-      throw new IllegalArgumentException("Malformed extraction payload: " + payload, e);
-    }
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionWriter.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionWriter.java
@@ -27,6 +27,8 @@ import io.qnop.entity.PlacementStatus;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobEnqueuer;
+import io.qnop.service.job.JobPayload;
+import io.qnop.service.job.JobPayloadCodec;
 import io.qnop.service.review.ReanchorJobHandler;
 import java.util.List;
 import java.util.UUID;
@@ -81,7 +83,9 @@ class DocumentExtractionWriter {
     if (!placements
         .findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING)
         .isEmpty()) {
-      jobs.enqueue(ReanchorJobHandler.TYPE, DocumentIngestService.extractionPayload(versionId));
+      jobs.enqueue(
+          ReanchorJobHandler.TYPE,
+          JobPayloadCodec.serialize(new JobPayload.DocumentVersionRef(versionId)));
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -31,6 +31,8 @@ import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.job.JobPayload;
+import io.qnop.service.job.JobPayloadCodec;
 import io.qnop.service.job.JobService;
 import io.qnop.service.storage.StagedObject;
 import io.qnop.service.storage.StorageQuotaExceededException;
@@ -184,7 +186,9 @@ public class DocumentIngestService {
                 actor));
     // Outbox (ADR-0033): the job commits with the version row, so extraction can never be lost
     // for a version that exists, and never fires for one that rolled back.
-    jobs.enqueue(EXTRACTION_JOB_TYPE, extractionPayload(version.getId()));
+    jobs.enqueue(
+        EXTRACTION_JOB_TYPE,
+        JobPayloadCodec.serialize(new JobPayload.DocumentVersionRef(version.getId())));
     return version;
   }
 
@@ -217,11 +221,6 @@ public class DocumentIngestService {
                   new AnnotationPlacement(
                       annotation.getId(), newVersion.getId(), source.getAnchor())));
     }
-  }
-
-  /** The job payload; a tiny hand-built JSON object (single UUID — no mapper needed). */
-  static String extractionPayload(UUID versionId) {
-    return "{\"versionId\":\"" + versionId + "\"}";
   }
 
   private static String requireTitle(String title) {

--- a/qnop-core/src/main/java/io/qnop/service/job/JobPayload.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobPayload.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * The closed set of async job payload shapes (issue #319). A job's {@code payload} column is JSON;
+ * modelling it as records serialized through {@link JobPayloadCodec} keeps producer and consumer on
+ * one type-safe (de)serialization line instead of hand-built strings that drift. New job types add
+ * their record here.
+ */
+public sealed interface JobPayload {
+
+  /**
+   * A reference to a {@code DocumentVersion} — the payload shared by the extraction and
+   * re-anchoring jobs, which both operate on a single version. Serializes to {@code {"versionId":
+   * "<uuid>"}}.
+   */
+  record DocumentVersionRef(UUID versionId) implements JobPayload {
+    public DocumentVersionRef {
+      // A missing/null id is a malformed payload — the codec surfaces the NPE as such.
+      Objects.requireNonNull(versionId, "versionId");
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/job/JobPayloadCodec.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobPayloadCodec.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * (De)serializes {@link JobPayload}s for the job queue's JSON {@code payload} column (issue #319),
+ * through one shared {@link ObjectMapper} so producers and consumers can never diverge. Jackson 3
+ * (tools.jackson) matches the stack used elsewhere for the stored jsonb and HTTP models.
+ */
+public final class JobPayloadCodec {
+
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  private JobPayloadCodec() {}
+
+  /** Serializes a payload to its JSON string for {@code JobService.enqueue}. */
+  public static String serialize(JobPayload payload) {
+    try {
+      return MAPPER.writeValueAsString(payload);
+    } catch (JacksonException e) {
+      // Serializing our own records can only fail on a code bug.
+      throw new IllegalStateException("Failed to serialize job payload: " + payload, e);
+    }
+  }
+
+  /**
+   * Reads a stored payload back into its record. A malformed payload can only come from a code bug;
+   * failing loudly (the job goes FAILED after its retries) surfaces it rather than dropping work.
+   */
+  public static <T extends JobPayload> T deserialize(String payload, Class<T> type) {
+    try {
+      return MAPPER.readValue(payload, type);
+    } catch (JacksonException | IllegalArgumentException e) {
+      throw new IllegalArgumentException("Malformed job payload: " + payload, e);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
@@ -27,6 +27,8 @@ import io.qnop.entity.PlacementStatus;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobHandler;
+import io.qnop.service.job.JobPayload;
+import io.qnop.service.job.JobPayloadCodec;
 import io.qnop.spi.extract.RenderedDocument;
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.core.JacksonException;
-import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -80,7 +81,8 @@ public class ReanchorJobHandler implements JobHandler {
   @Override
   @Transactional
   public void handle(String payload) {
-    UUID versionId = parseVersionId(payload);
+    UUID versionId =
+        JobPayloadCodec.deserialize(payload, JobPayload.DocumentVersionRef.class).versionId();
     Optional<DocumentVersion> found = versions.findById(versionId);
     if (found.isEmpty()) {
       log.info("Re-anchoring skipped: version {} no longer exists.", versionId);
@@ -118,15 +120,6 @@ public class ReanchorJobHandler implements JobHandler {
     } catch (JacksonException e) {
       throw new IllegalStateException(
           "stored rendered document of version " + version.getId() + " is unreadable", e);
-    }
-  }
-
-  private static UUID parseVersionId(String payload) {
-    try {
-      JsonNode node = MAPPER.readTree(payload);
-      return UUID.fromString(node.get("versionId").asText());
-    } catch (JacksonException | NullPointerException | IllegalArgumentException e) {
-      throw new IllegalArgumentException("Malformed re-anchor payload: " + payload, e);
     }
   }
 }

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
@@ -32,6 +32,8 @@ import io.qnop.entity.ExtractionStatus;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobEnqueuer;
+import io.qnop.service.job.JobPayload;
+import io.qnop.service.job.JobPayloadCodec;
 import io.qnop.service.storage.StorageService;
 import io.qnop.spi.extract.DocumentExtractor;
 import io.qnop.spi.extract.ExtractionException;
@@ -76,7 +78,7 @@ class DocumentExtractionJobHandlerTest {
   }
 
   private static String payload(UUID versionId) {
-    return DocumentIngestService.extractionPayload(versionId);
+    return JobPayloadCodec.serialize(new JobPayload.DocumentVersionRef(versionId));
   }
 
   private void givenStoredContent() {

--- a/qnop-core/src/test/java/io/qnop/service/job/JobPayloadCodecTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/job/JobPayloadCodecTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.service.job.JobPayload.DocumentVersionRef;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the shared job-payload (de)serialization (issue #319). */
+class JobPayloadCodecTest {
+
+  private final UUID versionId = UUID.fromString("019f2a07-67a1-7d19-a114-6d602897729d");
+
+  @Test
+  @DisplayName("serializes a version-ref payload to the compact {\"versionId\":...} shape")
+  void serializesToTheStableShape() {
+    String json = JobPayloadCodec.serialize(new DocumentVersionRef(versionId));
+
+    assertThat(json).isEqualTo("{\"versionId\":\"" + versionId + "\"}");
+  }
+
+  @Test
+  @DisplayName("round-trips a payload through serialize/deserialize")
+  void roundTrips() {
+    DocumentVersionRef original = new DocumentVersionRef(versionId);
+
+    String json = JobPayloadCodec.serialize(original);
+    DocumentVersionRef back = JobPayloadCodec.deserialize(json, DocumentVersionRef.class);
+
+    assertThat(back).isEqualTo(original);
+    assertThat(back.versionId()).isEqualTo(versionId);
+  }
+
+  @Test
+  @DisplayName("reads a payload written by the previous hand-built format (backward compatible)")
+  void readsLegacyHandBuiltPayload() {
+    String legacy = "{\"versionId\":\"" + versionId + "\"}";
+
+    DocumentVersionRef payload = JobPayloadCodec.deserialize(legacy, DocumentVersionRef.class);
+
+    assertThat(payload.versionId()).isEqualTo(versionId);
+  }
+
+  @Test
+  @DisplayName("rejects a malformed payload with a clear IllegalArgumentException")
+  void rejectsMalformedPayload() {
+    assertThatThrownBy(() -> JobPayloadCodec.deserialize("not json", DocumentVersionRef.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Malformed job payload");
+  }
+
+  @Test
+  @DisplayName("rejects a payload with a missing versionId")
+  void rejectsMissingVersionId() {
+    assertThatThrownBy(() -> JobPayloadCodec.deserialize("{}", DocumentVersionRef.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Malformed job payload");
+  }
+
+  @Test
+  @DisplayName("rejects a payload whose versionId is not a UUID")
+  void rejectsNonUuidVersionId() {
+    assertThatThrownBy(
+            () -> JobPayloadCodec.deserialize("{\"versionId\":\"nope\"}", DocumentVersionRef.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Malformed job payload");
+  }
+}


### PR DESCRIPTION
## Summary

Job payloads were **hand-built JSON strings** on the producer side (`"{\"versionId\":\"" + id + "\"}"`) and parsed with duplicated ad-hoc `ObjectMapper.readTree` + `parseVersionId` logic in each handler — brittle and inconsistent with the `ObjectMapper` used everywhere else (issue #319, MEDIUM).

## Changes
- **`JobPayload`** — a `sealed interface` with a `DocumentVersionRef(UUID versionId)` record (the payload shared by the extraction and re-anchor jobs, which both operate on a single version). New job types add their record here.
- **`JobPayloadCodec`** — `serialize` / `deserialize` through one shared Jackson 3 `ObjectMapper`, so producer and consumer can never diverge. Malformed input → a clear `IllegalArgumentException`.
- **Producers** (`DocumentIngestService`, `DocumentExtractionWriter`) enqueue via the codec; the odd cross-class `DocumentIngestService.extractionPayload(...)` helper is gone.
- **Consumers** (`DocumentExtractionJobHandler`, `ReanchorJobHandler`) parse via the codec, dropping their duplicated `MAPPER.readTree`/`parseVersionId` helpers (each keeps its `ObjectMapper` only for the rendered-document jsonb, a separate concern).

## Compatibility
The wire format is **unchanged** — `{"versionId":"<uuid>"}` — so any queued jobs stay readable (a test asserts the exact shape and a legacy-string round-trip). A missing or non-UUID `versionId` is still rejected as malformed (the record requires a non-null id).

## Scope note
The two other manual-JSON sites (`ReviewWorkflowService`, `AnnotationService`) are **audit-event `detail` strings**, not job payloads, so they're out of scope for this issue.

## Test plan
- [x] New `JobPayloadCodecTest` (5 cases): stable shape, round-trip, legacy-format read, malformed + missing/non-UUID id rejection.
- [x] `DocumentExtractionJobHandlerTest` updated to build its payload via the codec; `ReanchorJobHandlerTest` unchanged and green.
- [x] Local: `spotlessCheck`, ArchUnit, full `:qnop-core:test` green. Docker ITs (ingest, re-anchoring) exercise the producer→consumer round-trip in CI.

Closes #319

🤖 Co-Author: Claude (Opus 4.x) via Claude Code