### PR TITLE
feat: prominent labeled view tabs for Document / Focus / Tasks / Compare

### DIFF
--- a/qnop-ui/src/components/reviews/hub/ReviewViewTabs.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewViewTabs.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import { ReviewViewTabs } from './ReviewViewTabs';
+
+function renderTabs(props: Partial<Parameters<typeof ReviewViewTabs>[0]> = {}) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter>
+        <ReviewViewTabs
+          documentId="d1"
+          active="document"
+          openTaskCount={2}
+          compareEnabled
+          {...props}
+        />
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('ReviewViewTabs', () => {
+  it('links every view and marks the active one', () => {
+    renderTabs({ active: 'tasks' });
+
+    expect(screen.getByTestId('review-view-tab-document')).toHaveAttribute(
+      'href',
+      '/reviews/d1?view=panel',
+    );
+    expect(screen.getByTestId('review-view-tab-focus')).toHaveAttribute(
+      'href',
+      '/reviews/d1?view=focus',
+    );
+    expect(screen.getByTestId('review-view-tab-compare')).toHaveAttribute(
+      'href',
+      '/reviews/d1/compare',
+    );
+    const tasks = screen.getByTestId('review-view-tab-tasks');
+    expect(tasks).toHaveAttribute('href', '/reviews/d1/tasks');
+    expect(tasks).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('review-view-tab-document')).not.toHaveAttribute('aria-current');
+  });
+
+  it('shows the open-task pill only when a count is provided', () => {
+    renderTabs({ openTaskCount: 3 });
+    expect(within(screen.getByTestId('review-view-tab-tasks')).getByText('3')).toBeInTheDocument();
+  });
+
+  it('disables Compare until two versions are extracted', () => {
+    renderTabs({ compareEnabled: false });
+    const compare = screen.getByTestId('review-view-tab-compare');
+    expect(compare).not.toHaveAttribute('href');
+    expect(compare).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/qnop-ui/src/components/reviews/hub/ReviewViewTabs.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewViewTabs.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Link as RouterLink } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import type { LucideIcon } from 'lucide-react';
+import { FileText, Focus, GitCompareArrows, SquareKanban } from 'lucide-react';
+import { tokens } from '../../../theme/tokens';
+
+/** The review's four ways of working (issue #398). */
+export type ReviewView = 'document' | 'focus' | 'tasks' | 'compare';
+
+interface ReviewViewTabsProps {
+  documentId: string;
+  active: ReviewView;
+  /** Open + in-discussion count for the Tasks pill; omit to hide the pill. */
+  openTaskCount?: number;
+  /** Compare needs two extracted versions; disabled (with a tooltip) until then. */
+  compareEnabled: boolean;
+}
+
+const TABS: { view: ReviewView; label: string; icon: LucideIcon; href: (id: string) => string }[] =
+  [
+    {
+      view: 'document',
+      label: 'Document',
+      icon: FileText,
+      href: (id) => `/reviews/${id}?view=panel`,
+    },
+    { view: 'focus', label: 'Focus', icon: Focus, href: (id) => `/reviews/${id}?view=focus` },
+    { view: 'tasks', label: 'Tasks', icon: SquareKanban, href: (id) => `/reviews/${id}/tasks` },
+    {
+      view: 'compare',
+      label: 'Compare',
+      icon: GitCompareArrows,
+      href: (id) => `/reviews/${id}/compare`,
+    },
+  ];
+
+/**
+ * The review's view switcher (issue #398, prototype `rh-tab`): one labeled,
+ * always-visible strip under the hub head on every review page — Document,
+ * Focus, Tasks (with the open-count pill), Compare. Every tab is a plain
+ * link (router tabs, not ARIA tabpanels), so the strip is stateless and
+ * identical everywhere; the active tab carries the prototype's 2px accent
+ * underline. Icon-only navigation was the discoverability problem this
+ * replaces — labels stay at every width.
+ */
+export function ReviewViewTabs({
+  documentId,
+  active,
+  openTaskCount,
+  compareEnabled,
+}: ReviewViewTabsProps) {
+  const theme = useTheme();
+  return (
+    <Box
+      component="nav"
+      aria-label="Review views"
+      sx={{
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        overflowX: 'auto',
+        flexShrink: 0,
+      }}
+    >
+      <Stack direction="row" spacing={2.75} sx={{ px: 0.5 }}>
+        {TABS.map(({ view, label, icon: Icon, href }) => {
+          const isActive = view === active;
+          const isCompareDisabled = view === 'compare' && !compareEnabled;
+          const tab = (
+            <ButtonBase
+              key={view}
+              component={isCompareDisabled ? 'span' : RouterLink}
+              to={isCompareDisabled ? undefined : href(documentId)}
+              disabled={isCompareDisabled}
+              aria-current={isActive ? 'page' : undefined}
+              data-testid={`review-view-tab-${view}`}
+              sx={{
+                position: 'relative',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.75,
+                py: 1.1,
+                px: 0.5,
+                whiteSpace: 'nowrap',
+                fontFamily: 'inherit',
+                fontSize: 14,
+                fontWeight: 500,
+                color: isCompareDisabled
+                  ? 'text.disabled'
+                  : isActive
+                    ? 'text.primary'
+                    : 'text.secondary',
+                transition: 'color 120ms ease',
+                '&:hover': { color: isCompareDisabled ? 'text.disabled' : 'text.primary' },
+                '&:focus-visible': { boxShadow: theme.qnop.focusRing, borderRadius: 0.5 },
+                '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+                // The prototype's rh-tab.on::after — a 2px accent underline
+                // overlapping the strip's divider.
+                '&::after': {
+                  content: '""',
+                  position: 'absolute',
+                  left: 0,
+                  right: 0,
+                  bottom: -1,
+                  height: 2,
+                  borderRadius: 2,
+                  bgcolor: isActive ? theme.qnop.brand.blue : 'transparent',
+                },
+              }}
+            >
+              <Icon size={15} aria-hidden />
+              {label}
+              {view === 'tasks' && openTaskCount !== undefined && (
+                <Typography
+                  component="span"
+                  sx={{
+                    fontSize: 11,
+                    fontWeight: 600,
+                    lineHeight: 1,
+                    px: 0.75,
+                    py: 0.4,
+                    borderRadius: 999,
+                    fontVariantNumeric: 'tabular-nums',
+                    bgcolor:
+                      openTaskCount > 0 ? alpha(theme.qnop.brand.blue, 0.12) : theme.qnop.surface2,
+                    color:
+                      openTaskCount > 0
+                        ? theme.palette.mode === 'dark'
+                          ? tokens.badge.blue.fgDark
+                          : tokens.badge.blue.fg
+                        : 'text.secondary',
+                  }}
+                >
+                  {openTaskCount}
+                </Typography>
+              )}
+            </ButtonBase>
+          );
+          return isCompareDisabled ? (
+            <Tooltip key={view} title="Needs two extracted versions">
+              <span>{tab}</span>
+            </Tooltip>
+          ) : (
+            tab
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/tasks/TaskListRows.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskListRows.tsx
@@ -51,10 +51,7 @@ interface TaskListRowsProps {
 export function TaskListRows({ annotations, taskKeyOf, authorNameOf, onOpen }: TaskListRowsProps) {
   const theme = useTheme();
   return (
-    <Paper
-      variant="outlined"
-      sx={{ overflow: 'hidden', maxWidth: 1100, mx: 'auto', width: '100%' }}
-    >
+    <Paper variant="outlined" sx={{ overflow: 'hidden', width: '100%' }}>
       {annotations.map((annotation, index) => {
         const type = annotation.type ? TYPE_CUES[annotation.type] : null;
         const priority = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -30,22 +30,10 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { Link as RouterLink } from 'react-router-dom';
-import {
-  BoxSelect,
-  ChevronDown,
-  ChevronUp,
-  GitCompareArrows,
-  SquareKanban,
-  NotebookPen,
-  PanelRight,
-  Scan,
-  TextCursor,
-} from 'lucide-react';
+import { BoxSelect, ChevronDown, ChevronUp, NotebookPen, TextCursor } from 'lucide-react';
 import type { DocumentVersionSummary } from '../../../api/generated';
 import { ExtractionStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
-import type { ReviewViewMode } from '../focus/useViewMode';
 import { ZoomControls } from './ZoomControls';
 
 export type ViewerTool = 'text' | 'region';
@@ -67,13 +55,8 @@ interface ViewerToolbarProps {
   canAnnotate: boolean;
   zoom: number;
   onZoomChange: (zoom: number) => void;
-  /** Link to the version comparison (#252); undefined hides the button (fewer than two extracted versions). */
-  compareHref?: string;
-  /** Link to the tasks board/list of this review (issue #393). */
-  tasksHref?: string;
-  /** The review's presentation (issue #291): side panel, or full-width focus mode. */
-  viewMode: ReviewViewMode;
-  onViewModeChange: (mode: ReviewViewMode) => void;
+  /** True in focus mode (issue #291) — shows the annotation drawer's entry point. */
+  focusMode: boolean;
   /** Shown on the list button in focus mode — the drawer's entry point. */
   annotationCount: number;
   onOpenAnnotationList: () => void;
@@ -99,10 +82,7 @@ export function ViewerToolbar({
   canAnnotate,
   zoom,
   onZoomChange,
-  compareHref,
-  tasksHref,
-  viewMode,
-  onViewModeChange,
+  focusMode,
   annotationCount,
   onOpenAnnotationList,
 }: ViewerToolbarProps) {
@@ -132,25 +112,6 @@ export function ViewerToolbar({
           </MenuItem>
         ))}
       </TextField>
-      {compareHref && (
-        <Tooltip title="Compare versions">
-          <IconButton
-            size="small"
-            aria-label="Compare versions"
-            component={RouterLink}
-            to={compareHref}
-          >
-            <GitCompareArrows size={16} />
-          </IconButton>
-        </Tooltip>
-      )}
-      {tasksHref && (
-        <Tooltip title="Tasks board">
-          <IconButton size="small" aria-label="Tasks board" component={RouterLink} to={tasksHref}>
-            <SquareKanban size={16} />
-          </IconButton>
-        </Tooltip>
-      )}
 
       <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center' }}>
         <IconButton
@@ -216,28 +177,7 @@ export function ViewerToolbar({
 
         <ZoomControls zoom={zoom} onZoomChange={onZoomChange} />
 
-        <Divider orientation="vertical" flexItem />
-
-        <ToggleButtonGroup
-          exclusive
-          size="small"
-          value={viewMode}
-          onChange={(_event, next: ReviewViewMode | null) => next && onViewModeChange(next)}
-          aria-label="View mode"
-        >
-          <ToggleButton value="panel" aria-label="Panel view">
-            <Tooltip title="Panel view — the annotation list stays beside the document">
-              <PanelRight size={16} />
-            </Tooltip>
-          </ToggleButton>
-          <ToggleButton value="focus" aria-label="Focus view">
-            <Tooltip title="Focus view — full document width, discussion on demand">
-              <Scan size={16} />
-            </Tooltip>
-          </ToggleButton>
-        </ToggleButtonGroup>
-
-        {viewMode === 'focus' && (
+        {focusMode && (
           <Tooltip title="Show the annotation list">
             <IconButton
               size="small"

--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -42,14 +42,15 @@ const COLLAPSE_KEY = 'qnop-nav-collapsed';
 export function AppShell() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-  // The document review workspace (#250) and the version comparison (#252)
-  // span the full width; every other surface keeps the centred reading
-  // container. /reviews/new also matches the dynamic segment but is a regular
-  // centred page (the wizard, #251).
+  // The document review workspace (#250), the version comparison (#252) and
+  // the tasks board (#393) span the full width; every other surface keeps the
+  // centred reading container. /reviews/new also matches the dynamic segment
+  // but is a regular centred page (the wizard, #251).
   const reviewMatch = useMatch('/reviews/:documentId');
   const compareMatch = useMatch('/reviews/:documentId/compare');
+  const tasksMatch = useMatch('/reviews/:documentId/tasks');
   const fullBleed = Boolean(
-    (reviewMatch && reviewMatch.params.documentId !== 'new') || compareMatch,
+    (reviewMatch && reviewMatch.params.documentId !== 'new') || compareMatch || tasksMatch,
   );
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -327,15 +327,23 @@ describe('DocumentReviewPage focus mode', () => {
     expect(screen.getByText(/Annotations \(/)).toBeInTheDocument();
   });
 
-  it('switches back to panel mode via the toolbar toggle and stores it', () => {
+  it('switches back to panel mode via the Document view tab and stores it', () => {
     localStorage.setItem('qnop-review-view-mode', 'focus');
     seedHappyPath();
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Panel view' }));
+    // The view tabs (issue #398) navigate — ?view=panel syncs into the mode.
+    fireEvent.click(screen.getByTestId('review-view-tab-document'));
 
     expect(screen.getByRole('complementary', { name: 'Annotations' })).toBeInTheDocument();
     expect(localStorage.getItem('qnop-review-view-mode')).toBe('panel');
+  });
+
+  it('activates focus mode through the ?view= deep link', () => {
+    seedHappyPath();
+    renderPage('/reviews/doc-1?view=focus');
+    expect(screen.queryByRole('complementary', { name: 'Annotations' })).not.toBeInTheDocument();
+    expect(localStorage.getItem('qnop-review-view-mode')).toBe('focus');
   });
 });
 

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -47,6 +47,7 @@ import { useToast } from '../../components/admin/layout/useToast';
 import { BoundaryFallback } from '../../components/errors/BoundaryFallback';
 import { ErrorBoundary } from '../../components/errors/ErrorBoundary';
 import { ReviewHubHead } from '../../components/reviews/hub/ReviewHubHead';
+import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
 import { PANEL_MIN_WIDTH, PanelResizer } from '../../components/reviews/PanelResizer';
 import { FocusAnnotationCard } from '../../components/reviews/focus/FocusAnnotationCard';
@@ -58,6 +59,7 @@ import {
 } from '../../components/reviews/focus/spotlightModel';
 import { useAnchorElement } from '../../components/reviews/focus/useAnchorElement';
 import { useViewMode } from '../../components/reviews/focus/useViewMode';
+import { columnOf } from '../../components/reviews/tasks/tasksModel';
 import { Composer } from '../../components/reviews/panel/Composer';
 import { WorkflowBadge } from '../../components/reviews/WorkflowBadge';
 import type {
@@ -123,6 +125,16 @@ export function DocumentReviewPage() {
   const [tool, setTool] = useState<ViewerTool>('text');
   const [zoom, setZoom] = useState(1);
   const [viewMode, setViewMode] = useViewMode();
+  // The view tabs (issue #398) address the mode through the URL — ?view= wins
+  // over (and updates) the stored preference; the param stays shareable.
+  const urlView = searchParams.get('view');
+  useEffect(() => {
+    if (urlView === 'focus' || urlView === 'panel') {
+      setViewMode(urlView === 'panel' ? 'panel' : 'focus');
+    }
+    // setViewMode is a stable setter-like callback; syncing on param change only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlView]);
   const [listOpen, setListOpen] = useState(false);
   // Deep link from the tasks view (issue #393): ?annotation= seeds the active
   // annotation once; the param is consumed so in-page selection owns the state.
@@ -314,6 +326,16 @@ export function DocumentReviewPage() {
           />
         }
       />
+      <ReviewViewTabs
+        documentId={documentId}
+        active={focusMode ? 'focus' : 'document'}
+        openTaskCount={annotations.filter((a) => columnOf(a) !== 'done').length}
+        compareEnabled={
+          (versionsQuery.data?.versions.filter(
+            (version) => version.extractionStatus === ExtractionStatus.Ready,
+          ).length ?? 0) >= 2
+        }
+      />
       {versionNumber === undefined ? (
         <Alert severity="info">This review has no uploaded document version yet.</Alert>
       ) : (
@@ -338,19 +360,7 @@ export function DocumentReviewPage() {
               canAnnotate={canAnnotate}
               zoom={zoom}
               onZoomChange={setZoom}
-              compareHref={
-                (versionsQuery.data?.versions.filter(
-                  (version) => version.extractionStatus === ExtractionStatus.Ready,
-                ).length ?? 0) >= 2
-                  ? `/reviews/${documentId}/compare`
-                  : undefined
-              }
-              tasksHref={`/reviews/${documentId}/tasks`}
-              viewMode={viewMode}
-              onViewModeChange={(mode) => {
-                setViewMode(mode);
-                setListOpen(false);
-              }}
+              focusMode={focusMode}
               annotationCount={annotations.length}
               onOpenAnnotationList={() => setListOpen(true)}
             />

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -20,9 +20,8 @@
  */
 
 import { useState } from 'react';
-import { Link as RouterLink, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Divider from '@mui/material/Divider';
@@ -31,11 +30,12 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import { ArrowLeft, LayoutGrid, List as ListIcon, Search } from 'lucide-react';
+import { LayoutGrid, List as ListIcon, Search } from 'lucide-react';
 import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useParticipants } from '../../api/hooks/useReviews';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
 import {
@@ -53,7 +53,7 @@ import {
   taskKeys,
 } from '../../components/reviews/tasks/tasksModel';
 import { useTasksViewMode } from '../../components/reviews/tasks/useTasksViewMode';
-import { AnnotationDecision } from '../../api/generated';
+import { AnnotationDecision, ExtractionStatus } from '../../api/generated';
 import { useAuthStore } from '../../stores/authStore';
 
 const FILTERS: { key: TaskFilter; label: string }[] = [
@@ -168,16 +168,15 @@ export function ReviewTasksPage() {
       <PageHeader
         title={document.title}
         titleAdornment={<Chip size="small" variant="outlined" label="Tasks" />}
-        action={
-          <Button
-            component={RouterLink}
-            to={`/reviews/${documentId}`}
-            variant="outlined"
-            size="small"
-            startIcon={<ArrowLeft size={15} />}
-          >
-            Back to review
-          </Button>
+      />
+      <ReviewViewTabs
+        documentId={documentId}
+        active="tasks"
+        openTaskCount={annotations.filter((annotation) => columnOf(annotation) !== 'done').length}
+        compareEnabled={
+          (versionsQuery.data?.versions.filter(
+            (version) => version.extractionStatus === ExtractionStatus.Ready,
+          ).length ?? 0) >= 2
         }
       />
 

--- a/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
@@ -46,6 +46,9 @@ vi.mock('../../api/hooks/useDocuments', () => ({
 vi.mock('../../api/hooks/useReviews', () => ({
   useParticipants: vi.fn(),
 }));
+vi.mock('../../api/hooks/useAnnotations', () => ({
+  useAnnotations: vi.fn().mockReturnValue({ data: undefined }),
+}));
 vi.mock('../../api/hooks/useVersionDiff', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   useVersionDiff: vi.fn(),

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -20,29 +20,31 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Link as RouterLink, useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { ArrowLeft, PanelRightOpen } from 'lucide-react';
+import { PanelRightOpen } from 'lucide-react';
 import { ExtractionStatus } from '../../api/generated';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useOriginalPdf } from '../../api/hooks/useDocuments';
 import { useRenderedDocument } from '../../api/hooks/useDocuments';
 import { useParticipants } from '../../api/hooks/useReviews';
+import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useVersionDiff, versionDiffErrorCode } from '../../api/hooks/useVersionDiff';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { ChangeSummaryPanel } from '../../components/reviews/diff/ChangeSummaryPanel';
 import { ComparePane } from '../../components/reviews/diff/ComparePane';
 import { CompareToolbar } from '../../components/reviews/diff/CompareToolbar';
 import { useRailCollapsed } from '../../components/reviews/diff/useRailCollapsed';
 import { useSyncScroll } from '../../components/reviews/diff/useSyncScroll';
+import { columnOf } from '../../components/reviews/tasks/tasksModel';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import { formatDateTime } from '../../utils/formatDate';
 
@@ -91,6 +93,11 @@ export function VersionComparePage() {
   const fromRendered = useRenderedDocument(documentId, from ?? 0, from !== undefined);
   const toRendered = useRenderedDocument(documentId, to ?? 0, to !== undefined);
   const diffQuery = useVersionDiff(documentId, from, to);
+  // The tasks pill on the view tabs (issue #398) — cached alongside the other pages.
+  const annotationsQuery = useAnnotations(documentId, readyNumbers.at(-1));
+  const openTaskCount = (annotationsQuery.data?.annotations ?? []).filter(
+    (annotation) => columnOf(annotation) !== 'done',
+  ).length;
 
   const [activeChange, setActiveChange] = useState<number | null>(null);
   const [syncScroll, setSyncScroll] = useState(true);
@@ -144,24 +151,18 @@ export function VersionComparePage() {
   };
 
   const changes = diffQuery.data?.changes ?? null;
-  const backHref = `/reviews/${documentId}${to !== undefined ? `?version=${to}` : ''}`;
 
   return (
     <Stack spacing={2.5} sx={{ height: { md: '100%' }, minHeight: { md: 480 } }}>
       <PageHeader
         title={document_.title}
         titleAdornment={<Chip size="small" variant="outlined" label="Compare versions" />}
-        action={
-          <Button
-            component={RouterLink}
-            to={backHref}
-            variant="outlined"
-            size="small"
-            startIcon={<ArrowLeft size={15} />}
-          >
-            Back to review
-          </Button>
-        }
+      />
+      <ReviewViewTabs
+        documentId={documentId}
+        active="compare"
+        openTaskCount={openTaskCount}
+        compareEnabled={readyNumbers.length >= 2}
       />
 
       {from === undefined || to === undefined ? (


### PR DESCRIPTION
Closes #398 — the review view switcher from the design prototype (`rh-tab` in `reviewhub.jsx`), plan in the [issue comment](https://github.com/qnophq/qnop/issues/398#issuecomment-4883141322).

## What changed

### One labeled strip, everywhere
`ReviewViewTabs` sits under the hub head on all three review pages: **Document · Focus · Tasks (n) · Compare** — 15px icon + 14px/500 label, the prototype's 2px brand-blue underline on the active tab, a blue open-count pill on Tasks (open + in-discussion), and Compare **disabled with a tooltip** ("Needs two extracted versions") instead of hidden. Labels stay at every width; the strip scrolls horizontally on xs — icon-only controls for primary navigation were the discoverability problem this replaces.

### Tabs are plain links
Router tabs (`<nav>` + `aria-current="page"`), stateless and identical on every page. Document/Focus address the mode through the URL (`?view=panel` / `?view=focus`); the review page syncs the param into the stored `useViewMode` preference (loop-safe, param → mode only) — **the view is now shareable and deep-linkable**, and coexists with `?annotation=`.

### De-duplicated navigation
- The compare icon, tasks icon and the panel/focus icon toggle leave the `ViewerToolbar` — it keeps document tools only (version, pages, tool, zoom; the focus drawer button stays, it belongs to the mode).
- "Back to review" on the tasks and compare pages gives way to the strip — one click to any view from anywhere, no dead ends.
- The compare page loads the annotations for a consistent tasks pill (cached query, shared with the other pages).

## Test plan
- [x] `ReviewViewTabs` component: links + active `aria-current`, count pill, compare disabled state
- [x] Review page: `?view=focus` deep link activates focus mode and persists; the old toolbar-toggle test now runs through the Document tab
- [x] Tasks/compare page tests moved from "Back to review" to the strip; compare test mocks the annotations query
- [x] Gates: `tsc`, `eslint`, `prettier`, 445 frontend tests green
- [x] Visual pass: full round trip Document → Focus → Tasks → Compare via tabs on a real review (active states, pill, cleaned toolbar), both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
