### PR TITLE
fix(core): persist OidcProviderService.update() with an explicit save (#339)

### DIFF
--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcProviderService.java
@@ -244,7 +244,9 @@ public class OidcProviderService {
     if (patch.displayNameAttribute() != null) {
       provider.setDisplayNameAttribute(trimToNull(patch.displayNameAttribute()));
     }
-    OidcProviderView view = toView(provider);
+    // Explicit save rather than relying on transactional dirty-checking, mirroring create()
+    // and keeping the persistence intent visible at the call site (issue #339).
+    OidcProviderView view = toView(providers.save(provider));
     events.publishEvent(new OidcProvidersChangedEvent());
     return view;
   }

--- a/qnop-core/src/test/java/io/qnop/service/oidc/OidcProviderServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/oidc/OidcProviderServiceTest.java
@@ -28,8 +28,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.qnop.entity.OidcProvider;
+import io.qnop.entity.OidcProviderType;
 import io.qnop.repository.OidcProviderRepository;
 import io.qnop.service.oidc.OidcProviderService.OidcDiscoveryOutcome;
+import io.qnop.service.oidc.OidcProviderService.OidcProviderPatch;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -103,6 +106,38 @@ class OidcProviderServiceTest {
                     null))
         .isInstanceOf(IllegalArgumentException.class);
     verify(providers, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("update persists the managed entity through an explicit save")
+  void updatePersistsExplicitly() {
+    UUID id = UUID.randomUUID();
+    OidcProvider existing = new OidcProvider("Google", OidcProviderType.OIDC, "cid");
+    existing.setEnabled(false);
+    when(providers.findById(id)).thenReturn(Optional.of(existing));
+    when(providers.save(any(OidcProvider.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    OidcProviderView view =
+        service.update(
+            id,
+            new OidcProviderPatch(
+                true,
+                "Google SSO",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+    verify(providers).save(existing);
+    assertThat(view.enabled()).isTrue();
+    assertThat(view.name()).isEqualTo("Google SSO");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes #339. `OidcProviderService.update()` mutated the managed `OidcProvider` and relied on JPA transactional dirty-checking to flush — functionally correct, but the persistence intent was invisible at the call site and inconsistent with `create()`, which calls `providers.save(...)` explicitly.

`update()` now routes through `providers.save(provider)` too. Behaviour is unchanged (it's the same managed instance), just explicit and consistent.

## Test plan
- [x] New unit test `updatePersistsExplicitly` — `update()` had **no** unit coverage; it now asserts the explicit `save()` and that the patched fields (`enabled`, `name`) are reflected in the returned view.
- [x] Local: `spotlessApply`, `:qnop-core:test` green.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code