### PR TITLE
fix(ui): stable diff-list keys and memoized annotation derivations (#334)

### DIFF
--- a/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.tsx
+++ b/qnop-ui/src/components/reviews/diff/ChangeSummaryPanel.tsx
@@ -27,7 +27,7 @@ import { ArrowRight } from 'lucide-react';
 import type { DiffChange } from '../../../api/generated';
 import { DiffChangeType } from '../../../api/generated';
 import { tokens } from '../../../theme/tokens';
-import { CHANGE_KIND, changePageNumber, excerpt } from './diffModel';
+import { CHANGE_KIND, changeKey, changePageNumber, excerpt } from './diffModel';
 
 interface ChangeSummaryPanelProps {
   changes: DiffChange[];
@@ -83,7 +83,7 @@ export function ChangeSummaryPanel({
         const isChanged = change.type === DiffChangeType.Changed;
         return (
           <ButtonBase
-            key={index}
+            key={changeKey(change)}
             data-testid={`change-card-${index}`}
             onClick={() => onSelectChange(active ? null : index)}
             aria-pressed={active}

--- a/qnop-ui/src/components/reviews/diff/diffModel.test.ts
+++ b/qnop-ui/src/components/reviews/diff/diffModel.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, it } from 'vitest';
 import type { DiffChange } from '../../../api/generated';
 import { DiffChangeType } from '../../../api/generated';
 import {
+  changeKey,
   changePageNumber,
   diffStats,
   excerpt,
@@ -103,6 +104,25 @@ describe('diffStats', () => {
 
   it('is empty for an empty diff', () => {
     expect(diffStats([])).toEqual({ addedWords: 0, removedWords: 0, pages: [] });
+  });
+});
+
+describe('changeKey', () => {
+  it('is stable for a change and distinct across changes at different locations', () => {
+    const a = change(DiffChangeType.Changed, [3], [2]);
+    const b = change(DiffChangeType.Deleted, [4], []);
+    expect(changeKey(a)).toBe(changeKey(a));
+    expect(changeKey(a)).not.toBe(changeKey(b));
+  });
+
+  it('anchors on the baseline location when there is no newer geometry', () => {
+    expect(changeKey(change(DiffChangeType.Deleted, [4], []))).toContain('4:');
+  });
+
+  it('falls back to the text when a change carries no geometry', () => {
+    const key = changeKey(change(DiffChangeType.Inserted, [], [], { toText: 'added' }));
+    expect(key).toContain('t:');
+    expect(key).toContain('added');
   });
 });
 

--- a/qnop-ui/src/components/reviews/diff/diffModel.ts
+++ b/qnop-ui/src/components/reviews/diff/diffModel.ts
@@ -97,6 +97,20 @@ export function changePageNumber(change: DiffChange): number | null {
   return location ? location.surfaceIndex + 1 : null;
 }
 
+/**
+ * A stable identity for a change within its (immutable) diff — a React list key
+ * that survives re-renders without leaning on the array index. Each change is a
+ * distinct contiguous region, so its type plus its anchor location's surface and
+ * box is unique; a change with no geometry falls back to its text.
+ */
+export function changeKey(change: DiffChange): string {
+  const location = change.toLocations[0] ?? change.fromLocations[0];
+  const where = location
+    ? `${location.surfaceIndex}:${location.box.x},${location.box.y},${location.box.width},${location.box.height}`
+    : `t:${change.fromText}>${change.toText}`;
+  return `${change.type}#${where}`;
+}
+
 /** Words in a text — the unit of the diff statistics. */
 export function wordCount(text: string): number {
   const trimmed = text.trim();

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
@@ -188,16 +188,24 @@ export function AnnotationPanel({
   const userId = useAuthStore((state) => state.userId);
   const { decideWith, isPending: deciding } = useDecideWithFeedback(notify);
 
-  const matchesFilter = (annotation: AnnotationView) =>
-    filter === 'all' ||
-    (filter === 'open'
-      ? annotation.status === AnnotationStatus.Open
-      : annotation.status !== AnnotationStatus.Open);
-
-  const sorted = [...annotations].sort(compareAnnotationsByPosition);
-  const placed = sorted.filter((annotation) => annotation.anchor && matchesFilter(annotation));
-  const unplaced = sorted.filter((annotation) => !annotation.anchor && matchesFilter(annotation));
-  const hiddenByFilter = annotations.length > 0 && placed.length + unplaced.length === 0;
+  // Sort + status-filter once per (annotations, filter) change, not on every
+  // render (e.g. a hover or selection): the list can be large and the sort is
+  // O(n log n) (issue #334).
+  const { placed, unplaced, hiddenByFilter } = useMemo(() => {
+    const matchesFilter = (annotation: AnnotationView) =>
+      filter === 'all' ||
+      (filter === 'open'
+        ? annotation.status === AnnotationStatus.Open
+        : annotation.status !== AnnotationStatus.Open);
+    const sorted = [...annotations].sort(compareAnnotationsByPosition);
+    const placedItems = sorted.filter((a) => a.anchor && matchesFilter(a));
+    const unplacedItems = sorted.filter((a) => !a.anchor && matchesFilter(a));
+    return {
+      placed: placedItems,
+      unplaced: unplacedItems,
+      hiddenByFilter: annotations.length > 0 && placedItems.length + unplacedItems.length === 0,
+    };
+  }, [annotations, filter]);
 
   const renderItem = (annotation: AnnotationView) => {
     const active = annotation.id === activeAnnotationId;


### PR DESCRIPTION
Closes #334.

The multi-role review flagged four viewer-path render issues. On inspection **two are real** (fixed here) and **two are already correct** in current `main` (verified, no change) — detailed below.

## Fixed

**1. `ChangeSummaryPanel` — index list keys → stable identity**
Cards were keyed by array index. Replaced with a stable `changeKey(change)` derived from the change's `type` + its anchor location (surface + box), falling back to its text when a change has no geometry. React now reconciles cards by identity, so a `ButtonBase`'s focus/ripple state can't smear onto a different change. The index-based `data-testid` and the index-addressed selection contract (`onSelectChange(index)`) are intentionally unchanged.

**2. `AnnotationPanel` — unmemoized derivations → `useMemo`**
The sort (`O(n log n)`) + status-filter of `placed`/`unplaced`/`hiddenByFilter` ran on **every** render, including hover/selection re-renders that don't touch the list. Wrapped in `useMemo` keyed on `[annotations, filter]`; `matchesFilter` moved inside the memo.

## Already correct (verified, no change)

**3. Compare-pane scroll handler — no stale closure.**
The scroll sync now lives in `useSyncScroll` (`src/components/reviews/diff/useSyncScroll.ts`), which reads scroll geometry **fresh from the DOM** on each event and has correct effect deps `[left, right, enabled]`. It is covered by `useSyncScroll.test.ts`. The inline handler the review saw at `ComparePane:91-96` was extracted into this hook; the stale-closure risk is gone.

**4. `DocumentViewer` / `ComparePane` page keys — index is the correct key.**
The page lists are a fixed positional sequence (`Array.from({ length: pageCount })`). A page's identity **is** its ordinal (`surface.index === pageIndex`), `pageRefs.current[pageIndex]` and scroll-to-page are index-addressed, and `SurfacePage` is driven entirely by props. Index keys are the idiomatic, intended choice here; a synthetic key would break the ref/scroll indexing.

## Changes

- `ChangeSummaryPanel.tsx`: `key={changeKey(change)}`
- `AnnotationPanel.tsx`: `useMemo` around the sort/filter derivations
- `diffModel.ts`: new `changeKey(change)` helper + `diffModel.test.ts` cases (stability, distinctness, baseline + text fallbacks)

## Test plan

- [x] `tsc -b --noEmit` — clean
- [x] `eslint` (incl. `react-hooks/exhaustive-deps`) on all changed files — clean
- [x] `prettier --check` — clean
- [x] `vitest run` diff + panel suites — 48 passed (incl. new `changeKey` tests)

🤖 Co-Author: Claude (Opus 4.8) via Claude Code