### PR TITLE
feat: tasks view — annotations as a kanban board and task list

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4210,6 +4210,11 @@ components:
           $ref: '#/components/schemas/Anchor'
         placementStatus:
           $ref: '#/components/schemas/PlacementStatus'
+        firstComment:
+          type: string
+          description: >-
+            Excerpt (first 300 characters) of the thread's opening comment —
+            the annotation's de-facto title (issue #393).
         commentCount:
           type: integer
           description: Number of comments in the thread.

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -156,6 +156,7 @@ public class AnnotationController implements AnnotationsApi {
             view.placementStatus() == null
                 ? null
                 : PlacementStatus.fromValue(view.placementStatus()))
+        .firstComment(view.firstComment())
         .commentCount(view.commentCount())
         .createdAt(view.createdAt().atOffset(ZoneOffset.UTC))
         .updatedAt(view.updatedAt().atOffset(ZoneOffset.UTC));

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -288,6 +288,45 @@ class AnnotationApiIT extends SeededIntegrationTest {
         .andExpect(status().isNotFound());
   }
 
+  @Test
+  void carriesTheFirstCommentExcerptEverywhere() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+
+    // The tasks view's card title (issue #393): the first comment rides along on the view.
+    String annotationId =
+        JsonPath.read(
+            mockMvc
+                .perform(
+                    as(post("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            "{\"versionNumber\":1,\"anchor\":"
+                                + ANCHOR
+                                + ",\"comment\":\"please clarify\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.firstComment").value("please clarify"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString(),
+            "$.id");
+
+    // Later replies never displace it.
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/comments"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"a later reply\"}"))
+        .andExpect(status().isCreated());
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.firstComment").value("please clarify"));
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].firstComment").value("please clarify"));
+  }
+
   // --- classification: optional type & priority (issue #392) --------------------------------
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/repository/AnnotationFirstComment.java
+++ b/qnop-core/src/main/java/io/qnop/repository/AnnotationFirstComment.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/**
+ * The opening comment per annotation, for the annotation list (avoids an N+1; the tasks view's card
+ * title). Interface projection because the query is native (Postgres DISTINCT ON). Issue #393.
+ */
+public interface AnnotationFirstComment {
+
+  UUID getAnnotationId();
+
+  String getBody();
+}

--- a/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
@@ -23,6 +23,7 @@ package io.qnop.repository;
 import io.qnop.entity.Comment;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -33,6 +34,22 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
   /** The discussion thread of an annotation, oldest message first. */
   List<Comment> findByAnnotationIdOrderByCreatedAtAsc(UUID annotationId);
+
+  /** The opening message of an annotation's thread (issue #393); id breaks created_at ties. */
+  Optional<Comment> findFirstByAnnotationIdOrderByCreatedAtAscIdAsc(UUID annotationId);
+
+  /**
+   * The opening message per annotation in one query (issue #393) — the tasks view's card title,
+   * batched like the thread sizes (#313). Postgres {@code DISTINCT ON}; ties resolve by id.
+   */
+  @Query(
+      value =
+          "SELECT DISTINCT ON (annotation_id) annotation_id AS \"annotationId\", body"
+              + " FROM comment WHERE annotation_id IN (:annotationIds)"
+              + " ORDER BY annotation_id, created_at, id",
+      nativeQuery = true)
+  List<AnnotationFirstComment> findFirstByAnnotationIdIn(
+      @Param("annotationIds") Collection<UUID> annotationIds);
 
   /** The size of an annotation's thread (issue #247). */
   long countByAnnotationId(UUID annotationId);

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -31,6 +31,7 @@ import io.qnop.entity.AuditEvent;
 import io.qnop.entity.Comment;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.repository.AnnotationCommentCount;
+import io.qnop.repository.AnnotationFirstComment;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.AuditEventRepository;
@@ -59,6 +60,9 @@ public class AnnotationService {
 
   static final String AUDIT_ANNOTATION_CREATED = "annotation.created";
   static final String AUDIT_ANNOTATION_CLASSIFIED = "annotation.classified";
+
+  /** Comments can be 20k chars; the view carries only what a card title needs (issue #393). */
+  static final int FIRST_COMMENT_EXCERPT_CHARS = 300;
 
   private final AnnotationRepository annotations;
   private final AnnotationPlacementRepository placements;
@@ -99,6 +103,7 @@ public class AnnotationService {
       String priority,
       String anchorJson,
       String placementStatus,
+      String firstComment,
       int commentCount,
       Instant createdAt,
       Instant updatedAt) {}
@@ -162,7 +167,7 @@ public class AnnotationService {
             AUDIT_ANNOTATION_CREATED,
             author,
             "{\"annotationId\":\"" + annotation.getId() + "\"}"));
-    return view(annotation, placement, commentCount);
+    return view(annotation, placement, excerpt(firstComment), commentCount);
   }
 
   /**
@@ -197,12 +202,14 @@ public class AnnotationService {
             : placements.findByDocumentVersionId(versionId).stream()
                 .collect(toMap(AnnotationPlacement::getAnnotationId, placement -> placement));
     Map<UUID, Integer> threadSizeByAnnotation = threadSizes(documentAnnotations);
+    Map<UUID, String> firstCommentByAnnotation = firstComments(documentAnnotations);
     return documentAnnotations.stream()
         .map(
             annotation ->
                 view(
                     annotation,
                     placementByAnnotation.get(annotation.getId()),
+                    firstCommentByAnnotation.get(annotation.getId()),
                     threadSizeByAnnotation.getOrDefault(annotation.getId(), 0)))
         .filter(view -> placementStatus == null || placementStatus.equals(view.placementStatus()))
         .filter(view -> type == null || type.equals(view.type()))
@@ -237,7 +244,7 @@ public class AnnotationService {
             actor,
             "{\"annotationId\":\"%s\",\"type\":%s,\"priority\":%s}"
                 .formatted(annotationId, jsonString(type), jsonString(priority))));
-    return view(annotation, null, threadSize(annotationId));
+    return view(annotation, null, firstComment(annotationId), threadSize(annotationId));
   }
 
   private static String jsonString(String value) {
@@ -258,7 +265,7 @@ public class AnnotationService {
   public AnnotationView get(UUID annotationId, UUID actor, boolean admin) {
     Annotation annotation = requireAnnotation(annotationId);
     documentAccess.getDocument(annotation.getDocumentId(), actor, admin);
-    return view(annotation, null, threadSize(annotationId));
+    return view(annotation, null, firstComment(annotationId), threadSize(annotationId));
   }
 
   /**
@@ -269,7 +276,7 @@ public class AnnotationService {
   public AnnotationView decide(UUID annotationId, boolean accept, UUID actor) {
     AnnotationStatus decision = accept ? AnnotationStatus.ACCEPTED : AnnotationStatus.REJECTED;
     Annotation updated = workflow.decideAnnotation(annotationId, decision, actor);
-    return view(updated, null, threadSize(updated.getId()));
+    return view(updated, null, firstComment(updated.getId()), threadSize(updated.getId()));
   }
 
   /** Appends a comment to an annotation's thread; visible participants only. */
@@ -311,8 +318,32 @@ public class AnnotationService {
         .collect(toMap(AnnotationCommentCount::annotationId, count -> (int) count.count()));
   }
 
+  /** The opening comment's excerpt for one annotation (list uses the batched variant). */
+  private String firstComment(UUID annotationId) {
+    return comments
+        .findFirstByAnnotationIdOrderByCreatedAtAscIdAsc(annotationId)
+        .map(comment -> excerpt(comment.getBody()))
+        .orElse(null);
+  }
+
+  /** Opening-comment excerpts for a batch of annotations in a single query (issue #393). */
+  private Map<UUID, String> firstComments(List<Annotation> forAnnotations) {
+    if (forAnnotations.isEmpty()) {
+      return Map.of();
+    }
+    List<UUID> ids = forAnnotations.stream().map(Annotation::getId).toList();
+    return comments.findFirstByAnnotationIdIn(ids).stream()
+        .collect(toMap(AnnotationFirstComment::getAnnotationId, first -> excerpt(first.getBody())));
+  }
+
+  private static String excerpt(String body) {
+    return body.length() <= FIRST_COMMENT_EXCERPT_CHARS
+        ? body
+        : body.substring(0, FIRST_COMMENT_EXCERPT_CHARS);
+  }
+
   private static AnnotationView view(
-      Annotation annotation, AnnotationPlacement placement, int commentCount) {
+      Annotation annotation, AnnotationPlacement placement, String firstComment, int commentCount) {
     return new AnnotationView(
         annotation.getId(),
         annotation.getDocumentId(),
@@ -322,6 +353,7 @@ public class AnnotationService {
         annotation.getPriority() == null ? null : annotation.getPriority().name(),
         placement == null ? null : placement.getAnchor(),
         placement == null ? null : placement.getStatus().name(),
+        firstComment,
         commentCount,
         annotation.getCreatedAt(),
         annotation.getUpdatedAt());

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -145,7 +145,17 @@ export function ReviewHubHead({
 
   return (
     <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
-      {total > 0 && <ProgressBar decided={decided} total={total} color={theme.qnop.brand.blue} />}
+      {total > 0 && (
+        <ProgressBar
+          decided={decided}
+          total={total}
+          color={theme.palette.success.main}
+          discussion={
+            annotations.filter((a) => a.status === AnnotationStatus.Open && a.commentCount > 1)
+              .length
+          }
+        />
+      )}
 
       {isOwner ? (
         <Tooltip title="Set review due date">

--- a/qnop-ui/src/components/reviews/list/ReviewListParts.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewListParts.tsx
@@ -67,15 +67,21 @@ export function DocumentIcon({ size = 30 }: { size?: number }) {
   );
 }
 
-/** Decided/total bar in the status colour. */
+/**
+ * Decided/total bar in the status colour. `discussion` (issue #393) adds the
+ * prototype's second tone: open-but-discussed annotations trail the decided
+ * segment in amber, so the strip reads "done · in flight · untouched".
+ */
 export function ProgressBar({
   decided,
   total,
   color,
+  discussion = 0,
 }: {
   decided: number;
   total: number;
   color: string;
+  discussion?: number;
 }) {
   const theme = useTheme();
   return (
@@ -87,6 +93,7 @@ export function ProgressBar({
           borderRadius: 99,
           bgcolor: theme.palette.divider,
           overflow: 'hidden',
+          display: 'flex',
         }}
         role="progressbar"
         aria-valuemin={0}
@@ -95,6 +102,15 @@ export function ProgressBar({
         aria-label={`${decided} of ${total} annotations decided`}
       >
         <Box sx={{ width: `${(decided / total) * 100}%`, height: '100%', bgcolor: color }} />
+        {discussion > 0 && (
+          <Box
+            sx={{
+              width: `${(discussion / total) * 100}%`,
+              height: '100%',
+              bgcolor: theme.palette.warning.main,
+            }}
+          />
+        )}
       </Box>
       <Typography
         variant="caption"

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
@@ -72,6 +72,7 @@ function renderBoard({
     <ThemeProvider theme={buildTheme('light')}>
       <TaskBoard
         annotations={ANNOTATIONS}
+        taskKeyOf={() => 'T-1'}
         authorNameOf={() => 'Maxim'}
         mayDecide={mayDecide}
         onOpen={onOpen}

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
@@ -20,6 +20,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView } from '../../../api/generated';
@@ -58,7 +59,15 @@ const ANNOTATIONS = [
   annotation('a-done', { status: AnnotationStatus.Accepted }),
 ];
 
-function renderBoard({ mayDecide = () => true, onAccept = vi.fn(), onOpen = vi.fn() } = {}) {
+function renderBoard({
+  mayDecide = () => true,
+  onAccept = vi.fn<(annotationId: string) => void>(),
+  onOpen = vi.fn<(annotationId: string) => void>(),
+}: {
+  mayDecide?: (annotation: AnnotationView) => boolean;
+  onAccept?: Mock<(annotationId: string) => void>;
+  onOpen?: Mock<(annotationId: string) => void>;
+} = {}) {
   render(
     <ThemeProvider theme={buildTheme('light')}>
       <TaskBoard

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import {
+  AnnotationPriority,
+  AnnotationStatus,
+  AnnotationType,
+  PlacementStatus,
+} from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { TaskBoard } from './TaskBoard';
+import { TASK_DRAG_TYPE } from './TaskCard';
+
+const annotation = (id: string, overrides: Partial<AnnotationView> = {}): AnnotationView => ({
+  id,
+  documentId: 'd1',
+  authorId: 'u1',
+  status: AnnotationStatus.Open,
+  placementStatus: PlacementStatus.Placed,
+  anchor: {
+    region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 } },
+    textQuote: { quote: 'quoted text' },
+  },
+  type: AnnotationType.Conflict,
+  priority: AnnotationPriority.High,
+  firstComment: `first comment of ${id}`,
+  commentCount: 1,
+  createdAt: '2026-07-01T10:00:00Z',
+  updatedAt: '2026-07-01T10:00:00Z',
+  ...overrides,
+});
+
+const ANNOTATIONS = [
+  annotation('a-open'),
+  annotation('a-talk', { commentCount: 3 }),
+  annotation('a-done', { status: AnnotationStatus.Accepted }),
+];
+
+function renderBoard({ mayDecide = () => true, onAccept = vi.fn(), onOpen = vi.fn() } = {}) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <TaskBoard
+        annotations={ANNOTATIONS}
+        authorNameOf={() => 'Maxim'}
+        mayDecide={mayDecide}
+        onOpen={onOpen}
+        onAccept={onAccept}
+      />
+    </ThemeProvider>,
+  );
+  return { onAccept, onOpen };
+}
+
+const dataTransfer = (id: string) => ({
+  types: [TASK_DRAG_TYPE],
+  getData: (key: string) => (key === TASK_DRAG_TYPE ? id : ''),
+  setData: vi.fn(),
+  dropEffect: 'move',
+});
+
+describe('TaskBoard', () => {
+  it('sorts annotations into open, derived discussion and done columns', () => {
+    renderBoard();
+    expect(
+      within(screen.getByTestId('task-column-open')).getByTestId('task-card-a-open'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('task-column-discussion')).getByTestId('task-card-a-talk'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('task-column-done')).getByTestId('task-card-a-done'),
+    ).toBeInTheDocument();
+  });
+
+  it('opens a task on click', () => {
+    const { onOpen } = renderBoard();
+    fireEvent.click(screen.getByTestId('task-card-a-open'));
+    expect(onOpen).toHaveBeenCalledWith('a-open');
+  });
+
+  it('accepts a card dropped on the Done column', () => {
+    const { onAccept } = renderBoard();
+    fireEvent.drop(screen.getByTestId('task-column-done'), {
+      dataTransfer: dataTransfer('a-open'),
+    });
+    expect(onAccept).toHaveBeenCalledWith('a-open');
+  });
+
+  it('only permitted cards are draggable; done cards never are', () => {
+    renderBoard({ mayDecide: (a) => a.id === 'a-open' });
+    expect(screen.getByTestId('task-card-a-open')).toHaveAttribute('draggable', 'true');
+    expect(screen.getByTestId('task-card-a-talk')).toHaveAttribute('draggable', 'false');
+    expect(screen.getByTestId('task-card-a-done')).toHaveAttribute('draggable', 'false');
+  });
+});

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import type { DragEvent } from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { TaskCard, TASK_DRAG_TYPE } from './TaskCard';
+import type { TaskColumn } from './tasksModel';
+import { TASK_COLUMNS, columnOf } from './tasksModel';
+
+const COLUMN_CUES: Record<TaskColumn, { label: string; color: (theme: Theme) => string }> = {
+  open: { label: 'Open', color: (theme) => theme.qnop.brand.blue },
+  discussion: { label: 'In discussion', color: (theme) => theme.palette.warning.main },
+  done: { label: 'Done', color: (theme) => theme.palette.success.main },
+};
+
+interface TaskBoardProps {
+  annotations: AnnotationView[];
+  authorNameOf: (authorId: string) => string;
+  /** Whether the viewer may decide this annotation — gates dragging to Done. */
+  mayDecide: (annotation: AnnotationView) => boolean;
+  onOpen: (annotationId: string) => void;
+  /** Dropping an undecided card on Done accepts it (the drawer offers reject). */
+  onAccept: (annotationId: string) => void;
+}
+
+/**
+ * The kanban presentation (issue #393, prototype `reviewhub.jsx`): three
+ * columns — Open, the derived In discussion, Done — with independently
+ * scrolling card stacks. Done is the only drop target (Open ↔ In discussion
+ * is derived state); the drag-over column shows the prototype's dashed
+ * accent outline. Deciding via the drawer stays the keyboard path.
+ */
+export function TaskBoard({
+  annotations,
+  authorNameOf,
+  mayDecide,
+  onOpen,
+  onAccept,
+}: TaskBoardProps) {
+  const theme = useTheme();
+  const [dropActive, setDropActive] = useState(false);
+
+  const itemsOf = (column: TaskColumn) =>
+    annotations.filter((annotation) => columnOf(annotation) === column);
+
+  const onDragOver = (event: DragEvent) => {
+    if (!event.dataTransfer.types.includes(TASK_DRAG_TYPE)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    setDropActive(true);
+  };
+
+  const onDrop = (event: DragEvent) => {
+    event.preventDefault();
+    setDropActive(false);
+    const annotationId = event.dataTransfer.getData(TASK_DRAG_TYPE);
+    if (annotationId) onAccept(annotationId);
+  };
+
+  return (
+    <Box
+      data-testid="task-board"
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(232px, 1fr))' },
+        gap: 1.75,
+        flex: 1,
+        minHeight: 0,
+        alignItems: 'stretch',
+      }}
+    >
+      {TASK_COLUMNS.map((column) => {
+        const cue = COLUMN_CUES[column];
+        const items = itemsOf(column);
+        const isDone = column === 'done';
+        return (
+          <Stack
+            key={column}
+            data-testid={`task-column-${column}`}
+            onDragOver={isDone ? onDragOver : undefined}
+            onDragLeave={isDone ? () => setDropActive(false) : undefined}
+            onDrop={isDone ? onDrop : undefined}
+            sx={{
+              borderRadius: 0.75,
+              border: '1px solid',
+              borderColor: 'divider',
+              bgcolor: 'background.default',
+              minHeight: 0,
+              overflow: 'hidden',
+              ...(isDone &&
+                dropActive && {
+                  outline: `2px dashed ${theme.qnop.brand.blue}`,
+                  outlineOffset: -2,
+                  bgcolor: alpha(theme.qnop.brand.blue, 0.05),
+                }),
+            }}
+          >
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{
+                alignItems: 'center',
+                px: 1.5,
+                py: 1.25,
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+              }}
+            >
+              <Box
+                sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: cue.color(theme) }}
+                aria-hidden
+              />
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {cue.label}
+              </Typography>
+              <Typography
+                component="span"
+                variant="caption"
+                sx={{
+                  color: 'text.secondary',
+                  bgcolor: 'background.paper',
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 999,
+                  px: 0.75,
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                {items.length}
+              </Typography>
+            </Stack>
+            <Stack spacing={1.25} sx={{ flex: 1, overflowY: 'auto', p: 1.25, minHeight: 96 }}>
+              {items.map((annotation) => (
+                <TaskCard
+                  key={annotation.id}
+                  annotation={annotation}
+                  authorName={authorNameOf(annotation.authorId)}
+                  draggable={!isDone && mayDecide(annotation)}
+                  onOpen={onOpen}
+                />
+              ))}
+              {items.length === 0 && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ textAlign: 'center', py: 3 }}
+                >
+                  {isDone ? 'Drop a card here to accept it' : 'Nothing here'}
+                </Typography>
+              )}
+            </Stack>
+          </Stack>
+        );
+      })}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.tsx
@@ -27,18 +27,28 @@ import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
 import type { AnnotationView } from '../../../api/generated';
+import { ToneBadge } from '../../admin/ToneBadge';
 import { TaskCard, TASK_DRAG_TYPE } from './TaskCard';
 import type { TaskColumn } from './tasksModel';
 import { TASK_COLUMNS, columnOf } from './tasksModel';
 
-const COLUMN_CUES: Record<TaskColumn, { label: string; color: (theme: Theme) => string }> = {
-  open: { label: 'Open', color: (theme) => theme.qnop.brand.blue },
-  discussion: { label: 'In discussion', color: (theme) => theme.palette.warning.main },
-  done: { label: 'Done', color: (theme) => theme.palette.success.main },
+const COLUMN_CUES: Record<
+  TaskColumn,
+  { label: string; tone: 'blue' | 'amber' | 'green'; color: (theme: Theme) => string }
+> = {
+  open: { label: 'Open', tone: 'blue', color: (theme) => theme.qnop.brand.blue },
+  discussion: {
+    label: 'In discussion',
+    tone: 'amber',
+    color: (theme) => theme.palette.warning.main,
+  },
+  done: { label: 'Done', tone: 'green', color: (theme) => theme.palette.success.main },
 };
 
 interface TaskBoardProps {
   annotations: AnnotationView[];
+  /** Tracker-style shorthand per annotation id ("T-3"). */
+  taskKeyOf: (annotationId: string) => string;
   authorNameOf: (authorId: string) => string;
   /** Whether the viewer may decide this annotation — gates dragging to Done. */
   mayDecide: (annotation: AnnotationView) => boolean;
@@ -56,6 +66,7 @@ interface TaskBoardProps {
  */
 export function TaskBoard({
   annotations,
+  taskKeyOf,
   authorNameOf,
   mayDecide,
   onOpen,
@@ -108,8 +119,10 @@ export function TaskBoard({
               borderRadius: 0.75,
               border: '1px solid',
               borderColor: 'divider',
-              bgcolor: 'background.default',
-              minHeight: 0,
+              // The board contrast the trackers share: tinted lanes, white
+              // cards lifted on top; lanes run the full board height.
+              bgcolor: theme.qnop.surface2,
+              minHeight: { xs: 0, md: 480 },
               overflow: 'hidden',
               ...(isDone &&
                 dropActive && {
@@ -124,40 +137,26 @@ export function TaskBoard({
               spacing={1}
               sx={{
                 alignItems: 'center',
-                px: 1.5,
-                py: 1.25,
+                px: 1.25,
+                py: 1.1,
                 borderBottom: '1px solid',
                 borderColor: 'divider',
+                bgcolor: 'background.paper',
               }}
             >
+              <ToneBadge tone={cue.tone} label={`${cue.label} (${items.length})`} />
+              <Box sx={{ flex: 1 }} />
               <Box
                 sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: cue.color(theme) }}
                 aria-hidden
               />
-              <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                {cue.label}
-              </Typography>
-              <Typography
-                component="span"
-                variant="caption"
-                sx={{
-                  color: 'text.secondary',
-                  bgcolor: 'background.paper',
-                  border: '1px solid',
-                  borderColor: 'divider',
-                  borderRadius: 999,
-                  px: 0.75,
-                  fontVariantNumeric: 'tabular-nums',
-                }}
-              >
-                {items.length}
-              </Typography>
             </Stack>
             <Stack spacing={1.25} sx={{ flex: 1, overflowY: 'auto', p: 1.25, minHeight: 96 }}>
               {items.map((annotation) => (
                 <TaskCard
                   key={annotation.id}
                   annotation={annotation}
+                  taskKey={taskKeyOf(annotation.id)}
                   authorName={authorNameOf(annotation.authorId)}
                   draggable={!isDone && mayDecide(annotation)}
                   onOpen={onOpen}

--- a/qnop-ui/src/components/reviews/tasks/TaskCard.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskCard.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { DragEvent } from 'react';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { MessageSquare } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus } from '../../../api/generated';
+import { ToneBadge } from '../../admin/ToneBadge';
+import { UserAvatar } from '../../shell/UserAvatar';
+import { STATUS_CUES } from '../panel/statusCues';
+import { PRIORITY_CUES, TYPE_CUES, taskTitle } from './tasksModel';
+
+/** The DnD payload key the board's drop target reads (issue #393). */
+export const TASK_DRAG_TYPE = 'text/qnop-annotation';
+
+interface TaskCardProps {
+  annotation: AnnotationView;
+  authorName: string;
+  /** True when the viewer may decide — only then the card can be dragged to Done. */
+  draggable: boolean;
+  onOpen: (annotationId: string) => void;
+}
+
+/**
+ * One annotation as a board card (issue #393, prototype `reviewhub.jsx`):
+ * priority dot + type badge + anchor cue on top, the opening comment as the
+ * title, the quoted passage as a secondary line, author and thread size at
+ * the bottom. Shares the annotation cards' 6px radius — one system.
+ */
+export function TaskCard({ annotation, authorName, draggable, onOpen }: TaskCardProps) {
+  const theme = useTheme();
+  const type = annotation.type ? TYPE_CUES[annotation.type] : null;
+  const priority = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
+  const quote = annotation.anchor?.textQuote?.quote;
+  const page = annotation.anchor?.region ? annotation.anchor.region.surfaceIndex + 1 : null;
+  const statusCue = STATUS_CUES[annotation.status];
+  const TypeIcon = type?.icon;
+
+  const onDragStart = (event: DragEvent) => {
+    event.dataTransfer.setData(TASK_DRAG_TYPE, annotation.id);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  return (
+    <ButtonBase
+      onClick={() => onOpen(annotation.id)}
+      draggable={draggable}
+      onDragStart={draggable ? onDragStart : undefined}
+      data-testid={`task-card-${annotation.id}`}
+      sx={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'left',
+        p: 1.5,
+        borderRadius: 0.75,
+        border: '1px solid',
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+        cursor: draggable ? 'grab' : 'pointer',
+        transition: 'box-shadow 140ms ease, border-color 140ms ease, transform 140ms ease',
+        '&:hover': {
+          borderColor: theme.palette.text.disabled,
+          transform: 'translateY(-1px)',
+          boxShadow: `0 8px 22px -10px ${alpha(theme.qnop.brand.navy, 0.25)}`,
+        },
+        '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+        '@media (prefers-reduced-motion: reduce)': { transition: 'none', transform: 'none' },
+      }}
+    >
+      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
+        {priority && (
+          <Tooltip title={`${priority.label} priority`}>
+            <Box
+              sx={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                bgcolor: priority.color(theme),
+                flexShrink: 0,
+              }}
+              data-testid="priority-dot"
+            />
+          </Tooltip>
+        )}
+        {type && TypeIcon && (
+          <Stack
+            direction="row"
+            spacing={0.5}
+            sx={{ alignItems: 'center', color: type.color(theme) }}
+          >
+            <TypeIcon size={12} aria-hidden />
+            <Typography component="span" sx={{ fontSize: 11, fontWeight: 600 }}>
+              {type.label}
+            </Typography>
+          </Stack>
+        )}
+        <Box sx={{ flex: 1 }} />
+        {page !== null && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ fontVariantNumeric: 'tabular-nums' }}
+          >
+            p. {page}
+          </Typography>
+        )}
+      </Stack>
+
+      <Typography
+        variant="body2"
+        sx={{
+          fontWeight: 500,
+          lineHeight: 1.35,
+          mb: quote ? 0.5 : 1,
+          display: '-webkit-box',
+          WebkitLineClamp: 3,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+        }}
+      >
+        {taskTitle(annotation)}
+      </Typography>
+      {quote && (
+        <Typography
+          variant="caption"
+          noWrap
+          sx={{ display: 'block', fontStyle: 'italic', color: 'text.secondary', mb: 1 }}
+        >
+          “{quote}”
+        </Typography>
+      )}
+
+      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+        <UserAvatar name={authorName} size={20} />
+        <Typography variant="caption" color="text.secondary" noWrap sx={{ minWidth: 0 }}>
+          {authorName}
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        {annotation.status !== AnnotationStatus.Open && (
+          <ToneBadge tone={statusCue.tone} label={statusCue.label} />
+        )}
+        <Stack
+          direction="row"
+          spacing={0.5}
+          sx={{ alignItems: 'center', color: 'text.secondary', flexShrink: 0 }}
+        >
+          <MessageSquare size={12} aria-hidden />
+          <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
+            {annotation.commentCount}
+          </Typography>
+        </Stack>
+      </Stack>
+    </ButtonBase>
+  );
+}

--- a/qnop-ui/src/components/reviews/tasks/TaskCard.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskCard.tsx
@@ -31,6 +31,7 @@ import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { UserAvatar } from '../../shell/UserAvatar';
+import { tokens } from '../../../theme/tokens';
 import { STATUS_CUES } from '../panel/statusCues';
 import { PRIORITY_CUES, TYPE_CUES, taskTitle } from './tasksModel';
 
@@ -39,6 +40,8 @@ export const TASK_DRAG_TYPE = 'text/qnop-annotation';
 
 interface TaskCardProps {
   annotation: AnnotationView;
+  /** Tracker-style shorthand ("T-3") — display only, the UUID stays the identity. */
+  taskKey: string;
   authorName: string;
   /** True when the viewer may decide — only then the card can be dragged to Done. */
   draggable: boolean;
@@ -51,7 +54,7 @@ interface TaskCardProps {
  * title, the quoted passage as a secondary line, author and thread size at
  * the bottom. Shares the annotation cards' 6px radius — one system.
  */
-export function TaskCard({ annotation, authorName, draggable, onOpen }: TaskCardProps) {
+export function TaskCard({ annotation, taskKey, authorName, draggable, onOpen }: TaskCardProps) {
   const theme = useTheme();
   const type = annotation.type ? TYPE_CUES[annotation.type] : null;
   const priority = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
@@ -76,9 +79,15 @@ export function TaskCard({ annotation, authorName, draggable, onOpen }: TaskCard
         width: '100%',
         textAlign: 'left',
         p: 1.5,
+        pl: 1.25,
         borderRadius: 0.75,
         border: '1px solid',
         borderColor: 'divider',
+        // The tracker card language (YouTrack/Zoho): a coloured left edge
+        // carrying the priority, a white card lifted off the tinted lane.
+        borderLeft: '3px solid',
+        borderLeftColor: priority ? priority.color(theme) : theme.palette.divider,
+        boxShadow: tokens.shadow.xs,
         bgcolor: 'background.paper',
         cursor: draggable ? 'grab' : 'pointer',
         transition: 'box-shadow 140ms ease, border-color 140ms ease, transform 140ms ease',
@@ -92,20 +101,21 @@ export function TaskCard({ annotation, authorName, draggable, onOpen }: TaskCard
       }}
     >
       <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
-        {priority && (
-          <Tooltip title={`${priority.label} priority`}>
-            <Box
-              sx={{
-                width: 7,
-                height: 7,
-                borderRadius: '50%',
-                bgcolor: priority.color(theme),
-                flexShrink: 0,
-              }}
-              data-testid="priority-dot"
-            />
-          </Tooltip>
-        )}
+        <Tooltip title={priority ? `${priority.label} priority` : 'No priority'}>
+          <Typography
+            component="span"
+            data-testid="task-key"
+            sx={{
+              fontFamily: tokens.font.mono,
+              fontSize: 11,
+              fontWeight: 600,
+              color: 'text.secondary',
+              letterSpacing: '0.02em',
+            }}
+          >
+            {taskKey}
+          </Typography>
+        </Tooltip>
         {type && TypeIcon && (
           <Stack
             direction="row"

--- a/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { ExternalLink, X } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import { useAuthStore } from '../../../stores/authStore';
+import type { Notify } from '../../admin/layout/useToast';
+import { ToneBadge } from '../../admin/ToneBadge';
+import { CommentThread } from '../panel/CommentThread';
+import { DecisionBar } from '../panel/DecisionBar';
+import { mayDecideAnnotation, useDecideWithFeedback } from '../panel/decisions';
+import { PlacementStatusChip } from '../panel/PlacementStatusChip';
+import { STATUS_CUES } from '../panel/statusCues';
+import { PRIORITY_CUES, TYPE_CUES, taskTitle } from './tasksModel';
+
+interface TaskDrawerProps {
+  annotation: AnnotationView | null;
+  authorName: string;
+  ownerId: string;
+  notify: Notify;
+  onClose: () => void;
+  /** Jumps to the review page with this annotation active (deep link). */
+  onShowInDocument: (annotationId: string) => void;
+}
+
+/**
+ * The task's issue-detail drawer (issue #393, prototype `reviewhub.jsx`):
+ * type/priority/anchor header, the opening comment as the title, the full
+ * discussion thread and the decision actions — reusing the panel's
+ * `CommentThread` and `DecisionBar`, so a thread reads and behaves
+ * identically on every surface. Also the keyboard path for deciding (the
+ * board's drag-to-Done is a pointer shortcut).
+ */
+export function TaskDrawer({
+  annotation,
+  authorName,
+  ownerId,
+  notify,
+  onClose,
+  onShowInDocument,
+}: TaskDrawerProps) {
+  const theme = useTheme();
+  const userId = useAuthStore((state) => state.userId);
+  const { decideWith, isPending } = useDecideWithFeedback(notify);
+
+  if (!annotation) return null;
+  const type = annotation.type ? TYPE_CUES[annotation.type] : null;
+  const priority = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
+  const TypeIcon = type?.icon;
+  const statusCue = STATUS_CUES[annotation.status];
+  const page = annotation.anchor?.region ? annotation.anchor.region.surfaceIndex + 1 : null;
+
+  return (
+    <Drawer
+      anchor="right"
+      open
+      onClose={onClose}
+      slotProps={{ paper: { sx: { width: { xs: '100%', sm: 460 } } } }}
+      data-testid="task-drawer"
+    >
+      <Stack sx={{ height: '100%' }}>
+        <Box sx={{ p: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1 }}>
+            {type && TypeIcon && (
+              <Stack
+                direction="row"
+                spacing={0.5}
+                sx={{ alignItems: 'center', color: type.color(theme) }}
+              >
+                <TypeIcon size={13} aria-hidden />
+                <Typography component="span" sx={{ fontSize: 11.5, fontWeight: 600 }}>
+                  {type.label}
+                </Typography>
+              </Stack>
+            )}
+            {priority && (
+              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                <Box
+                  sx={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: '50%',
+                    bgcolor: priority.color(theme),
+                  }}
+                  aria-hidden
+                />
+                <Typography variant="caption" color="text.secondary">
+                  {priority.label}
+                </Typography>
+              </Stack>
+            )}
+            <Box sx={{ flex: 1 }} />
+            <IconButton size="small" onClick={onClose} aria-label="Close task">
+              <X size={16} />
+            </IconButton>
+          </Stack>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+            {taskTitle(annotation)}
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mt: 1, flexWrap: 'wrap' }}>
+            <ToneBadge tone={statusCue.tone} label={statusCue.label} />
+            <PlacementStatusChip status={annotation.placementStatus} />
+            {page !== null && (
+              <Typography variant="caption" color="text.secondary">
+                p. {page}
+              </Typography>
+            )}
+            <Typography variant="caption" color="text.secondary">
+              · opened by {authorName}
+            </Typography>
+          </Stack>
+          {annotation.anchor?.textQuote?.quote && (
+            <Typography
+              variant="body2"
+              sx={{
+                mt: 1.25,
+                fontStyle: 'italic',
+                color: 'text.secondary',
+                borderLeft: '3px solid',
+                borderColor: 'divider',
+                pl: 1.25,
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              “{annotation.anchor.textQuote.quote}”
+            </Typography>
+          )}
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<ExternalLink size={13} />}
+            onClick={() => onShowInDocument(annotation.id)}
+            sx={{ mt: 1 }}
+          >
+            Show in document
+          </Button>
+        </Box>
+
+        <Box sx={{ flex: 1, overflowY: 'auto', px: 2, py: 1 }}>
+          <CommentThread annotationId={annotation.id} notify={notify} />
+        </Box>
+
+        {mayDecideAnnotation(annotation, userId, ownerId) && (
+          <Box sx={{ borderTop: '1px solid', borderColor: 'divider', px: 1, py: 0.5 }}>
+            <DecisionBar
+              disabled={isPending}
+              onDecide={(decision) => decideWith(annotation, decision)}
+            />
+          </Box>
+        )}
+      </Stack>
+    </Drawer>
+  );
+}

--- a/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
@@ -29,6 +29,7 @@ import { useTheme } from '@mui/material/styles';
 import { ExternalLink, X } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { useAuthStore } from '../../../stores/authStore';
+import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { CommentThread } from '../panel/CommentThread';
@@ -40,6 +41,8 @@ import { PRIORITY_CUES, TYPE_CUES, taskTitle } from './tasksModel';
 
 interface TaskDrawerProps {
   annotation: AnnotationView | null;
+  /** Tracker-style shorthand ("T-3") of the open annotation. */
+  taskKey: string;
   authorName: string;
   ownerId: string;
   notify: Notify;
@@ -58,6 +61,7 @@ interface TaskDrawerProps {
  */
 export function TaskDrawer({
   annotation,
+  taskKey,
   authorName,
   ownerId,
   notify,
@@ -86,6 +90,17 @@ export function TaskDrawer({
       <Stack sx={{ height: '100%' }}>
         <Box sx={{ p: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1 }}>
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: tokens.font.mono,
+                fontSize: 12,
+                fontWeight: 600,
+                color: 'text.secondary',
+              }}
+            >
+              {taskKey}
+            </Typography>
             {type && TypeIcon && (
               <Stack
                 direction="row"

--- a/qnop-ui/src/components/reviews/tasks/TaskListRows.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskListRows.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { ChevronRight, MessageSquare } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus } from '../../../api/generated';
+import { ToneBadge } from '../../admin/ToneBadge';
+import { UserAvatar } from '../../shell/UserAvatar';
+import { STATUS_CUES } from '../panel/statusCues';
+import { PRIORITY_CUES, TYPE_CUES, columnOf, taskTitle } from './tasksModel';
+
+interface TaskListRowsProps {
+  annotations: AnnotationView[];
+  authorNameOf: (authorId: string) => string;
+  onOpen: (annotationId: string) => void;
+}
+
+/**
+ * The list presentation (issue #393): the board's cards as dense single rows —
+ * priority dot, type, title with quote/page meta, status badge, author,
+ * chevron — for reviews where scanning beats spatial grouping.
+ */
+export function TaskListRows({ annotations, authorNameOf, onOpen }: TaskListRowsProps) {
+  const theme = useTheme();
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ overflow: 'hidden', maxWidth: 1100, mx: 'auto', width: '100%' }}
+    >
+      {annotations.map((annotation, index) => {
+        const type = annotation.type ? TYPE_CUES[annotation.type] : null;
+        const priority = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
+        const TypeIcon = type?.icon;
+        const statusCue = STATUS_CUES[annotation.status];
+        const column = columnOf(annotation);
+        const page = annotation.anchor?.region ? annotation.anchor.region.surfaceIndex + 1 : null;
+        return (
+          <ButtonBase
+            key={annotation.id}
+            onClick={() => onOpen(annotation.id)}
+            data-testid={`task-row-${annotation.id}`}
+            sx={{
+              display: 'flex',
+              width: '100%',
+              textAlign: 'left',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 2,
+              py: 1.5,
+              borderTop: index ? '1px solid' : 'none',
+              borderColor: 'divider',
+              '&:hover': { bgcolor: 'action.hover' },
+              '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+            }}
+          >
+            <Tooltip title={priority ? `${priority.label} priority` : 'No priority'}>
+              <Box
+                sx={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  bgcolor: priority ? priority.color(theme) : 'transparent',
+                  border: priority ? 'none' : `1px solid ${theme.palette.divider}`,
+                  flexShrink: 0,
+                }}
+              />
+            </Tooltip>
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{
+                alignItems: 'center',
+                width: 92,
+                flexShrink: 0,
+                color: type ? type.color(theme) : 'text.disabled',
+              }}
+            >
+              {TypeIcon && <TypeIcon size={13} aria-hidden />}
+              <Typography component="span" sx={{ fontSize: 11.5, fontWeight: 600 }} noWrap>
+                {type ? type.label : '—'}
+              </Typography>
+            </Stack>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+                {taskTitle(annotation)}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
+                {annotation.anchor?.textQuote?.quote
+                  ? `“${annotation.anchor.textQuote.quote}”`
+                  : 'No text anchor'}
+                {page !== null && ` · p. ${page}`}
+                {` · ${authorNameOf(annotation.authorId)}`}
+              </Typography>
+            </Box>
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{ alignItems: 'center', color: 'text.secondary', flexShrink: 0 }}
+            >
+              <MessageSquare size={12} aria-hidden />
+              <Typography variant="caption">{annotation.commentCount}</Typography>
+            </Stack>
+            <ToneBadge
+              tone={annotation.status === AnnotationStatus.Open ? 'blue' : statusCue.tone}
+              label={
+                annotation.status === AnnotationStatus.Open
+                  ? column === 'discussion'
+                    ? 'In discussion'
+                    : 'Open'
+                  : statusCue.label
+              }
+            />
+            <UserAvatar name={authorNameOf(annotation.authorId)} size={22} />
+            <ChevronRight size={15} aria-hidden color={theme.palette.text.disabled} />
+          </ButtonBase>
+        );
+      })}
+      {annotations.length === 0 && (
+        <Typography variant="body2" color="text.secondary" sx={{ p: 3, textAlign: 'center' }}>
+          No annotations match the current filter.
+        </Typography>
+      )}
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/reviews/tasks/TaskListRows.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskListRows.tsx
@@ -31,11 +31,14 @@ import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { UserAvatar } from '../../shell/UserAvatar';
+import { tokens } from '../../../theme/tokens';
 import { STATUS_CUES } from '../panel/statusCues';
 import { PRIORITY_CUES, TYPE_CUES, columnOf, taskTitle } from './tasksModel';
 
 interface TaskListRowsProps {
   annotations: AnnotationView[];
+  /** Tracker-style shorthand per annotation id ("T-3"). */
+  taskKeyOf: (annotationId: string) => string;
   authorNameOf: (authorId: string) => string;
   onOpen: (annotationId: string) => void;
 }
@@ -45,7 +48,7 @@ interface TaskListRowsProps {
  * priority dot, type, title with quote/page meta, status badge, author,
  * chevron — for reviews where scanning beats spatial grouping.
  */
-export function TaskListRows({ annotations, authorNameOf, onOpen }: TaskListRowsProps) {
+export function TaskListRows({ annotations, taskKeyOf, authorNameOf, onOpen }: TaskListRowsProps) {
   const theme = useTheme();
   return (
     <Paper
@@ -90,6 +93,19 @@ export function TaskListRows({ annotations, authorNameOf, onOpen }: TaskListRows
                 }}
               />
             </Tooltip>
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: tokens.font.mono,
+                fontSize: 11,
+                fontWeight: 600,
+                color: 'text.secondary',
+                width: 34,
+                flexShrink: 0,
+              }}
+            >
+              {taskKeyOf(annotation.id)}
+            </Typography>
             <Stack
               direction="row"
               spacing={0.5}

--- a/qnop-ui/src/components/reviews/tasks/tasksModel.test.ts
+++ b/qnop-ui/src/components/reviews/tasks/tasksModel.test.ts
@@ -22,7 +22,7 @@
 import { describe, expect, it } from 'vitest';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
-import { columnOf, matchesQuery, parseTaskFilter, taskTitle } from './tasksModel';
+import { columnOf, matchesQuery, parseTaskFilter, taskKeys, taskTitle } from './tasksModel';
 
 const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => ({
   id: 'a1',
@@ -75,6 +75,16 @@ describe('taskTitle', () => {
   it('falls back to the quote, then to a generic label', () => {
     expect(taskTitle(annotation({ firstComment: undefined }))).toBe('the disputed clause');
     expect(taskTitle(annotation({ firstComment: '  ', anchor: undefined }))).toBe('Annotation');
+  });
+});
+
+describe('taskKeys', () => {
+  it('assigns stable T-n keys in creation order regardless of input order', () => {
+    const first = annotation({ id: 'b', createdAt: '2026-07-01T09:00:00Z' });
+    const second = annotation({ id: 'a', createdAt: '2026-07-01T10:00:00Z' });
+    const keys = taskKeys([second, first]);
+    expect(keys.get('b')).toBe('T-1');
+    expect(keys.get('a')).toBe('T-2');
   });
 });
 

--- a/qnop-ui/src/components/reviews/tasks/tasksModel.test.ts
+++ b/qnop-ui/src/components/reviews/tasks/tasksModel.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
+import { columnOf, matchesQuery, parseTaskFilter, taskTitle } from './tasksModel';
+
+const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => ({
+  id: 'a1',
+  documentId: 'd1',
+  authorId: 'u1',
+  status: AnnotationStatus.Open,
+  placementStatus: PlacementStatus.Placed,
+  anchor: {
+    region: { surfaceIndex: 2, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 } },
+    textQuote: { quote: 'the disputed clause' },
+  },
+  firstComment: 'Please extend the payment target',
+  commentCount: 1,
+  createdAt: '2026-07-01T10:00:00Z',
+  updatedAt: '2026-07-01T10:00:00Z',
+  ...overrides,
+});
+
+describe('columnOf', () => {
+  it('places a fresh OPEN annotation (only its mandatory first comment) in open', () => {
+    expect(columnOf(annotation())).toBe('open');
+  });
+
+  it('derives "discussion" once the thread grew beyond the first comment', () => {
+    expect(columnOf(annotation({ commentCount: 2 }))).toBe('discussion');
+  });
+
+  it('places decided annotations in done regardless of thread size', () => {
+    expect(columnOf(annotation({ status: AnnotationStatus.Accepted, commentCount: 5 }))).toBe(
+      'done',
+    );
+    expect(columnOf(annotation({ status: AnnotationStatus.Rejected }))).toBe('done');
+  });
+});
+
+describe('parseTaskFilter', () => {
+  it('accepts the known filters and falls back to all', () => {
+    expect(parseTaskFilter('discussion')).toBe('discussion');
+    expect(parseTaskFilter('done')).toBe('done');
+    expect(parseTaskFilter('bogus')).toBe('all');
+    expect(parseTaskFilter(null)).toBe('all');
+  });
+});
+
+describe('taskTitle', () => {
+  it('prefers the opening comment', () => {
+    expect(taskTitle(annotation())).toBe('Please extend the payment target');
+  });
+
+  it('falls back to the quote, then to a generic label', () => {
+    expect(taskTitle(annotation({ firstComment: undefined }))).toBe('the disputed clause');
+    expect(taskTitle(annotation({ firstComment: '  ', anchor: undefined }))).toBe('Annotation');
+  });
+});
+
+describe('matchesQuery', () => {
+  it('searches title, quote and author name case-insensitively', () => {
+    expect(matchesQuery(annotation(), 'Maxim', 'PAYMENT')).toBe(true);
+    expect(matchesQuery(annotation(), 'Maxim', 'disputed')).toBe(true);
+    expect(matchesQuery(annotation(), 'Maxim', 'maxim')).toBe(true);
+    expect(matchesQuery(annotation(), 'Maxim', 'liability')).toBe(false);
+  });
+
+  it('matches everything on a blank query', () => {
+    expect(matchesQuery(annotation(), 'Maxim', '  ')).toBe(true);
+  });
+});

--- a/qnop-ui/src/components/reviews/tasks/tasksModel.ts
+++ b/qnop-ui/src/components/reviews/tasks/tasksModel.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { LucideIcon } from 'lucide-react';
+import { Flag, MessageCircleQuestion, Pencil, Plus, TriangleAlert } from 'lucide-react';
+import type { Theme } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { AnnotationPriority, AnnotationStatus, AnnotationType } from '../../../api/generated';
+
+/**
+ * The board's columns (issue #393, prototype reviewhub): *In discussion* is
+ * DERIVED — an OPEN annotation whose thread grew beyond its mandatory first
+ * comment (#301) is being discussed, exactly like the prototype's auto
+ * promotion on reply. *Done* is any decided annotation.
+ */
+export type TaskColumn = 'open' | 'discussion' | 'done';
+
+export const TASK_COLUMNS: TaskColumn[] = ['open', 'discussion', 'done'];
+
+export function columnOf(annotation: AnnotationView): TaskColumn {
+  if (annotation.status !== AnnotationStatus.Open) return 'done';
+  return annotation.commentCount > 1 ? 'discussion' : 'open';
+}
+
+/** The sub-toolbar's status filter; `all` shows every column. */
+export type TaskFilter = 'all' | TaskColumn;
+
+export function parseTaskFilter(raw: string | null): TaskFilter {
+  return raw === 'open' || raw === 'discussion' || raw === 'done' ? raw : 'all';
+}
+
+/** The card's title: the thread's opening comment; quote/fallback otherwise. */
+export function taskTitle(annotation: AnnotationView): string {
+  return annotation.firstComment?.trim() || annotation.anchor?.textQuote?.quote || 'Annotation';
+}
+
+/**
+ * The free-text search of the sub-toolbar — title, quoted passage and the
+ * resolved author name, mirroring the prototype's task search.
+ */
+export function matchesQuery(
+  annotation: AnnotationView,
+  authorName: string,
+  query: string,
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    taskTitle(annotation).toLowerCase().includes(q) ||
+    (annotation.anchor?.textQuote?.quote ?? '').toLowerCase().includes(q) ||
+    authorName.toLowerCase().includes(q)
+  );
+}
+
+/** Prototype's violet for proposals — no semantic palette slot fits it. */
+const PROPOSAL_VIOLET = '#6B54E5';
+/** Prototype's dark amber for risks — readable on both surfaces. */
+const RISK_AMBER = '#B77F00';
+
+/**
+ * Type → label/icon/colour, the tasks view's visual language (prototype
+ * `typeMeta`). Colours lean on the semantic palette where one fits.
+ */
+export const TYPE_CUES: Record<
+  AnnotationType,
+  { label: string; icon: LucideIcon; color: (theme: Theme) => string }
+> = {
+  [AnnotationType.Change]: {
+    label: 'Change',
+    icon: Pencil,
+    color: (theme) => theme.qnop.brand.blue,
+  },
+  [AnnotationType.Proposal]: {
+    label: 'Proposal',
+    icon: Plus,
+    color: () => PROPOSAL_VIOLET,
+  },
+  [AnnotationType.Conflict]: {
+    label: 'Conflict',
+    icon: TriangleAlert,
+    color: (theme) => theme.palette.error.main,
+  },
+  [AnnotationType.Question]: {
+    label: 'Question',
+    icon: MessageCircleQuestion,
+    color: (theme) => theme.palette.text.secondary,
+  },
+  [AnnotationType.Risk]: {
+    label: 'Risk',
+    icon: Flag,
+    color: () => RISK_AMBER,
+  },
+};
+
+/** Priority → label/colour for the card's leading dot (prototype `prioMeta`). */
+export const PRIORITY_CUES: Record<
+  AnnotationPriority,
+  { label: string; color: (theme: Theme) => string }
+> = {
+  [AnnotationPriority.High]: { label: 'High', color: (theme) => theme.palette.error.main },
+  [AnnotationPriority.Medium]: { label: 'Medium', color: (theme) => theme.palette.warning.main },
+  [AnnotationPriority.Low]: { label: 'Low', color: (theme) => theme.palette.text.disabled },
+};

--- a/qnop-ui/src/components/reviews/tasks/tasksModel.ts
+++ b/qnop-ui/src/components/reviews/tasks/tasksModel.ts
@@ -53,6 +53,18 @@ export function taskTitle(annotation: AnnotationView): string {
 }
 
 /**
+ * Stable per-review shorthand keys (T-1, T-2, …) in creation order — the
+ * tracker-style card id (YouTrack's "CSS-17", Zoho's "MBA-I78"). Purely a
+ * display affordance; the UUID stays the identity.
+ */
+export function taskKeys(annotations: AnnotationView[]): Map<string, string> {
+  const ordered = [...annotations].sort(
+    (a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id),
+  );
+  return new Map(ordered.map((annotation, index) => [annotation.id, `T-${index + 1}`]));
+}
+
+/**
  * The free-text search of the sub-toolbar — title, quoted passage and the
  * resolved author name, mirroring the prototype's task search.
  */

--- a/qnop-ui/src/components/reviews/tasks/useTasksViewMode.ts
+++ b/qnop-ui/src/components/reviews/tasks/useTasksViewMode.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+
+/** The tasks view's two presentations (issue #393). */
+export type TasksViewMode = 'board' | 'list';
+
+const TASKS_VIEW_KEY = 'qnop-tasks-view';
+
+function storedMode(): TasksViewMode {
+  try {
+    return localStorage.getItem(TASKS_VIEW_KEY) === 'list' ? 'list' : 'board';
+  } catch {
+    return 'board';
+  }
+}
+
+/**
+ * The persisted board/list choice (issue #393) — a personal preference like
+ * the other viewer choices, so localStorage rather than the URL. Defaults to
+ * the board.
+ */
+export function useTasksViewMode(): [TasksViewMode, (mode: TasksViewMode) => void] {
+  const [mode, setMode] = useState<TasksViewMode>(storedMode);
+
+  const set = (value: TasksViewMode) => {
+    setMode(value);
+    try {
+      localStorage.setItem(TASKS_VIEW_KEY, value);
+    } catch {
+      // best-effort persistence
+    }
+  };
+
+  return [mode, set];
+}

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -36,6 +36,7 @@ import {
   ChevronDown,
   ChevronUp,
   GitCompareArrows,
+  SquareKanban,
   NotebookPen,
   PanelRight,
   Scan,
@@ -68,6 +69,8 @@ interface ViewerToolbarProps {
   onZoomChange: (zoom: number) => void;
   /** Link to the version comparison (#252); undefined hides the button (fewer than two extracted versions). */
   compareHref?: string;
+  /** Link to the tasks board/list of this review (issue #393). */
+  tasksHref?: string;
   /** The review's presentation (issue #291): side panel, or full-width focus mode. */
   viewMode: ReviewViewMode;
   onViewModeChange: (mode: ReviewViewMode) => void;
@@ -97,6 +100,7 @@ export function ViewerToolbar({
   zoom,
   onZoomChange,
   compareHref,
+  tasksHref,
   viewMode,
   onViewModeChange,
   annotationCount,
@@ -137,6 +141,13 @@ export function ViewerToolbar({
             to={compareHref}
           >
             <GitCompareArrows size={16} />
+          </IconButton>
+        </Tooltip>
+      )}
+      {tasksHref && (
+        <Tooltip title="Tasks board">
+          <IconButton size="small" aria-label="Tasks board" component={RouterLink} to={tasksHref}>
+            <SquareKanban size={16} />
           </IconButton>
         </Tooltip>
       )}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -341,6 +341,16 @@ describe('DocumentReviewPage focus mode', () => {
 
 // Issue #306: mutating review activity is latest-only — older versions read as
 // an archive: banner + jump, annotation tools off, threads read-only.
+describe('DocumentReviewPage deep link', () => {
+  // The tasks view's "Show in document" (issue #393): ?annotation= seeds the
+  // active annotation once and is then consumed from the URL.
+  it('activates the annotation named by ?annotation=', () => {
+    seedHappyPath();
+    renderPage('/reviews/doc-1?annotation=a1');
+    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
 describe('DocumentReviewPage on an older version', () => {
   it('shows the read-only banner with a jump to the latest version', () => {
     seedHappyPath();

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -124,7 +124,17 @@ export function DocumentReviewPage() {
   const [zoom, setZoom] = useState(1);
   const [viewMode, setViewMode] = useViewMode();
   const [listOpen, setListOpen] = useState(false);
-  const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null);
+  // Deep link from the tasks view (issue #393): ?annotation= seeds the active
+  // annotation once; the param is consumed so in-page selection owns the state.
+  const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(() =>
+    searchParams.get('annotation'),
+  );
+  useEffect(() => {
+    if (!searchParams.has('annotation')) return;
+    const next = new URLSearchParams(searchParams);
+    next.delete('annotation');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
   // Card↔mark linking (prototype): hovering either side lights up the other.
   const [hoverAnnotationId, setHoverAnnotationId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
@@ -335,6 +345,7 @@ export function DocumentReviewPage() {
                   ? `/reviews/${documentId}/compare`
                   : undefined
               }
+              tasksHref={`/reviews/${documentId}/tasks`}
               viewMode={viewMode}
               onViewModeChange={(mode) => {
                 setViewMode(mode);

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView } from '../../api/generated';
+import {
+  AnnotationPriority,
+  AnnotationStatus,
+  AnnotationType,
+  PlacementStatus,
+} from '../../api/generated';
+import { useAnnotations } from '../../api/hooks/useAnnotations';
+import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
+import { useParticipants } from '../../api/hooks/useReviews';
+import { buildTheme } from '../../theme/theme';
+import { useAuthStore } from '../../stores/authStore';
+import { ReviewTasksPage } from './ReviewTasksPage';
+
+vi.mock('../../api/hooks/useDocuments', () => ({
+  useDocument: vi.fn(),
+  useDocumentVersions: vi.fn(),
+}));
+vi.mock('../../api/hooks/useAnnotations', () => ({
+  useAnnotations: vi.fn(),
+  useDecideAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('../../api/hooks/useReviews', () => ({
+  useParticipants: vi.fn(),
+}));
+vi.mock('../../api/hooks/useComments', () => ({
+  useComments: vi.fn().mockReturnValue({ isPending: true, isError: false, data: undefined }),
+  useAddComment: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+}));
+
+const annotation = (id: string, overrides: Partial<AnnotationView> = {}): AnnotationView => ({
+  id,
+  documentId: 'd1',
+  authorId: 'author-1',
+  status: AnnotationStatus.Open,
+  placementStatus: PlacementStatus.Placed,
+  anchor: {
+    region: { surfaceIndex: 1, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 } },
+    textQuote: { quote: 'liability clause' },
+  },
+  type: AnnotationType.Conflict,
+  priority: AnnotationPriority.High,
+  firstComment: `Concern ${id}`,
+  commentCount: 1,
+  createdAt: '2026-07-01T10:00:00Z',
+  updatedAt: '2026-07-01T10:00:00Z',
+  ...overrides,
+});
+
+function mockData() {
+  vi.mocked(useDocument).mockReturnValue({
+    isPending: false,
+    isError: false,
+    data: { id: 'd1', title: 'Supply Contract', ownerId: 'owner-1', latestVersionNumber: 2 },
+  } as never);
+  vi.mocked(useDocumentVersions).mockReturnValue({
+    data: { versions: [{ versionNumber: 1 }, { versionNumber: 2 }] },
+  } as never);
+  vi.mocked(useAnnotations).mockReturnValue({
+    isPending: false,
+    data: {
+      annotations: [
+        annotation('a-open'),
+        annotation('a-talk', { commentCount: 4, type: AnnotationType.Question }),
+        annotation('a-done', { status: AnnotationStatus.Accepted }),
+      ],
+    },
+  } as never);
+  vi.mocked(useParticipants).mockReturnValue({
+    data: { participants: [{ principalId: 'author-1', displayName: 'Sabine Weber' }] },
+  } as never);
+}
+
+function renderPage(initialEntry = '/reviews/d1/tasks') {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/reviews/:documentId/tasks" element={<ReviewTasksPage />} />
+          <Route path="/reviews/:documentId" element={<div data-testid="review-page" />} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({ userId: 'owner-1' });
+});
+
+afterEach(() => {
+  useAuthStore.setState({ userId: null });
+  localStorage.removeItem('qnop-tasks-view');
+});
+
+describe('ReviewTasksPage', () => {
+  it('renders the board with derived columns and filter counts', () => {
+    mockData();
+    renderPage();
+
+    expect(
+      within(screen.getByTestId('task-column-open')).getByTestId('task-card-a-open'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('task-column-discussion')).getByTestId('task-card-a-talk'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('task-column-done')).getByTestId('task-card-a-done'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('task-filter-all')).toHaveTextContent('All 3');
+    expect(screen.getByTestId('task-filter-discussion')).toHaveTextContent('In discussion 1');
+  });
+
+  it('filters by status chip and by search', () => {
+    mockData();
+    renderPage('/reviews/d1/tasks?filter=done');
+    expect(screen.queryByTestId('task-card-a-open')).not.toBeInTheDocument();
+    expect(screen.getByTestId('task-card-a-done')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('task-filter-all'));
+    fireEvent.change(screen.getByLabelText('Search tasks'), { target: { value: 'a-talk' } });
+    expect(screen.getByTestId('task-card-a-talk')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-card-a-open')).not.toBeInTheDocument();
+  });
+
+  it('resolves author names through the participants', () => {
+    mockData();
+    renderPage();
+    expect(
+      within(screen.getByTestId('task-card-a-open')).getByText('Sabine Weber'),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the drawer from a card and jumps to the document with the deep link', () => {
+    mockData();
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('task-card-a-open'));
+    const drawer = screen.getByTestId('task-drawer');
+    expect(within(drawer).getByText('Concern a-open')).toBeInTheDocument();
+
+    fireEvent.click(within(drawer).getByRole('button', { name: /Show in document/ }));
+    expect(screen.getByTestId('review-page')).toBeInTheDocument();
+  });
+
+  it('honours the stored list preference', () => {
+    localStorage.setItem('qnop-tasks-view', 'list');
+    mockData();
+    renderPage();
+    expect(screen.getByTestId('task-row-a-open')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-board')).not.toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -111,11 +111,11 @@ function renderPage(initialEntry = '/reviews/d1/tasks') {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useAuthStore.setState({ userId: 'owner-1' });
+  useAuthStore.setState({ userId: 'owner-1', displayName: 'Maxim Owner' });
 });
 
 afterEach(() => {
-  useAuthStore.setState({ userId: null });
+  useAuthStore.setState({ userId: null, displayName: null });
   localStorage.removeItem('qnop-tasks-view');
 });
 
@@ -149,11 +149,19 @@ describe('ReviewTasksPage', () => {
     expect(screen.queryByTestId('task-card-a-open')).not.toBeInTheDocument();
   });
 
-  it('resolves author names through the participants', () => {
+  it('resolves author names through the participants, and self by display name', () => {
     mockData();
+    vi.mocked(useAnnotations).mockReturnValue({
+      isPending: false,
+      data: { annotations: [annotation('a-open'), annotation('a-mine', { authorId: 'owner-1' })] },
+    } as never);
     renderPage();
     expect(
       within(screen.getByTestId('task-card-a-open')).getByText('Sabine Weber'),
+    ).toBeInTheDocument();
+    // The owner is never a participant row — self resolves via the auth store.
+    expect(
+      within(screen.getByTestId('task-card-a-mine')).getByText('Maxim Owner'),
     ).toBeInTheDocument();
   });
 

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import { Link as RouterLink, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import InputAdornment from '@mui/material/InputAdornment';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import { ArrowLeft, LayoutGrid, List as ListIcon, Search } from 'lucide-react';
+import { useAnnotations } from '../../api/hooks/useAnnotations';
+import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
+import { useParticipants } from '../../api/hooks/useReviews';
+import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { useToast } from '../../components/admin/layout/useToast';
+import {
+  mayDecideAnnotation,
+  useDecideWithFeedback,
+} from '../../components/reviews/panel/decisions';
+import { TaskBoard } from '../../components/reviews/tasks/TaskBoard';
+import { TaskDrawer } from '../../components/reviews/tasks/TaskDrawer';
+import { TaskListRows } from '../../components/reviews/tasks/TaskListRows';
+import type { TaskFilter } from '../../components/reviews/tasks/tasksModel';
+import { columnOf, matchesQuery, parseTaskFilter } from '../../components/reviews/tasks/tasksModel';
+import { useTasksViewMode } from '../../components/reviews/tasks/useTasksViewMode';
+import { AnnotationDecision } from '../../api/generated';
+import { useAuthStore } from '../../stores/authStore';
+
+const FILTERS: { key: TaskFilter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'open', label: 'Open' },
+  { key: 'discussion', label: 'In discussion' },
+  { key: 'done', label: 'Done' },
+];
+
+/**
+ * The review's tasks workspace (issue #393, prototype `reviewhub.jsx`):
+ * every annotation as an issue-tracker task on a kanban board or in a dense
+ * list. The status filter and search live in the URL (shareable); the
+ * board/list choice is a persisted personal preference. Dropping a card on
+ * Done accepts it; everything else runs through the task drawer, which reuses
+ * the panel's thread and decision pieces.
+ */
+export function ReviewTasksPage() {
+  const { documentId = '' } = useParams();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { toast, notify, clear } = useToast();
+  const userId = useAuthStore((state) => state.userId);
+
+  const documentQuery = useDocument(documentId);
+  const versionsQuery = useDocumentVersions(documentId);
+  const participantsQuery = useParticipants(documentId);
+
+  const document = documentQuery.data;
+  const latestVersion = Math.max(
+    document?.latestVersionNumber ?? 0,
+    ...(versionsQuery.data?.versions.map((version) => version.versionNumber) ?? [0]),
+  );
+  const annotationsQuery = useAnnotations(
+    documentId,
+    latestVersion >= 1 ? latestVersion : undefined,
+  );
+  const annotations = annotationsQuery.data?.annotations ?? [];
+
+  const [view, setView] = useTasksViewMode();
+  const filter = parseTaskFilter(searchParams.get('filter'));
+  const query = searchParams.get('q') ?? '';
+  const [openTaskId, setOpenTaskId] = useState<string | null>(null);
+
+  const { decideWith } = useDecideWithFeedback(notify);
+
+  const setParam = (key: 'filter' | 'q', value: string | null) => {
+    const next = new URLSearchParams(searchParams);
+    if (value === null || value === '' || value === 'all') {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+    setSearchParams(next, { replace: true });
+  };
+
+  const participants = participantsQuery.data?.participants ?? [];
+  const authorNameOf = (authorId: string) =>
+    participants.find((participant) => participant.principalId === authorId)?.displayName ??
+    'Participant';
+
+  const countOf = (key: TaskFilter) =>
+    key === 'all'
+      ? annotations.length
+      : annotations.filter((annotation) => columnOf(annotation) === key).length;
+
+  const visible = annotations
+    .filter((annotation) => filter === 'all' || columnOf(annotation) === filter)
+    .filter((annotation) => matchesQuery(annotation, authorNameOf(annotation.authorId), query));
+
+  const openTask = annotations.find((annotation) => annotation.id === openTaskId) ?? null;
+
+  const mayDecide = (annotation: (typeof annotations)[number]) =>
+    mayDecideAnnotation(annotation, userId, document?.ownerId ?? null);
+
+  const acceptByDrop = (annotationId: string) => {
+    const annotation = annotations.find((candidate) => candidate.id === annotationId);
+    if (!annotation || !mayDecide(annotation)) return;
+    decideWith(annotation, AnnotationDecision.Accepted);
+  };
+
+  const showInDocument = (annotationId: string) => {
+    void navigate(`/reviews/${documentId}?annotation=${annotationId}`);
+  };
+
+  if (documentQuery.isPending) {
+    return (
+      <Stack sx={{ alignItems: 'center', py: 8 }}>
+        <CircularProgress size={24} />
+      </Stack>
+    );
+  }
+  if (documentQuery.isError || !document) {
+    return (
+      <PageHeader
+        title="This review is not available"
+        titleAdornment={<Chip size="small" variant="outlined" label="Tasks" />}
+      />
+    );
+  }
+
+  return (
+    <Stack spacing={2.5} sx={{ height: { md: '100%' }, minHeight: { md: 480 } }}>
+      <PageHeader
+        title={document.title}
+        titleAdornment={<Chip size="small" variant="outlined" label="Tasks" />}
+        action={
+          <Button
+            component={RouterLink}
+            to={`/reviews/${documentId}`}
+            variant="outlined"
+            size="small"
+            startIcon={<ArrowLeft size={15} />}
+          >
+            Back to review
+          </Button>
+        }
+      />
+
+      {/* sub toolbar: view segment · status filter chips · search */}
+      <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={view}
+          onChange={(_event, next: 'board' | 'list' | null) => next && setView(next)}
+          aria-label="Tasks presentation"
+        >
+          <ToggleButton value="board" aria-label="Board">
+            <LayoutGrid size={14} style={{ marginRight: 6 }} /> Board
+          </ToggleButton>
+          <ToggleButton value="list" aria-label="List">
+            <ListIcon size={14} style={{ marginRight: 6 }} /> List
+          </ToggleButton>
+        </ToggleButtonGroup>
+        <Box sx={{ width: 1, height: 22, bgcolor: 'divider' }} />
+        {FILTERS.map(({ key, label }) => (
+          <Chip
+            key={key}
+            size="small"
+            label={`${label} ${countOf(key)}`}
+            color={filter === key ? 'primary' : 'default'}
+            variant={filter === key ? 'filled' : 'outlined'}
+            onClick={() => setParam('filter', key)}
+            data-testid={`task-filter-${key}`}
+          />
+        ))}
+        <Box sx={{ flex: 1 }} />
+        <TextField
+          size="small"
+          placeholder="Search tasks…"
+          value={query}
+          onChange={(event) => setParam('q', event.target.value)}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={14} />
+                </InputAdornment>
+              ),
+              'aria-label': 'Search tasks',
+            },
+          }}
+          sx={{ width: 220 }}
+        />
+      </Stack>
+
+      {annotationsQuery.isPending ? (
+        <Stack sx={{ alignItems: 'center', py: 6 }}>
+          <CircularProgress size={22} />
+        </Stack>
+      ) : view === 'board' ? (
+        <TaskBoard
+          annotations={visible}
+          authorNameOf={authorNameOf}
+          mayDecide={mayDecide}
+          onOpen={setOpenTaskId}
+          onAccept={acceptByDrop}
+        />
+      ) : (
+        <TaskListRows annotations={visible} authorNameOf={authorNameOf} onOpen={setOpenTaskId} />
+      )}
+
+      <TaskDrawer
+        annotation={openTask}
+        authorName={openTask ? authorNameOf(openTask.authorId) : ''}
+        ownerId={document.ownerId}
+        notify={notify}
+        onClose={() => setOpenTaskId(null)}
+        onShowInDocument={showInDocument}
+      />
+      <AdminToast toast={toast} onClose={clear} />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -45,7 +45,12 @@ import { TaskBoard } from '../../components/reviews/tasks/TaskBoard';
 import { TaskDrawer } from '../../components/reviews/tasks/TaskDrawer';
 import { TaskListRows } from '../../components/reviews/tasks/TaskListRows';
 import type { TaskFilter } from '../../components/reviews/tasks/tasksModel';
-import { columnOf, matchesQuery, parseTaskFilter } from '../../components/reviews/tasks/tasksModel';
+import {
+  columnOf,
+  matchesQuery,
+  parseTaskFilter,
+  taskKeys,
+} from '../../components/reviews/tasks/tasksModel';
 import { useTasksViewMode } from '../../components/reviews/tasks/useTasksViewMode';
 import { AnnotationDecision } from '../../api/generated';
 import { useAuthStore } from '../../stores/authStore';
@@ -125,6 +130,8 @@ export function ReviewTasksPage() {
     .filter((annotation) => matchesQuery(annotation, authorNameOf(annotation.authorId), query));
 
   const openTask = annotations.find((annotation) => annotation.id === openTaskId) ?? null;
+  const keyByAnnotation = taskKeys(annotations);
+  const taskKeyOf = (annotationId: string) => keyByAnnotation.get(annotationId) ?? '';
 
   const mayDecide = (annotation: (typeof annotations)[number]) =>
     mayDecideAnnotation(annotation, userId, document?.ownerId ?? null);
@@ -228,17 +235,24 @@ export function ReviewTasksPage() {
       ) : view === 'board' ? (
         <TaskBoard
           annotations={visible}
+          taskKeyOf={taskKeyOf}
           authorNameOf={authorNameOf}
           mayDecide={mayDecide}
           onOpen={setOpenTaskId}
           onAccept={acceptByDrop}
         />
       ) : (
-        <TaskListRows annotations={visible} authorNameOf={authorNameOf} onOpen={setOpenTaskId} />
+        <TaskListRows
+          annotations={visible}
+          taskKeyOf={taskKeyOf}
+          authorNameOf={authorNameOf}
+          onOpen={setOpenTaskId}
+        />
       )}
 
       <TaskDrawer
         annotation={openTask}
+        taskKey={openTask ? taskKeyOf(openTask.id) : ''}
         authorName={openTask ? authorNameOf(openTask.authorId) : ''}
         ownerId={document.ownerId}
         notify={notify}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -71,6 +71,7 @@ export function ReviewTasksPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { toast, notify, clear } = useToast();
   const userId = useAuthStore((state) => state.userId);
+  const ownDisplayName = useAuthStore((state) => state.displayName);
 
   const documentQuery = useDocument(documentId);
   const versionsQuery = useDocumentVersions(documentId);
@@ -105,9 +106,14 @@ export function ReviewTasksPage() {
   };
 
   const participants = participantsQuery.data?.participants ?? [];
+  // The panel's naming rule: self by display name; reviewers through the
+  // participant directory; the owner stays structural on the document (never
+  // a participant row), so a foreign owner reads as a plain participant.
   const authorNameOf = (authorId: string) =>
-    participants.find((participant) => participant.principalId === authorId)?.displayName ??
-    'Participant';
+    authorId === userId
+      ? (ownDisplayName ?? 'You')
+      : (participants.find((participant) => participant.principalId === authorId)?.displayName ??
+        'Participant');
 
   const countOf = (key: TaskFilter) =>
     key === 'all'

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -25,6 +25,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
 import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
@@ -196,7 +197,7 @@ export function ReviewTasksPage() {
             <ListIcon size={14} style={{ marginRight: 6 }} /> List
           </ToggleButton>
         </ToggleButtonGroup>
-        <Box sx={{ width: 1, height: 22, bgcolor: 'divider' }} />
+        <Divider orientation="vertical" flexItem sx={{ my: 0.5 }} />
         {FILTERS.map(({ key, label }) => (
           <Chip
             key={key}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -63,6 +63,9 @@ const DocumentReviewPage = lazy(() =>
 const VersionComparePage = lazy(() =>
   import('../pages/reviews/VersionComparePage').then((m) => ({ default: m.VersionComparePage })),
 );
+const ReviewTasksPage = lazy(() =>
+  import('../pages/reviews/ReviewTasksPage').then((m) => ({ default: m.ReviewTasksPage })),
+);
 
 /**
  * Central route table. Public routes (login, errors) sit outside the shell;
@@ -103,6 +106,14 @@ export const router = createBrowserRouter([
         element: (
           <LazyBoundary>
             <VersionComparePage />
+          </LazyBoundary>
+        ),
+      },
+      {
+        path: 'reviews/:documentId/tasks',
+        element: (
+          <LazyBoundary>
+            <ReviewTasksPage />
           </LazyBoundary>
         ),
       },


### PR DESCRIPTION
Closes #393 — the tasks view from the design prototype (`docs/qnop-design-prototype/app/reviewhub.jsx`), plan in the [issue comment](https://github.com/qnophq/qnop/issues/393#issuecomment-4882643897). Builds on the #392 classification (PR #396).

## What changed

### Board + list at `/reviews/:documentId/tasks`
Every annotation is a task: a kanban board with **Open / In discussion / Done** columns, or a dense list. **In discussion is derived** — an OPEN annotation whose thread grew beyond its mandatory first comment (#301) — exactly the prototype's auto-promotion on reply, and no status-model change. Cards carry the type badge + priority dot (#392, degrade gracefully without), the anchor cue (page), the opening comment as the title, the quote as a secondary line, author avatar/name (resolved through the participants), thread size and the resolution badge on done cards.

### Drag to Done = accept
Native HTML5 DnD, no new dependency. Only cards the viewer may decide (`mayDecideAnnotation`) are draggable; the only drop target is the Done column, which triggers the existing accept mutation with toast feedback. The drag-over column shows the prototype's dashed accent outline. The **task drawer** (reusing the panel's `CommentThread` + `DecisionBar`) stays the keyboard path and offers reject.

### Backend: `AnnotationView.firstComment`
Cards need a title; threads load per annotation, so the view now carries an excerpt (300 chars) of the opening comment — batched via one Postgres `DISTINCT ON` query exactly like the thread-size aggregation (#313). Covered by a new IT (`carriesTheFirstCommentExcerptEverywhere`).

### Integrations
- Filter chips + search in the URL (shareable); board/list choice persists (`qnop-tasks-view`).
- "Show in document" deep-links back: the review page gains `?annotation=` (seeds the active annotation once, then consumes the param).
- The hub head's progress bar gains the prototype's second tone (in-discussion amber trailing the decided green — `ProgressBar` stays compatible for the overview lists).
- Viewer toolbar links to the board (`SquareKanban`) next to Compare.

## Test plan
- [x] `tasksModel` units: column derivation, filter parsing, title fallback chain, search
- [x] `TaskBoard`: column assignment, open-on-click, drop-on-Done accepts, draggable gating
- [x] `ReviewTasksPage`: board rendering + counts, URL filter + search, author resolution, drawer + deep-link navigation, stored list preference
- [x] `DocumentReviewPage`: `?annotation=` activates the annotation
- [x] `AnnotationApiIT`: firstComment excerpt on create/get/list, replies never displace it
- [x] Gates: `./gradlew build` (Spotless/ArchUnit/ITs), `tsc`, `eslint`, `prettier`, 440 frontend tests
- [x] Manual visual pass — done 2026-07-04 on a doc2 review with three classified annotations (CONFLICT/HIGH, QUESTION/LOW, CHANGE/MEDIUM): board columns incl. the derived *In discussion* after a reply; **drag-to-Done accepted the card live** (toast + Accepted badge + workflow cascade to CHANGES_REQUESTED); drawer with thread + decisions; filter/search survive a reload (URL) and the list preference persists; "Show in document" lands on the review page with the annotation expanded and the param consumed; two-tone progress strip in the hub head; both themes. It caught one bug — every card read 'Participant' because the owner is never a participant row; fixed by resolving self through the auth store (panel's naming rule) with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code

