### PR TITLE
chore: expand the shared test seed — 20-user crowd, 5 teams, Mailpit SMTP

### DIFF
--- a/qnop-app/src/test/java/io/qnop/settings/SettingsServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/SettingsServiceIT.java
@@ -61,7 +61,9 @@ class SettingsServiceIT extends AbstractIntegrationTest {
     assertThat(settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME))
         .isEqualTo("qnop");
     assertThat(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).isEqualTo(25);
-    assertThat(settings.getString(ApplicationSettingKey.SMTP_ENCRYPTION)).isEqualTo("starttls");
+    // No SMTP key here: the test seed repoints SMTP at Mailpit (issue #401),
+    // but the snapshot loads at BOOT while the seed runs per test transaction —
+    // an SMTP value would depend on which test refreshed the snapshot first.
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/SeededMailTemplateIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededMailTemplateIT.java
@@ -41,6 +41,9 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  */
 class SeededMailTemplateIT extends SeededIntegrationTest {
 
+  @org.springframework.beans.factory.annotation.Autowired
+  private io.qnop.service.ApplicationSettingsService settings;
+
   private static final String TEMPLATES = "/api/v1/admin/email/templates";
   private static final String RESET_KEY = "auth.password_reset";
 
@@ -111,6 +114,10 @@ class SeededMailTemplateIT extends SeededIntegrationTest {
 
   @Test
   void sendingATestEmailIsSkippedWhenSmtpIsNotConfigured() throws Exception {
+    // The seed points SMTP at Mailpit (issue #401) — this test owns the
+    // skip path, so it switches the master toggle off itself.
+    settings.update(java.util.Map.of("smtp.enabled", "false"), null);
+
     mockMvc
         .perform(
             asAdmin(post("/api/v1/admin/email/test"))

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,7 +31,9 @@ testdata/
 │   └── not-an-image.txt      # plain text — must be rejected as an unsupported type (415)
 ├── db/                       # deterministic SQL fixtures (issue #163)
 │   ├── clean.sql             # wipes the seeded tables to a known-empty slate
-│   └── seed.sql              # the shared seeded dataset (users, team, OIDC provider)
+│   └── seed.sql              # the shared seeded dataset (users, teams, OIDC provider,
+│                             # Mailpit SMTP settings; issue #401 adds a 20-user crowd
+│                             # and 5 department teams for manual testing)
 └── documents/                # review document payloads (issues #308, #370)
     ├── sample.pdf            # minimal valid single-page PDF, text "QNOP SMOKE TEST"
     ├── doc1/                 # multi-version dummy: test-dummy-v1..v5.pdf (1 page each)
@@ -52,5 +54,13 @@ the smoke's multi-version/diff steps:
   Signal") with real word-level edits between versions; v1→v2 replaces
   *letzten* → *einsamen* in the Kalinda sentence, which the diff assertions
   pin down. Keep those anchor words stable when regenerating the fixtures.
+
+The seed's role/state users (`admin`, `member`, `auditor`, …) are pinned by
+`SeededAdminUsersIT`/`SeededTeamIT` — keep their rows and the Alpha/Beta teams
+byte-stable. The issue #401 crowd (20 MEMBER users `nora`…`david`, teams Legal/
+Compliance/Finance/Procurement/Engineering, 5 users teamless) exists for manual
+testing and carries no pinned counts; all passwords are `Test-Pass-1234!`. The
+SMTP settings point at the docker-compose Mailpit (`localhost:1025`, inbox on
+`localhost:8025`).
 
 Add new fixture families as sibling directories as the suites that need them land.

--- a/testdata/db/seed.sql
+++ b/testdata/db/seed.sql
@@ -89,3 +89,84 @@ VALUES
   ('d0000000-0000-0000-0000-000000000002', 'Seeded OIDC (disabled)', 'OIDC', false,
    'seed-client-oidc', NULL, 'https://idp.example',
    'openid email', TIMESTAMPTZ '2026-01-03 08:05:00+00', TIMESTAMPTZ '2026-01-03 08:05:00+00');
+
+-- ---------------------------------------------------------------------------
+-- Crowd users (issue #401): twenty regular members for manual testing —
+-- populated pickers, team assignment, realistic participant lists. Same
+-- shared password; ids continue the a0000000 scheme (…09 – …1c). Roles are
+-- MEMBER only: SeededAdminUsersIT pins the ADMIN (2) and AUDITOR (1) counts.
+-- ---------------------------------------------------------------------------
+INSERT INTO qnop_user
+  (id, display_name, email, source, username, password_hash, enabled,
+   password_change_required, role, last_login_at, created_at, updated_at, version)
+VALUES
+  ('a0000000-0000-0000-0000-000000000009', 'Nora Weber',    'nora@qnop.test',  'INTERNAL', 'nora',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:00:00+00', TIMESTAMPTZ '2026-01-05 09:00:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000a', 'Felix Braun',   'felix@qnop.test', 'INTERNAL', 'felix', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:01:00+00', TIMESTAMPTZ '2026-01-05 09:01:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000b', 'Lena Fischer',  'lena@qnop.test',  'INTERNAL', 'lena',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:02:00+00', TIMESTAMPTZ '2026-01-05 09:02:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000c', 'Jonas Keller',  'jonas@qnop.test', 'INTERNAL', 'jonas', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:03:00+00', TIMESTAMPTZ '2026-01-05 09:03:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000d', 'Clara Vogt',    'clara@qnop.test', 'INTERNAL', 'clara', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:04:00+00', TIMESTAMPTZ '2026-01-05 09:04:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000e', 'Paul Richter',  'paul@qnop.test',  'INTERNAL', 'paul',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:05:00+00', TIMESTAMPTZ '2026-01-05 09:05:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000f', 'Ida Hoffmann',  'ida@qnop.test',   'INTERNAL', 'ida',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:06:00+00', TIMESTAMPTZ '2026-01-05 09:06:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000010', 'Tom Schneider', 'tom@qnop.test',   'INTERNAL', 'tom',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:07:00+00', TIMESTAMPTZ '2026-01-05 09:07:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000011', 'Eva Brandt',    'eva@qnop.test',   'INTERNAL', 'eva',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:08:00+00', TIMESTAMPTZ '2026-01-05 09:08:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000012', 'Nils Weiss',    'nils@qnop.test',  'INTERNAL', 'nils',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:09:00+00', TIMESTAMPTZ '2026-01-05 09:09:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000013', 'Anna Krause',   'anna@qnop.test',  'INTERNAL', 'anna',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:10:00+00', TIMESTAMPTZ '2026-01-05 09:10:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000014', 'Ben Roth',      'ben@qnop.test',   'INTERNAL', 'ben',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:11:00+00', TIMESTAMPTZ '2026-01-05 09:11:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000015', 'Marie Lang',    'marie@qnop.test', 'INTERNAL', 'marie', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:12:00+00', TIMESTAMPTZ '2026-01-05 09:12:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000016', 'Leo Hartmann',  'leo@qnop.test',   'INTERNAL', 'leo',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:13:00+00', TIMESTAMPTZ '2026-01-05 09:13:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000017', 'Sofia Berg',    'sofia@qnop.test', 'INTERNAL', 'sofia', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:14:00+00', TIMESTAMPTZ '2026-01-05 09:14:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000018', 'Emil Franke',   'emil@qnop.test',  'INTERNAL', 'emil',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:15:00+00', TIMESTAMPTZ '2026-01-05 09:15:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000019', 'Greta Simon',   'greta@qnop.test', 'INTERNAL', 'greta', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:16:00+00', TIMESTAMPTZ '2026-01-05 09:16:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000001a', 'Oskar Thiel',   'oskar@qnop.test', 'INTERNAL', 'oskar', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:17:00+00', TIMESTAMPTZ '2026-01-05 09:17:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000001b', 'Julia Winter',  'julia@qnop.test', 'INTERNAL', 'julia', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:18:00+00', TIMESTAMPTZ '2026-01-05 09:18:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000001c', 'David Sommer',  'david@qnop.test', 'INTERNAL', 'david', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:19:00+00', TIMESTAMPTZ '2026-01-05 09:19:00+00', 0);
+
+-- ---------------------------------------------------------------------------
+-- Crowd teams (issue #401): five departments, 3 crowd users each (one LEAD),
+-- five crowd users deliberately teamless (emil, greta, oskar, julia, david).
+-- Alpha/Beta above stay untouched — SeededTeamIT pins their member counts.
+-- ---------------------------------------------------------------------------
+INSERT INTO team (id, name, description, enabled, created_at, updated_at, version)
+VALUES
+  ('b0000000-0000-0000-0000-000000000003', 'Legal',       'Contract review',        true, TIMESTAMPTZ '2026-01-05 10:00:00+00', TIMESTAMPTZ '2026-01-05 10:00:00+00', 0),
+  ('b0000000-0000-0000-0000-000000000004', 'Compliance',  'Policy conformance',     true, TIMESTAMPTZ '2026-01-05 10:01:00+00', TIMESTAMPTZ '2026-01-05 10:01:00+00', 0),
+  ('b0000000-0000-0000-0000-000000000005', 'Finance',     'Commercial terms',       true, TIMESTAMPTZ '2026-01-05 10:02:00+00', TIMESTAMPTZ '2026-01-05 10:02:00+00', 0),
+  ('b0000000-0000-0000-0000-000000000006', 'Procurement', 'Supplier agreements',    true, TIMESTAMPTZ '2026-01-05 10:03:00+00', TIMESTAMPTZ '2026-01-05 10:03:00+00', 0),
+  ('b0000000-0000-0000-0000-000000000007', 'Engineering', 'Technical annexes',      true, TIMESTAMPTZ '2026-01-05 10:04:00+00', TIMESTAMPTZ '2026-01-05 10:04:00+00', 0);
+
+INSERT INTO team_membership (id, team_id, user_id, team_role, joined_at, version)
+VALUES
+  ('c1000000-0000-0000-0000-000000000006', 'b0000000-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000009', 'LEAD',   TIMESTAMPTZ '2026-01-05 11:00:00+00', 0),
+  ('c1000000-0000-0000-0000-000000000007', 'b0000000-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-00000000000a', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:01:00+00', 0),
+  ('c1000000-0000-0000-0000-000000000008', 'b0000000-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-00000000000b', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:02:00+00', 0),
+  ('c1000000-0000-0000-0000-000000000009', 'b0000000-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-00000000000c', 'LEAD',   TIMESTAMPTZ '2026-01-05 11:03:00+00', 0),
+  ('c1000000-0000-0000-0000-00000000000a', 'b0000000-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-00000000000d', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:04:00+00', 0),
+  ('c1000000-0000-0000-0000-00000000000b', 'b0000000-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-00000000000e', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:05:00+00', 0),
+  ('c1000000-0000-0000-0000-00000000000c', 'b0000000-0000-0000-0000-000000000005', 'a0000000-0000-0000-0000-00000000000f', 'LEAD',   TIMESTAMPTZ '2026-01-05 11:06:00+00', 0),
+  ('c1000000-0000-0000-0000-00000000000d', 'b0000000-0000-0000-0000-000000000005', 'a0000000-0000-0000-0000-000000000010', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:07:00+00', 0),
+  ('c1000000-0000-0000-0000-00000000000e', 'b0000000-0000-0000-0000-000000000005', 'a0000000-0000-0000-0000-000000000011', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:08:00+00', 0),
+  ('c1000000-0000-0000-0000-00000000000f', 'b0000000-0000-0000-0000-000000000006', 'a0000000-0000-0000-0000-000000000012', 'LEAD',   TIMESTAMPTZ '2026-01-05 11:09:00+00', 0),
+  ('c1000000-0000-0000-0000-000000000010', 'b0000000-0000-0000-0000-000000000006', 'a0000000-0000-0000-0000-000000000013', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:10:00+00', 0),
+  ('c1000000-0000-0000-0000-000000000011', 'b0000000-0000-0000-0000-000000000006', 'a0000000-0000-0000-0000-000000000014', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:11:00+00', 0),
+  ('c1000000-0000-0000-0000-000000000012', 'b0000000-0000-0000-0000-000000000007', 'a0000000-0000-0000-0000-000000000015', 'LEAD',   TIMESTAMPTZ '2026-01-05 11:12:00+00', 0),
+  ('c1000000-0000-0000-0000-000000000013', 'b0000000-0000-0000-0000-000000000007', 'a0000000-0000-0000-0000-000000000016', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:13:00+00', 0),
+  ('c1000000-0000-0000-0000-000000000014', 'b0000000-0000-0000-0000-000000000007', 'a0000000-0000-0000-0000-000000000017', 'MEMBER', TIMESTAMPTZ '2026-01-05 11:14:00+00', 0);
+
+-- ---------------------------------------------------------------------------
+-- Mail: point the (Liquibase-seeded) SMTP settings at the docker-compose
+-- Mailpit (issue #401) — localhost:1025, no auth, no TLS; inbox on :8025.
+-- UPDATEs, not INSERTs: application_setting carries migration seeds and
+-- survives clean.sql by design.
+-- ---------------------------------------------------------------------------
+UPDATE application_setting AS s
+SET setting_value = v.new_value
+FROM (VALUES
+  ('smtp.enabled',   'true'),
+  ('smtp.host',      'localhost'),
+  ('smtp.port',      '1025'),
+  ('smtp.username',  ''),
+  ('smtp.encryption', 'none'),
+  ('smtp.from',      'noreply@qnop.test'),
+  ('smtp.from_name', 'qnop')
+) AS v(key, new_value)
+WHERE s.setting_key = v.key;


### PR DESCRIPTION
Closes #401 — the shared test seed grows from the role-matrix minimum to a dataset that carries manual testing.

## What changed

- **20 crowd users** (`nora`…`david`), all MEMBER/enabled/INTERNAL with the shared test password (`Test-Pass-1234!`), stable UUIDs continuing the `a0000000-…` scheme, `<username>@qnop.test` emails. No new ADMIN/AUDITOR roles — `SeededAdminUsersIT` pins those counts; names avoid the seeded search probes (`dana`, `auditor@qnop.test`, `alpha`).
- **5 department teams** (Legal, Compliance, Finance, Procurement, Engineering) with 3 crowd users each (one LEAD); `emil`, `greta`, `oskar`, `julia`, `david` stay teamless. Alpha/Beta remain byte-identical (`SeededTeamIT` pins their member counts).
- **SMTP → docker-compose Mailpit**: the Liquibase-seeded settings are UPDATEd (never inserted — `application_setting` survives `clean.sql` by design) to `localhost:1025`, no auth, encryption `none`, `noreply@qnop.test` sender; inbox on `localhost:8025`.
- Two seeded ITs adjusted to own their state instead of leaning on defaults: the mail skip-path test switches the master toggle off itself, and the settings-snapshot test no longer pins an SMTP key (the snapshot loads at boot while the seed runs per test transaction — the value depends on JVM history).
- `testdata/README.md` documents the crowd, the pinned rows and the Mailpit settings.

## Test plan
- [x] Full `:qnop-app:test --rerun` against the new seed: 442 tests green (incl. the two adjusted ITs)
- [x] Seed applied to the local dev DB (25 users, 5 teams, SMTP at Mailpit) — used for ongoing manual testing
- [x] Smoke's `total >= 8` unaffected (additive rows only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
