### PR TITLE
docs: document accepted upload formats + fix supportedFormats (#345)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2445,7 +2445,19 @@ components:
         - ENTERPRISE
     SupportedFormat:
       type: string
-      description: A document format qnop can ingest and review.
+      description: |
+        A document format qnop can ingest and review. Each value maps to the MIME
+        type accepted by the multipart upload endpoints, enforced by server-side
+        magic-byte sniffing (the client-declared `Content-Type` is never trusted;
+        an unrecognized file is rejected with `415`):
+
+        - `PDF`  → `application/pdf` (magic `%PDF-`)
+        - `DOCX` → `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+        - `MD`   → `text/markdown`
+
+        The Community edition accepts `PDF` only; `DOCX` and `MD` are planned
+        (Enterprise) and will appear in `ServerConfig.supportedFormats` when their
+        extractors ship.
       enum:
         - PDF
         - DOCX
@@ -2570,7 +2582,14 @@ components:
           $ref: '#/components/schemas/ServerConfigUpload'
         supportedFormats:
           type: array
-          description: Document formats this server can ingest and review.
+          description: |
+            The document formats this deployment accepts for upload. Uploads go to
+            the multipart `POST /documents` and `POST /documents/{documentId}/versions`
+            endpoints (both `multipart/form-data`, deliberately outside this generated
+            JSON contract — ADR-0021/0028); the ingest pipeline validates the file by
+            magic-byte sniffing and rejects an unsupported type with `415`. Clients
+            should offer only these formats. The Community edition returns `["PDF"]`
+            (`application/pdf`).
           items:
             $ref: '#/components/schemas/SupportedFormat'
         branding:

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2455,9 +2455,10 @@ components:
         - `DOCX` → `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
         - `MD`   → `text/markdown`
 
-        The Community edition accepts `PDF` only; `DOCX` and `MD` are planned
-        (Enterprise) and will appear in `ServerConfig.supportedFormats` when their
-        extractors ship.
+        `PDF`, `DOCX` and `MD` are the Community-scope document formats; further
+        formats are an Enterprise feature. A deployment reports the subset whose
+        extractor currently ships in `ServerConfig.supportedFormats` — `PDF` today,
+        with `DOCX` and Markdown to follow.
       enum:
         - PDF
         - DOCX
@@ -2588,8 +2589,9 @@ components:
             endpoints (both `multipart/form-data`, deliberately outside this generated
             JSON contract — ADR-0021/0028); the ingest pipeline validates the file by
             magic-byte sniffing and rejects an unsupported type with `415`. Clients
-            should offer only these formats. The Community edition returns `["PDF"]`
-            (`application/pdf`).
+            should offer only these formats. It reflects the subset whose extractor
+            currently ships — `["PDF"]` today; the Community edition's `DOCX` and
+            Markdown support extends it once their extractors land.
           items:
             $ref: '#/components/schemas/SupportedFormat'
         branding:

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -89,8 +89,11 @@ public class ConfigController implements ServerConfigApi {
                     .selfRegistrationEnabled(
                         settings.getBoolean(ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED)))
             .upload(new ServerConfigUpload().maxDocumentSizeMb(DEFAULT_MAX_DOCUMENT_SIZE_MB))
-            .supportedFormats(
-                List.of(SupportedFormat.PDF, SupportedFormat.DOCX, SupportedFormat.MD))
+            // The Community edition ingests PDF only — the ingest pipeline sniffs the %PDF- magic
+            // bytes and rejects anything else with 415 (issue #345). DOCX/Markdown are planned
+            // (Enterprise) and will extend this list when their extractors ship; advertising them
+            // now would mislead clients into offering uploads the server refuses.
+            .supportedFormats(List.of(SupportedFormat.PDF))
             .branding(buildBranding());
     return ResponseEntity.ok(body);
   }

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -89,10 +89,11 @@ public class ConfigController implements ServerConfigApi {
                     .selfRegistrationEnabled(
                         settings.getBoolean(ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED)))
             .upload(new ServerConfigUpload().maxDocumentSizeMb(DEFAULT_MAX_DOCUMENT_SIZE_MB))
-            // The Community edition ingests PDF only — the ingest pipeline sniffs the %PDF- magic
-            // bytes and rejects anything else with 415 (issue #345). DOCX/Markdown are planned
-            // (Enterprise) and will extend this list when their extractors ship; advertising them
-            // now would mislead clients into offering uploads the server refuses.
+            // Report only the formats whose extractor actually ships, so a client never offers an
+            // upload the ingest pipeline would reject with 415 (magic-byte sniffing, issue #345).
+            // Today that is PDF; DOCX and Markdown are Community-scope and join this list once
+            // their
+            // extractors land (further formats are an Enterprise feature).
             .supportedFormats(List.of(SupportedFormat.PDF))
             .branding(buildBranding());
     return ResponseEntity.ok(body);

--- a/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
@@ -89,6 +89,9 @@ class ConfigControllerTest {
         .andExpect(jsonPath("$.auth.oidcProviders").isArray())
         .andExpect(jsonPath("$.auth.oidcProviders").isEmpty())
         .andExpect(jsonPath("$.upload.maxDocumentSizeMb").value(50))
+        // Community ingests PDF only — the list must not advertise unsupported formats (issue
+        // #345).
+        .andExpect(jsonPath("$.supportedFormats.length()").value(1))
         .andExpect(jsonPath("$.supportedFormats[0]").value("PDF"))
         .andExpect(jsonPath("$.branding.logoLight.source").value("DEFAULT"))
         .andExpect(


### PR DESCRIPTION
## Summary

`GET /config` advertised `supportedFormats: [PDF, DOCX, MD]`, but the ingest pipeline currently accepts **PDF only** — it sniffs the `%PDF-` magic bytes and rejects everything else with `415` (only the PDF extractor ships today). Clients were told about formats the server refuses. The accepted MIME types were also undocumented in the contract (issue #345).

## Changes
- **`ConfigController`** — reports `supportedFormats = [PDF]` (was PDF/DOCX/MD): the list now reflects only the formats whose extractor actually ships, so a client never offers an upload the server would `415`. `ConfigControllerTest` asserts the list is exactly `["PDF"]`.
- **OpenAPI** — documents the accepted types where the contract exposes them:
  - `SupportedFormat`: each value's accepted **MIME type** (`PDF → application/pdf`, etc.) and that uploads are validated by **server-side magic-byte sniffing** (client `Content-Type` untrusted; `415` otherwise).
  - `ServerConfig.supportedFormats`: names the multipart upload endpoints (`POST /documents`, `POST /documents/{documentId}/versions`) and the `415` behaviour.

## Scope of the formats
**PDF, DOCX and Markdown are all Community-scope** document formats; further formats (e.g. images) are an Enterprise feature. Only the **PDF** extractor is implemented so far, so the deployment reports `["PDF"]` today — `DOCX` and Markdown join the list once their extractors land. (The enum keeps all three as the known Community vocabulary; the reported list is the currently-shipping subset.)

## Why not add the upload operation to the contract
The multipart upload endpoints deliberately sit **outside** the generated JSON contract as hand-written controllers (ADR-0021/0028 — binary/multipart is not part of the published JSON surface). Adding them to the generated spec would create a conflicting handler mapping against `DocumentUploadController`. So the accepted types are documented at the contract's format surface (`SupportedFormat` / `supportedFormats`), which is where clients discover them.

## Test plan
- [x] `ConfigControllerTest` (WebMvc slice) asserts `supportedFormats == ["PDF"]`; ArchUnit green; Spotless + OpenAPI regeneration clean locally.

Closes #345

🤖 Co-Author: Claude (Opus 4.x) via Claude Code