### PR TITLE
refactor: modernise the re-anchoring core (AnchorResolver) (#320)

### DIFF
--- a/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
@@ -22,6 +22,7 @@ package io.qnop.bootstrap;
 
 import io.qnop.security.QnopProperties;
 import io.qnop.service.http.HttpClientProperties;
+import io.qnop.service.review.ReanchoringProperties;
 import io.qnop.web.security.ratelimit.RateLimitProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -42,7 +43,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableConfigurationProperties({
   QnopProperties.class,
   RateLimitProperties.class,
-  HttpClientProperties.class
+  HttpClientProperties.class,
+  ReanchoringProperties.class
 })
 @EntityScan("io.qnop.entity")
 @EnableJpaRepositories("io.qnop.repository")

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -85,6 +85,10 @@ qnop:
     smtp-connect-timeout: ${QNOP_HTTP_CLIENT_SMTP_CONNECT_TIMEOUT:10s}
     smtp-read-timeout: ${QNOP_HTTP_CLIENT_SMTP_READ_TIMEOUT:30s}
     smtp-write-timeout: ${QNOP_HTTP_CLIENT_SMTP_WRITE_TIMEOUT:30s}
+  # Re-anchoring cascade tunables (ADR-0009, issue #320). Advanced; the conservative
+  # defaults live in ReanchoringProperties. Override per key via QNOP_REANCHORING_*:
+  #   *_SIMILARITY_THRESHOLD (0.75), *_AMBIGUITY_MARGIN (0.05), *_CONTEXT_LENGTH (32),
+  #   *_MAX_CANDIDATES (64), *_QUOTE_WEIGHT (0.7), *_CONTEXT_WEIGHT (0.3)
   # Object storage for binary documents (issue #243, ADR-0005). Defaults target the
   # docker-compose MinIO; leave `endpoint` blank to target real AWS S3 (SaaS). The
   # access/secret keys are storage credentials, not crypto secrets, so short local

--- a/qnop-core/src/main/java/io/qnop/service/review/AnchorResolver.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnchorResolver.java
@@ -20,6 +20,7 @@
  */
 package io.qnop.service.review;
 
+import io.qnop.spi.extract.NormalizedBox;
 import io.qnop.spi.extract.RenderedDocument;
 import io.qnop.spi.extract.Surface;
 import io.qnop.spi.extract.TextSpan;
@@ -28,6 +29,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeSet;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
@@ -54,6 +56,10 @@ import tools.jackson.databind.json.JsonMapper;
  *
  * <p>Same inputs always produce the same resolution (job replay, ADR-0033): candidate scanning is
  * ordered, and ties break on (surface, offset).
+ *
+ * <p>The cascade is expressed as an ordered list of {@link CascadeStep}s (issue #320); its
+ * thresholds and weights come from {@link ReanchoringProperties}, and an unreadable anchor surfaces
+ * as a typed {@link Result} rather than a null.
  */
 public final class AnchorResolver {
 
@@ -67,51 +73,124 @@ public final class AnchorResolver {
   /** The decision plus the anchor to store — updated on PLACED/MOVED, untouched on ORPHANED. */
   public record Resolution(Outcome outcome, String anchorJson) {}
 
-  static final double SIMILARITY_THRESHOLD = 0.75;
-  static final double AMBIGUITY_MARGIN = 0.05;
-  private static final int CONTEXT_LENGTH = 32;
-  private static final int MAX_CANDIDATES = 64;
-  private static final double QUOTE_WEIGHT = 0.7;
-  private static final double CONTEXT_WEIGHT = 0.3;
+  /** Why an anchor could not be parsed — the typed alternative to returning {@code null} (#320). */
+  private enum ParseError {
+    BLANK,
+    MALFORMED_JSON
+  }
 
   private static final ObjectMapper MAPPER = JsonMapper.builder().build();
 
+  /** The ordered ADR-0009 cascade; the first step to reach a decision wins. */
+  private static final List<CascadeStep> CASCADE =
+      List.of(new ExactWithContext(), new ExactQuoteOnly(), new DuplicatedQuote(), new Fuzzy());
+
+  private final ReanchoringProperties config;
+
+  /** Uses the documented ADR-0009 defaults (for tests and non-Spring callers). */
+  public AnchorResolver() {
+    this(ReanchoringProperties.defaults());
+  }
+
+  public AnchorResolver(ReanchoringProperties config) {
+    this.config = config;
+  }
+
   /** Resolves {@code anchorJson} against {@code rendered}; never throws on bad anchor content. */
   public Resolution resolve(String anchorJson, RenderedDocument rendered) {
-    ParsedAnchor anchor = parse(anchorJson);
-    if (anchor == null) {
-      // Unreadable anchor: be honest rather than guess (ADR-0009).
-      return new Resolution(Outcome.ORPHANED, anchorJson);
+    ParsedAnchor anchor;
+    switch (parse(anchorJson)) {
+      case Result.Err<ParsedAnchor, ParseError> ignored -> {
+        // Unreadable anchor: be honest rather than guess (ADR-0009).
+        return new Resolution(Outcome.ORPHANED, anchorJson);
+      }
+      case Result.Ok<ParsedAnchor, ParseError> ok -> anchor = ok.value();
     }
     if (anchor.quote() == null || anchor.quote().isEmpty()) {
       // Geometric-only anchor (image region): coordinates carry over, flagged "to review".
       return new Resolution(Outcome.MOVED, anchorJson);
     }
 
-    List<SurfaceText> surfaces = surfaceTexts(rendered);
-
-    // 1) Exact, context-qualified: prefix+quote+suffix unchanged exactly once in the document.
-    List<Match> withContext = exactMatches(surfaces, anchor, true);
-    if (withContext.size() == 1) {
-      return placed(anchor, withContext.get(0), surfaces);
+    Cascade cascade = new Cascade(this, anchor, surfaceTexts(rendered), anchorJson);
+    for (CascadeStep step : CASCADE) {
+      Optional<Resolution> decision = step.attempt(cascade);
+      if (decision.isPresent()) {
+        return decision.get();
+      }
     }
-    // 2) Exact quote alone, unique in the document.
-    List<Match> quoteOnly = exactMatches(surfaces, anchor, false);
-    if (quoteOnly.size() == 1) {
-      return placed(anchor, quoteOnly.get(0), surfaces);
-    }
-    // 3) Duplicated exact quote: context similarity picks one — flagged MOVED — or nobody wins.
-    if (quoteOnly.size() > 1) {
-      return disambiguate(anchor, quoteOnly, surfaces, anchorJson);
-    }
-    // 4) Quote not found verbatim: fuzzy candidates from quote-chunk seeds.
-    List<Match> fuzzy = fuzzyCandidates(surfaces, anchor);
-    return disambiguate(anchor, fuzzy, surfaces, anchorJson);
+    // The Fuzzy step always decides, so this is unreachable — defensive only.
+    return new Resolution(Outcome.ORPHANED, anchorJson);
   }
 
   // --- cascade steps ----------------------------------------------------------
 
-  private static List<Match> exactMatches(
+  /** One stage of the re-anchoring cascade; an empty result means "no decision, try the next". */
+  private sealed interface CascadeStep
+      permits ExactWithContext, ExactQuoteOnly, DuplicatedQuote, Fuzzy {
+    Optional<Resolution> attempt(Cascade cascade);
+  }
+
+  /** Prefix+quote+suffix unchanged and occurring exactly once → a confident PLACED. */
+  private record ExactWithContext() implements CascadeStep {
+    @Override
+    public Optional<Resolution> attempt(Cascade c) {
+      List<Match> matches = c.exactMatches(true);
+      return matches.size() == 1 ? Optional.of(c.placed(matches.get(0))) : Optional.empty();
+    }
+  }
+
+  /** The quote alone, unique in the document → PLACED. */
+  private record ExactQuoteOnly() implements CascadeStep {
+    @Override
+    public Optional<Resolution> attempt(Cascade c) {
+      List<Match> matches = c.exactMatches(false);
+      return matches.size() == 1 ? Optional.of(c.placed(matches.get(0))) : Optional.empty();
+    }
+  }
+
+  /**
+   * The quote occurs verbatim more than once → context similarity disambiguates (or nobody wins).
+   */
+  private record DuplicatedQuote() implements CascadeStep {
+    @Override
+    public Optional<Resolution> attempt(Cascade c) {
+      List<Match> matches = c.exactMatches(false);
+      return matches.size() > 1 ? Optional.of(c.disambiguate(matches)) : Optional.empty();
+    }
+  }
+
+  /** Quote not found verbatim → fuzzy candidates seeded from quote chunks; always decides. */
+  private record Fuzzy() implements CascadeStep {
+    @Override
+    public Optional<Resolution> attempt(Cascade c) {
+      return Optional.of(c.disambiguate(c.fuzzyCandidates()));
+    }
+  }
+
+  /** The per-resolution working set the steps operate on; delegates to the owning resolver. */
+  private record Cascade(
+      AnchorResolver resolver, ParsedAnchor anchor, List<SurfaceText> surfaces, String original) {
+
+    List<Match> exactMatches(boolean withContext) {
+      return resolver.exactMatches(surfaces, anchor, withContext);
+    }
+
+    List<Match> fuzzyCandidates() {
+      return resolver.fuzzyCandidates(surfaces, anchor);
+    }
+
+    Resolution disambiguate(List<Match> candidates) {
+      return resolver.disambiguate(anchor, candidates, original);
+    }
+
+    Resolution placed(Match match) {
+      return new Resolution(Outcome.PLACED, resolver.rebuiltAnchor(match));
+    }
+  }
+
+  // --- matching (config-driven) -----------------------------------------------
+
+  private List<Match> exactMatches(
       List<SurfaceText> surfaces, ParsedAnchor anchor, boolean withContext) {
     String prefix = anchor.prefix() == null ? "" : anchor.prefix();
     String suffix = anchor.suffix() == null ? "" : anchor.suffix();
@@ -128,7 +207,7 @@ public final class AnchorResolver {
       while ((idx = surface.text().indexOf(needle, from)) >= 0) {
         matches.add(new Match(surface, idx + quoteShift, anchor.quote(), 1.0));
         from = idx + 1;
-        if (matches.size() > MAX_CANDIDATES) {
+        if (matches.size() > config.maxCandidates()) {
           return matches; // pathological repetition; counts as ambiguous anyway
         }
       }
@@ -137,14 +216,13 @@ public final class AnchorResolver {
   }
 
   /** The similarity-best candidate wins only above the threshold and with a clear margin. */
-  private Resolution disambiguate(
-      ParsedAnchor anchor, List<Match> candidates, List<SurfaceText> surfaces, String original) {
+  private Resolution disambiguate(ParsedAnchor anchor, List<Match> candidates, String original) {
     if (candidates.isEmpty()) {
       return new Resolution(Outcome.ORPHANED, original);
     }
     List<Scored> scored = new ArrayList<>(candidates.size());
     for (Match candidate : candidates) {
-      scored.add(new Scored(candidate, score(anchor, candidate, surfaces)));
+      scored.add(new Scored(candidate, score(anchor, candidate)));
     }
     scored.sort(
         Comparator.comparingDouble(Scored::score)
@@ -152,31 +230,30 @@ public final class AnchorResolver {
             .thenComparingInt(s -> s.match().surface().index())
             .thenComparingInt(s -> s.match().start()));
     Scored best = scored.get(0);
-    if (best.score() < SIMILARITY_THRESHOLD) {
+    if (best.score() < config.similarityThreshold()) {
       return new Resolution(Outcome.ORPHANED, original);
     }
-    if (scored.size() > 1 && best.score() - scored.get(1).score() < AMBIGUITY_MARGIN) {
+    if (scored.size() > 1 && best.score() - scored.get(1).score() < config.ambiguityMargin()) {
       return new Resolution(Outcome.ORPHANED, original); // ambiguous — never guessed
     }
     return new Resolution(Outcome.MOVED, rebuiltAnchor(best.match()));
   }
 
   /** Candidate windows seeded by verbatim occurrences of quote chunks (cheap, conservative). */
-  private static List<Match> fuzzyCandidates(List<SurfaceText> surfaces, ParsedAnchor anchor) {
+  private List<Match> fuzzyCandidates(List<SurfaceText> surfaces, ParsedAnchor anchor) {
     String quote = anchor.quote();
     List<String> seeds = seeds(quote);
     List<Match> candidates = new ArrayList<>();
     for (SurfaceText surface : surfaces) {
       TreeSet<Integer> starts = new TreeSet<>();
-      for (int s = 0; s < seeds.size(); s++) {
-        String seed = seeds.get(s);
+      for (String seed : seeds) {
         int seedOffset = quote.indexOf(seed);
         int from = 0;
         int idx;
         while ((idx = surface.text().indexOf(seed, from)) >= 0) {
           starts.add(Math.max(0, idx - seedOffset));
           from = idx + 1;
-          if (starts.size() >= MAX_CANDIDATES) {
+          if (starts.size() >= config.maxCandidates()) {
             break;
           }
         }
@@ -189,8 +266,7 @@ public final class AnchorResolver {
         previous = start;
         int end = Math.min(surface.text().length(), start + quote.length());
         String window = surface.text().substring(start, end);
-        double similarity = similarity(quote, window);
-        candidates.add(new Match(surface, start, window, similarity));
+        candidates.add(new Match(surface, start, window, similarity(quote, window)));
       }
     }
     return candidates;
@@ -211,7 +287,7 @@ public final class AnchorResolver {
 
   // --- scoring ----------------------------------------------------------------
 
-  private static double score(ParsedAnchor anchor, Match match, List<SurfaceText> surfaces) {
+  private double score(ParsedAnchor anchor, Match match) {
     String text = match.surface().text();
     double quoteSimilarity = match.quoteSimilarity();
 
@@ -233,7 +309,8 @@ public final class AnchorResolver {
       contextSimilarity += similarity(suffix, text.substring(end, to));
       layers++;
     }
-    return QUOTE_WEIGHT * quoteSimilarity + CONTEXT_WEIGHT * (contextSimilarity / layers);
+    return config.quoteWeight() * quoteSimilarity
+        + config.contextWeight() * (contextSimilarity / layers);
   }
 
   /** Normalized Levenshtein similarity in 0..1; both inputs are window-sized (bounded cost). */
@@ -263,36 +340,33 @@ public final class AnchorResolver {
     return 1.0 - (double) distance / Math.max(a.length(), b.length());
   }
 
-  // --- anchor (re)construction --------------------------------------------------
-
-  private Resolution placed(ParsedAnchor anchor, Match match, List<SurfaceText> surfaces) {
-    return new Resolution(Outcome.PLACED, rebuiltAnchor(match));
-  }
+  // --- anchor (re)construction ------------------------------------------------
 
   /**
    * Builds the resolved anchor: fresh position offsets, the matched text as the new quote with
    * regenerated context slices, and a region box unioned from the spans the match covers.
    */
-  private static String rebuiltAnchor(Match match) {
+  private String rebuiltAnchor(Match match) {
     SurfaceText surface = match.surface();
     int start = match.start();
     int end = start + match.window().length();
     String text = surface.text();
+    int contextLength = config.contextLength();
 
     Map<String, Object> anchor = new LinkedHashMap<>();
     anchor.put(
         "region", Map.of("surfaceIndex", surface.index(), "box", boxFor(surface, start, end)));
     Map<String, Object> quote = new LinkedHashMap<>();
     quote.put("quote", match.window());
-    quote.put("prefix", text.substring(Math.max(0, start - CONTEXT_LENGTH), start));
-    quote.put("suffix", text.substring(end, Math.min(text.length(), end + CONTEXT_LENGTH)));
+    quote.put("prefix", text.substring(Math.max(0, start - contextLength), start));
+    quote.put("suffix", text.substring(end, Math.min(text.length(), end + contextLength)));
     anchor.put("textQuote", quote);
     anchor.put("textPosition", Map.of("start", start, "end", end));
     return MAPPER.writeValueAsString(anchor);
   }
 
   /** Union of the boxes of all spans overlapping [start, end) — the match's visual footprint. */
-  private static Map<String, Double> boxFor(SurfaceText surface, int start, int end) {
+  private static NormalizedBox boxFor(SurfaceText surface, int start, int end) {
     double minX = Double.MAX_VALUE;
     double minY = Double.MAX_VALUE;
     double maxX = -Double.MAX_VALUE;
@@ -308,14 +382,14 @@ public final class AnchorResolver {
       }
     }
     if (!any) {
-      // Text matched but no span covers it — impossible for extractor-produced text; degrade to
-      // a zero-size box at the surface origin rather than invent geometry.
-      return Map.of("x", 0.0, "y", 0.0, "width", 0.0, "height", 0.0);
+      // Text matched but no span covers it — impossible for extractor-produced text; degrade to a
+      // zero-size box at the surface origin rather than invent geometry.
+      return new NormalizedBox(0.0, 0.0, 0.0, 0.0);
     }
-    return Map.of("x", minX, "y", minY, "width", maxX - minX, "height", maxY - minY);
+    return new NormalizedBox(minX, minY, maxX - minX, maxY - minY);
   }
 
-  // --- input models -------------------------------------------------------------
+  // --- input models -----------------------------------------------------------
 
   /**
    * Canonical text per surface: span texts joined by a single {@code \n} (extractor convention).
@@ -335,20 +409,21 @@ public final class AnchorResolver {
     return texts;
   }
 
-  /** Lenient parse of the stored anchor JSON; null when unreadable. */
-  private static ParsedAnchor parse(String anchorJson) {
+  /** Lenient parse of the stored anchor JSON into a typed {@link Result} (issue #320). */
+  private static Result<ParsedAnchor, ParseError> parse(String anchorJson) {
     if (anchorJson == null || anchorJson.isBlank()) {
-      return null;
+      return Result.err(ParseError.BLANK);
     }
     try {
       JsonNode root = MAPPER.readTree(anchorJson);
       JsonNode quote = root.path("textQuote");
-      return new ParsedAnchor(
-          textOrNull(quote.path("quote")),
-          textOrNull(quote.path("prefix")),
-          textOrNull(quote.path("suffix")));
+      return Result.ok(
+          new ParsedAnchor(
+              textOrNull(quote.path("quote")),
+              textOrNull(quote.path("prefix")),
+              textOrNull(quote.path("suffix"))));
     } catch (JacksonException e) {
-      return null;
+      return Result.err(ParseError.MALFORMED_JSON);
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
@@ -62,12 +62,15 @@ public class ReanchorJobHandler implements JobHandler {
 
   private final DocumentVersionRepository versions;
   private final AnnotationPlacementRepository placements;
-  private final AnchorResolver resolver = new AnchorResolver();
+  private final AnchorResolver resolver;
 
   public ReanchorJobHandler(
-      DocumentVersionRepository versions, AnnotationPlacementRepository placements) {
+      DocumentVersionRepository versions,
+      AnnotationPlacementRepository placements,
+      ReanchoringProperties reanchoringProperties) {
     this.versions = versions;
     this.placements = placements;
+    this.resolver = new AnchorResolver(reanchoringProperties);
   }
 
   @Override

--- a/qnop-core/src/main/java/io/qnop/service/review/ReanchoringProperties.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReanchoringProperties.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Tunables for the re-anchoring cascade (ADR-0009, issue #320), previously hard-coded magic
+ * numbers. Every value is overridable via {@code qnop.reanchoring.*} (or the matching {@code
+ * QNOP_REANCHORING_*} environment variable); an unset value falls back to the documented default.
+ * The defaults are deliberately conservative — the cascade never guesses, so raising thresholds
+ * only ever makes it more cautious.
+ *
+ * @param similarityThreshold minimum normalized similarity for a fuzzy match to be accepted (0.75)
+ * @param ambiguityMargin minimum score lead the winner must hold over the runner-up (0.05)
+ * @param contextLength characters of prefix/suffix context regenerated around a re-placed quote
+ *     (32)
+ * @param maxCandidates cap on candidate windows scanned per surface — bounds pathological input
+ *     (64)
+ * @param quoteWeight weight of the quote's own similarity in the blended score (0.7)
+ * @param contextWeight weight of the surrounding context similarity in the blended score (0.3)
+ */
+@ConfigurationProperties(prefix = "qnop.reanchoring")
+public record ReanchoringProperties(
+    Double similarityThreshold,
+    Double ambiguityMargin,
+    Integer contextLength,
+    Integer maxCandidates,
+    Double quoteWeight,
+    Double contextWeight) {
+
+  public ReanchoringProperties {
+    similarityThreshold = similarityThreshold == null ? 0.75 : similarityThreshold;
+    ambiguityMargin = ambiguityMargin == null ? 0.05 : ambiguityMargin;
+    contextLength = contextLength == null ? 32 : contextLength;
+    maxCandidates = maxCandidates == null ? 64 : maxCandidates;
+    quoteWeight = quoteWeight == null ? 0.7 : quoteWeight;
+    contextWeight = contextWeight == null ? 0.3 : contextWeight;
+  }
+
+  /** The documented ADR-0009 defaults — for direct construction in tests and non-Spring callers. */
+  public static ReanchoringProperties defaults() {
+    return new ReanchoringProperties(null, null, null, null, null, null);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/Result.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/Result.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+/**
+ * A success-or-failure value (issue #320): either an {@link Ok} carrying a {@code T} or an {@link
+ * Err} carrying a typed error {@code E}. Being {@code sealed}, a {@code switch} over it is
+ * exhaustive — so a caller cannot forget the failure arm, which is exactly the inconsistency
+ * (null-on-parse vs exception-on-parse) this replaces in {@link AnchorResolver}.
+ *
+ * @param <T> the success value type
+ * @param <E> the error type
+ */
+public sealed interface Result<T, E> permits Result.Ok, Result.Err {
+
+  record Ok<T, E>(T value) implements Result<T, E> {}
+
+  record Err<T, E>(E error) implements Result<T, E> {}
+
+  static <T, E> Result<T, E> ok(T value) {
+    return new Ok<>(value);
+  }
+
+  static <T, E> Result<T, E> err(E error) {
+    return new Err<>(error);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/AnchorResolverTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnchorResolverTest.java
@@ -225,6 +225,24 @@ class AnchorResolverTest {
     assertThat(first).isEqualTo(second);
   }
 
+  // --- configurable thresholds (issue #320) ----------------------------------
+
+  @Test
+  @DisplayName(
+      "the similarity threshold is configurable: a lower bar re-places what the default orphans")
+  void similarityThresholdIsConfigurable() {
+    // The single fuzzy candidate scores exactly 0.5 (8 of 16 chars match, no context layer).
+    String anchor = anchor("abcdefghijklmnop", null, null);
+    RenderedDocument v2 = doc(surface(0, "abcdefgh________"));
+
+    // Default threshold (0.75): 0.5 is below the bar → ORPHANED, never guessed.
+    assertThat(new AnchorResolver().resolve(anchor, v2).outcome()).isEqualTo(Outcome.ORPHANED);
+
+    // A deployment that lowers the bar to 0.4 accepts the same candidate → MOVED.
+    ReanchoringProperties lenient = new ReanchoringProperties(0.4, null, null, null, null, null);
+    assertThat(new AnchorResolver(lenient).resolve(anchor, v2).outcome()).isEqualTo(Outcome.MOVED);
+  }
+
   // --- helpers ---------------------------------------------------------------
 
   /** An anchor JSON in the stored shape (#247): region + textQuote (+ position best-effort). */

--- a/qnop-core/src/test/java/io/qnop/service/review/ReanchorJobHandlerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReanchorJobHandlerTest.java
@@ -47,7 +47,8 @@ class ReanchorJobHandlerTest {
   private final DocumentVersionRepository versions = mock(DocumentVersionRepository.class);
   private final AnnotationPlacementRepository placements =
       mock(AnnotationPlacementRepository.class);
-  private final ReanchorJobHandler handler = new ReanchorJobHandler(versions, placements);
+  private final ReanchorJobHandler handler =
+      new ReanchorJobHandler(versions, placements, ReanchoringProperties.defaults());
 
   private final UUID versionId = UUID.randomUUID();
   private DocumentVersion version;

--- a/qnop-core/src/test/java/io/qnop/service/review/ReanchoringPropertiesTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReanchoringPropertiesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ReanchoringProperties} defaults and null-coalescing (issue #320). */
+class ReanchoringPropertiesTest {
+
+  @Test
+  @DisplayName("defaults() carries the documented ADR-0009 thresholds")
+  void defaultsCarryDocumentedThresholds() {
+    ReanchoringProperties props = ReanchoringProperties.defaults();
+
+    assertThat(props.similarityThreshold()).isEqualTo(0.75);
+    assertThat(props.ambiguityMargin()).isEqualTo(0.05);
+    assertThat(props.contextLength()).isEqualTo(32);
+    assertThat(props.maxCandidates()).isEqualTo(64);
+    assertThat(props.quoteWeight()).isEqualTo(0.7);
+    assertThat(props.contextWeight()).isEqualTo(0.3);
+  }
+
+  @Test
+  @DisplayName("a null component falls back to its default; supplied values are kept")
+  void nullComponentsFallBackToDefaults() {
+    ReanchoringProperties props = new ReanchoringProperties(0.9, null, null, 128, null, null);
+
+    assertThat(props.similarityThreshold()).isEqualTo(0.9); // supplied
+    assertThat(props.maxCandidates()).isEqualTo(128); // supplied
+    assertThat(props.ambiguityMargin()).isEqualTo(0.05); // default
+    assertThat(props.contextLength()).isEqualTo(32); // default
+    assertThat(props.quoteWeight()).isEqualTo(0.7); // default
+    assertThat(props.contextWeight()).isEqualTo(0.3); // default
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/ResultTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ResultTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.service.review.Result.Err;
+import io.qnop.service.review.Result.Ok;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the sealed {@link Result} value type (issue #320). */
+class ResultTest {
+
+  @Test
+  @DisplayName("ok carries the value and matches the Ok arm")
+  void okCarriesValue() {
+    Result<String, Integer> result = Result.ok("done");
+
+    assertThat(result).isInstanceOf(Ok.class);
+    assertThat(describe(result)).isEqualTo("ok:done");
+  }
+
+  @Test
+  @DisplayName("err carries the error and matches the Err arm")
+  void errCarriesError() {
+    Result<String, Integer> result = Result.err(404);
+
+    assertThat(result).isInstanceOf(Err.class);
+    assertThat(describe(result)).isEqualTo("err:404");
+  }
+
+  /** Exercises exhaustive pattern matching over the sealed hierarchy. */
+  private static String describe(Result<String, Integer> result) {
+    return switch (result) {
+      case Ok<String, Integer> ok -> "ok:" + ok.value();
+      case Err<String, Integer> err -> "err:" + err.error();
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Four maintainability refinements to `AnchorResolver` — the ADR-0009 re-anchoring cascade (issue #320). **Behaviour-preserving**: the existing `AnchorResolverTest` (13 cases: exact/duplicated/fuzzy/orphan/geometric/determinism) is the safety net and stays green.

## Changes
1. **Split the cascade** — the long `resolve()` becomes an ordered, `sealed interface CascadeStep` pipeline (`ExactWithContext` → `ExactQuoteOnly` → `DuplicatedQuote` → `Fuzzy`) driven by a small `Cascade` context; each stage returns `Optional<Resolution>` (decide, or defer to the next). The Fuzzy stage always decides.
2. **Config thresholds** — the six magic numbers move to **`ReanchoringProperties`** (`@ConfigurationProperties("qnop.reanchoring")`) with conservative defaults; `AnchorResolver` keeps a no-arg constructor that uses them, and `ReanchorJobHandler` now injects the bean.
3. **Typed parse result** — `parse()` returns a `sealed Result<ParsedAnchor, ParseError>` instead of null-on-parse, so the failure arm can't be forgotten (exhaustive `switch`).
4. **Value object for boxes** — `boxFor` returns `io.qnop.spi.extract.NormalizedBox` instead of an ad-hoc `Map<String, Double>` — same wire JSON (`{x,y,width,height}`), now range-validated.

## TDD
- `ResultTest` — Ok/Err construction + exhaustive pattern match (RED → GREEN).
- `ReanchoringPropertiesTest` — defaults + null-coalescing (RED → GREEN).
- `AnchorResolverTest.similarityThresholdIsConfigurable` — a candidate scoring exactly 0.5 is **ORPHANED** at the default 0.75 bar but **MOVED** when a deployment lowers the threshold to 0.4 (written first, RED against the pre-refactor no-config resolver, then GREEN).
- All pre-existing behaviour tests remain unchanged and green.

## Test plan
- [x] Local: `spotlessCheck`, ArchUnit, full `:qnop-core:test` (incl. all AnchorResolver behaviour tests + the three new suites) green. The `ReanchoringIT` (Docker) exercises the real re-anchoring path in CI.

Closes #320

🤖 Co-Author: Claude (Opus 4.x) via Claude Code