### PR TITLE
fix: derive download filename extension from the content type (#328)

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/DocumentContentController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentContentController.java
@@ -67,7 +67,9 @@ public class DocumentContentController {
     }
     ContentDisposition disposition =
         ContentDisposition.inline()
-            .filename(download.title() + "-v" + download.versionNumber() + ".pdf")
+            .filename(
+                DownloadFilename.forVersion(
+                    download.title(), download.versionNumber(), download.contentType()))
             .build();
     return ResponseEntity.ok()
         .eTag(etag)

--- a/qnop-app/src/main/java/io/qnop/web/DownloadFilename.java
+++ b/qnop-app/src/main/java/io/qnop/web/DownloadFilename.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import java.util.Locale;
+
+/**
+ * Builds the download filename for a document version, deriving the extension from the stored
+ * content type instead of hardcoding {@code .pdf} (issue #328). PDF is the only ingested format
+ * today, but DOCX and Markdown are on the roadmap (see {@code CLAUDE.md}); each new format is one
+ * added {@code case} here, so the download seam does not need a rewrite. An unknown content type
+ * yields <em>no</em> extension rather than a misleading one.
+ */
+final class DownloadFilename {
+
+  private DownloadFilename() {}
+
+  static String forVersion(String title, int versionNumber, String contentType) {
+    return title + "-v" + versionNumber + extensionFor(contentType);
+  }
+
+  /** The dotted file extension for a content type, or an empty string when it is not recognized. */
+  static String extensionFor(String contentType) {
+    if (contentType == null) {
+      return "";
+    }
+    // Drop any parameters (e.g. "text/markdown; charset=utf-8") and normalize.
+    String type = contentType.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
+    return switch (type) {
+      case "application/pdf" -> ".pdf";
+      case "application/vnd.openxmlformats-officedocument.wordprocessingml.document" -> ".docx";
+      case "text/markdown", "text/x-markdown" -> ".md";
+      default -> "";
+    };
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/document/DocumentIngestIT.java
+++ b/qnop-app/src/test/java/io/qnop/document/DocumentIngestIT.java
@@ -135,6 +135,12 @@ class DocumentIngestIT extends AbstractIntegrationTest {
                 get("/api/v1/documents/{id}/versions/1/original", documentId).with(asUser(owner)))
             .andExpect(status().isOk())
             .andExpect(header().string("Content-Type", "application/pdf"))
+            // Filename extension is derived from the content type, not hardcoded (issue #328).
+            .andExpect(
+                header()
+                    .string(
+                        "Content-Disposition",
+                        org.hamcrest.Matchers.containsString("Ingest IT-v1.pdf")))
             .andExpect(header().exists("ETag"))
             .andReturn();
     assertThat(original.getResponse().getContentAsByteArray()).isEqualTo(pdf);

--- a/qnop-app/src/test/java/io/qnop/web/DownloadFilenameTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/DownloadFilenameTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+/** Extension derivation from the stored content type (issue #328). */
+class DownloadFilenameTest {
+
+  @ParameterizedTest(name = "{0} -> {1}")
+  @CsvSource({
+    "application/pdf, .pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document, .docx",
+    "text/markdown, .md",
+    "text/x-markdown, .md",
+    "'text/markdown; charset=utf-8', .md", // parameters are ignored
+    "APPLICATION/PDF, .pdf", // case-insensitive
+    "application/octet-stream, ''", // unknown → no (misleading) extension
+  })
+  void derivesExtensionFromContentType(String contentType, String expected) {
+    assertThat(DownloadFilename.extensionFor(contentType)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  void nullContentTypeHasNoExtension(String contentType) {
+    assertThat(DownloadFilename.extensionFor(contentType)).isEmpty();
+  }
+
+  @Test
+  void composesTitleVersionAndExtension() {
+    assertThat(DownloadFilename.forVersion("Quarterly report", 3, "application/pdf"))
+        .isEqualTo("Quarterly report-v3.pdf");
+  }
+
+  @Test
+  void unknownTypeStillProducesAName() {
+    assertThat(DownloadFilename.forVersion("Doc", 1, "application/octet-stream"))
+        .isEqualTo("Doc-v1");
+  }
+}


### PR DESCRIPTION
## Summary

MEDIUM review finding #328. `DocumentContentController` hardcoded `.pdf` in the download `Content-Disposition` filename, which would be wrong once DOCX/MD versions are supported (see `CLAUDE.md` scope).

- Extracted a small pure `DownloadFilename` helper that derives the extension from the stored content type: `application/pdf` → `.pdf`, the OOXML wordprocessing type → `.docx`, `text/markdown` / `text/x-markdown` → `.md`. Content-type **parameters** (`; charset=…`) and casing are normalized.
- Each future format is one added `case` — matching the "a new format is an added implementation, not a core rewrite" seam guidance.
- An **unrecognized** content type yields *no* extension rather than a misleading `.pdf`; a `null` type is handled too.
- Title handling is unchanged (`ContentDisposition.filename(...)` still owns RFC 6266 encoding).

## Test plan
- [x] `DownloadFilenameTest` (pure unit, ran locally 10/10): PDF/DOCX/MD, parameters, case-insensitivity, unknown → empty, null → empty, and full `title-vN.ext` composition.
- [x] `DocumentIngestIT` round-trip now asserts `Content-Disposition` contains `Ingest IT-v1.pdf` (end-to-end for the only ingested format today).
- [x] Local gate green: `spotlessApply`, `:qnop-app:compileTestJava`, `ArchitectureRulesTest`, `DownloadFilenameTest`.
- [ ] CI: full IT suite (Testcontainers).

Closes #328

🤖 Co-Author: Claude (Opus 4.x) via Claude Code