### PR TITLE
feat(core): optional annotation classification — type & priority

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2046,6 +2046,12 @@ paths:
             (issue #248). Requires `version`.
           schema:
             $ref: '#/components/schemas/PlacementStatus'
+        - name: type
+          in: query
+          required: false
+          description: Only annotations classified with this type (issue #392).
+          schema:
+            $ref: '#/components/schemas/AnnotationType'
       responses:
         '200':
           description: The annotations
@@ -2128,6 +2134,50 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           description: Unknown annotation, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags: [Annotations]
+      summary: Reclassify an annotation
+      description: |
+        Replaces the annotation's optional classification (type + priority,
+        issue #392) wholesale — an absent field clears that facet. Permitted
+        for the document owner or the annotation's author while the annotation
+        is still OPEN; a decided annotation is immutable.
+      operationId: classifyAnnotation
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnnotationClassificationRequest'
+      responses:
+        '200':
+          description: The reclassified annotation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationView'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: The caller is a participant but neither owner nor author
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown annotation, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The annotation is already decided (`ANNOTATION_ALREADY_DECIDED`)
           content:
             application/json:
               schema:
@@ -4069,6 +4119,27 @@ components:
         - MOVED
         - ORPHANED
         - FAILED
+    AnnotationType:
+      type: string
+      description: >-
+        The optional kind of point an annotation raises (issue #392). Purely
+        descriptive — it drives the tasks view's visual language and filtering,
+        never the workflow.
+      enum:
+        - CHANGE
+        - PROPOSAL
+        - CONFLICT
+        - QUESTION
+        - RISK
+    AnnotationPriority:
+      type: string
+      description: >-
+        The optional urgency of an annotation (issue #392). Purely descriptive,
+        never workflow-relevant.
+      enum:
+        - HIGH
+        - MEDIUM
+        - LOW
     AnnotationCreateRequest:
       type: object
       description: Create an annotation anchored to a region of a version.
@@ -4091,6 +4162,21 @@ components:
             The first comment seeding the discussion thread. Required — an
             annotation without text must not exist (issue #301); blank-only
             comments are rejected.
+        type:
+          $ref: '#/components/schemas/AnnotationType'
+        priority:
+          $ref: '#/components/schemas/AnnotationPriority'
+    AnnotationClassificationRequest:
+      type: object
+      description: >-
+        Replaces an annotation's classification wholesale (issue #392): the
+        request body becomes the new classification, so an absent field clears
+        that facet. Send both fields to keep both.
+      properties:
+        type:
+          $ref: '#/components/schemas/AnnotationType'
+        priority:
+          $ref: '#/components/schemas/AnnotationPriority'
     AnnotationView:
       type: object
       description: |
@@ -4116,6 +4202,10 @@ components:
           format: uuid
         status:
           $ref: '#/components/schemas/AnnotationStatus'
+        type:
+          $ref: '#/components/schemas/AnnotationType'
+        priority:
+          $ref: '#/components/schemas/AnnotationPriority'
         anchor:
           $ref: '#/components/schemas/Anchor'
         placementStatus:

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -22,11 +22,14 @@ package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.AnnotationsApi;
 import io.qnop.api.v1.model.Anchor;
+import io.qnop.api.v1.model.AnnotationClassificationRequest;
 import io.qnop.api.v1.model.AnnotationCreateRequest;
 import io.qnop.api.v1.model.AnnotationDecision;
 import io.qnop.api.v1.model.AnnotationDecisionRequest;
 import io.qnop.api.v1.model.AnnotationListResponse;
+import io.qnop.api.v1.model.AnnotationPriority;
 import io.qnop.api.v1.model.AnnotationStatus;
+import io.qnop.api.v1.model.AnnotationType;
 import io.qnop.api.v1.model.AnnotationView;
 import io.qnop.api.v1.model.CommentCreateRequest;
 import io.qnop.api.v1.model.CommentListResponse;
@@ -75,22 +78,38 @@ public class AnnotationController implements AnnotationsApi {
             CurrentUser.requireUserId(),
             CurrentUser.isAdmin(),
             mapper.writeValueAsString(request.getAnchor()),
-            request.getComment());
+            request.getComment(),
+            request.getType() == null ? null : request.getType().getValue(),
+            request.getPriority() == null ? null : request.getPriority().getValue());
     return ResponseEntity.status(HttpStatus.CREATED).body(toDto(view));
   }
 
   @Override
   public ResponseEntity<AnnotationListResponse> listAnnotations(
-      UUID documentId, Integer version, PlacementStatus placementStatus) {
+      UUID documentId, Integer version, PlacementStatus placementStatus, AnnotationType type) {
     var views =
         annotations.list(
             documentId,
             version,
             placementStatus == null ? null : placementStatus.getValue(),
+            type == null ? null : type.getValue(),
             CurrentUser.requireUserId(),
             CurrentUser.isAdmin());
     return ResponseEntity.ok(
         new AnnotationListResponse().annotations(views.stream().map(this::toDto).toList()));
+  }
+
+  @Override
+  public ResponseEntity<AnnotationView> classifyAnnotation(
+      UUID annotationId, AnnotationClassificationRequest request) {
+    AnnotationService.AnnotationView view =
+        annotations.updateClassification(
+            annotationId,
+            CurrentUser.requireUserId(),
+            CurrentUser.isAdmin(),
+            request.getType() == null ? null : request.getType().getValue(),
+            request.getPriority() == null ? null : request.getPriority().getValue());
+    return ResponseEntity.ok(toDto(view));
   }
 
   @Override
@@ -129,6 +148,8 @@ public class AnnotationController implements AnnotationsApi {
         .documentId(view.documentId())
         .authorId(view.authorId())
         .status(AnnotationStatus.fromValue(view.status()))
+        .type(view.type() == null ? null : AnnotationType.fromValue(view.type()))
+        .priority(view.priority() == null ? null : AnnotationPriority.fromValue(view.priority()))
         .anchor(
             view.anchorJson() == null ? null : mapper.readValue(view.anchorJson(), Anchor.class))
         .placementStatus(

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -22,6 +22,7 @@ package io.qnop.review;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -285,6 +286,123 @@ class AnnotationApiIT extends SeededIntegrationTest {
     mockMvc
         .perform(as(get("/api/v1/annotations/" + UUID.randomUUID()), MEMBER_ID))
         .andExpect(status().isNotFound());
+  }
+
+  // --- classification: optional type & priority (issue #392) --------------------------------
+
+  @Test
+  void createsWithClassificationAndRoundTripsIt() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"versionNumber\":1,\"anchor\":"
+                        + ANCHOR
+                        + ",\"comment\":\"conflicts with policy\","
+                        + "\"type\":\"CONFLICT\",\"priority\":\"HIGH\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.type").value("CONFLICT"))
+        .andExpect(jsonPath("$.priority").value("HIGH"));
+
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].type").value("CONFLICT"))
+        .andExpect(jsonPath("$.annotations[0].priority").value("HIGH"));
+  }
+
+  @Test
+  void createsWithoutClassificationAsBefore() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    // Uncategorised stays a plain annotation — both fields absent, not defaulted.
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.type").doesNotExist())
+        .andExpect(jsonPath("$.priority").doesNotExist());
+  }
+
+  @Test
+  void authorAndOwnerReclassifyWhileOpen() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    mockMvc
+        .perform(
+            as(patch("/api/v1/annotations/" + annotationId), AUDITOR_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"QUESTION\",\"priority\":\"LOW\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.type").value("QUESTION"))
+        .andExpect(jsonPath("$.priority").value("LOW"));
+
+    // The body replaces the classification wholesale — an absent field clears it.
+    mockMvc
+        .perform(
+            as(patch("/api/v1/annotations/" + annotationId), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"RISK\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.type").value("RISK"))
+        .andExpect(jsonPath("$.priority").doesNotExist());
+  }
+
+  @Test
+  void anotherReviewerCannotReclassify() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    // MEMBER2 is a participant (annotation visible) but neither owner nor author.
+    mockMvc
+        .perform(
+            as(patch("/api/v1/annotations/" + annotationId), MEMBER2_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"RISK\"}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void reclassifyingADecidedAnnotationIsConflict() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+    decide(annotationId, "ACCEPTED", MEMBER_ID).andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            as(patch("/api/v1/annotations/" + annotationId), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"RISK\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("ANNOTATION_ALREADY_DECIDED"));
+  }
+
+  @Test
+  void listsFilteredByType() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"versionNumber\":1,\"anchor\":"
+                        + ANCHOR
+                        + ",\"comment\":\"a conflict\",\"type\":\"CONFLICT\"}"))
+        .andExpect(status().isCreated());
+    createAnnotation(documentId, MEMBER2_ID); // uncategorised
+
+    mockMvc
+        .perform(
+            as(
+                get("/api/v1/documents/" + documentId + "/annotations").param("type", "CONFLICT"),
+                MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations.length()").value(1))
+        .andExpect(jsonPath("$.annotations[0].type").value("CONFLICT"));
   }
 
   private org.springframework.test.web.servlet.ResultActions decide(

--- a/qnop-core/src/main/java/io/qnop/entity/Annotation.java
+++ b/qnop-core/src/main/java/io/qnop/entity/Annotation.java
@@ -63,6 +63,14 @@ public class Annotation {
   @Column(name = "status", nullable = false, length = 16)
   private AnnotationStatus status;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "type", length = 16)
+  private AnnotationType type;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "priority", length = 16)
+  private AnnotationPriority priority;
+
   @CreationTimestamp
   @Column(name = "created_at", nullable = false, updatable = false)
   private Instant createdAt;
@@ -101,6 +109,12 @@ public class Annotation {
     this.status = AnnotationStatus.OPEN;
   }
 
+  /** (Re)classifies the point — both facets optional, {@code null} clears (issue #392). */
+  public void classify(AnnotationType type, AnnotationPriority priority) {
+    this.type = type;
+    this.priority = priority;
+  }
+
   public UUID getId() {
     return id;
   }
@@ -115,6 +129,14 @@ public class Annotation {
 
   public AnnotationStatus getStatus() {
     return status;
+  }
+
+  public AnnotationType getType() {
+    return type;
+  }
+
+  public AnnotationPriority getPriority() {
+    return priority;
   }
 
   public Instant getCreatedAt() {

--- a/qnop-core/src/main/java/io/qnop/entity/AnnotationPriority.java
+++ b/qnop-core/src/main/java/io/qnop/entity/AnnotationPriority.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+/**
+ * The optional urgency of an {@link Annotation} (issue #392). Purely descriptive — it drives the
+ * tasks view's priority cue and sorting, never the workflow. A closed set, pinned by a Postgres
+ * {@code CHECK} in Liquibase (ADR-0020); {@code null} means unprioritised.
+ */
+public enum AnnotationPriority {
+  HIGH,
+  MEDIUM,
+  LOW
+}

--- a/qnop-core/src/main/java/io/qnop/entity/AnnotationType.java
+++ b/qnop-core/src/main/java/io/qnop/entity/AnnotationType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+/**
+ * The optional kind of point an {@link Annotation} raises (issue #392). Purely descriptive — it
+ * drives the tasks view's visual language and filtering, never the workflow. A closed set, pinned
+ * by a Postgres {@code CHECK} in Liquibase (ADR-0020); {@code null} means uncategorised.
+ */
+public enum AnnotationType {
+  /** A concrete change request to the document's content. */
+  CHANGE,
+  /** A suggestion to add something new. */
+  PROPOSAL,
+  /** A contradiction with a policy, another clause, or an agreement. */
+  CONFLICT,
+  /** A clarification request. */
+  QUESTION,
+  /** A flagged risk to assess. */
+  RISK
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -24,7 +24,9 @@ import static java.util.stream.Collectors.toMap;
 
 import io.qnop.entity.Annotation;
 import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.AnnotationPriority;
 import io.qnop.entity.AnnotationStatus;
+import io.qnop.entity.AnnotationType;
 import io.qnop.entity.AuditEvent;
 import io.qnop.entity.Comment;
 import io.qnop.entity.DocumentVersion;
@@ -56,6 +58,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnnotationService {
 
   static final String AUDIT_ANNOTATION_CREATED = "annotation.created";
+  static final String AUDIT_ANNOTATION_CLASSIFIED = "annotation.classified";
 
   private final AnnotationRepository annotations;
   private final AnnotationPlacementRepository placements;
@@ -92,6 +95,8 @@ public class AnnotationService {
       UUID documentId,
       UUID authorId,
       String status,
+      String type,
+      String priority,
       String anchorJson,
       String placementStatus,
       int commentCount,
@@ -116,7 +121,9 @@ public class AnnotationService {
       UUID author,
       boolean admin,
       String anchorJson,
-      String firstComment) {
+      String firstComment,
+      String type,
+      String priority) {
     if (firstComment == null || firstComment.isBlank()) {
       throw DocumentValidationException.invalidRequest("annotation requires a first comment");
     }
@@ -139,7 +146,9 @@ public class AnnotationService {
 
     // saveAndFlush so the @CreationTimestamp / @UpdateTimestamp are populated on the returned
     // entity (they are only set when the INSERT is flushed) before the view is built.
-    Annotation annotation = annotations.saveAndFlush(new Annotation(documentId, author));
+    Annotation created = new Annotation(documentId, author);
+    created.classify(typeOf(type), priorityOf(priority));
+    Annotation annotation = annotations.saveAndFlush(created);
     AnnotationPlacement placement =
         new AnnotationPlacement(annotation.getId(), version.getId(), anchorJson);
     placement.markPlaced(anchorJson);
@@ -163,7 +172,12 @@ public class AnnotationService {
    */
   @Transactional(readOnly = true)
   public List<AnnotationView> list(
-      UUID documentId, Integer versionNumber, String placementStatus, UUID actor, boolean admin) {
+      UUID documentId,
+      Integer versionNumber,
+      String placementStatus,
+      String type,
+      UUID actor,
+      boolean admin) {
     if (placementStatus != null && versionNumber == null) {
       throw DocumentValidationException.invalidRequest("placementStatus requires version");
     }
@@ -191,7 +205,52 @@ public class AnnotationService {
                     placementByAnnotation.get(annotation.getId()),
                     threadSizeByAnnotation.getOrDefault(annotation.getId(), 0)))
         .filter(view -> placementStatus == null || placementStatus.equals(view.placementStatus()))
+        .filter(view -> type == null || type.equals(view.type()))
         .toList();
+  }
+
+  /**
+   * (Re)classifies an annotation — the request replaces the classification wholesale, an absent
+   * facet clears it (issue #392). Permitted for the document owner or the annotation's author while
+   * the annotation is still OPEN. Classification is descriptive only, so it lives here and never
+   * drives the workflow.
+   */
+  @Transactional
+  public AnnotationView updateClassification(
+      UUID annotationId, UUID actor, boolean admin, String type, String priority) {
+    Annotation annotation = requireAnnotation(annotationId);
+    DocumentAccessService.DocumentView document =
+        documentAccess.getDocument(annotation.getDocumentId(), actor, admin);
+    if (!document.ownerId().equals(actor) && !annotation.getAuthorId().equals(actor)) {
+      throw new AnnotationDecisionForbiddenException();
+    }
+    if (annotation.getStatus() != AnnotationStatus.OPEN) {
+      throw new WorkflowTransitionException(
+          WorkflowTransitionException.ANNOTATION_ALREADY_DECIDED,
+          "annotation " + annotationId + " is already " + annotation.getStatus());
+    }
+    annotation.classify(typeOf(type), priorityOf(priority));
+    auditEvents.save(
+        new AuditEvent(
+            annotation.getDocumentId(),
+            AUDIT_ANNOTATION_CLASSIFIED,
+            actor,
+            "{\"annotationId\":\"%s\",\"type\":%s,\"priority\":%s}"
+                .formatted(annotationId, jsonString(type), jsonString(priority))));
+    return view(annotation, null, threadSize(annotationId));
+  }
+
+  private static String jsonString(String value) {
+    return value == null ? "null" : "\"" + value + "\"";
+  }
+
+  /** The entity enum for a contract-validated name; the closed set is enforced by the contract. */
+  private static AnnotationType typeOf(String type) {
+    return type == null ? null : AnnotationType.valueOf(type);
+  }
+
+  private static AnnotationPriority priorityOf(String priority) {
+    return priority == null ? null : AnnotationPriority.valueOf(priority);
   }
 
   /** A single annotation (no version context, so no placement), visible to participants. */
@@ -259,6 +318,8 @@ public class AnnotationService {
         annotation.getDocumentId(),
         annotation.getAuthorId(),
         annotation.getStatus().name(),
+        annotation.getType() == null ? null : annotation.getType().name(),
+        annotation.getPriority() == null ? null : annotation.getPriority().name(),
         placement == null ? null : placement.getAnchor(),
         placement == null ? null : placement.getStatus().name(),
         commentCount,

--- a/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
@@ -242,6 +242,12 @@ databaseChangeLog:
                   type: VARCHAR(16)
                   constraints: { nullable: false }
               - column:
+                  name: type
+                  type: VARCHAR(16)
+              - column:
+                  name: priority
+                  type: VARCHAR(16)
+              - column:
                   name: created_at
                   type: TIMESTAMP WITH TIME ZONE
                   constraints: { nullable: false }
@@ -279,10 +285,14 @@ databaseChangeLog:
             columns:
               - column: { name: author_id }
         - sql:
-            comment: Closed set of annotation outcomes (not expressible in JPA).
+            comment: Closed sets for outcome and classification (not expressible in JPA).
             sql: |
               ALTER TABLE annotation ADD CONSTRAINT ck_annotation_status
                 CHECK (status IN ('OPEN', 'ACCEPTED', 'REJECTED'));
+              ALTER TABLE annotation ADD CONSTRAINT ck_annotation_type
+                CHECK (type IN ('CHANGE', 'PROPOSAL', 'CONFLICT', 'QUESTION', 'RISK'));
+              ALTER TABLE annotation ADD CONSTRAINT ck_annotation_priority
+                CHECK (priority IN ('HIGH', 'MEDIUM', 'LOW'));
 
   - changeSet:
       id: 0011-comment


### PR DESCRIPTION
Closes #392 — the backend half of the tasks-view integration (#393), plan in the [issue comment](https://github.com/qnophq/qnop/issues/392#issuecomment-4882510244).

## What changed

- **Model**: `Annotation` gains two optional, purely descriptive facets — `type` (`CHANGE | PROPOSAL | CONFLICT | QUESTION | RISK`) and `priority` (`HIGH | MEDIUM | LOW`) — with a `classify()` mutator. Both nullable: an uncategorised annotation stays a plain annotation.
- **Migration**: both columns and their `CHECK` closed sets are amended into the existing `0011-annotation` changeset (pre-production convention — no follow-up changeset). Existing dev DBs: `ALTER TABLE annotation ADD COLUMN type varchar(16); ALTER TABLE annotation ADD COLUMN priority varchar(16);` + the two CHECKs, then `UPDATE databasechangelog SET md5sum = NULL WHERE id = '0011-annotation';` — or recreate the DB.
- **Service**: `create(...)` takes the optional classification; new `updateClassification(...)` replaces it wholesale (absent facet = cleared) for the **owner or author while OPEN** — decided annotations answer `409 ANNOTATION_ALREADY_DECIDED`, other participants 403 (same circle as deciding); audit event `annotation.classified`. `list(...)` gains a `type` filter. The service API carries enum *names* as strings — the web layer never touches `io.qnop.entity` (ADR-0004; the first draft violated the ArchUnit layer rule and was reworked).
- **Contract**: `AnnotationType` / `AnnotationPriority` schemas, both fields on `AnnotationCreateRequest` + `AnnotationView`, new `PATCH /annotations/{annotationId}` (`classifyAnnotation`) with explicit replacement semantics, `type` query param on `listAnnotations`.

No UI — #393 consumes this; the regenerated typescript client is additive.

## Test plan
- [x] `AnnotationApiIT` (6 new): create with classification round-trips through create + list; create without stays absent (regression); PATCH by author and owner incl. the clear semantics; 403 for another participant; 409 after a decision; `?type=` listing filter
- [x] Full suite: `./gradlew build` (Spotless, ArchUnit layer rules, all ITs) green
- [x] Frontend gates with the regenerated client: `tsc`, `eslint`, 419 tests green
- [x] No visual pass needed — backend-only (#393 makes it visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
