### PR TITLE
perf(ui): fetch the PDF eagerly from an explicit ?version= (#332)

### DIFF
--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -27,7 +27,7 @@ import type { AnnotationView, RenderedSurface } from '../../api/generated';
 import { AnnotationStatus, ExtractionStatus, PlacementStatus } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { DocumentReviewPage } from './DocumentReviewPage';
-import { resolveEffectiveVersion } from './resolveEffectiveVersion';
+import { pdfFetchVersion, resolveEffectiveVersion } from './resolveEffectiveVersion';
 import {
   useDocument,
   useDocumentVersions,
@@ -214,6 +214,24 @@ describe('resolveEffectiveVersion', () => {
 
   it('is undefined while nothing is known yet', () => {
     expect(resolveEffectiveVersion(2, 0, [])).toBeUndefined();
+  });
+});
+
+// Issue #332: the PDF fetch starts from an explicit ?version= before the
+// metadata queries resolve it, so a shared deep link downloads its bytes in
+// parallel with the document + version-list queries.
+describe('pdfFetchVersion', () => {
+  it('uses the resolved version once it is known', () => {
+    expect(pdfFetchVersion(2, 5)).toBe(2);
+  });
+
+  it('fetches the requested version eagerly before resolution (deep-link first paint)', () => {
+    expect(pdfFetchVersion(undefined, 3)).toBe(3);
+  });
+
+  it('is undefined before resolution when no version was requested', () => {
+    expect(pdfFetchVersion(undefined, NaN)).toBeUndefined();
+    expect(pdfFetchVersion(undefined, 0)).toBeUndefined();
   });
 });
 

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -72,7 +72,7 @@ import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
 import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
 import { useAuthStore } from '../../stores/authStore';
 import { apiErrorCode } from '../../utils/apiError';
-import { resolveEffectiveVersion } from './resolveEffectiveVersion';
+import { pdfFetchVersion, resolveEffectiveVersion } from './resolveEffectiveVersion';
 
 const PANEL_WIDTH_KEY = 'qnop-review-panel-width';
 
@@ -112,7 +112,10 @@ export function DocumentReviewPage() {
   const extractionReady = extractionStatus === ExtractionStatus.Ready;
 
   const renderedQuery = useRenderedDocument(documentId, versionNumber ?? 0, extractionReady);
-  const pdfQuery = useOriginalPdf(documentId, versionNumber);
+  // The heavy PDF download starts from an explicit ?version= without waiting for
+  // the metadata queries to validate it, so a shared deep link fetches its bytes
+  // in parallel with useDocument/useDocumentVersions (issue #332).
+  const pdfQuery = useOriginalPdf(documentId, pdfFetchVersion(versionNumber, requestedVersion));
   const { pdf, error: pdfError } = usePdfDocument(pdfQuery.data);
   const annotationsQuery = useAnnotations(documentId, versionNumber);
   const createAnnotation = useCreateAnnotation(documentId);

--- a/qnop-ui/src/pages/reviews/resolveEffectiveVersion.ts
+++ b/qnop-ui/src/pages/reviews/resolveEffectiveVersion.ts
@@ -35,3 +35,18 @@ export function resolveEffectiveVersion(
   if (requestedVersion >= 1 && requestedVersion <= maxKnown) return requestedVersion;
   return maxKnown >= 1 ? maxKnown : undefined;
 }
+
+/**
+ * The version whose original bytes to fetch. Prefers the resolved version, but
+ * before any metadata query has settled it, an explicit `?version=` lets the
+ * heavy PDF download start in parallel with the document + version-list queries
+ * — a shared deep link's first paint no longer waits a round-trip for the
+ * metadata to validate the number (issue #332). An out-of-range URL simply
+ * corrects to the resolved version once known, discarding the eager 404.
+ */
+export function pdfFetchVersion(
+  resolvedVersion: number | undefined,
+  requestedVersion: number,
+): number | undefined {
+  return resolvedVersion ?? (requestedVersion >= 1 ? requestedVersion : undefined);
+}


### PR DESCRIPTION
Closes #332.

## What the review flagged vs. current `main`

The finding cited `main@72f1fb7`, which predates the **#300** refactor (`176458b`). On current `main` the broad waterfall no longer holds:

- `useDocument` and `useDocumentVersions` both fire **at mount** with no `enabled` gate → they run in parallel.
- `resolveEffectiveVersion` (post-#300) resolves the version from `max(latestFromDetail, …knownVersions)` — i.e. from **whichever query returns first** — so `useOriginalPdf` / `useAnnotations` start as soon as either the document detail or the version list is back; the PDF does **not** wait for the version list.
- `useRenderedDocument` genuinely follows the version list (it needs the `READY` extraction status to avoid a 409), but the viewer paints the PDF without surfaces, so this never blocks first paint.

## The one remaining gap — cold deep-link first paint

A shared link `/reviews/:id?version=N` (the core collaboration flow) still made the **heavy PDF download** wait a round-trip: `versionNumber` only becomes `N` after `useDocument` resolves and validates it. Yet `N` is already known from the URL.

`pdfFetchVersion(resolvedVersion, requestedVersion)` starts the PDF from the URL version immediately, so the bytes download **in parallel** with the metadata queries. Once the version resolves this collapses to the resolved number; an out-of-range/tampered URL simply corrects itself (the eager 404 is discarded, and the endpoint already 404s a bad version — surfaced by the existing error state).

Scoped to the PDF (the heavy first-paint blocker the issue names). `useRenderedDocument` (needs extraction status) and `useAnnotations` (small) stay on the resolved version.

## Changes

- `resolveEffectiveVersion.ts`: new pure `pdfFetchVersion()` helper
- `DocumentReviewPage.tsx`: `useOriginalPdf(documentId, pdfFetchVersion(versionNumber, requestedVersion))`
- `DocumentReviewPage.test.tsx`: `pdfFetchVersion` cases (resolved wins, eager URL fallback, undefined when nothing requested)

## Test plan

- [x] `tsc -b --noEmit` — clean
- [x] `eslint` (incl. `react-hooks/exhaustive-deps`) — clean
- [x] `prettier --check` — clean
- [x] `vitest run DocumentReviewPage.test.tsx` — 20 passed (incl. new `pdfFetchVersion` tests)

🤖 Co-Author: Claude (Opus 4.8) via Claude Code