### PR TITLE
feat: unseen markers since the participant's last visit

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1952,6 +1952,37 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /documents/{documentId}/visit:
+    post:
+      tags:
+        - Documents
+      summary: Record a visit of this review
+      description: |
+        Stamps the caller's personal last-visit time (issue #307) and returns
+        the PREVIOUS stamp — the client's baseline for the unseen markers.
+        The session keeps comparing against the returned value, so content
+        being read right now never flips to "seen" mid-session; the fresh
+        stamp takes effect on the next visit. Absent on the first visit.
+      operationId: recordVisit
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/DocumentIdParam'
+      responses:
+        '200':
+          description: The previous visit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VisitResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown document, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /documents/{documentId}/versions:
     get:
       tags:
@@ -4119,6 +4150,14 @@ components:
         - MOVED
         - ORPHANED
         - FAILED
+    VisitResponse:
+      type: object
+      description: The caller's previous visit of the review (issue #307).
+      properties:
+        previousSeenAt:
+          type: string
+          format: date-time
+          description: Absent on the first visit — nothing reads as new then.
     AnnotationType:
       type: string
       description: >-
@@ -4215,6 +4254,13 @@ components:
           description: >-
             Excerpt (first 300 characters) of the thread's opening comment —
             the annotation's de-facto title (issue #393).
+        latestCommentFromOthersAt:
+          type: string
+          format: date-time
+          description: >-
+            Newest comment time by authors other than the caller (issue #307)
+            — compared against the previous visit for the unseen markers.
+            Absent when the thread holds only the caller's own comments.
         commentCount:
           type: integer
           description: Number of comments in the thread.

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -158,6 +158,10 @@ public class AnnotationController implements AnnotationsApi {
                 : PlacementStatus.fromValue(view.placementStatus()))
         .firstComment(view.firstComment())
         .commentCount(view.commentCount())
+        .latestCommentFromOthersAt(
+            view.latestCommentFromOthersAt() == null
+                ? null
+                : view.latestCommentFromOthersAt().atOffset(ZoneOffset.UTC))
         .createdAt(view.createdAt().atOffset(ZoneOffset.UTC))
         .updatedAt(view.updatedAt().atOffset(ZoneOffset.UTC));
   }

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -38,6 +38,7 @@ import io.qnop.api.v1.model.ParticipantListResponse;
 import io.qnop.api.v1.model.ParticipantView;
 import io.qnop.api.v1.model.RenderedDocumentResponse;
 import io.qnop.api.v1.model.VersionDiffResponse;
+import io.qnop.api.v1.model.VisitResponse;
 import io.qnop.service.diff.VersionDiffService;
 import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.document.DocumentAccessService.DocumentVersionView;
@@ -45,6 +46,7 @@ import io.qnop.service.document.DocumentAccessService.DocumentView;
 import io.qnop.service.document.DocumentOverviewService;
 import io.qnop.service.document.DocumentUpdateService;
 import io.qnop.service.document.ReviewParticipantService;
+import io.qnop.service.review.ReviewVisitService;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -68,18 +70,21 @@ public class DocumentsController implements DocumentsApi {
   private final DocumentOverviewService overview;
   private final ReviewParticipantService participants;
   private final DocumentUpdateService updates;
+  private final ReviewVisitService visits;
 
   public DocumentsController(
       DocumentAccessService documents,
       VersionDiffService diffs,
       DocumentOverviewService overview,
       ReviewParticipantService participants,
-      DocumentUpdateService updates) {
+      DocumentUpdateService updates,
+      ReviewVisitService visits) {
     this.documents = documents;
     this.diffs = diffs;
     this.overview = overview;
     this.participants = participants;
     this.updates = updates;
+    this.visits = visits;
   }
 
   @Override
@@ -202,6 +207,15 @@ public class DocumentsController implements DocumentsApi {
     DocumentView view =
         documents.getDocument(documentId, CurrentUser.requireUserId(), CurrentUser.isAdmin());
     return ResponseEntity.ok(toResponse(view));
+  }
+
+  @Override
+  public ResponseEntity<VisitResponse> recordVisit(UUID documentId) {
+    Instant previous =
+        visits.recordVisit(documentId, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.ok(
+        new VisitResponse()
+            .previousSeenAt(previous == null ? null : previous.atOffset(ZoneOffset.UTC)));
   }
 
   @Override

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -327,6 +327,34 @@ class AnnotationApiIT extends SeededIntegrationTest {
         .andExpect(jsonPath("$.annotations[0].firstComment").value("please clarify"));
   }
 
+  @Test
+  void tracksTheLatestCommentFromOthers() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    // The author sees no foreign activity yet; the owner sees the author's opener.
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.latestCommentFromOthersAt").doesNotExist());
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/annotations"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].latestCommentFromOthersAt").exists());
+
+    // After the owner replies, the author sees foreign activity too (issue #307).
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/comments"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"the owner weighs in\"}"))
+        .andExpect(status().isCreated());
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.latestCommentFromOthersAt").exists());
+  }
+
   // --- classification: optional type & priority (issue #392) --------------------------------
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/review/ReviewVisitApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewVisitApiIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Visit stamping for the unseen markers (issue #307): recording a visit returns the PREVIOUS
+ * visit's timestamp and stores the new one atomically — the page compares its whole session against
+ * the returned value, so the fresh stamp only matters on the next visit. Personal per user;
+ * non-participants read as 404 (anti-enumeration).
+ */
+class ReviewVisitApiIT extends SeededIntegrationTest {
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private ReviewParticipantRepository participants;
+
+  private UUID seedDocument() {
+    Document document = documents.save(new Document(MEMBER_ID, "Master services agreement"));
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    return document.getId();
+  }
+
+  private MockHttpServletRequestBuilder visit(UUID documentId, UUID user) {
+    return post("/api/v1/documents/" + documentId + "/visit")
+        .header("Authorization", "Bearer " + token(user));
+  }
+
+  @Test
+  void firstVisitHasNoPreviousStampAndTheSecondReturnsTheFirst() throws Exception {
+    UUID documentId = seedDocument();
+
+    mockMvc
+        .perform(visit(documentId, AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.previousSeenAt").doesNotExist());
+
+    mockMvc
+        .perform(visit(documentId, AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.previousSeenAt").exists());
+  }
+
+  @Test
+  void visitsArePersonal() throws Exception {
+    UUID documentId = seedDocument();
+    mockMvc.perform(visit(documentId, AUDITOR_ID)).andExpect(status().isOk());
+
+    // The owner's first visit is unaffected by the reviewer's stamp.
+    mockMvc
+        .perform(visit(documentId, MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.previousSeenAt").doesNotExist());
+  }
+
+  @Test
+  void nonParticipantSees404() throws Exception {
+    UUID documentId = seedDocument();
+
+    mockMvc.perform(visit(documentId, EXTERNAL_ID)).andExpect(status().isNotFound());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/ReviewVisit.java
+++ b/qnop-core/src/main/java/io/qnop/entity/ReviewVisit.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * A participant's last visit of a review (issue #307): one row per (document, user), stamped when a
+ * review page opens. Powers the unseen markers — everything created after the PREVIOUS visit reads
+ * as new. Personal by design: team members carry their own stamp, never the team principal.
+ */
+@Entity
+@Table(name = "review_visit")
+public class ReviewVisit {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "document_id", nullable = false, updatable = false)
+  private UUID documentId;
+
+  @Column(name = "user_id", nullable = false, updatable = false)
+  private UUID userId;
+
+  @Column(name = "last_seen_at", nullable = false)
+  private Instant lastSeenAt;
+
+  protected ReviewVisit() {
+    // for JPA
+  }
+
+  public ReviewVisit(UUID documentId, UUID userId, Instant lastSeenAt) {
+    this.documentId = documentId;
+    this.userId = userId;
+    this.lastSeenAt = lastSeenAt;
+  }
+
+  /** Moves the stamp forward and returns the previous value (the marker baseline). */
+  public Instant stamp(Instant now) {
+    Instant previous = this.lastSeenAt;
+    this.lastSeenAt = now;
+    return previous;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getDocumentId() {
+    return documentId;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public Instant getLastSeenAt() {
+    return lastSeenAt;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/AnnotationCommentActivity.java
+++ b/qnop-core/src/main/java/io/qnop/repository/AnnotationCommentActivity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * The newest comment time by OTHER authors per annotation (issue #307) — the unseen-marker input,
+ * batched for the annotation list like the thread sizes (#313).
+ */
+public record AnnotationCommentActivity(UUID annotationId, Instant latestAt) {}

--- a/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
@@ -54,6 +54,22 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
   /** The size of an annotation's thread (issue #247). */
   long countByAnnotationId(UUID annotationId);
 
+  /** The newest comment by someone other than {@code viewer} (issue #307), single annotation. */
+  Optional<Comment> findFirstByAnnotationIdAndAuthorIdNotOrderByCreatedAtDesc(
+      UUID annotationId, UUID viewer);
+
+  /**
+   * The newest foreign comment time per annotation in one aggregation (issue #307) — the unseen
+   * marker's input, batched like the thread sizes (#313). Annotations whose thread holds only the
+   * viewer's own comments are absent from the result.
+   */
+  @Query(
+      "SELECT new io.qnop.repository.AnnotationCommentActivity(c.annotationId, MAX(c.createdAt))"
+          + " FROM Comment c WHERE c.annotationId IN :annotationIds AND c.authorId <> :viewer"
+          + " GROUP BY c.annotationId")
+  List<AnnotationCommentActivity> latestForeignActivityByAnnotationIdIn(
+      @Param("annotationIds") Collection<UUID> annotationIds, @Param("viewer") UUID viewer);
+
   /**
    * Thread sizes for a set of annotations in one aggregation (issue #313) — annotations with no
    * comments are simply absent from the result, so the caller defaults them to 0.

--- a/qnop-core/src/main/java/io/qnop/repository/ReviewVisitRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ReviewVisitRepository.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.ReviewVisit;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Data access for the per-user visit stamps (issue #307). */
+public interface ReviewVisitRepository extends JpaRepository<ReviewVisit, UUID> {
+
+  Optional<ReviewVisit> findByDocumentIdAndUserId(UUID documentId, UUID userId);
+
+  /**
+   * Race-free stamp: a concurrent first visit (second tab) simply updates instead of violating the
+   * unique pair — no exception path, both sessions keep a usable baseline.
+   */
+  @Modifying
+  @Query(
+      value =
+          "INSERT INTO review_visit (id, document_id, user_id, last_seen_at)"
+              + " VALUES (:id, :documentId, :userId, :now)"
+              + " ON CONFLICT (document_id, user_id) DO UPDATE SET last_seen_at = EXCLUDED.last_seen_at",
+      nativeQuery = true)
+  void upsert(
+      @Param("id") UUID id,
+      @Param("documentId") UUID documentId,
+      @Param("userId") UUID userId,
+      @Param("now") Instant now);
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -30,6 +30,7 @@ import io.qnop.entity.AnnotationType;
 import io.qnop.entity.AuditEvent;
 import io.qnop.entity.Comment;
 import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.AnnotationCommentActivity;
 import io.qnop.repository.AnnotationCommentCount;
 import io.qnop.repository.AnnotationFirstComment;
 import io.qnop.repository.AnnotationPlacementRepository;
@@ -105,6 +106,7 @@ public class AnnotationService {
       String placementStatus,
       String firstComment,
       int commentCount,
+      Instant latestCommentFromOthersAt,
       Instant createdAt,
       Instant updatedAt) {}
 
@@ -167,7 +169,7 @@ public class AnnotationService {
             AUDIT_ANNOTATION_CREATED,
             author,
             "{\"annotationId\":\"" + annotation.getId() + "\"}"));
-    return view(annotation, placement, excerpt(firstComment), commentCount);
+    return view(annotation, placement, excerpt(firstComment), commentCount, null);
   }
 
   /**
@@ -203,6 +205,7 @@ public class AnnotationService {
                 .collect(toMap(AnnotationPlacement::getAnnotationId, placement -> placement));
     Map<UUID, Integer> threadSizeByAnnotation = threadSizes(documentAnnotations);
     Map<UUID, String> firstCommentByAnnotation = firstComments(documentAnnotations);
+    Map<UUID, Instant> foreignActivityByAnnotation = foreignActivity(documentAnnotations, actor);
     return documentAnnotations.stream()
         .map(
             annotation ->
@@ -210,7 +213,8 @@ public class AnnotationService {
                     annotation,
                     placementByAnnotation.get(annotation.getId()),
                     firstCommentByAnnotation.get(annotation.getId()),
-                    threadSizeByAnnotation.getOrDefault(annotation.getId(), 0)))
+                    threadSizeByAnnotation.getOrDefault(annotation.getId(), 0),
+                    foreignActivityByAnnotation.get(annotation.getId())))
         .filter(view -> placementStatus == null || placementStatus.equals(view.placementStatus()))
         .filter(view -> type == null || type.equals(view.type()))
         .toList();
@@ -244,7 +248,12 @@ public class AnnotationService {
             actor,
             "{\"annotationId\":\"%s\",\"type\":%s,\"priority\":%s}"
                 .formatted(annotationId, jsonString(type), jsonString(priority))));
-    return view(annotation, null, firstComment(annotationId), threadSize(annotationId));
+    return view(
+        annotation,
+        null,
+        firstComment(annotationId),
+        threadSize(annotationId),
+        foreignActivity(annotationId, actor));
   }
 
   private static String jsonString(String value) {
@@ -265,7 +274,12 @@ public class AnnotationService {
   public AnnotationView get(UUID annotationId, UUID actor, boolean admin) {
     Annotation annotation = requireAnnotation(annotationId);
     documentAccess.getDocument(annotation.getDocumentId(), actor, admin);
-    return view(annotation, null, firstComment(annotationId), threadSize(annotationId));
+    return view(
+        annotation,
+        null,
+        firstComment(annotationId),
+        threadSize(annotationId),
+        foreignActivity(annotationId, actor));
   }
 
   /**
@@ -276,7 +290,12 @@ public class AnnotationService {
   public AnnotationView decide(UUID annotationId, boolean accept, UUID actor) {
     AnnotationStatus decision = accept ? AnnotationStatus.ACCEPTED : AnnotationStatus.REJECTED;
     Annotation updated = workflow.decideAnnotation(annotationId, decision, actor);
-    return view(updated, null, firstComment(updated.getId()), threadSize(updated.getId()));
+    return view(
+        updated,
+        null,
+        firstComment(updated.getId()),
+        threadSize(updated.getId()),
+        foreignActivity(updated.getId(), actor));
   }
 
   /** Appends a comment to an annotation's thread; visible participants only. */
@@ -336,6 +355,25 @@ public class AnnotationService {
         .collect(toMap(AnnotationFirstComment::getAnnotationId, first -> excerpt(first.getBody())));
   }
 
+  /** The newest foreign comment time for one annotation (list uses the batched variant). */
+  private Instant foreignActivity(UUID annotationId, UUID viewer) {
+    return comments
+        .findFirstByAnnotationIdAndAuthorIdNotOrderByCreatedAtDesc(annotationId, viewer)
+        .map(Comment::getCreatedAt)
+        .orElse(null);
+  }
+
+  /** Newest foreign comment times for a batch of annotations in a single query (issue #307). */
+  private Map<UUID, Instant> foreignActivity(List<Annotation> forAnnotations, UUID viewer) {
+    if (forAnnotations.isEmpty()) {
+      return Map.of();
+    }
+    List<UUID> ids = forAnnotations.stream().map(Annotation::getId).toList();
+    return comments.latestForeignActivityByAnnotationIdIn(ids, viewer).stream()
+        .collect(
+            toMap(AnnotationCommentActivity::annotationId, AnnotationCommentActivity::latestAt));
+  }
+
   private static String excerpt(String body) {
     return body.length() <= FIRST_COMMENT_EXCERPT_CHARS
         ? body
@@ -343,7 +381,11 @@ public class AnnotationService {
   }
 
   private static AnnotationView view(
-      Annotation annotation, AnnotationPlacement placement, String firstComment, int commentCount) {
+      Annotation annotation,
+      AnnotationPlacement placement,
+      String firstComment,
+      int commentCount,
+      Instant latestCommentFromOthersAt) {
     return new AnnotationView(
         annotation.getId(),
         annotation.getDocumentId(),
@@ -355,6 +397,7 @@ public class AnnotationService {
         placement == null ? null : placement.getStatus().name(),
         firstComment,
         commentCount,
+        latestCommentFromOthersAt,
         annotation.getCreatedAt(),
         annotation.getUpdatedAt());
   }

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewVisitService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewVisitService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.ReviewVisit;
+import io.qnop.repository.ReviewVisitRepository;
+import io.qnop.service.document.DocumentAccessService;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Per-user visit stamps powering the unseen markers (issue #307). Recording a visit returns the
+ * PREVIOUS stamp and stores the new one atomically: the page compares its whole session against the
+ * returned value, so content the user is currently reading never flips to "seen" mid-session.
+ * Visits are personal (team members stamp individually); visibility follows the participant rule —
+ * a non-participant sees the same 404 as for the document itself (anti-enumeration).
+ */
+@Service
+public class ReviewVisitService {
+
+  private final ReviewVisitRepository visits;
+  private final DocumentAccessService documentAccess;
+
+  public ReviewVisitService(ReviewVisitRepository visits, DocumentAccessService documentAccess) {
+    this.visits = visits;
+    this.documentAccess = documentAccess;
+  }
+
+  /** The previous visit, or null on the first — the client's marker baseline. */
+  @Transactional
+  public Instant recordVisit(UUID documentId, UUID actor, boolean admin) {
+    documentAccess.getDocument(documentId, actor, admin); // visibility → 404 if not a participant
+    Instant previous =
+        visits
+            .findByDocumentIdAndUserId(documentId, actor)
+            .map(ReviewVisit::getLastSeenAt)
+            .orElse(null);
+    // Read-then-upsert: a concurrent first visit (second tab, same user) makes both sessions
+    // return null — a marginally generous baseline, never an error.
+    visits.upsert(UUID.randomUUID(), documentId, actor, Instant.now());
+    return previous;
+  }
+}

--- a/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
@@ -468,3 +468,46 @@ databaseChangeLog:
             tableName: audit_event
             columns:
               - column: { name: actor_id }
+
+  - changeSet:
+      id: 0011-review-visit
+      author: qnop
+      comment: Per-user last-visit stamp powering the unseen markers (issue #307).
+      changes:
+        - createTable:
+            tableName: review_visit
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: document_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: last_seen_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+        - addForeignKeyConstraint:
+            constraintName: fk_review_visit_document
+            baseTableName: review_visit
+            baseColumnNames: document_id
+            referencedTableName: document
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: fk_review_visit_user
+            baseTableName: review_visit
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            constraintName: ux_review_visit_pair
+            tableName: review_visit
+            columnNames: document_id, user_id

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useEffect, useRef, useState } from 'react';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   DocumentListResponse,
@@ -244,4 +245,27 @@ export function useUploadVersion(documentId: string) {
       queryClient.invalidateQueries({ queryKey: reviewKeys.all });
     },
   });
+}
+
+/**
+ * Stamps the caller's visit once per page mount and returns the PREVIOUS
+ * visit (issue #307) — the session's unseen-marker baseline. The ref guard
+ * keeps StrictMode's double effect from firing a second stamp, which would
+ * instantly wipe the fresh markers. Best-effort: on failure the markers
+ * simply stay off.
+ */
+export function useRecordVisit(documentId: string): string | null {
+  const [previousSeenAt, setPreviousSeenAt] = useState<string | null>(null);
+  const stampedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!documentId || stampedFor.current === documentId) return;
+    stampedFor.current = documentId;
+    documentsApi.recordVisit({ documentId }).then(
+      (response) => setPreviousSeenAt(response.data.previousSeenAt ?? null),
+      () => undefined,
+    );
+  }, [documentId]);
+
+  return previousSeenAt;
 }

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -56,6 +56,8 @@ interface FocusAnnotationCardProps {
   notify: Notify;
   /** True while an OLDER version is viewed (#306): thread readable, nothing writable. */
   readOnly?: boolean;
+  /** The previous visit (issue #307) — enables the thread's "new" divider. */
+  previousSeenAt?: string | null;
 }
 
 /** True when the key event originates in a text field (arrows must move the caret). */
@@ -83,6 +85,7 @@ export function FocusAnnotationCard({
   userId,
   notify,
   readOnly = false,
+  previousSeenAt = null,
 }: FocusAnnotationCardProps) {
   const theme = useTheme();
   const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
@@ -291,7 +294,12 @@ export function FocusAnnotationCard({
                 )}
 
                 <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0, px: 0.5, pb: 0.5 }}>
-                  <CommentThread annotationId={annotation.id} notify={notify} readOnly={readOnly} />
+                  <CommentThread
+                    annotationId={annotation.id}
+                    notify={notify}
+                    readOnly={readOnly}
+                    previousSeenAt={previousSeenAt}
+                  />
                 </Box>
                 {/* Discoverability for the native resize grip underneath. */}
                 <Box

--- a/qnop-ui/src/components/reviews/newSince.test.ts
+++ b/qnop-ui/src/components/reviews/newSince.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AnnotationView, CommentView } from '../../api/generated';
+import { AnnotationStatus, PlacementStatus } from '../../api/generated';
+import { hasNewComments, isNewAnnotation, isNewComment, isUnseen } from './newSince';
+
+const SEEN = '2026-07-04T12:00:00Z';
+
+const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => ({
+  id: 'a1',
+  documentId: 'd1',
+  authorId: 'other',
+  status: AnnotationStatus.Open,
+  placementStatus: PlacementStatus.Placed,
+  commentCount: 1,
+  createdAt: '2026-07-04T13:00:00Z',
+  updatedAt: '2026-07-04T13:00:00Z',
+  ...overrides,
+});
+
+const comment = (overrides: Partial<CommentView> = {}): CommentView => ({
+  id: 'c1',
+  annotationId: 'a1',
+  authorId: 'other',
+  body: 'hello',
+  createdAt: '2026-07-04T13:00:00Z',
+  ...overrides,
+});
+
+describe('isNewAnnotation', () => {
+  it('marks a foreign annotation created after the previous visit', () => {
+    expect(isNewAnnotation(annotation(), SEEN, 'me')).toBe(true);
+    expect(isNewAnnotation(annotation({ createdAt: '2026-07-04T11:00:00Z' }), SEEN, 'me')).toBe(
+      false,
+    );
+  });
+
+  it('never marks own annotations or first visits', () => {
+    expect(isNewAnnotation(annotation({ authorId: 'me' }), SEEN, 'me')).toBe(false);
+    expect(isNewAnnotation(annotation(), null, 'me')).toBe(false);
+  });
+});
+
+describe('hasNewComments', () => {
+  it('relies on the foreign-activity timestamp', () => {
+    expect(
+      hasNewComments(annotation({ latestCommentFromOthersAt: '2026-07-04T13:00:00Z' }), SEEN),
+    ).toBe(true);
+    expect(
+      hasNewComments(annotation({ latestCommentFromOthersAt: '2026-07-04T11:00:00Z' }), SEEN),
+    ).toBe(false);
+    expect(hasNewComments(annotation(), SEEN)).toBe(false);
+    expect(
+      hasNewComments(annotation({ latestCommentFromOthersAt: '2026-07-04T13:00:00Z' }), null),
+    ).toBe(false);
+  });
+});
+
+describe('isNewComment', () => {
+  it('marks foreign comments after the previous visit, never own ones', () => {
+    expect(isNewComment(comment(), SEEN, 'me')).toBe(true);
+    expect(isNewComment(comment({ authorId: 'me' }), SEEN, 'me')).toBe(false);
+    expect(isNewComment(comment({ createdAt: '2026-07-04T11:00:00Z' }), SEEN, 'me')).toBe(false);
+    expect(isNewComment(comment(), null, 'me')).toBe(false);
+  });
+});
+
+describe('isUnseen', () => {
+  it('combines new annotations and new foreign comments', () => {
+    expect(isUnseen(annotation(), SEEN, 'me')).toBe(true);
+    expect(
+      isUnseen(
+        annotation({
+          createdAt: '2026-07-04T11:00:00Z',
+          latestCommentFromOthersAt: '2026-07-04T13:00:00Z',
+        }),
+        SEEN,
+        'me',
+      ),
+    ).toBe(true);
+    expect(isUnseen(annotation({ createdAt: '2026-07-04T11:00:00Z' }), SEEN, 'me')).toBe(false);
+  });
+});

--- a/qnop-ui/src/components/reviews/newSince.ts
+++ b/qnop-ui/src/components/reviews/newSince.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { AnnotationView, CommentView } from '../../api/generated';
+
+/**
+ * The unseen rules (issue #307), shared by the panel, the focus card and the
+ * task board. `previousSeenAt` is the PREVIOUS visit returned by the visit
+ * stamp — null on the first visit, when nothing may read as new.
+ */
+
+/** Timestamp comparison over epoch millis — ISO offset spellings vary (Z vs +00:00). */
+function isAfter(instant: string, baseline: string): boolean {
+  return new Date(instant).getTime() > new Date(baseline).getTime();
+}
+
+/** A foreign annotation created after the previous visit. */
+export function isNewAnnotation(
+  annotation: AnnotationView,
+  previousSeenAt: string | null,
+  userId: string | null,
+): boolean {
+  if (!previousSeenAt || annotation.authorId === userId) return false;
+  return isAfter(annotation.createdAt, previousSeenAt);
+}
+
+/**
+ * Foreign comments arrived after the previous visit. Relies on the server's
+ * `latestCommentFromOthersAt` (newest comment by someone else), so the check
+ * works from the list without loading threads.
+ */
+export function hasNewComments(annotation: AnnotationView, previousSeenAt: string | null): boolean {
+  if (!previousSeenAt || !annotation.latestCommentFromOthersAt) return false;
+  return isAfter(annotation.latestCommentFromOthersAt, previousSeenAt);
+}
+
+/** A foreign comment inside an opened thread that arrived after the previous visit. */
+export function isNewComment(
+  comment: CommentView,
+  previousSeenAt: string | null,
+  userId: string | null,
+): boolean {
+  if (!previousSeenAt || comment.authorId === userId) return false;
+  return isAfter(comment.createdAt, previousSeenAt);
+}
+
+/** Anything unseen on this annotation — the card-level cue. */
+export function isUnseen(
+  annotation: AnnotationView,
+  previousSeenAt: string | null,
+  userId: string | null,
+): boolean {
+  return (
+    isNewAnnotation(annotation, previousSeenAt, userId) ||
+    hasNewComments(annotation, previousSeenAt)
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -32,6 +32,7 @@ import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { UserAvatar } from '../../shell/UserAvatar';
+import { hasNewComments, isUnseen } from '../newSince';
 import { highlightColorFor } from '../viewer/markerColors';
 import { PlacementStatusChip } from './PlacementStatusChip';
 import { STATUS_CUES } from './statusCues';
@@ -87,6 +88,8 @@ function ParticipantAvatars({ ids }: { ids: string[] }) {
 interface AnnotationListItemProps {
   annotation: AnnotationView;
   active: boolean;
+  /** The previous visit (issue #307) — null hides every unseen cue. */
+  previousSeenAt?: string | null;
   /** True while the mark on the page is hovered — mirrors the link visually. */
   linked?: boolean;
   /**
@@ -113,11 +116,15 @@ interface AnnotationListItemProps {
 function AnnotationListItemBase({
   annotation,
   active,
+  previousSeenAt = null,
   linked = false,
   onSelect,
   onHover,
 }: AnnotationListItemProps) {
   const theme = useTheme();
+  const viewerId = useAuthStore((state) => state.userId);
+  const unseen = isUnseen(annotation, previousSeenAt, viewerId);
+  const freshComments = hasNewComments(annotation, previousSeenAt);
   const quote = annotation.anchor?.textQuote?.quote;
   const region = annotation.anchor?.region;
   const statusCue = STATUS_CUES[annotation.status];
@@ -211,6 +218,7 @@ function AnnotationListItemBase({
         <Stack spacing={0.75}>
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
             <ToneBadge tone={statusCue.tone} label={statusCue.label} />
+            {unseen && <ToneBadge tone="blue" label="New" />}
             <PlacementStatusChip status={annotation.placementStatus} />
             <Stack
               direction="row"
@@ -253,6 +261,20 @@ function AnnotationListItemBase({
               <StatusIcon size={15} aria-label={statusCue.label} />
             </Box>
           </Tooltip>
+          {unseen && (
+            <Tooltip title="New since your last visit">
+              <Box
+                data-testid="unseen-dot"
+                sx={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: '50%',
+                  bgcolor: theme.qnop.brand.blue,
+                  flexShrink: 0,
+                }}
+              />
+            </Tooltip>
+          )}
           <Typography
             variant="body2"
             noWrap
@@ -268,7 +290,13 @@ function AnnotationListItemBase({
           <Stack
             direction="row"
             spacing={0.5}
-            sx={{ alignItems: 'center', color: 'text.secondary', flexShrink: 0 }}
+            data-testid="comment-count"
+            sx={{
+              alignItems: 'center',
+              color: freshComments ? theme.qnop.brand.blue : 'text.secondary',
+              fontWeight: freshComments ? 600 : undefined,
+              flexShrink: 0,
+            }}
           >
             <MessageSquare size={13} aria-hidden />
             <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -87,6 +87,34 @@ function renderPanel(props: Partial<Parameters<typeof AnnotationPanel>[0]> = {})
 }
 
 describe('AnnotationPanel', () => {
+  it('marks unseen foreign activity and counts it in the section header', () => {
+    useAuthStore.setState({ userId: 'me' });
+    renderPanel({
+      previousSeenAt: '2026-07-02T00:00:00Z',
+      annotations: [
+        // Foreign and new → dot; own and new → no dot; old with a fresh foreign reply → dot.
+        annotation('a-new', { authorId: 'other', createdAt: '2026-07-03T10:00:00Z' }),
+        annotation('a-mine', { authorId: 'me', createdAt: '2026-07-03T10:00:00Z' }),
+        annotation('a-replied', {
+          authorId: 'me',
+          createdAt: '2026-07-01T10:00:00Z',
+          latestCommentFromOthersAt: '2026-07-03T12:00:00Z',
+        }),
+      ],
+    });
+
+    expect(
+      within(screen.getByTestId('annotation-item-a-new')).getByTestId('unseen-dot'),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('annotation-item-a-mine')).queryByTestId('unseen-dot'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('annotation-item-a-replied')).getByTestId('unseen-dot'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('section-new-count')).toHaveTextContent('2 new');
+  });
+
   it('shows the empty state with the how-to hint when annotating is possible', () => {
     renderPanel();
     expect(

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -35,6 +35,7 @@ import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
 import { compareAnnotationsByPosition } from '../viewer/anchoring';
+import { isUnseen } from '../newSince';
 import { AnnotationListItem } from './AnnotationListItem';
 import { CommentThread } from './CommentThread';
 import { Composer } from './Composer';
@@ -66,6 +67,8 @@ interface AnnotationPanelProps {
   notify: Notify;
   /** True while an OLDER version is viewed (#306): threads readable, nothing writable. */
   readOnly?: boolean;
+  /** The previous visit (issue #307) — null hides every unseen cue. */
+  previousSeenAt?: string | null;
 }
 
 /** A collapsible, counted group of annotation cards (prototype sidebar section). */
@@ -74,6 +77,7 @@ function PanelSection({
   subtitle,
   icon,
   count,
+  newCount = 0,
   defaultOpen = true,
   children,
 }: {
@@ -81,6 +85,8 @@ function PanelSection({
   subtitle?: string;
   icon: ReactNode;
   count: number;
+  /** Unseen entries in this group (issue #307) — rendered as "· n new". */
+  newCount?: number;
   defaultOpen?: boolean;
   children: ReactNode;
 }) {
@@ -151,6 +157,15 @@ function PanelSection({
         >
           {count}
         </Typography>
+        {newCount > 0 && (
+          <Typography
+            variant="caption"
+            data-testid="section-new-count"
+            sx={{ color: theme.qnop.brand.blue, fontWeight: 600, flexShrink: 0 }}
+          >
+            · {newCount} new
+          </Typography>
+        )}
       </ButtonBase>
       <Collapse in={open} unmountOnExit>
         <Stack spacing={1.5} sx={{ pt: 1 }}>
@@ -183,6 +198,7 @@ export function AnnotationPanel({
   ownerId,
   notify,
   readOnly = false,
+  previousSeenAt = null,
 }: AnnotationPanelProps) {
   const [filter, setFilter] = useState<StatusFilter>('all');
   const userId = useAuthStore((state) => state.userId);
@@ -214,6 +230,7 @@ export function AnnotationPanel({
         <AnnotationListItem
           annotation={annotation}
           active={active}
+          previousSeenAt={previousSeenAt}
           linked={annotation.id === hoverAnnotationId}
           onSelect={onSelect}
           onHover={onHover}
@@ -225,7 +242,12 @@ export function AnnotationPanel({
               onDecide={(decision) => decideWith(annotation, decision)}
             />
           )}
-          <CommentThread annotationId={annotation.id} notify={notify} readOnly={readOnly} />
+          <CommentThread
+            annotationId={annotation.id}
+            notify={notify}
+            readOnly={readOnly}
+            previousSeenAt={previousSeenAt}
+          />
         </Collapse>
       </Stack>
     );
@@ -278,6 +300,7 @@ export function AnnotationPanel({
             subtitle="Anchored to the document"
             icon={<Link2 size={13} aria-hidden />}
             count={placed.length}
+            newCount={placed.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
           >
             {placed.map(renderItem)}
           </PanelSection>
@@ -288,6 +311,7 @@ export function AnnotationPanel({
             subtitle="Anchor lost — needs manual handling"
             icon={<Unlink size={13} aria-hidden />}
             count={unplaced.length}
+            newCount={unplaced.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
           >
             {unplaced.map(renderItem)}
           </PanelSection>

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -34,10 +34,15 @@ vi.mock('../../../api/hooks/useComments', () => ({
 
 const addMutate = vi.fn();
 
-function renderThread(readOnly = false) {
+function renderThread(readOnly = false, previousSeenAt: string | null = null) {
   return render(
     <ThemeProvider theme={buildTheme('light')}>
-      <CommentThread annotationId="a1" notify={vi.fn()} readOnly={readOnly} />
+      <CommentThread
+        annotationId="a1"
+        notify={vi.fn()}
+        readOnly={readOnly}
+        previousSeenAt={previousSeenAt}
+      />
     </ThemeProvider>,
   );
 }
@@ -52,6 +57,66 @@ beforeEach(() => {
 });
 
 describe('CommentThread', () => {
+  it('separates foreign comments newer than the previous visit with a divider', () => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        comments: [
+          {
+            id: 'c1',
+            annotationId: 'a1',
+            authorId: 'other',
+            body: 'Old',
+            createdAt: '2026-07-01T10:00:00Z',
+          },
+          {
+            id: 'c2',
+            annotationId: 'a1',
+            authorId: 'me',
+            body: 'Mine, new',
+            createdAt: '2026-07-03T10:00:00Z',
+          },
+          {
+            id: 'c3',
+            annotationId: 'a1',
+            authorId: 'other',
+            body: 'Theirs, new',
+            createdAt: '2026-07-04T10:00:00Z',
+          },
+        ],
+      },
+    } as unknown as ReturnType<typeof useComments>);
+
+    renderThread(false, '2026-07-02T00:00:00Z');
+
+    // Exactly one divider, sitting before the first NEW FOREIGN comment —
+    // the user's own newer reply never triggers it (issue #307).
+    expect(screen.getAllByTestId('new-since-divider')).toHaveLength(1);
+    expect(screen.getByText('New since your last visit')).toBeInTheDocument();
+  });
+
+  it('shows no divider on a first visit', () => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        comments: [
+          {
+            id: 'c1',
+            annotationId: 'a1',
+            authorId: 'other',
+            body: 'Hi',
+            createdAt: '2026-07-04T10:00:00Z',
+          },
+        ],
+      },
+    } as unknown as ReturnType<typeof useComments>);
+
+    renderThread(false, null);
+    expect(screen.queryByTestId('new-since-divider')).not.toBeInTheDocument();
+  });
+
   it('renders the thread with authorship relative to the signed-in user', () => {
     vi.mocked(useComments).mockReturnValue({
       isPending: false,

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
@@ -27,12 +27,13 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/material/styles';
+import { alpha, useTheme } from '@mui/material/styles';
 import { SendHorizontal } from 'lucide-react';
 import { useAddComment, useComments } from '../../../api/hooks/useComments';
 import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
+import { isNewComment } from '../newSince';
 import { UserAvatar } from '../../shell/UserAvatar';
 
 const AVATAR_SIZE = 26;
@@ -44,6 +45,8 @@ interface CommentThreadProps {
   notify: Notify;
   /** Hides the reply composer — older versions are a read-only record (#306). */
   readOnly?: boolean;
+  /** The previous visit (issue #307) — enables the "new" divider inside the thread. */
+  previousSeenAt?: string | null;
 }
 
 const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
@@ -59,7 +62,12 @@ const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
  * of the annotation API yet, so authorship is shown relative to the signed-in
  * user.
  */
-export function CommentThread({ annotationId, notify, readOnly = false }: CommentThreadProps) {
+export function CommentThread({
+  annotationId,
+  notify,
+  readOnly = false,
+  previousSeenAt = null,
+}: CommentThreadProps) {
   const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
   const displayName = useAuthStore((state) => state.displayName);
@@ -78,6 +86,9 @@ export function CommentThread({ annotationId, notify, readOnly = false }: Commen
   };
 
   const comments = commentsQuery.data?.comments ?? [];
+  const firstNewCommentId = comments.find((comment) =>
+    isNewComment(comment, previousSeenAt, userId),
+  )?.id;
 
   return (
     <Box sx={{ position: 'relative', mt: 0.5, ml: 1.5, pl: 0 }}>
@@ -109,36 +120,59 @@ export function CommentThread({ annotationId, notify, readOnly = false }: Commen
           const own = comment.authorId === userId;
           const name = own ? (displayName ?? 'You') : 'Participant';
           return (
-            <Stack key={comment.id} direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
-              <Box sx={{ position: 'relative', zIndex: 1, pt: 0.25 }}>
-                <UserAvatar name={name} size={AVATAR_SIZE} imageUrl={own ? avatarUrl : null} />
-              </Box>
-              <Box
-                sx={{
-                  flex: 1,
-                  minWidth: 0,
-                  bgcolor: theme.qnop.surface2,
-                  borderRadius: '3px 8px 8px 8px',
-                  px: 1.25,
-                  py: 0.75,
-                }}
-              >
-                <Stack direction="row" spacing={1} sx={{ alignItems: 'baseline' }}>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    {own ? 'You' : name}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {TIME_FORMAT.format(new Date(comment.createdAt))}
-                  </Typography>
-                </Stack>
-                <Typography
-                  variant="body2"
-                  sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', mt: 0.25 }}
+            <Fragment key={comment.id}>
+              {comment.id === firstNewCommentId && (
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  data-testid="new-since-divider"
+                  sx={{ alignItems: 'center', pl: 4.5 }}
                 >
-                  {comment.body}
-                </Typography>
-              </Box>
-            </Stack>
+                  <Box
+                    sx={{ flex: 1, height: '1px', bgcolor: alpha(theme.qnop.brand.blue, 0.4) }}
+                  />
+                  <Typography
+                    variant="caption"
+                    sx={{ color: theme.qnop.brand.blue, fontWeight: 600, whiteSpace: 'nowrap' }}
+                  >
+                    New since your last visit
+                  </Typography>
+                  <Box
+                    sx={{ flex: 1, height: '1px', bgcolor: alpha(theme.qnop.brand.blue, 0.4) }}
+                  />
+                </Stack>
+              )}
+              <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+                <Box sx={{ position: 'relative', zIndex: 1, pt: 0.25 }}>
+                  <UserAvatar name={name} size={AVATAR_SIZE} imageUrl={own ? avatarUrl : null} />
+                </Box>
+                <Box
+                  sx={{
+                    flex: 1,
+                    minWidth: 0,
+                    bgcolor: theme.qnop.surface2,
+                    borderRadius: '3px 8px 8px 8px',
+                    px: 1.25,
+                    py: 0.75,
+                  }}
+                >
+                  <Stack direction="row" spacing={1} sx={{ alignItems: 'baseline' }}>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {own ? 'You' : name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {TIME_FORMAT.format(new Date(comment.createdAt))}
+                    </Typography>
+                  </Stack>
+                  <Typography
+                    variant="body2"
+                    sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', mt: 0.25 }}
+                  >
+                    {comment.body}
+                  </Typography>
+                </Box>
+              </Stack>
+            </Fragment>
           );
         })}
         {!commentsQuery.isPending && !commentsQuery.isError && comments.length === 0 && (

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
@@ -118,6 +118,25 @@ describe('TaskBoard', () => {
     expect(onAccept).toHaveBeenCalledWith('a-open');
   });
 
+  it('marks foreign cards created after the previous visit', () => {
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <TaskBoard
+          annotations={[annotation('a-new', { authorId: 'someone-else' })]}
+          previousSeenAt="2026-06-30T00:00:00Z"
+          taskKeyOf={() => 'T-1'}
+          authorNameOf={() => 'Maxim'}
+          mayDecide={() => true}
+          onOpen={vi.fn()}
+          onAccept={vi.fn()}
+        />
+      </ThemeProvider>,
+    );
+    expect(
+      within(screen.getByTestId('task-card-a-new')).getByTestId('unseen-dot'),
+    ).toBeInTheDocument();
+  });
+
   it('only permitted cards are draggable; done cards never are', () => {
     renderBoard({ mayDecide: (a) => a.id === 'a-open' });
     expect(screen.getByTestId('task-card-a-open')).toHaveAttribute('draggable', 'true');

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.tsx
@@ -47,6 +47,8 @@ const COLUMN_CUES: Record<
 
 interface TaskBoardProps {
   annotations: AnnotationView[];
+  /** The previous visit (issue #307). */
+  previousSeenAt?: string | null;
   /** Tracker-style shorthand per annotation id ("T-3"). */
   taskKeyOf: (annotationId: string) => string;
   authorNameOf: (authorId: string) => string;
@@ -66,6 +68,7 @@ interface TaskBoardProps {
  */
 export function TaskBoard({
   annotations,
+  previousSeenAt = null,
   taskKeyOf,
   authorNameOf,
   mayDecide,
@@ -156,6 +159,7 @@ export function TaskBoard({
                 <TaskCard
                   key={annotation.id}
                   annotation={annotation}
+                  previousSeenAt={previousSeenAt}
                   taskKey={taskKeyOf(annotation.id)}
                   authorName={authorNameOf(annotation.authorId)}
                   draggable={!isDone && mayDecide(annotation)}

--- a/qnop-ui/src/components/reviews/tasks/TaskCard.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskCard.tsx
@@ -30,7 +30,9 @@ import { MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
+import { useAuthStore } from '../../../stores/authStore';
 import { UserAvatar } from '../../shell/UserAvatar';
+import { isUnseen } from '../newSince';
 import { tokens } from '../../../theme/tokens';
 import { STATUS_CUES } from '../panel/statusCues';
 import { PRIORITY_CUES, TYPE_CUES, taskTitle } from './tasksModel';
@@ -40,6 +42,8 @@ export const TASK_DRAG_TYPE = 'text/qnop-annotation';
 
 interface TaskCardProps {
   annotation: AnnotationView;
+  /** The previous visit (issue #307) — null hides the unseen dot. */
+  previousSeenAt?: string | null;
   /** Tracker-style shorthand ("T-3") — display only, the UUID stays the identity. */
   taskKey: string;
   authorName: string;
@@ -54,8 +58,17 @@ interface TaskCardProps {
  * title, the quoted passage as a secondary line, author and thread size at
  * the bottom. Shares the annotation cards' 6px radius — one system.
  */
-export function TaskCard({ annotation, taskKey, authorName, draggable, onOpen }: TaskCardProps) {
+export function TaskCard({
+  annotation,
+  previousSeenAt = null,
+  taskKey,
+  authorName,
+  draggable,
+  onOpen,
+}: TaskCardProps) {
   const theme = useTheme();
+  const viewerId = useAuthStore((state) => state.userId);
+  const unseen = isUnseen(annotation, previousSeenAt, viewerId);
   const type = annotation.type ? TYPE_CUES[annotation.type] : null;
   const priority = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
   const quote = annotation.anchor?.textQuote?.quote;
@@ -101,6 +114,20 @@ export function TaskCard({ annotation, taskKey, authorName, draggable, onOpen }:
       }}
     >
       <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
+        {unseen && (
+          <Tooltip title="New since your last visit">
+            <Box
+              data-testid="unseen-dot"
+              sx={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                bgcolor: theme.qnop.brand.blue,
+                flexShrink: 0,
+              }}
+            />
+          </Tooltip>
+        )}
         <Tooltip title={priority ? `${priority.label} priority` : 'No priority'}>
           <Typography
             component="span"

--- a/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
@@ -41,6 +41,8 @@ import { PRIORITY_CUES, TYPE_CUES, taskTitle } from './tasksModel';
 
 interface TaskDrawerProps {
   annotation: AnnotationView | null;
+  /** The previous visit (issue #307) — enables the thread's "new" divider. */
+  previousSeenAt?: string | null;
   /** Tracker-style shorthand ("T-3") of the open annotation. */
   taskKey: string;
   authorName: string;
@@ -61,6 +63,7 @@ interface TaskDrawerProps {
  */
 export function TaskDrawer({
   annotation,
+  previousSeenAt = null,
   taskKey,
   authorName,
   ownerId,
@@ -180,7 +183,11 @@ export function TaskDrawer({
         </Box>
 
         <Box sx={{ flex: 1, overflowY: 'auto', px: 2, py: 1 }}>
-          <CommentThread annotationId={annotation.id} notify={notify} />
+          <CommentThread
+            annotationId={annotation.id}
+            notify={notify}
+            previousSeenAt={previousSeenAt}
+          />
         </Box>
 
         {mayDecideAnnotation(annotation, userId, ownerId) && (

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -49,6 +49,9 @@ vi.mock('../../api/hooks/useAnnotations', () => ({
   useCreateAnnotation: vi.fn(),
   useDecideAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
 }));
+vi.mock('../../api/hooks/useReviews', () => ({
+  useRecordVisit: vi.fn().mockReturnValue(null),
+}));
 vi.mock('../../api/hooks/useComments', () => ({
   useComments: vi.fn().mockReturnValue({ isPending: true, isError: false, data: undefined }),
   useAddComment: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -58,6 +58,7 @@ import {
   walkPosition,
 } from '../../components/reviews/focus/spotlightModel';
 import { useAnchorElement } from '../../components/reviews/focus/useAnchorElement';
+import { useRecordVisit } from '../../api/hooks/useReviews';
 import { useViewMode } from '../../components/reviews/focus/useViewMode';
 import { columnOf } from '../../components/reviews/tasks/tasksModel';
 import { Composer } from '../../components/reviews/panel/Composer';
@@ -125,6 +126,8 @@ export function DocumentReviewPage() {
   const [tool, setTool] = useState<ViewerTool>('text');
   const [zoom, setZoom] = useState(1);
   const [viewMode, setViewMode] = useViewMode();
+  // The unseen-marker baseline (issue #307): the PREVIOUS visit, stamped once.
+  const previousSeenAt = useRecordVisit(documentId);
   // The view tabs (issue #398) address the mode through the URL — ?view= wins
   // over (and updates) the stored preference; the param stays shareable.
   const urlView = searchParams.get('view');
@@ -493,6 +496,7 @@ export function DocumentReviewPage() {
                   ownerId={document.ownerId}
                   notify={notify}
                   readOnly={!isLatestVersion}
+                  previousSeenAt={previousSeenAt}
                 />
               </ErrorBoundary>
             </Box>
@@ -521,6 +525,7 @@ export function DocumentReviewPage() {
               ownerId={document.ownerId}
               notify={notify}
               readOnly={!isLatestVersion}
+              previousSeenAt={previousSeenAt}
             />
           </ErrorBoundary>
         </FocusDrawer>
@@ -536,6 +541,7 @@ export function DocumentReviewPage() {
           userId={userId}
           notify={notify}
           readOnly={!isLatestVersion}
+          previousSeenAt={previousSeenAt}
         />
       )}
       {focusMode && composingPending && pending && (

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../api/hooks/useAnnotations', () => ({
 }));
 vi.mock('../../api/hooks/useReviews', () => ({
   useParticipants: vi.fn(),
+  useRecordVisit: vi.fn().mockReturnValue(null),
 }));
 vi.mock('../../api/hooks/useComments', () => ({
   useComments: vi.fn().mockReturnValue({ isPending: true, isError: false, data: undefined }),

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -33,7 +33,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { LayoutGrid, List as ListIcon, Search } from 'lucide-react';
 import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
-import { useParticipants } from '../../api/hooks/useReviews';
+import { useParticipants, useRecordVisit } from '../../api/hooks/useReviews';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
@@ -95,6 +95,8 @@ export function ReviewTasksPage() {
   const annotations = annotationsQuery.data?.annotations ?? [];
 
   const [view, setView] = useTasksViewMode();
+  // The unseen-marker baseline (issue #307): the PREVIOUS visit, stamped once.
+  const previousSeenAt = useRecordVisit(documentId);
   const filter = parseTaskFilter(searchParams.get('filter'));
   const query = searchParams.get('q') ?? '';
   const [openTaskId, setOpenTaskId] = useState<string | null>(null);
@@ -235,6 +237,7 @@ export function ReviewTasksPage() {
       ) : view === 'board' ? (
         <TaskBoard
           annotations={visible}
+          previousSeenAt={previousSeenAt}
           taskKeyOf={taskKeyOf}
           authorNameOf={authorNameOf}
           mayDecide={mayDecide}
@@ -252,6 +255,7 @@ export function ReviewTasksPage() {
 
       <TaskDrawer
         annotation={openTask}
+        previousSeenAt={previousSeenAt}
         taskKey={openTask ? taskKeyOf(openTask.id) : ''}
         authorName={openTask ? authorNameOf(openTask.authorId) : ''}
         ownerId={document.ownerId}


### PR DESCRIPTION
Closes #307 — unseen markers for returning participants, plan in the [issue comment](https://github.com/qnophq/qnop/issues/307#issuecomment-4883569689).

## What changed

### Visit stamping
`POST /documents/{documentId}/visit` stamps the caller's **personal** last-visit time (`review_visit`, unique per document+user; team members stamp individually) and returns the **previous** stamp — the session's marker baseline, so content being read never flips to "seen" mid-session; the fresh stamp takes effect on the next visit. A native `ON CONFLICT` upsert makes a concurrent second tab race-free (both sessions get a usable baseline, never an error). First visit returns nothing — and marks nothing. New changeset block inside the existing 0011 file (additive, pre-production convention). Participant visibility, 404 anti-enumeration.

### Foreign-activity signal on the list
`AnnotationView.latestCommentFromOthersAt` — the newest comment by *other* authors, actor-aware and batched in one grouped MAX query like the existing aggregations (#313/#393) — lets the list detect fresh replies without loading threads. "Own activity is never new" holds by construction.

### Client-side markers (shared `newSince` helpers)
- Panel cards: blue unseen dot (collapsed) / `New` badge (expanded) for foreign annotations or fresh foreign replies; the comment count turns accent+bold when new replies arrived.
- Threads: a subtle "New since your last visit" divider before the first new foreign comment (panel, focus card, task drawer — one `CommentThread`).
- Panel sections show "· n new"; task-board cards carry the same dot.
- Both pages stamp via `useRecordVisit` — ref-guarded so StrictMode's double effect cannot fire a second stamp and wipe the fresh markers.

## Test plan
- [x] `ReviewVisitApiIT`: first visit → no previous stamp, second returns the first; stamps are personal; non-participant 404
- [x] `AnnotationApiIT`: `latestCommentFromOthersAt` reacts to foreign comments only, from both perspectives
- [x] `newSince` units: all four rules incl. first-visit-null and own-activity exclusions
- [x] Component tests: panel dots + section count (foreign new / own new / foreign reply), thread divider (own newer reply never triggers it; none on first visit), task-card dot
- [x] Gates: `./gradlew build` (Spotless/ArchUnit/ITs), `tsc`, `eslint`, `prettier`, 454 frontend tests
- [ ] Manual visual pass (second-user activity via backdated stamp, markers clear on reload, both themes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
