### PR TITLE
perf: memoize annotation panel rows to cut re-render overhead (#333)

### DIFF
--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { memo } from 'react';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
@@ -88,7 +89,12 @@ interface AnnotationListItemProps {
   active: boolean;
   /** True while the mark on the page is hovered — mirrors the link visually. */
   linked?: boolean;
-  onClick: () => void;
+  /**
+   * Selects this annotation, or deselects (null) when it is already active. Passed the resolved id
+   * so the parent can forward a stable handler — the toggle lives here, keeping the item's props
+   * referentially stable for {@link memo} (issue #333).
+   */
+  onSelect: (annotationId: string | null) => void;
   onHover?: (annotationId: string | null) => void;
 }
 
@@ -100,12 +106,15 @@ interface AnnotationListItemProps {
  * comment timeline follows below. The left rail always carries the colour the
  * mark paints with on the page, and hovering either side of the card↔mark
  * pair lights up the other.
+ *
+ * Memoized (issue #333): the panel re-renders on every hover/selection, but with stable props only
+ * the two items whose {@code active}/{@code linked} actually changed re-render — not the whole list.
  */
-export function AnnotationListItem({
+function AnnotationListItemBase({
   annotation,
   active,
   linked = false,
-  onClick,
+  onSelect,
   onHover,
 }: AnnotationListItemProps) {
   const theme = useTheme();
@@ -129,7 +138,7 @@ export function AnnotationListItem({
 
   return (
     <ButtonBase
-      onClick={onClick}
+      onClick={() => onSelect(active ? null : annotation.id)}
       onMouseEnter={() => onHover?.(annotation.id)}
       onMouseLeave={() => onHover?.(null)}
       onFocus={() => onHover?.(annotation.id)}
@@ -281,3 +290,5 @@ export function AnnotationListItem({
     </ButtonBase>
   );
 }
+
+export const AnnotationListItem = memo(AnnotationListItemBase);

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -215,7 +215,7 @@ export function AnnotationPanel({
           annotation={annotation}
           active={active}
           linked={annotation.id === hoverAnnotationId}
-          onClick={() => onSelect(active ? null : annotation.id)}
+          onSelect={onSelect}
           onHover={onHover}
         />
         <Collapse in={active} unmountOnExit>

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -242,6 +242,17 @@ export function DocumentReviewPage() {
       },
     );
   };
+
+  // Stable so the focus-mode panel's memoized rows don't all re-render on every hover (issue #333).
+  const handleFocusSelect = useCallback(
+    (id: string | null) => {
+      setActiveAnnotationId(id);
+      // A placed annotation continues in the spotlight; unplaced ones keep their
+      // thread inside the drawer (no mark to spotlight).
+      if (id && annotations.find((a) => a.id === id)?.anchor) setListOpen(false);
+    },
+    [annotations],
+  );
 
   if (documentQuery.isPending) {
     return (
@@ -476,12 +487,7 @@ export function DocumentReviewPage() {
               annotations={annotations}
               activeAnnotationId={activeAnnotationId}
               hoverAnnotationId={hoverAnnotationId}
-              onSelect={(id) => {
-                setActiveAnnotationId(id);
-                // A placed annotation continues in the spotlight; unplaced ones
-                // keep their thread inside the drawer (no mark to spotlight).
-                if (id && annotations.find((a) => a.id === id)?.anchor) setListOpen(false);
-              }}
+              onSelect={handleFocusSelect}
               onHover={setHoverAnnotationId}
               pendingAnchor={null}
               creating={createAnnotation.isPending}


### PR DESCRIPTION
## Summary

MEDIUM review finding #333. The annotation panel re-renders on **every hover and selection** (`hoverAnnotationId` / `activeAnnotationId` are parent state), and each row is a plain, un-memoized component that also calls a per-annotation `useComments` hook. So hovering one card re-rendered **all N rows** and re-ran N cache reads — the render overhead flagged on large annotation sets.

- **`AnnotationListItem` is now `React.memo`'d.** The click toggle moved into the row (it already receives `active`), so the parent forwards a **stable `onSelect`** instead of minting a fresh `() => onSelect(...)` closure per row per render — which would have defeated `memo`. With stable props, only the two rows whose `active`/`linked` actually changed re-render on a hover/selection, not the whole list.
- `DocumentReviewPage` wraps the focus-mode panel's inline `onSelect` in `useCallback` so that panel instance gets the same benefit.

Row `annotation` refs are already stable (the sorted/filtered lists are `useMemo`'d on `[annotations, filter]`), so the shallow prop compare holds across hover/selection churn.

## Why not virtualization
The list is grouped into **collapsible sections** with the **active row expanding in place** (its comment thread), which makes windowing intrusive and risky for what is a one-time *mount* cost. The repeated *per-interaction* cost — the actual complaint — is removed by memoization. In-row comment loads are already lazy (rows read cache with `enabled: false`; only the open thread fetches), so there is nothing to batch. Virtualization can follow as a separate change if profiling shows initial mount is still a bottleneck (no windowing dependency is in the tree today).

## Test plan
- [x] Behaviour unchanged — existing `AnnotationPanel.test.tsx` covers select/deselect toggle (`click active row → onSelect(null)`), filters, and decisions; `CommentThread.test.tsx` unchanged. Ran locally: **16/16 green**.
- [x] `tsc -b --noEmit` and `eslint` on the three changed files — clean (incl. `react-hooks/exhaustive-deps`).

Closes #333

🤖 Co-Author: Claude (Opus 4.x) via Claude Code