### PR TITLE
fix: review surfaces — polish & bugfix round (#403)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -157,17 +157,18 @@ class AnnotationApiIT extends SeededIntegrationTest {
   }
 
   @Test
-  void authorDecidesTheirOwnAnnotation() throws Exception {
+  void theAuthorCannotDecideTheirOwnAnnotation() throws Exception {
     UUID documentId = seedDocumentWithVersion();
     String annotationId = createAnnotation(documentId, AUDITOR_ID);
 
+    // Deciding is the owner's call alone (issue #403) — reviewers, including
+    // the annotation's author, can neither accept nor reject.
     mockMvc
         .perform(
             as(post("/api/v1/annotations/" + annotationId + "/decision"), AUDITOR_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"decision\":\"REJECTED\"}"))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.status").value("REJECTED"));
+        .andExpect(status().isForbidden());
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationDecisionForbiddenException.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationDecisionForbiddenException.java
@@ -22,11 +22,11 @@ package io.qnop.service.review;
 
 /**
  * The acting user may not decide this annotation (issue #247, ADR-0011): accept/reject is limited
- * to the document owner or the annotation's author. Mapped to HTTP 403.
+ * to the document owner (issue #403). Mapped to HTTP 403.
  */
 public class AnnotationDecisionForbiddenException extends RuntimeException {
 
   public AnnotationDecisionForbiddenException() {
-    super("Only the document owner or the annotation's author may decide this annotation");
+    super("Only the document owner may decide this annotation");
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -126,9 +126,10 @@ public class ReviewWorkflowService {
 
   /**
    * Applies a decision on an annotation — the {@code OPEN → ACCEPTED | REJECTED} sub-machine
-   * (ADR-0011), permitted for the document owner or the annotation's author (issue #247). Accepting
-   * while the document is {@code IN_REVIEW} drives the workflow to {@code CHANGES_REQUESTED}
-   * through the same choke-point (with its own audit event).
+   * (ADR-0011), permitted for the document owner alone (issue #403 tightened the original
+   * owner-or-author rule of #247: reviewers raise and discuss, the owner rules). Accepting while
+   * the document is {@code IN_REVIEW} drives the workflow to {@code CHANGES_REQUESTED} through the
+   * same choke-point (with its own audit event).
    */
   @Transactional
   public Annotation decideAnnotation(UUID annotationId, AnnotationStatus decision, UUID actorId) {
@@ -140,7 +141,7 @@ public class ReviewWorkflowService {
             .findById(annotationId)
             .orElseThrow(() -> new AnnotationNotFoundException(annotationId));
     Document document = loadForUpdate(annotation.getDocumentId());
-    if (!document.getOwnerId().equals(actorId) && !annotation.getAuthorId().equals(actorId)) {
+    if (!document.getOwnerId().equals(actorId)) {
       throw new AnnotationDecisionForbiddenException();
     }
     if (!ReviewWorkflowMachine.canDecide(annotation.getStatus())) {

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -94,7 +94,12 @@ describe('FocusAnnotationCard', () => {
     expect(screen.getByText('“the disputed clause”')).toBeInTheDocument();
     expect(screen.getByText('Open')).toBeInTheDocument();
     expect(screen.getByTestId('thread-a2')).toBeInTheDocument();
-    // The author may decide their own annotation (ADR-0011).
+    // Deciding is owner-only (issue #403) — the author sees no decision bar.
+    expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
+  });
+
+  it('offers deciding to the owner alone', () => {
+    renderCard({ userId: 'owner-1' });
     expect(screen.getByTestId('decision-bar')).toBeInTheDocument();
   });
 

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -284,6 +284,17 @@ export function FocusAnnotationCard({
                       {`“${quote}”`}
                     </Typography>
                   )}
+                  {/* The opening annotation text — the thread below carries
+                      only the replies (issue #403). */}
+                  {annotation.firstComment && (
+                    <Typography
+                      variant="body2"
+                      sx={{ mt: 0.75, whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
+                      data-testid="opening-text"
+                    >
+                      {annotation.firstComment}
+                    </Typography>
+                  )}
                 </Box>
 
                 {!readOnly && mayDecideAnnotation(annotation, userId, ownerId) && (
@@ -299,6 +310,7 @@ export function FocusAnnotationCard({
                     notify={notify}
                     readOnly={readOnly}
                     previousSeenAt={previousSeenAt}
+                    skipOpener
                   />
                 </Box>
                 {/* Discoverability for the native resize grip underneath. */}

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -33,6 +33,7 @@ import { useAuthStore } from '../../../stores/authStore';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { hasNewComments, isUnseen } from '../newSince';
+import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
 import { highlightColorFor } from '../viewer/markerColors';
 import { PlacementStatusChip } from './PlacementStatusChip';
 import { STATUS_CUES } from './statusCues';
@@ -42,6 +43,12 @@ const railGlow = keyframes`
   0%, 100% { box-shadow: 0 0 0 0 transparent; }
   50% { box-shadow: 0 0 10px 2px var(--rail-glow); }
 `;
+
+/** Compact date for the head card's author line. */
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
 
 /** Up to this many participant avatars stack in the collapsed row. */
 const MAX_AVATARS = 3;
@@ -123,6 +130,9 @@ function AnnotationListItemBase({
 }: AnnotationListItemProps) {
   const theme = useTheme();
   const viewerId = useAuthStore((state) => state.userId);
+  const selfDisplayName = useAuthStore((state) => state.displayName);
+  const avatarUrl = useAuthStore((state) => state.avatarUrl);
+  const userId = viewerId;
   const unseen = isUnseen(annotation, previousSeenAt, viewerId);
   const freshComments = hasNewComments(annotation, previousSeenAt);
   const quote = annotation.anchor?.textQuote?.quote;
@@ -137,6 +147,13 @@ function AnnotationListItemBase({
   // the cache (enabled: false never fetches — rows stay cheap; the stack
   // enriches once a thread has been opened or hover-prefetched).
   const cachedComments = useComments(annotation.id, false).data?.comments ?? [];
+  const typeCue = annotation.type ? TYPE_CUES[annotation.type] : null;
+  const TypeIcon = typeCue?.icon;
+  const priorityCue = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
+  // The opening annotation text: the full body once the thread is cached,
+  // the server-side excerpt as the placeholder until then.
+  const openerText = cachedComments[0]?.body ?? annotation.firstComment ?? null;
+  const authorName = annotation.authorId === userId ? (selfDisplayName ?? 'You') : 'Participant';
   const participantIds = [
     ...new Set([annotation.authorId, ...cachedComments.map((comment) => comment.authorId)]),
   ];
@@ -215,10 +232,35 @@ function AnnotationListItemBase({
         }}
       />
       {active ? (
-        <Stack spacing={0.75}>
+        <Stack spacing={1} data-testid="annotation-head-card">
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
             <ToneBadge tone={statusCue.tone} label={statusCue.label} />
             {unseen && <ToneBadge tone="blue" label="New" />}
+            {typeCue && TypeIcon && (
+              <Stack
+                direction="row"
+                spacing={0.5}
+                sx={{ alignItems: 'center', color: typeCue.color(theme) }}
+              >
+                <TypeIcon size={12} aria-hidden />
+                <Typography component="span" sx={{ fontSize: 11, fontWeight: 600 }}>
+                  {typeCue.label}
+                </Typography>
+              </Stack>
+            )}
+            {priorityCue && (
+              <Tooltip title={`${priorityCue.label} priority`}>
+                <Box
+                  sx={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: '50%',
+                    bgcolor: priorityCue.color(theme),
+                    flexShrink: 0,
+                  }}
+                />
+              </Tooltip>
+            )}
             <PlacementStatusChip status={annotation.placementStatus} />
             <Stack
               direction="row"
@@ -234,25 +276,58 @@ function AnnotationListItemBase({
               </Stack>
             </Stack>
           </Stack>
+          {/* The anchored passage, styled as a real quotation. */}
           {quote ? (
-            <Typography
-              variant="body2"
+            <Box
               sx={{
-                fontStyle: 'italic',
-                color: 'text.secondary',
-                display: '-webkit-box',
-                WebkitLineClamp: 4,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
+                borderLeft: '3px solid',
+                borderColor: alpha(railColor, 0.6),
+                bgcolor: theme.qnop.surface2,
+                borderRadius: '0 6px 6px 0',
+                px: 1.25,
+                py: 0.75,
               }}
             >
-              “{quote}”
-            </Typography>
+              <Typography
+                variant="body2"
+                sx={{
+                  fontStyle: 'italic',
+                  color: 'text.secondary',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 4,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                “{quote}”
+              </Typography>
+            </Box>
           ) : (
             <Typography variant="body2" color="text.secondary">
               {fallbackLabel}
             </Typography>
           )}
+          {/* The opening annotation text — full body once the thread is cached,
+              the server's excerpt until then (issue #403). */}
+          {openerText && (
+            <Typography
+              variant="body2"
+              sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
+              data-testid="opening-text"
+            >
+              {openerText}
+            </Typography>
+          )}
+          <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+            <UserAvatar
+              name={authorName}
+              size={20}
+              imageUrl={annotation.authorId === userId ? avatarUrl : null}
+            />
+            <Typography variant="caption" color="text.secondary" noWrap>
+              {authorName} · {DATE_FORMAT.format(new Date(annotation.createdAt))}
+            </Typography>
+          </Stack>
         </Stack>
       ) : (
         <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -180,6 +180,24 @@ describe('AnnotationPanel', () => {
     expect(header).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('passes the chosen classification to onCreate (issue #403)', () => {
+    const props = renderPanel({
+      pendingAnchor: {
+        region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.1 } },
+      },
+    });
+    const composer = within(screen.getByTestId('annotation-composer'));
+    fireEvent.change(composer.getByLabelText('Annotation comment'), {
+      target: { value: 'Conflicts with policy' },
+    });
+    fireEvent.mouseDown(composer.getAllByRole('combobox')[0]);
+    fireEvent.click(screen.getByRole('option', { name: /Conflict/ }));
+    fireEvent.mouseDown(composer.getAllByRole('combobox')[1]);
+    fireEvent.click(screen.getByRole('option', { name: /High/ }));
+    fireEvent.click(composer.getByRole('button', { name: /Create annotation/ }));
+    expect(props.onCreate).toHaveBeenCalledWith('Conflicts with policy', 'CONFLICT', 'HIGH');
+  });
+
   it('opens the composer for a pending anchor and creates with the comment', () => {
     const props = renderPanel({
       pendingAnchor: {
@@ -194,7 +212,7 @@ describe('AnnotationPanel', () => {
       target: { value: 'Wrong figure' },
     });
     fireEvent.click(composer.getByRole('button', { name: /Create annotation/ }));
-    expect(props.onCreate).toHaveBeenCalledWith('Wrong figure');
+    expect(props.onCreate).toHaveBeenCalledWith('Wrong figure', undefined, undefined);
 
     fireEvent.click(composer.getByRole('button', { name: 'Cancel' }));
     expect(props.onCancelPending).toHaveBeenCalled();
@@ -223,7 +241,7 @@ describe('AnnotationPanel', () => {
     fireEvent.change(field, { target: { value: 'Needs a source' } });
     expect(create).toBeEnabled();
     fireEvent.click(create);
-    expect(props.onCreate).toHaveBeenCalledWith('Needs a source');
+    expect(props.onCreate).toHaveBeenCalledWith('Needs a source', undefined, undefined);
   });
 
   it('offers Accept/Reject to the owner on an open active annotation', () => {
@@ -238,16 +256,11 @@ describe('AnnotationPanel', () => {
     );
   });
 
-  it('offers the decision to the author as well', () => {
+  it('hides the decision from the author — deciding is owner-only (#403)', () => {
     useAuthStore.setState({ userId: 'u1' });
     renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });
 
-    fireEvent.click(within(screen.getByTestId('decision-bar')).getByText('Reject'));
-
-    expect(decideMutate).toHaveBeenCalledWith(
-      { annotationId: 'a1', decision: 'REJECTED' },
-      expect.anything(),
-    );
+    expect(screen.queryByTestId('decision-bar')).not.toBeInTheDocument();
   });
 
   it('hides the decision bar from uninvolved participants and on decided annotations', () => {
@@ -277,7 +290,7 @@ describe('AnnotationPanel', () => {
     const field = composer.getByLabelText('Annotation comment');
     fireEvent.change(field, { target: { value: 'Shortcut comment' } });
     fireEvent.keyDown(field, { key: 'Enter', metaKey: true });
-    expect(props.onCreate).toHaveBeenCalledWith('Shortcut comment');
+    expect(props.onCreate).toHaveBeenCalledWith('Shortcut comment', undefined, undefined);
 
     // Plain Enter stays a newline, Alt+Enter submits too.
     fireEvent.keyDown(field, { key: 'Enter' });

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -29,7 +29,12 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import { ChevronRight, Link2, NotebookPen, Unlink } from 'lucide-react';
-import type { Anchor, AnnotationView } from '../../../api/generated';
+import type {
+  AnnotationPriority,
+  AnnotationType,
+  Anchor,
+  AnnotationView,
+} from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
@@ -59,7 +64,7 @@ interface AnnotationPanelProps {
   /** The drawn-but-not-yet-created anchor; non-null opens the composer. */
   pendingAnchor: Anchor | null;
   creating: boolean;
-  onCreate: (comment: string) => void;
+  onCreate: (comment: string, type?: AnnotationType, priority?: AnnotationPriority) => void;
   onCancelPending: () => void;
   canAnnotate: boolean;
   /** The document owner — owner or author may decide an annotation (ADR-0011). */
@@ -247,6 +252,7 @@ export function AnnotationPanel({
             notify={notify}
             readOnly={readOnly}
             previousSeenAt={previousSeenAt}
+            skipOpener
           />
         </Collapse>
       </Stack>

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -47,6 +47,8 @@ interface CommentThreadProps {
   readOnly?: boolean;
   /** The previous visit (issue #307) — enables the "new" divider inside the thread. */
   previousSeenAt?: string | null;
+  /** True when the surrounding card already renders the opening annotation (issue #403). */
+  skipOpener?: boolean;
 }
 
 const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
@@ -67,6 +69,7 @@ export function CommentThread({
   notify,
   readOnly = false,
   previousSeenAt = null,
+  skipOpener = false,
 }: CommentThreadProps) {
   const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
@@ -86,7 +89,10 @@ export function CommentThread({
   };
 
   const comments = commentsQuery.data?.comments ?? [];
-  const firstNewCommentId = comments.find((comment) =>
+  // With the opening annotation living in the head card (issue #403), the
+  // timeline carries only the replies.
+  const visibleComments = skipOpener ? comments.slice(1) : comments;
+  const firstNewCommentId = visibleComments.find((comment) =>
     isNewComment(comment, previousSeenAt, userId),
   )?.id;
 
@@ -116,7 +122,7 @@ export function CommentThread({
             Could not load the comments.
           </Typography>
         )}
-        {comments.map((comment) => {
+        {visibleComments.map((comment) => {
           const own = comment.authorId === userId;
           const name = own ? (displayName ?? 'You') : 'Participant';
           return (
@@ -175,9 +181,9 @@ export function CommentThread({
             </Fragment>
           );
         })}
-        {!commentsQuery.isPending && !commentsQuery.isError && comments.length === 0 && (
+        {!commentsQuery.isPending && !commentsQuery.isError && visibleComments.length === 0 && (
           <Typography variant="body2" color="text.secondary" sx={{ pl: 4.5 }}>
-            No comments yet. Start the discussion.
+            {skipOpener ? 'No replies yet.' : 'No comments yet. Start the discussion.'}
           </Typography>
         )}
         {/* Composer continues the thread rail with the signed-in user's avatar.

--- a/qnop-ui/src/components/reviews/panel/Composer.tsx
+++ b/qnop-ui/src/components/reviews/panel/Composer.tsx
@@ -20,13 +20,18 @@
  */
 
 import { useState } from 'react';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
 import type { Anchor } from '../../../api/generated';
+import { AnnotationPriority, AnnotationType } from '../../../api/generated';
 import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
+import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
 
 /**
  * The composer for a freshly drawn anchor — rendered in the panel, and in
@@ -43,12 +48,16 @@ export function Composer({
 }: {
   pendingAnchor: Anchor;
   creating: boolean;
-  onCreate: (comment: string) => void;
+  onCreate: (comment: string, type?: AnnotationType, priority?: AnnotationPriority) => void;
   onCancel: () => void;
 }) {
+  const theme = useTheme();
   const [comment, setComment] = useState('');
+  const [type, setType] = useState<AnnotationType | ''>('');
+  const [priority, setPriority] = useState<AnnotationPriority | ''>('');
   const canCreate = !creating && comment.trim().length > 0;
   const quote = pendingAnchor.textQuote?.quote;
+  const create = () => onCreate(comment, type || undefined, priority || undefined);
   return (
     <Paper variant="outlined" sx={{ p: 1.5 }} data-testid="annotation-composer">
       <Stack spacing={1}>
@@ -77,18 +86,80 @@ export function Composer({
           onKeyDown={(event) => {
             if (isSubmitShortcut(event)) {
               event.preventDefault();
-              if (canCreate) onCreate(comment);
+              if (canCreate) create();
             }
           }}
           slotProps={{ htmlInput: { maxLength: 20000, 'aria-label': 'Annotation comment' } }}
         />
-        <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
-          <Button
+        {/* Optional classification (issue #392) in the system's task language. */}
+        <Stack direction="row" spacing={1}>
+          <TextField
+            select
             size="small"
-            variant="contained"
-            onClick={() => onCreate(comment)}
-            disabled={!canCreate}
+            label="Type"
+            value={type}
+            onChange={(event) => setType(event.target.value as AnnotationType | '')}
+            sx={{ flex: 1 }}
+            slotProps={{ htmlInput: { 'aria-label': 'Annotation type' } }}
           >
+            <MenuItem value="">
+              <Typography component="span" variant="body2" color="text.secondary">
+                None
+              </Typography>
+            </MenuItem>
+            {Object.values(AnnotationType).map((value) => {
+              const cue = TYPE_CUES[value];
+              const CueIcon = cue.icon;
+              return (
+                <MenuItem key={value} value={value}>
+                  <Stack
+                    direction="row"
+                    spacing={0.75}
+                    sx={{ alignItems: 'center', color: cue.color(theme) }}
+                  >
+                    <CueIcon size={13} aria-hidden />
+                    <Typography component="span" variant="body2">
+                      {cue.label}
+                    </Typography>
+                  </Stack>
+                </MenuItem>
+              );
+            })}
+          </TextField>
+          <TextField
+            select
+            size="small"
+            label="Priority"
+            value={priority}
+            onChange={(event) => setPriority(event.target.value as AnnotationPriority | '')}
+            sx={{ flex: 1 }}
+            slotProps={{ htmlInput: { 'aria-label': 'Annotation priority' } }}
+          >
+            <MenuItem value="">
+              <Typography component="span" variant="body2" color="text.secondary">
+                None
+              </Typography>
+            </MenuItem>
+            {Object.values(AnnotationPriority).map((value) => {
+              const cue = PRIORITY_CUES[value];
+              return (
+                <MenuItem key={value} value={value}>
+                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                    <Box
+                      sx={{ width: 7, height: 7, borderRadius: '50%', bgcolor: cue.color(theme) }}
+                      aria-hidden
+                    />
+                    <Typography component="span" variant="body2">
+                      {cue.label}
+                    </Typography>
+                  </Stack>
+                </MenuItem>
+              );
+            })}
+          </TextField>
+        </Stack>
+        <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end' }}>
+          <Button size="small" variant="contained" onClick={create} disabled={!canCreate}>
             Create annotation ({submitShortcutLabel()})
           </Button>
           <Button size="small" onClick={onCancel} disabled={creating}>

--- a/qnop-ui/src/components/reviews/panel/decisions.ts
+++ b/qnop-ui/src/components/reviews/panel/decisions.ts
@@ -30,17 +30,17 @@ const DECISION_CONFLICTS: Record<string, string> = {
   ANNOTATION_ALREADY_DECIDED: 'This annotation was already decided.',
 };
 
-/** Owner or author may decide an OPEN annotation (ADR-0011). */
+/**
+ * Only the OWNER decides an OPEN annotation — issue #403 tightened the
+ * original owner-or-author rule (#247): reviewers raise and discuss, the
+ * owner rules. Mirrors the ReviewWorkflowService guard.
+ */
 export function mayDecideAnnotation(
   annotation: AnnotationView,
   userId: string | null,
   ownerId: string | null,
 ): boolean {
-  return (
-    annotation.status === AnnotationStatus.Open &&
-    userId !== null &&
-    (ownerId === userId || annotation.authorId === userId)
-  );
+  return annotation.status === AnnotationStatus.Open && userId !== null && ownerId === userId;
 }
 
 /**

--- a/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
@@ -187,6 +187,7 @@ export function TaskDrawer({
             annotationId={annotation.id}
             notify={notify}
             previousSeenAt={previousSeenAt}
+            skipOpener
           />
         </Box>
 

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -34,6 +34,7 @@ import Stack from '@mui/material/Stack';
 import { NotebookPen } from 'lucide-react';
 import type { Anchor, NormalizedBox } from '../../api/generated';
 import { ExtractionStatus } from '../../api/generated';
+import type { AnnotationPriority, AnnotationType } from '../../api/generated';
 import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotations';
 import {
   useDocument,
@@ -247,13 +248,13 @@ export function DocumentReviewPage() {
     if (anchor) stagePending(anchor, at);
   };
 
-  const handleCreate = (comment: string) => {
+  const handleCreate = (comment: string, type?: AnnotationType, priority?: AnnotationPriority) => {
     // The first comment is mandatory (issue #301) — the composer only submits
     // non-blank text; this guard keeps the invariant at the API boundary too.
     const trimmed = comment.trim();
     if (!pending || versionNumber === undefined || trimmed.length === 0) return;
     createAnnotation.mutate(
-      { versionNumber, anchor: pending.anchor, comment: trimmed },
+      { versionNumber, anchor: pending.anchor, comment: trimmed, type, priority },
       {
         onSuccess: (created) => {
           setPending(null);


### PR DESCRIPTION
The polish & bugfix round of #403 — items land here as the round progresses; the issue's checklist tracks them.

## Round items so far

1. **Deciding is owner-only.** Issue #403 tightens the original owner-or-author rule (#247): reviewers raise and discuss, the owner rules. Enforced in `ReviewWorkflowService` (the author now gets 403) and mirrored in `mayDecideAnnotation` — authors see no Accept/Reject on their own annotations anywhere (panel, focus card, task drawer, board drag).
2. **The opening annotation is a head card.** The expanded panel card unites the anchored passage (styled as a quotation on the marker-coloured edge), the opening annotation text (full body once the thread is cached, the server excerpt until then) and the meta — status, New cue, type, priority, placement, page, comment count, author, date. The thread below carries only the replies (`CommentThread.skipOpener`) on all three surfaces; the focus card header gains the opening text.
3. **Type & priority on create.** Both composers offer the optional #392 classification up front — two compact selects in the tasks view's colour language, defaulting to none.

## Test plan
- [x] `AnnotationApiIT`: the author's decision now answers 403; owner decides as before
- [x] FE suites: owner-only decision gating (panel + focus), head-card content, composer classification flows into `onCreate` — 456 tests green
- [x] Gates: `./gradlew build`, `tsc`, `eslint`, `prettier`
- [x] Visual pass as reviewer Paul Richter on a real review: no decision buttons on his own annotation; head card with quotation block, opening text and meta; classified create (Proposal/Medium) lands with badges on the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
