### PR TITLE
fix: review UI polish round 3 (#403)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1890,6 +1890,41 @@ paths:
                 $ref: '#/components/schemas/PrincipalListResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /principals/teams/{teamId}/members:
+    get:
+      tags:
+        - Principals
+      summary: List a team's members (names only)
+      description: |
+        The users behind a team principal (issue #403): lets a participant
+        list unfold a team to see who reviews behind it. Same deliberate
+        Community visibility rule as the directory itself — available to every
+        authenticated user, display names only.
+      operationId: listTeamMembers
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: teamId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The team's members as USER principals, ordered by display name
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrincipalListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown team (`TEAM_NOT_FOUND`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /documents/{documentId}:
     get:
       tags:

--- a/qnop-app/src/main/java/io/qnop/web/PrincipalsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/PrincipalsController.java
@@ -21,11 +21,17 @@
 package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.PrincipalsApi;
+import io.qnop.api.v1.model.ErrorResponse;
 import io.qnop.api.v1.model.ParticipantKind;
 import io.qnop.api.v1.model.PrincipalListResponse;
 import io.qnop.api.v1.model.PrincipalView;
 import io.qnop.service.PrincipalDirectoryService;
+import io.qnop.service.TeamNotFoundException;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -55,5 +61,31 @@ public class PrincipalsController implements PrincipalsApi {
                                 .kind(view.team() ? ParticipantKind.TEAM : ParticipantKind.USER)
                                 .displayName(view.displayName()))
                     .toList()));
+  }
+
+  @Override
+  public ResponseEntity<PrincipalListResponse> listTeamMembers(UUID teamId) {
+    CurrentUser.requireUserId();
+    return ResponseEntity.ok(
+        new PrincipalListResponse()
+            .principals(
+                directory.teamMembers(teamId).stream()
+                    .map(
+                        view ->
+                            new PrincipalView()
+                                .id(view.id())
+                                .kind(ParticipantKind.USER)
+                                .displayName(view.displayName()))
+                    .toList()));
+  }
+
+  @ExceptionHandler(TeamNotFoundException.class)
+  public ResponseEntity<ErrorResponse> onTeamNotFound(TeamNotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(
+            new ErrorResponse()
+                .code("TEAM_NOT_FOUND")
+                .message(ex.getMessage())
+                .timestamp(OffsetDateTime.now()));
   }
 }

--- a/qnop-app/src/test/java/io/qnop/document/ReanchoringIT.java
+++ b/qnop-app/src/test/java/io/qnop/document/ReanchoringIT.java
@@ -84,6 +84,48 @@ class ReanchoringIT extends AbstractIntegrationTest {
   }
 
   @Test
+  @DisplayName("a RESOLVED annotation follows the document onto the new version (#403 regression)")
+  void resolvedAnnotationsAreReanchoredToo() throws Exception {
+    UUID owner = createUser();
+    UUID documentId =
+        upload(owner, "whereas " + QUOTE + " from invoice", "a second unrelated line");
+    poller.poll(); // extract v1
+
+    String created =
+        mockMvc
+            .perform(
+                post("/api/v1/documents/{id}/annotations", documentId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(annotationBody())
+                    .with(asUser(owner)))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String annotationId = JsonPath.read(created, "$.id");
+
+    // The author settles the concern BEFORE the new version arrives — since
+    // #405 that is not terminal (the thread stays a record, reopen exists),
+    // so the mark must still follow the document.
+    mockMvc
+        .perform(post("/api/v1/annotations/{id}/resolve", annotationId).with(asUser(owner)))
+        .andExpect(status().isOk());
+
+    addVersion(owner, documentId, "a brand new intro line", "whereas " + QUOTE + " from invoice");
+    poller.poll(); // extract v2 → chains the re-anchor job
+    poller.poll(); // run the re-anchor job
+
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("version", "2")
+                .with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].status").value("RESOLVED"))
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("PLACED"));
+  }
+
+  @Test
   @DisplayName("a new version re-places the annotation; a version without the text orphans it")
   void reanchorsAcrossVersions() throws Exception {
     UUID owner = createUser();

--- a/qnop-app/src/test/java/io/qnop/review/DocumentOverviewApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DocumentOverviewApiIT.java
@@ -271,6 +271,30 @@ class DocumentOverviewApiIT extends SeededIntegrationTest {
   }
 
   @Test
+  void teamMembersAreListedForPlainMembersNamesOnly() throws Exception {
+    // Team Alpha carries three seeded members (SeededTeamIT pins that count).
+    mockMvc
+        .perform(as(get("/api/v1/principals/teams/" + TEAM_ALPHA_ID + "/members"), MEMBER2_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.principals.length()").value(3))
+        .andExpect(jsonPath("$.principals[0].kind").value("USER"))
+        .andExpect(jsonPath("$.principals[0].displayName").isNotEmpty())
+        // Names only — the members endpoint must never leak emails.
+        .andExpect(jsonPath("$.principals[0].email").doesNotExist());
+  }
+
+  @Test
+  void teamMembersOfAnUnknownTeamAre404() throws Exception {
+    mockMvc
+        .perform(
+            as(
+                get("/api/v1/principals/teams/00000000-0000-0000-0000-00000000dead/members"),
+                MEMBER_ID))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("TEAM_NOT_FOUND"));
+  }
+
+  @Test
   void principalDirectoryHidesDisabledUsersAndNeverMatchesEmails() throws Exception {
     mockMvc
         .perform(as(get("/api/v1/principals?q=dana"), MEMBER_ID))

--- a/qnop-core/src/main/java/io/qnop/service/PrincipalDirectoryService.java
+++ b/qnop-core/src/main/java/io/qnop/service/PrincipalDirectoryService.java
@@ -20,6 +20,7 @@
  */
 package io.qnop.service;
 
+import io.qnop.repository.TeamMembershipRepository;
 import io.qnop.repository.TeamRepository;
 import io.qnop.repository.UserRepository;
 import java.util.Comparator;
@@ -43,10 +44,13 @@ public class PrincipalDirectoryService {
 
   private final UserRepository users;
   private final TeamRepository teams;
+  private final TeamMembershipRepository memberships;
 
-  public PrincipalDirectoryService(UserRepository users, TeamRepository teams) {
+  public PrincipalDirectoryService(
+      UserRepository users, TeamRepository teams, TeamMembershipRepository memberships) {
     this.users = users;
     this.teams = teams;
+    this.memberships = memberships;
   }
 
   @Transactional(readOnly = true)
@@ -63,6 +67,20 @@ public class PrincipalDirectoryService {
     return Stream.concat(userViews, teamViews)
         .sorted(Comparator.comparing(view -> view.displayName().toLowerCase(Locale.ROOT)))
         .limit(size)
+        .toList();
+  }
+
+  /**
+   * A team's members, display names only (issue #403): lets a participant list unfold a team to see
+   * who reviews behind it — the same visibility rule as the directory itself.
+   */
+  @Transactional(readOnly = true)
+  public List<PrincipalView> teamMembers(UUID teamId) {
+    if (!teams.existsById(teamId)) {
+      throw new TeamNotFoundException("team not found: " + teamId);
+    }
+    return memberships.findMembersByTeamId(teamId).stream()
+        .map(member -> new PrincipalView(member.userId(), false, member.displayName()))
         .toList();
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -22,7 +22,6 @@ package io.qnop.service.document;
 
 import io.qnop.entity.Annotation;
 import io.qnop.entity.AnnotationPlacement;
-import io.qnop.entity.AnnotationStatus;
 import io.qnop.entity.Document;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.repository.AnnotationPlacementRepository;
@@ -193,21 +192,24 @@ public class DocumentIngestService {
   }
 
   /**
-   * Seeds a PENDING placement on the new version for every OPEN annotation (issue #248, ADR-0009),
-   * carrying the annotation's most recent anchor as the re-anchoring hypothesis. Runs in the upload
-   * transaction, so the version is never visible without its pending placements — which is exactly
-   * what keeps it non-finalizable until re-anchoring resolves (ADR-0011). The re-anchor job itself
-   * is enqueued by the extraction handler once the new text layer is READY.
+   * Seeds a PENDING placement on the new version for EVERY annotation (issue #248, ADR-0009),
+   * carrying the annotation's most recent anchor as the re-anchoring hypothesis. Resolved
+   * annotations are included deliberately: since #405/#394 RESOLVED is not terminal — the thread
+   * stays a readable record on the new version and the author may reopen, so the mark must follow
+   * the document (an OPEN-only filter left reopened annotations permanently placement-less). Runs
+   * in the upload transaction, so the version is never visible without its pending placements —
+   * which is exactly what keeps it non-finalizable until re-anchoring resolves (ADR-0011). The
+   * re-anchor job itself is enqueued by the extraction handler once the new text layer is READY.
    */
   private void seedPendingPlacements(UUID documentId, DocumentVersion newVersion) {
-    var open = annotations.findByDocumentIdAndStatus(documentId, AnnotationStatus.OPEN);
-    if (open.isEmpty()) {
+    var all = annotations.findByDocumentId(documentId);
+    if (all.isEmpty()) {
       return;
     }
     Map<UUID, Integer> versionNumberById =
         versions.findByDocumentIdOrderByVersionNumberAsc(documentId).stream()
             .collect(Collectors.toMap(DocumentVersion::getId, DocumentVersion::getVersionNumber));
-    for (Annotation annotation : open) {
+    for (Annotation annotation : all) {
       Optional<AnnotationPlacement> latest =
           placements.findByAnnotationId(annotation.getId()).stream()
               .filter(p -> !p.getDocumentVersionId().equals(newVersion.getId()))

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -45,6 +45,7 @@ export const reviewKeys = {
   participants: (documentId: string) => [...reviewKeys.all, 'participants', documentId] as const,
   workflow: (documentId: string) => [...reviewKeys.all, 'workflow', documentId] as const,
   principals: (q: string) => [...reviewKeys.all, 'principals', q] as const,
+  teamMembers: (teamId: string) => [...reviewKeys.all, 'team-members', teamId] as const,
 };
 
 /** A page of the caller's reviews (owned or participating, incl. via team). */
@@ -115,6 +116,18 @@ export function usePrincipalSearch(q: string) {
       return response.data;
     },
     placeholderData: keepPreviousData,
+  });
+}
+
+/** The users behind a team principal — names only (issue #403). */
+export function useTeamMembers(teamId: string, enabled: boolean) {
+  return useQuery<PrincipalListResponse>({
+    queryKey: reviewKeys.teamMembers(teamId),
+    queryFn: async () => {
+      const response = await principalsApi.listTeamMembers({ teamId });
+      return response.data;
+    },
+    enabled,
   });
 }
 

--- a/qnop-ui/src/components/admin/layout/SectionCard.tsx
+++ b/qnop-ui/src/components/admin/layout/SectionCard.tsx
@@ -35,6 +35,8 @@ interface SectionCardProps {
   description?: string;
   /** Optional element pinned to the top-right of the header (e.g. a status badge). */
   action?: ReactNode;
+  /** Drops the outlined card chrome — for hosts that bring their own edge (e.g. a drawer). */
+  frameless?: boolean;
   children: ReactNode;
 }
 
@@ -51,11 +53,16 @@ export function SectionCard({
   title,
   description,
   action,
+  frameless = false,
   children,
 }: SectionCardProps) {
   const theme = useTheme();
   return (
-    <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+    <Paper
+      variant={frameless ? 'elevation' : 'outlined'}
+      elevation={0}
+      sx={{ p: { xs: 2, sm: 3 }, ...(frameless && { bgcolor: 'transparent' }) }}
+    >
       <Stack direction="row" spacing={1.5} sx={{ mb: 2.5, alignItems: 'flex-start' }}>
         {Icon && (
           <Box

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -35,6 +35,10 @@ vi.mock('../panel/CommentThread', () => ({
   ),
 }));
 
+vi.mock('../../../api/hooks/useComments', () => ({
+  useComments: vi.fn().mockReturnValue({ isPending: false, isError: false, data: undefined }),
+}));
+
 const { resolveMutate } = vi.hoisted(() => ({ resolveMutate: vi.fn() }));
 vi.mock('../../../api/hooks/useAnnotations', () => ({
   useResolveAnnotation: () => ({ mutate: resolveMutate, isPending: false }),
@@ -142,7 +146,27 @@ describe('FocusAnnotationCard', () => {
     expect(style.minWidth).toBe('320px');
     expect(style.minHeight).toBe('220px');
     expect(style.maxWidth).toContain('640px');
-    expect(style.maxHeight).toContain('72vh');
+    expect(style.maxHeight).toContain('55vh');
+  });
+
+  it('drags by the header — buttons excluded — and offsets the card', () => {
+    renderCard();
+    const handle = screen.getByTestId('focus-card-handle');
+    const card = screen.getByTestId('focus-annotation-card');
+
+    fireEvent.pointerDown(handle, { button: 0, clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(handle, { clientX: 140, clientY: 70 });
+    fireEvent.pointerUp(handle);
+    expect(card.style.translate).toBe('40px -30px');
+
+    // A pointer-down on the walk buttons must not start a drag.
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Next annotation' }), {
+      button: 0,
+      clientX: 0,
+      clientY: 0,
+    });
+    fireEvent.pointerMove(handle, { clientX: 50, clientY: 50 });
+    expect(card.style.translate).toBe('40px -30px');
   });
 
   it('disables the ends of the walk and hides resolving from other reviewers', () => {

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -19,7 +19,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { KeyboardEvent } from 'react';
+import { useRef, useState } from 'react';
+import type { KeyboardEvent, PointerEvent as ReactPointerEvent } from 'react';
 import Box from '@mui/material/Box';
 import Grow from '@mui/material/Grow';
 import IconButton from '@mui/material/IconButton';
@@ -36,8 +37,7 @@ import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
-import { ToneBadge } from '../../admin/ToneBadge';
-import { STATUS_CUES } from '../panel/statusCues';
+import { AnnotationHead } from '../panel/AnnotationHead';
 import { CommentThread } from '../panel/CommentThread';
 import { ResolveBar } from '../panel/ResolveBar';
 import {
@@ -46,7 +46,6 @@ import {
   useReopenWithFeedback,
   useResolveWithFeedback,
 } from '../panel/resolve';
-import { PlacementStatusChip } from '../panel/PlacementStatusChip';
 import type { WalkPosition } from './spotlightModel';
 
 interface FocusAnnotationCardProps {
@@ -74,10 +73,11 @@ function isTypingTarget(event: KeyboardEvent): boolean {
 }
 
 /**
- * Focus mode's floating discussion card (issue #291): everything the panel
- * card offers — status and placement cues, the quote, the author's Resolve
+ * Focus mode's floating discussion card (issue #291): the panel's expanded
+ * unit as a floating card — the shared AnnotationHead, the author's Resolve
  * bar, the full comment thread with its composer — next to the spotlit mark,
- * never over it.
+ * never over it (issue #403: same anatomy as the document view, no status
+ * rail, no pointer arrow).
  * Prev/Next (and ↑/↓ outside text fields) walk the annotations in document
  * order without closing; the walk position is announced politely. Focus is
  * trapped inside the card; Escape (and the close button) return it to the
@@ -99,8 +99,51 @@ export function FocusAnnotationCard({
   const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
   const { resolveWith, isPending: resolving } = useResolveWithFeedback(notify);
   const { reopenWith } = useReopenWithFeedback(notify);
-  const statusCue = STATUS_CUES[annotation.status];
-  const quote = annotation.anchor?.textQuote?.quote;
+
+  // The card is draggable by its header (issue #403): the offset rides on
+  // top of the Popper's anchor position and resets when the walk moves to
+  // another annotation (the card snaps to the new mark, as expected).
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+  const dragStart = useRef({ pointerX: 0, pointerY: 0, x: 0, y: 0 });
+  const draggingRef = useRef(false);
+  const [lastAnnotationId, setLastAnnotationId] = useState(annotation.id);
+  if (annotation.id !== lastAnnotationId) {
+    setLastAnnotationId(annotation.id);
+    setDragOffset({ x: 0, y: 0 });
+  }
+
+  const handleDragStart = (event: ReactPointerEvent<HTMLDivElement>) => {
+    // The header's buttons keep their clicks; only the free area drags.
+    if (event.button !== 0 || (event.target as HTMLElement).closest('button')) return;
+    event.preventDefault();
+    dragStart.current = {
+      pointerX: event.clientX,
+      pointerY: event.clientY,
+      x: dragOffset.x,
+      y: dragOffset.y,
+    };
+    draggingRef.current = true;
+    setDragging(true);
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Synthetic pointer events (tests) have no active pointer to capture.
+    }
+  };
+
+  const handleDragMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!draggingRef.current) return;
+    setDragOffset({
+      x: dragStart.current.x + (event.clientX - dragStart.current.pointerX),
+      y: dragStart.current.y + (event.clientY - dragStart.current.pointerY),
+    });
+  };
+
+  const handleDragEnd = () => {
+    draggingRef.current = false;
+    setDragging(false);
+  };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Escape') {
@@ -147,6 +190,7 @@ export function FocusAnnotationCard({
             variant="outlined"
             data-testid="focus-annotation-card"
             onKeyDown={handleKeyDown}
+            style={{ translate: `${dragOffset.x}px ${dragOffset.y}px` }}
             sx={{
               display: 'flex',
               position: 'relative',
@@ -159,36 +203,6 @@ export function FocusAnnotationCard({
               overflow: 'visible',
             }}
           >
-            {/* The prototype's card↔mark link cues: a status rail on the edge
-                facing the reader, and a pointer arrow toward the spotlit mark
-                (flips with the Popper placement). */}
-            <Box
-              aria-hidden
-              sx={{
-                position: 'absolute',
-                left: 0,
-                top: 10,
-                bottom: 10,
-                width: 3,
-                borderRadius: '0 3px 3px 0',
-                bgcolor: statusCue.color(theme),
-              }}
-            />
-            <Box
-              aria-hidden
-              data-testid="focus-card-arrow"
-              sx={{
-                position: 'absolute',
-                top: 16,
-                width: 0,
-                height: 0,
-                borderTop: '7px solid transparent',
-                borderBottom: '7px solid transparent',
-                ...(placement.startsWith('left')
-                  ? { right: -8, borderLeft: `8px solid ${statusCue.color(theme)}` }
-                  : { left: -8, borderRight: `8px solid ${statusCue.color(theme)}` }),
-              }}
-            />
             {/* Enforcement stays off: the card coexists with interactive marks
                 and the toolbar — clicking them must not yank focus (and the
                 window scroll) back into the card. Tab still cycles inside. */}
@@ -211,18 +225,28 @@ export function FocusAnnotationCard({
                   minWidth: 320,
                   maxWidth: 'min(640px, calc(100vw - 48px))',
                   minHeight: 220,
-                  maxHeight: 'min(72vh, 680px)',
+                  // Tall threads scroll inside; the card itself stays a
+                  // modest share of the screen (issue #403).
+                  maxHeight: 'min(55vh, 520px)',
                 }}
               >
                 <Stack
                   direction="row"
                   spacing={0.5}
+                  data-testid="focus-card-handle"
+                  onPointerDown={handleDragStart}
+                  onPointerMove={handleDragMove}
+                  onPointerUp={handleDragEnd}
+                  onPointerCancel={handleDragEnd}
                   sx={{
                     alignItems: 'center',
                     px: 1.5,
                     py: 1,
                     borderBottom: `1px solid ${theme.palette.divider}`,
                     flexShrink: 0,
+                    cursor: dragging ? 'grabbing' : 'grab',
+                    touchAction: 'none',
+                    userSelect: 'none',
                   }}
                 >
                   <Typography
@@ -272,48 +296,23 @@ export function FocusAnnotationCard({
                 </Stack>
 
                 <Box sx={{ px: 1.5, pt: 1.25, flexShrink: 0 }}>
-                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.75 }}>
-                    <ToneBadge tone={statusCue.tone} label={statusCue.label} />
-                    <PlacementStatusChip status={annotation.placementStatus} />
-                  </Stack>
-                  {quote && (
-                    <Typography
-                      variant="body2"
-                      color="text.secondary"
-                      sx={{
-                        fontStyle: 'italic',
-                        borderLeft: `2px solid ${theme.palette.divider}`,
-                        pl: 1,
-                        display: '-webkit-box',
-                        WebkitLineClamp: 3,
-                        WebkitBoxOrient: 'vertical',
-                        overflow: 'hidden',
-                      }}
-                    >
-                      {`“${quote}”`}
-                    </Typography>
-                  )}
-                  {/* The opening annotation text — the thread below carries
-                      only the replies (issue #403). */}
-                  {annotation.firstComment && (
-                    <Typography
-                      variant="body2"
-                      sx={{ mt: 0.75, whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
-                      data-testid="opening-text"
-                    >
-                      {annotation.firstComment}
-                    </Typography>
-                  )}
+                  {/* The same root post the panel's expanded card shows. */}
+                  <AnnotationHead annotation={annotation} />
                 </Box>
 
                 {!readOnly && mayResolveAnnotation(annotation, userId) && (
-                  <ResolveBar
-                    disabled={resolving}
-                    onResolve={(note) => resolveWith(annotation, note)}
-                  />
+                  // The bar's flush-right button is the panel's look; inside
+                  // the floating card it breathes like the left side does.
+                  <Box sx={{ pr: 2 }}>
+                    <ResolveBar
+                      disabled={resolving}
+                      onResolve={(note) => resolveWith(annotation, note)}
+                    />
+                  </Box>
                 )}
 
-                <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0, px: 0.5, pb: 0.5 }}>
+                {/* Same breathing room at the bottom as the head keeps at the top. */}
+                <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0, pl: 0.5, pr: 2, pb: 1.25 }}>
                   <CommentThread
                     annotationId={annotation.id}
                     notify={notify}

--- a/qnop-ui/src/components/reviews/hub/ParticipantsDialog.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ParticipantsDialog.test.tsx
@@ -38,7 +38,7 @@ vi.mock('../../../api/config', () => ({
     addParticipant: vi.fn(),
     removeParticipant: vi.fn(),
   },
-  principalsApi: { searchPrincipals: vi.fn() },
+  principalsApi: { searchPrincipals: vi.fn(), listTeamMembers: vi.fn() },
   reviewWorkflowApi: {
     getDocumentWorkflow: vi.fn(),
     transitionDocumentWorkflow: vi.fn(),
@@ -166,5 +166,23 @@ describe('ParticipantsDialog — owner management', () => {
     await waitFor(() =>
       expect(notify).toHaveBeenCalledWith('Already a reviewer on this document.', 'error'),
     );
+  });
+
+  it('unfolds a team to show its members, names only (#403)', async () => {
+    vi.mocked(principalsApi.listTeamMembers).mockResolvedValue({
+      data: {
+        principals: [
+          { id: 'u-clara', kind: ParticipantKind.User, displayName: 'Clara Vogt' },
+          { id: 'u-jonas', kind: ParticipantKind.User, displayName: 'Jonas Keller' },
+        ],
+      },
+    } as Awaited<ReturnType<typeof principalsApi.listTeamMembers>>);
+    renderDialog(false);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Show members of Team Alpha' }));
+
+    expect(await screen.findByText('Clara Vogt')).toBeInTheDocument();
+    expect(screen.getByText('Jonas Keller')).toBeInTheDocument();
+    expect(vi.mocked(principalsApi.listTeamMembers)).toHaveBeenCalledWith({ teamId: 't-alpha' });
   });
 });

--- a/qnop-ui/src/components/reviews/hub/ParticipantsDialog.tsx
+++ b/qnop-ui/src/components/reviews/hub/ParticipantsDialog.tsx
@@ -19,8 +19,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Collapse from '@mui/material/Collapse';
 import Button from '@mui/material/Button';
 import ButtonBase from '@mui/material/ButtonBase';
 import Dialog from '@mui/material/Dialog';
@@ -34,7 +36,7 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { Plus, Search, Users, X } from 'lucide-react';
+import { ChevronRight, Plus, Search, Users, X } from 'lucide-react';
 import type { ParticipantView, PrincipalView } from '../../../api/generated';
 import { ParticipantKind } from '../../../api/generated';
 import {
@@ -42,6 +44,7 @@ import {
   useParticipants,
   usePrincipalSearch,
   useRemoveParticipant,
+  useTeamMembers,
 } from '../../../api/hooks/useReviews';
 import type { ToastSeverity } from '../../admin/layout/useToast';
 import { UserAvatar } from '../../shell/UserAvatar';
@@ -86,6 +89,42 @@ function PrincipalIcon({ kind, size }: { kind: ParticipantKind; size: number }) 
 }
 
 /** View & (owner-only) manage the reviewers of one document. */
+/** The unfolded team: its members as quiet indented rows on a thin branch. */
+function TeamMemberList({ teamId }: { teamId: string }) {
+  const membersQuery = useTeamMembers(teamId, true);
+  const members = membersQuery.data?.principals ?? [];
+  if (membersQuery.isPending) {
+    return (
+      <Stack sx={{ alignItems: 'flex-start', pl: 7, py: 0.5 }}>
+        <CircularProgress size={14} aria-label="Loading team members" />
+      </Stack>
+    );
+  }
+  if (members.length === 0) {
+    return (
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', pl: 7 }}>
+        No members in this team.
+      </Typography>
+    );
+  }
+  return (
+    <Stack
+      spacing={0.25}
+      data-testid={`team-members-${teamId}`}
+      sx={{ ml: 3.25, pl: 1.75, my: 0.25, borderLeft: '2px solid', borderColor: 'divider' }}
+    >
+      {members.map((member) => (
+        <Stack key={member.id} direction="row" spacing={1} sx={{ alignItems: 'center', py: 0.25 }}>
+          <UserAvatar name={member.displayName} size={20} />
+          <Typography variant="body2" noWrap>
+            {member.displayName}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
 export function ParticipantsDialog({
   documentId,
   open,
@@ -96,6 +135,15 @@ export function ParticipantsDialog({
 }: ParticipantsDialogProps) {
   const theme = useTheme();
   const [query, setQuery] = useState('');
+  // Teams unfold to show who reviews behind them (issue #403).
+  const [expandedTeams, setExpandedTeams] = useState<Set<string>>(new Set());
+  const toggleTeam = (teamId: string) =>
+    setExpandedTeams((current) => {
+      const next = new Set(current);
+      if (next.has(teamId)) next.delete(teamId);
+      else next.add(teamId);
+      return next;
+    });
 
   const participantsQuery = useParticipants(documentId, open);
   const searchQuery = usePrincipalSearch(open && isOwner ? query.trim() : '');
@@ -142,40 +190,63 @@ export function ParticipantsDialog({
             </Typography>
           ) : (
             <Stack spacing={0.5} data-testid="participants-list">
-              {participants.map((participant) => (
-                <Stack
-                  key={participant.id}
-                  direction="row"
-                  spacing={1.25}
-                  sx={{ alignItems: 'center', py: 0.5 }}
-                >
-                  {participant.kind === ParticipantKind.Team ? (
-                    <PrincipalIcon kind={participant.kind} size={28} />
-                  ) : (
-                    <UserAvatar name={participant.displayName} size={28} />
-                  )}
-                  <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
-                      {participant.displayName}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {participant.kind === ParticipantKind.Team ? 'Team' : 'User'}
-                    </Typography>
-                  </Box>
-                  {isOwner && (
-                    <Tooltip title={`Remove ${participant.displayName}`}>
-                      <IconButton
-                        size="small"
-                        aria-label={`Remove ${participant.displayName}`}
-                        disabled={removeParticipant.isPending}
-                        onClick={() => handleRemove(participant)}
-                      >
-                        <X size={15} />
-                      </IconButton>
-                    </Tooltip>
-                  )}
-                </Stack>
-              ))}
+              {participants.map((participant) => {
+                const isTeam = participant.kind === ParticipantKind.Team;
+                const expanded = isTeam && expandedTeams.has(participant.principalId);
+                return (
+                  <Fragment key={participant.id}>
+                    <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', py: 0.5 }}>
+                      {isTeam ? (
+                        <IconButton
+                          size="small"
+                          aria-label={`Show members of ${participant.displayName}`}
+                          aria-expanded={expanded}
+                          onClick={() => toggleTeam(participant.principalId)}
+                          sx={{ ml: -1, mr: -0.75 }}
+                        >
+                          <ChevronRight
+                            size={14}
+                            style={{
+                              transform: expanded ? 'rotate(90deg)' : 'none',
+                              transition: 'transform 150ms ease',
+                            }}
+                          />
+                        </IconButton>
+                      ) : null}
+                      {isTeam ? (
+                        <PrincipalIcon kind={participant.kind} size={28} />
+                      ) : (
+                        <UserAvatar name={participant.displayName} size={28} />
+                      )}
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+                          {participant.displayName}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {isTeam ? 'Team' : 'User'}
+                        </Typography>
+                      </Box>
+                      {isOwner && (
+                        <Tooltip title={`Remove ${participant.displayName}`}>
+                          <IconButton
+                            size="small"
+                            aria-label={`Remove ${participant.displayName}`}
+                            disabled={removeParticipant.isPending}
+                            onClick={() => handleRemove(participant)}
+                          >
+                            <X size={15} />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Stack>
+                    {isTeam && (
+                      <Collapse in={expanded} unmountOnExit>
+                        <TeamMemberList teamId={participant.principalId} />
+                      </Collapse>
+                    )}
+                  </Fragment>
+                );
+              })}
             </Stack>
           )}
 

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
@@ -33,6 +33,7 @@ import type {
 import { AnnotationStatus, ParticipantKind, PlacementStatus } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';
 import { axiosInstance, documentsApi, reviewWorkflowApi } from '../../../api/config';
+import { useAuthStore } from '../../../stores/authStore';
 import { ReviewHubHead } from './ReviewHubHead';
 
 vi.mock('../../../api/config', () => ({
@@ -103,6 +104,7 @@ function renderHub({
   return render(
     <ReviewHubHead
       documentId={DOC_ID}
+      ownerId={isOwner ? ME : 'owner-far-away'}
       isOwner={isOwner}
       ownUserId={ME}
       annotations={annotations}
@@ -127,6 +129,15 @@ beforeEach(() => {
     data: PARTICIPANTS,
   } as Awaited<ReturnType<typeof documentsApi.listParticipants>>);
   mockWorkflow({ state: 'IN_REVIEW', allowedTransitions: ['FINALIZED', 'CANCELLED'] });
+});
+
+describe('ReviewHubHead — owner', () => {
+  it('shows the owner prominently, resolved as self by display name', () => {
+    useAuthStore.setState({ userId: ME, displayName: 'Paula Owner' });
+    renderHub();
+    expect(screen.getByTestId('review-owner')).toHaveTextContent('Owner');
+    expect(screen.getByTestId('review-owner')).toHaveTextContent('Paula Owner');
+  });
 });
 
 describe('ReviewHubHead — progress & participants', () => {

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -21,6 +21,7 @@
 
 import { useRef, useState } from 'react';
 import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
 import Button from '@mui/material/Button';
 import ButtonBase from '@mui/material/ButtonBase';
 import Menu from '@mui/material/Menu';
@@ -35,10 +36,12 @@ import { AnnotationStatus, ParticipantKind } from '../../../api/generated';
 import { useConfig } from '../../../api/hooks/useConfig';
 import {
   useParticipants,
+  usePrincipalSearch,
   useTransitionWorkflow,
   useUploadVersion,
   useWorkflow,
 } from '../../../api/hooks/useReviews';
+import { useAuthStore } from '../../../stores/authStore';
 import { ConfirmDialog } from '../../admin/ConfirmDialog';
 import type { Notify } from '../../admin/layout/useToast';
 import { UserAvatar } from '../../shell/UserAvatar';
@@ -61,6 +64,8 @@ const TRANSITION_CONFLICTS: Record<string, string> = {
 
 interface ReviewHubHeadProps {
   documentId: string;
+  /** The document owner — shown prominently in the header (issue #403). */
+  ownerId: string;
   isOwner: boolean;
   ownUserId: string | null;
   annotations: AnnotationView[];
@@ -81,6 +86,7 @@ interface ReviewHubHeadProps {
  */
 export function ReviewHubHead({
   documentId,
+  ownerId,
   isOwner,
   ownUserId,
   annotations,
@@ -103,11 +109,23 @@ export function ReviewHubHead({
   const uploadVersion = useUploadVersion(documentId);
 
   const participants = participantsQuery.data?.participants ?? [];
+  // The owner never sits in the participant rows; the principal directory
+  // (names only, #292) resolves them — self by display name.
+  const principals = usePrincipalSearch('').data?.principals ?? [];
+  const ownDisplayName = useAuthStore((state) => state.displayName);
+  const ownAvatarUrl = useAuthStore((state) => state.avatarUrl);
+  const ownerName =
+    ownerId === ownUserId
+      ? (ownDisplayName ?? 'You')
+      : (principals.find((principal) => principal.id === ownerId)?.displayName ?? 'Owner');
   const transitions = workflowQuery.data?.allowedTransitions ?? [];
   const maxSizeMb = config?.upload.maxDocumentSizeMb ?? FALLBACK_MAX_SIZE_MB;
 
   const total = annotations.length;
   const resolved = annotations.filter((a) => a.status !== AnnotationStatus.Open).length;
+  const inDiscussion = annotations.filter(
+    (a) => a.status === AnnotationStatus.Open && a.commentCount > 1,
+  ).length;
 
   const handleTransitionConfirmed = (targetState: string) => {
     setConfirmTarget(null);
@@ -145,16 +163,57 @@ export function ReviewHubHead({
 
   return (
     <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+      <Tooltip title="Review owner">
+        <Stack
+          direction="row"
+          spacing={0.75}
+          data-testid="review-owner"
+          sx={{ alignItems: 'center', minWidth: 0 }}
+        >
+          <UserAvatar
+            name={ownerName}
+            size={24}
+            imageUrl={ownerId === ownUserId ? ownAvatarUrl : null}
+          />
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              sx={{
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                color: 'text.secondary',
+                lineHeight: 1.1,
+              }}
+            >
+              Owner
+            </Typography>
+            <Typography variant="body2" noWrap sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+              {ownerName}
+            </Typography>
+          </Box>
+        </Stack>
+      </Tooltip>
+      <Divider orientation="vertical" flexItem sx={{ my: 0.5 }} />
       {total > 0 && (
-        <ProgressBar
-          resolved={resolved}
-          total={total}
-          color={theme.palette.success.main}
-          discussion={
-            annotations.filter((a) => a.status === AnnotationStatus.Open && a.commentCount > 1)
-              .length
-          }
-        />
+        <Tooltip
+          title={`Review progress: ${resolved} of ${total} annotation${total === 1 ? '' : 's'} resolved${
+            inDiscussion > 0
+              ? ` · ${inDiscussion} open in discussion`
+              : total - resolved > 0
+                ? ` · ${total - resolved} still open`
+                : ' — ready to finalize'
+          }`}
+        >
+          <Box sx={{ display: 'flex' }}>
+            <ProgressBar
+              resolved={resolved}
+              total={total}
+              color={theme.palette.success.main}
+              discussion={inDiscussion}
+            />
+          </Box>
+        </Tooltip>
       )}
 
       {isOwner ? (

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { MessageSquare } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import { ToneBadge } from '../../admin/ToneBadge';
+import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
+import { PlacementStatusChip } from './PlacementStatusChip';
+import { STATUS_CUES } from './statusCues';
+
+interface AnnotationBadgeRowProps {
+  annotation: AnnotationView;
+  /** Adds the "New" badge (issue #307). */
+  unseen?: boolean;
+}
+
+/**
+ * The annotation's badge line — status, optional New, type cue, priority dot,
+ * placement cue, and page + thread size on the right. ONE component so the
+ * panel's head card and the mark's hover preview stay pixel-identical
+ * (issue #403).
+ */
+export function AnnotationBadgeRow({ annotation, unseen = false }: AnnotationBadgeRowProps) {
+  const theme = useTheme();
+  const statusCue = STATUS_CUES[annotation.status];
+  const typeCue = annotation.type ? TYPE_CUES[annotation.type] : null;
+  const TypeIcon = typeCue?.icon;
+  const priorityCue = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
+  const region = annotation.anchor?.region;
+
+  return (
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+      <ToneBadge tone={statusCue.tone} label={statusCue.label} />
+      {unseen && <ToneBadge tone="blue" label="New" />}
+      {typeCue && TypeIcon && (
+        <Stack
+          direction="row"
+          spacing={0.5}
+          sx={{ alignItems: 'center', color: typeCue.color(theme) }}
+        >
+          <TypeIcon size={12} aria-hidden />
+          <Typography component="span" sx={{ fontSize: 11, fontWeight: 600 }}>
+            {typeCue.label}
+          </Typography>
+        </Stack>
+      )}
+      {priorityCue && (
+        <Tooltip title={`${priorityCue.label} priority`}>
+          <Box
+            sx={{
+              width: 7,
+              height: 7,
+              borderRadius: '50%',
+              bgcolor: priorityCue.color(theme),
+              flexShrink: 0,
+            }}
+          />
+        </Tooltip>
+      )}
+      <PlacementStatusChip status={annotation.placementStatus} />
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{ alignItems: 'center', ml: 'auto', color: 'text.secondary' }}
+      >
+        {region && <Typography variant="caption">Page {region.surfaceIndex + 1}</Typography>}
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+          <MessageSquare size={13} aria-hidden />
+          <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
+            {annotation.commentCount}
+          </Typography>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { useComments } from '../../../api/hooks/useComments';
+import { useAuthStore } from '../../../stores/authStore';
+import { shortRelativeTime } from '../../../utils/relativeTime';
+import { UserAvatar } from '../../shell/UserAvatar';
+import { AnnotationBadgeRow } from './AnnotationBadgeRow';
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+interface AnnotationHeadProps {
+  annotation: AnnotationView;
+  /** Adds the "New" badge (issue #307). */
+  unseen?: boolean;
+}
+
+/**
+ * The opening annotation as the discussion's root post (issue #403): badge
+ * row, the anchored passage styled as a real quotation, the opening text and
+ * the author line. ONE component shared by the panel's expanded card and the
+ * focus mode's floating card, so the head reads identically on both.
+ */
+export function AnnotationHead({ annotation, unseen = false }: AnnotationHeadProps) {
+  const theme = useTheme();
+  const userId = useAuthStore((state) => state.userId);
+  const displayName = useAuthStore((state) => state.displayName);
+  const avatarUrl = useAuthStore((state) => state.avatarUrl);
+  // Full opener once the thread is cached; the server-side excerpt until then.
+  const cachedComments = useComments(annotation.id, false).data?.comments ?? [];
+  const openerText = cachedComments[0]?.body ?? annotation.firstComment ?? null;
+  const own = annotation.authorId === userId;
+  const authorName = own ? (displayName ?? 'You') : 'Participant';
+  const quote = annotation.anchor?.textQuote?.quote;
+  const fallbackLabel = annotation.anchor?.region
+    ? 'Region annotation'
+    : 'No placement on this version';
+
+  return (
+    <Stack spacing={1} data-testid="annotation-head-card">
+      <AnnotationBadgeRow annotation={annotation} unseen={unseen} />
+      {/* The anchored passage, styled as a real quotation. */}
+      {quote ? (
+        <Box
+          sx={{
+            borderLeft: '3px solid',
+            borderColor: 'divider',
+            bgcolor: theme.qnop.surface2,
+            borderRadius: '0 6px 6px 0',
+            px: 1.25,
+            py: 0.75,
+          }}
+        >
+          <Typography
+            variant="body2"
+            sx={{
+              fontStyle: 'italic',
+              color: 'text.secondary',
+              display: '-webkit-box',
+              WebkitLineClamp: 4,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            “{quote}”
+          </Typography>
+        </Box>
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          {fallbackLabel}
+        </Typography>
+      )}
+      {openerText && (
+        <Typography
+          variant="body2"
+          sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
+          data-testid="opening-text"
+        >
+          {openerText}
+        </Typography>
+      )}
+      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+        <UserAvatar name={authorName} size={20} imageUrl={own ? avatarUrl : null} />
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          noWrap
+          title={DATE_FORMAT.format(new Date(annotation.createdAt))}
+        >
+          {authorName} · {shortRelativeTime(annotation.createdAt)}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -30,20 +30,11 @@ import { MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
-import { ToneBadge } from '../../admin/ToneBadge';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { tokens } from '../../../theme/tokens';
-import { shortRelativeTime } from '../../../utils/relativeTime';
 import { hasNewComments, isUnseen } from '../newSince';
-import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
-import { PlacementStatusChip } from './PlacementStatusChip';
+import { AnnotationHead } from './AnnotationHead';
 import { STATUS_CUES } from './statusCues';
-
-/** Compact date for the head card's author line. */
-const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'medium',
-  timeStyle: 'short',
-});
 
 /** Up to this many participant avatars stack in the collapsed row. */
 const MAX_AVATARS = 3;
@@ -126,9 +117,6 @@ function AnnotationListItemBase({
 }: AnnotationListItemProps) {
   const theme = useTheme();
   const viewerId = useAuthStore((state) => state.userId);
-  const selfDisplayName = useAuthStore((state) => state.displayName);
-  const avatarUrl = useAuthStore((state) => state.avatarUrl);
-  const userId = viewerId;
   const unseen = isUnseen(annotation, previousSeenAt, viewerId);
   const freshComments = hasNewComments(annotation, previousSeenAt);
   const quote = annotation.anchor?.textQuote?.quote;
@@ -140,13 +128,6 @@ function AnnotationListItemBase({
   // the cache (enabled: false never fetches — rows stay cheap; the stack
   // enriches once a thread has been opened or hover-prefetched).
   const cachedComments = useComments(annotation.id, false).data?.comments ?? [];
-  const typeCue = annotation.type ? TYPE_CUES[annotation.type] : null;
-  const TypeIcon = typeCue?.icon;
-  const priorityCue = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
-  // The opening annotation text: the full body once the thread is cached,
-  // the server-side excerpt as the placeholder until then.
-  const openerText = cachedComments[0]?.body ?? annotation.firstComment ?? null;
-  const authorName = annotation.authorId === userId ? (selfDisplayName ?? 'You') : 'Participant';
   const participantIds = [
     ...new Set([annotation.authorId, ...cachedComments.map((comment) => comment.authorId)]),
   ];
@@ -187,108 +168,7 @@ function AnnotationListItemBase({
       }}
     >
       {active ? (
-        <Stack spacing={1} data-testid="annotation-head-card">
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
-            <ToneBadge tone={statusCue.tone} label={statusCue.label} />
-            {unseen && <ToneBadge tone="blue" label="New" />}
-            {typeCue && TypeIcon && (
-              <Stack
-                direction="row"
-                spacing={0.5}
-                sx={{ alignItems: 'center', color: typeCue.color(theme) }}
-              >
-                <TypeIcon size={12} aria-hidden />
-                <Typography component="span" sx={{ fontSize: 11, fontWeight: 600 }}>
-                  {typeCue.label}
-                </Typography>
-              </Stack>
-            )}
-            {priorityCue && (
-              <Tooltip title={`${priorityCue.label} priority`}>
-                <Box
-                  sx={{
-                    width: 7,
-                    height: 7,
-                    borderRadius: '50%',
-                    bgcolor: priorityCue.color(theme),
-                    flexShrink: 0,
-                  }}
-                />
-              </Tooltip>
-            )}
-            <PlacementStatusChip status={annotation.placementStatus} />
-            <Stack
-              direction="row"
-              spacing={1}
-              sx={{ alignItems: 'center', ml: 'auto', color: 'text.secondary' }}
-            >
-              {region && <Typography variant="caption">Page {region.surfaceIndex + 1}</Typography>}
-              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-                <MessageSquare size={13} aria-hidden />
-                <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
-                  {annotation.commentCount}
-                </Typography>
-              </Stack>
-            </Stack>
-          </Stack>
-          {/* The anchored passage, styled as a real quotation. */}
-          {quote ? (
-            <Box
-              sx={{
-                borderLeft: '3px solid',
-                borderColor: 'divider',
-                bgcolor: theme.qnop.surface2,
-                borderRadius: '0 6px 6px 0',
-                px: 1.25,
-                py: 0.75,
-              }}
-            >
-              <Typography
-                variant="body2"
-                sx={{
-                  fontStyle: 'italic',
-                  color: 'text.secondary',
-                  display: '-webkit-box',
-                  WebkitLineClamp: 4,
-                  WebkitBoxOrient: 'vertical',
-                  overflow: 'hidden',
-                }}
-              >
-                “{quote}”
-              </Typography>
-            </Box>
-          ) : (
-            <Typography variant="body2" color="text.secondary">
-              {fallbackLabel}
-            </Typography>
-          )}
-          {/* The opening annotation text — full body once the thread is cached,
-              the server's excerpt until then (issue #403). */}
-          {openerText && (
-            <Typography
-              variant="body2"
-              sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
-              data-testid="opening-text"
-            >
-              {openerText}
-            </Typography>
-          )}
-          <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-            <UserAvatar
-              name={authorName}
-              size={20}
-              imageUrl={annotation.authorId === userId ? avatarUrl : null}
-            />
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              noWrap
-              title={DATE_FORMAT.format(new Date(annotation.createdAt))}
-            >
-              {authorName} · {shortRelativeTime(annotation.createdAt)}
-            </Typography>
-          </Stack>
-        </Stack>
+        <AnnotationHead annotation={annotation} unseen={unseen} />
       ) : (
         <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
           <Tooltip title={statusCue.label}>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -75,6 +75,8 @@ interface AnnotationPanelProps {
   readOnly?: boolean;
   /** True once the review is FINALIZED/CANCELLED (issue #394): no reopening. */
   reviewClosed?: boolean;
+  /** Drops the section's outer card frame — the focus drawer brings its own edge. */
+  frameless?: boolean;
   /** The previous visit (issue #307) — null hides every unseen cue. */
   previousSeenAt?: string | null;
 }
@@ -207,6 +209,7 @@ export function AnnotationPanel({
   notify,
   readOnly = false,
   reviewClosed = false,
+  frameless = false,
   previousSeenAt = null,
 }: AnnotationPanelProps) {
   const [filters, setFilters] = useState<AnnotationFilters>(EMPTY_FILTERS);
@@ -291,6 +294,7 @@ export function AnnotationPanel({
       icon={NotebookPen}
       title={`Annotations (${annotations.length})`}
       description="Marks and their discussion on this version."
+      frameless={frameless}
     >
       <Stack spacing={1.5}>
         {annotations.length > 0 && (

--- a/qnop-ui/src/components/reviews/panel/CommentBubble.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentBubble.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { shortRelativeTime } from '../../../utils/relativeTime';
+import { UserAvatar } from '../../shell/UserAvatar';
+
+const AVATAR_SIZE = 26;
+
+const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+interface CommentBubbleProps {
+  /** The display name; the bubble prints "You" for the viewer's own. */
+  name: string;
+  own: boolean;
+  avatarUrl: string | null;
+  body: string;
+  createdAt: string;
+  /** Clamp the body to N lines (the hover preview); unset shows everything. */
+  clampLines?: number;
+}
+
+/**
+ * One comment in the social anatomy (issue #403): avatar, a softly rounded
+ * bubble carrying the bold author name above the text, and the compact
+ * relative timestamp in the meta line underneath (full date in the tooltip).
+ * Shared by the thread and the mark's hover preview, so a comment reads
+ * identically everywhere.
+ */
+export function CommentBubble({
+  name,
+  own,
+  avatarUrl,
+  body,
+  createdAt,
+  clampLines,
+}: CommentBubbleProps) {
+  const theme = useTheme();
+  return (
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+      <Box sx={{ position: 'relative', zIndex: 1, pt: 0.25 }}>
+        <UserAvatar name={name} size={AVATAR_SIZE} imageUrl={own ? avatarUrl : null} />
+      </Box>
+      <Box sx={{ minWidth: 0, maxWidth: '100%' }}>
+        <Box
+          sx={{
+            display: 'inline-block',
+            maxWidth: '100%',
+            bgcolor: theme.qnop.surface2,
+            borderRadius: '4px 10px 10px 10px',
+            px: 1.5,
+            py: 0.75,
+          }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+            {own ? 'You' : name}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              whiteSpace: 'pre-wrap',
+              overflowWrap: 'anywhere',
+              ...(clampLines !== undefined && {
+                display: '-webkit-box',
+                WebkitLineClamp: clampLines,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                whiteSpace: 'normal',
+              }),
+            }}
+          >
+            {body}
+          </Typography>
+        </Box>
+        <Typography
+          variant="caption"
+          title={TIME_FORMAT.format(new Date(createdAt))}
+          sx={{ display: 'block', pl: 1.5, mt: 0.25, fontWeight: 600, color: 'text.secondary' }}
+        >
+          {shortRelativeTime(createdAt)}
+        </Typography>
+      </Box>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -33,10 +33,10 @@ import { CircleCheck, RotateCcw, SendHorizontal } from 'lucide-react';
 import { useAddComment, useComments } from '../../../api/hooks/useComments';
 import { apiErrorCode } from '../../../utils/apiError';
 import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
-import { shortRelativeTime } from '../../../utils/relativeTime';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { isNewComment } from '../newSince';
+import { CommentBubble } from './CommentBubble';
 import { UserAvatar } from '../../shell/UserAvatar';
 
 const AVATAR_SIZE = 26;
@@ -57,11 +57,6 @@ interface CommentThreadProps {
   /** True when the surrounding card already renders the opening annotation (issue #403). */
   skipOpener?: boolean;
 }
-
-const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'medium',
-  timeStyle: 'short',
-});
 
 /**
  * The annotation's discussion — the comment anatomy of Facebook/Instagram
@@ -165,51 +160,13 @@ export function CommentThread({
                   />
                 </Stack>
               )}
-              <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
-                <Box sx={{ position: 'relative', zIndex: 1, pt: 0.25 }}>
-                  <UserAvatar name={name} size={AVATAR_SIZE} imageUrl={own ? avatarUrl : null} />
-                </Box>
-                <Box sx={{ minWidth: 0, maxWidth: '100%' }}>
-                  {/* The bubble: bold name on its own line, the text below —
-                      no date inside (Facebook anatomy); the tucked top-left
-                      corner points back at the avatar on the rail. */}
-                  <Box
-                    sx={{
-                      display: 'inline-block',
-                      maxWidth: '100%',
-                      bgcolor: theme.qnop.surface2,
-                      borderRadius: '4px 10px 10px 10px',
-                      px: 1.5,
-                      py: 0.75,
-                    }}
-                  >
-                    <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
-                      {own ? 'You' : name}
-                    </Typography>
-                    <Typography
-                      variant="body2"
-                      sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
-                    >
-                      {comment.body}
-                    </Typography>
-                  </Box>
-                  {/* The meta line under the bubble — the compact social
-                      timestamp; likes join here with #410. */}
-                  <Typography
-                    variant="caption"
-                    title={TIME_FORMAT.format(new Date(comment.createdAt))}
-                    sx={{
-                      display: 'block',
-                      pl: 1.5,
-                      mt: 0.25,
-                      fontWeight: 600,
-                      color: 'text.secondary',
-                    }}
-                  >
-                    {shortRelativeTime(comment.createdAt)}
-                  </Typography>
-                </Box>
-              </Stack>
+              <CommentBubble
+                name={name}
+                own={own}
+                avatarUrl={avatarUrl}
+                body={comment.body}
+                createdAt={comment.createdAt}
+              />
             </Fragment>
           );
         })}

--- a/qnop-ui/src/components/reviews/panel/PanelFilterBar.tsx
+++ b/qnop-ui/src/components/reviews/panel/PanelFilterBar.tsx
@@ -31,12 +31,27 @@ import Popover from '@mui/material/Popover';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { ListFilter, Search } from 'lucide-react';
-import { AnnotationPriority, AnnotationType } from '../../../api/generated';
+import { AnnotationPriority, AnnotationStatus, AnnotationType } from '../../../api/generated';
+import { UserAvatar } from '../../shell/UserAvatar';
+import { STATUS_CUES } from './statusCues';
 import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
 import type { AnnotationFilters } from './panelFilters';
 import { EMPTY_FILTERS, activeFacetCount } from './panelFilters';
+
+/** Compact facet pills living inside the search field — no second row, no layout shift. */
+const PILL_SX = {
+  height: 20,
+  fontSize: 11,
+  fontWeight: 600,
+  bgcolor: 'background.paper',
+  border: '1px solid',
+  borderColor: 'divider',
+  '& .MuiChip-deleteIcon': { fontSize: 14 },
+  '& .MuiChip-icon': { ml: 0.5, mr: -0.25 },
+} as const;
 
 const STATUS_OPTIONS: { value: AnnotationFilters['status']; label: string }[] = [
   { value: 'all', label: 'All' },
@@ -54,16 +69,27 @@ interface PanelFilterBarProps {
   onChange: (filters: AnnotationFilters) => void;
   /** Distinct annotation authors, names resolved where the directory knows them. */
   authors: FilterAuthor[];
+  /** Hide the status facet — the tasks view speaks status through its column chips. */
+  statusFacet?: boolean;
+  /** The search field's placeholder and accessible name. */
+  searchLabel?: string;
 }
 
 /**
  * The panel's search-and-filter head (issue #403): a rounded full-text field
  * plus a filter button that tucks the facets — status, type, priority,
- * author — into a popover, tracker-style. Active facets surface as small
- * removable chips underneath, so the filtered state stays visible and
- * reversible without reopening the popover.
+ * author — into a popover, tracker-style. Active facets live as compact
+ * removable pills INSIDE the search field (the Linear/GitHub pattern), so the
+ * filtered state stays visible and reversible without a second row — nothing
+ * below ever jumps.
  */
-export function PanelFilterBar({ filters, onChange, authors }: PanelFilterBarProps) {
+export function PanelFilterBar({
+  filters,
+  onChange,
+  authors,
+  statusFacet = true,
+  searchLabel = 'Search annotations',
+}: PanelFilterBarProps) {
   const theme = useTheme();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const facets = activeFacetCount(filters);
@@ -94,12 +120,80 @@ export function PanelFilterBar({ filters, onChange, authors }: PanelFilterBarPro
           }}
         >
           <Search size={14} aria-hidden style={{ flexShrink: 0 }} />
+          {facets > 0 && (
+            <Stack
+              direction="row"
+              spacing={0.5}
+              data-testid="active-filter-chips"
+              sx={{ alignItems: 'center', flexShrink: 0, maxWidth: '60%', overflow: 'hidden' }}
+            >
+              {statusFacet && filters.status !== 'all' && (
+                <Chip
+                  size="small"
+                  icon={(() => {
+                    const cue =
+                      STATUS_CUES[
+                        filters.status === 'open'
+                          ? AnnotationStatus.Open
+                          : AnnotationStatus.Resolved
+                      ];
+                    const CueIcon = cue.icon;
+                    return <CueIcon size={12} color={cue.color(theme)} aria-hidden />;
+                  })()}
+                  label={filters.status === 'open' ? 'Open' : 'Resolved'}
+                  onDelete={() => set({ status: 'all' })}
+                  sx={PILL_SX}
+                />
+              )}
+              {filters.type !== null && (
+                <Chip
+                  size="small"
+                  icon={(() => {
+                    const cue = TYPE_CUES[filters.type];
+                    const CueIcon = cue.icon;
+                    return <CueIcon size={12} color={cue.color(theme)} aria-hidden />;
+                  })()}
+                  label={TYPE_CUES[filters.type].label}
+                  onDelete={() => set({ type: null })}
+                  sx={PILL_SX}
+                />
+              )}
+              {filters.priority !== null && (
+                <Chip
+                  size="small"
+                  icon={
+                    <Box
+                      sx={{
+                        width: 7,
+                        height: 7,
+                        borderRadius: '50%',
+                        bgcolor: PRIORITY_CUES[filters.priority].color(theme),
+                      }}
+                      aria-hidden
+                    />
+                  }
+                  label={PRIORITY_CUES[filters.priority].label}
+                  onDelete={() => set({ priority: null })}
+                  sx={PILL_SX}
+                />
+              )}
+              {filters.author !== null && (
+                <Chip
+                  size="small"
+                  icon={<UserAvatar name={nameOf(filters.author)} size={14} imageUrl={null} />}
+                  label={nameOf(filters.author)}
+                  onDelete={() => set({ author: null })}
+                  sx={PILL_SX}
+                />
+              )}
+            </Stack>
+          )}
           <InputBase
             fullWidth
-            placeholder="Search annotations"
+            placeholder={searchLabel}
             value={filters.query}
             onChange={(event) => set({ query: event.target.value })}
-            inputProps={{ 'aria-label': 'Search annotations' }}
+            inputProps={{ 'aria-label': searchLabel }}
             sx={{ fontSize: 13, p: 0, color: 'text.primary' }}
           />
         </Stack>
@@ -117,44 +211,6 @@ export function PanelFilterBar({ filters, onChange, authors }: PanelFilterBarPro
         </Tooltip>
       </Stack>
 
-      {facets > 0 && (
-        <Stack
-          direction="row"
-          spacing={0.5}
-          data-testid="active-filter-chips"
-          sx={{ mt: 0.75, flexWrap: 'wrap', rowGap: 0.5 }}
-        >
-          {filters.status !== 'all' && (
-            <Chip
-              size="small"
-              label={filters.status === 'open' ? 'Open' : 'Resolved'}
-              onDelete={() => set({ status: 'all' })}
-            />
-          )}
-          {filters.type !== null && (
-            <Chip
-              size="small"
-              label={TYPE_CUES[filters.type].label}
-              onDelete={() => set({ type: null })}
-            />
-          )}
-          {filters.priority !== null && (
-            <Chip
-              size="small"
-              label={`${PRIORITY_CUES[filters.priority].label} priority`}
-              onDelete={() => set({ priority: null })}
-            />
-          )}
-          {filters.author !== null && (
-            <Chip
-              size="small"
-              label={nameOf(filters.author)}
-              onDelete={() => set({ author: null })}
-            />
-          )}
-        </Stack>
-      )}
-
       <Popover
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}
@@ -164,19 +220,23 @@ export function PanelFilterBar({ filters, onChange, authors }: PanelFilterBarPro
         slotProps={{ paper: { sx: { width: 260, p: 1.5 } } }}
       >
         <Stack spacing={1.5}>
-          <TextField
-            select
-            size="small"
-            label="Status"
-            value={filters.status}
-            onChange={(event) => set({ status: event.target.value as AnnotationFilters['status'] })}
-          >
-            {STATUS_OPTIONS.map((option) => (
-              <MenuItem key={option.value} value={option.value}>
-                {option.label}
-              </MenuItem>
-            ))}
-          </TextField>
+          {statusFacet && (
+            <TextField
+              select
+              size="small"
+              label="Status"
+              value={filters.status}
+              onChange={(event) =>
+                set({ status: event.target.value as AnnotationFilters['status'] })
+              }
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
           <TextField
             select
             size="small"
@@ -187,11 +247,24 @@ export function PanelFilterBar({ filters, onChange, authors }: PanelFilterBarPro
             }
           >
             <MenuItem value="">Any</MenuItem>
-            {Object.values(AnnotationType).map((type) => (
-              <MenuItem key={type} value={type}>
-                {TYPE_CUES[type].label}
-              </MenuItem>
-            ))}
+            {Object.values(AnnotationType).map((type) => {
+              const cue = TYPE_CUES[type];
+              const CueIcon = cue.icon;
+              return (
+                <MenuItem key={type} value={type}>
+                  <Stack
+                    direction="row"
+                    spacing={0.75}
+                    sx={{ alignItems: 'center', color: cue.color(theme) }}
+                  >
+                    <CueIcon size={13} aria-hidden />
+                    <Typography component="span" variant="body2">
+                      {cue.label}
+                    </Typography>
+                  </Stack>
+                </MenuItem>
+              );
+            })}
           </TextField>
           <TextField
             select
@@ -203,11 +276,28 @@ export function PanelFilterBar({ filters, onChange, authors }: PanelFilterBarPro
             }
           >
             <MenuItem value="">Any</MenuItem>
-            {Object.values(AnnotationPriority).map((priority) => (
-              <MenuItem key={priority} value={priority}>
-                {PRIORITY_CUES[priority].label}
-              </MenuItem>
-            ))}
+            {Object.values(AnnotationPriority).map((priority) => {
+              const cue = PRIORITY_CUES[priority];
+              return (
+                <MenuItem key={priority} value={priority}>
+                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                    <Box
+                      sx={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: '50%',
+                        bgcolor: cue.color(theme),
+                        flexShrink: 0,
+                      }}
+                      aria-hidden
+                    />
+                    <Typography component="span" variant="body2">
+                      {cue.label}
+                    </Typography>
+                  </Stack>
+                </MenuItem>
+              );
+            })}
           </TextField>
           <TextField
             select
@@ -219,7 +309,12 @@ export function PanelFilterBar({ filters, onChange, authors }: PanelFilterBarPro
             <MenuItem value="">Anyone</MenuItem>
             {authors.map((author) => (
               <MenuItem key={author.id} value={author.id}>
-                {author.name}
+                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                  <UserAvatar name={author.name} size={18} imageUrl={null} />
+                  <Typography component="span" variant="body2">
+                    {author.name}
+                  </Typography>
+                </Stack>
               </MenuItem>
             ))}
           </TextField>

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.test.tsx
@@ -88,7 +88,7 @@ describe('AnnotationHoverCard', () => {
     expect(screen.getByText('Participant')).toBeInTheDocument();
     expect(screen.getByText('Open')).toBeInTheDocument();
     expect(screen.getByText('Moved')).toBeInTheDocument();
-    expect(screen.getByText('3 comments')).toBeInTheDocument();
+    expect(screen.getByLabelText('3 comments')).toBeInTheDocument();
     expect(useComments).toHaveBeenCalledWith('a1', true);
   });
 
@@ -103,6 +103,6 @@ describe('AnnotationHoverCard', () => {
 
     await waitFor(() => expect(screen.getByText('No comments yet.')).toBeInTheDocument());
     expect(useComments).toHaveBeenCalledWith('a1', false);
-    expect(screen.getByText('0 comments')).toBeInTheDocument();
+    expect(screen.getByLabelText('0 comments')).toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
@@ -26,30 +26,15 @@ import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import type { ScreenPosition } from './anchoring';
-import { AnnotationStatus } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
-import type { BadgeTone } from '../../admin/ToneBadge';
-import { ToneBadge } from '../../admin/ToneBadge';
-import { UserAvatar } from '../../shell/UserAvatar';
-import { PlacementStatusChip } from '../panel/PlacementStatusChip';
-import { highlightColorFor } from './markerColors';
+import { AnnotationBadgeRow } from '../panel/AnnotationBadgeRow';
+import { CommentBubble } from '../panel/CommentBubble';
 
 /** Hover intent: the preview appears only after the pointer settles on a mark. */
 const SHOW_DELAY_MS = 320;
-
-const STATUS_CUES: Record<AnnotationStatus, { tone: BadgeTone; label: string }> = {
-  [AnnotationStatus.Open]: { tone: 'blue', label: 'Open' },
-  [AnnotationStatus.Resolved]: { tone: 'green', label: 'Resolved' },
-};
-
-const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'medium',
-  timeStyle: 'short',
-});
 
 /** Vertical offset so the card sits just below the pointer, not under it. */
 const POINTER_OFFSET_PX = 14;
@@ -62,10 +47,11 @@ interface AnnotationHoverCardProps {
 
 /**
  * The mark's hover preview: who opened the discussion and where it stands,
- * without leaving the document. Shows the first comment with its author's
- * avatar, the annotation status, the placement cue and the thread size.
- * Hovering also warms the comments cache, so opening the thread afterwards is
- * instant. Pointer events pass through — the card never traps the mouse.
+ * without leaving the document — speaking exactly the document view's
+ * language (issue #403): the panel's badge row on top, the opening comment
+ * as the same social bubble the thread renders. Hovering also warms the
+ * comments cache, so opening the thread afterwards is instant. Pointer
+ * events pass through — the card never traps the mouse.
  */
 export function AnnotationHoverCard({ annotation, getAnchorPosition }: AnnotationHoverCardProps) {
   const theme = useTheme();
@@ -94,10 +80,6 @@ export function AnnotationHoverCard({ annotation, getAnchorPosition }: Annotatio
   const authorId = firstComment?.authorId ?? annotation.authorId;
   const own = authorId === userId;
   const authorName = own ? (displayName ?? 'You') : 'Participant';
-  const statusCue = STATUS_CUES[annotation.status];
-  const railColor = highlightColorFor(annotation, theme.palette);
-  const commentLabel =
-    annotation.commentCount === 1 ? '1 comment' : `${annotation.commentCount} comments`;
 
   return (
     <Popover
@@ -125,25 +107,9 @@ export function AnnotationHoverCard({ annotation, getAnchorPosition }: Annotatio
         },
       }}
     >
-      <Box sx={{ position: 'relative', pl: 2, pr: 1.75, py: 1.5 }}>
-        {/* The rail binds the card to its mark: same colour as the highlight. */}
-        <Box
-          aria-hidden
-          sx={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: 4, bgcolor: railColor }}
-        />
+      <Box sx={{ px: 1.5, py: 1.25 }}>
         <Stack spacing={1}>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <UserAvatar name={authorName} size={28} imageUrl={own ? avatarUrl : null} />
-            <Box sx={{ minWidth: 0, flex: 1 }}>
-              <Typography variant="body2" sx={{ fontWeight: 600, lineHeight: 1.2 }} noWrap>
-                {own ? 'You' : authorName}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                {TIME_FORMAT.format(new Date(firstComment?.createdAt ?? annotation.createdAt))}
-              </Typography>
-            </Box>
-            <ToneBadge tone={statusCue.tone} label={statusCue.label} />
-          </Stack>
+          <AnnotationBadgeRow annotation={annotation} />
 
           {annotation.commentCount > 0 ? (
             commentsQuery.isPending ? (
@@ -152,18 +118,14 @@ export function AnnotationHoverCard({ annotation, getAnchorPosition }: Annotatio
                 <Skeleton variant="text" width="65%" />
               </Stack>
             ) : (
-              <Typography
-                variant="body2"
-                sx={{
-                  display: '-webkit-box',
-                  WebkitLineClamp: 3,
-                  WebkitBoxOrient: 'vertical',
-                  overflow: 'hidden',
-                  overflowWrap: 'anywhere',
-                }}
-              >
-                {firstComment?.body ?? ''}
-              </Typography>
+              <CommentBubble
+                name={authorName}
+                own={own}
+                avatarUrl={avatarUrl}
+                body={firstComment?.body ?? annotation.firstComment ?? ''}
+                createdAt={firstComment?.createdAt ?? annotation.createdAt}
+                clampLines={3}
+              />
             )
           ) : (
             <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
@@ -171,20 +133,9 @@ export function AnnotationHoverCard({ annotation, getAnchorPosition }: Annotatio
             </Typography>
           )}
 
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <Stack
-              direction="row"
-              spacing={0.5}
-              sx={{ alignItems: 'center', color: 'text.secondary' }}
-            >
-              <MessageSquare size={13} aria-hidden />
-              <Typography variant="caption">{commentLabel}</Typography>
-            </Stack>
-            <PlacementStatusChip status={annotation.placementStatus} />
-            <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
-              Click to open the thread
-            </Typography>
-          </Stack>
+          <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'right' }}>
+            Click to open the thread
+          </Typography>
         </Stack>
       </Box>
     </Popover>

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -333,6 +333,7 @@ export function DocumentReviewPage() {
         action={
           <ReviewHubHead
             documentId={documentId}
+            ownerId={document.ownerId}
             isOwner={document.ownerId === userId}
             ownUserId={userId}
             annotations={annotations}
@@ -527,6 +528,7 @@ export function DocumentReviewPage() {
           >
             <AnnotationPanel
               documentId={documentId}
+              frameless
               annotations={annotations}
               activeAnnotationId={activeAnnotationId}
               hoverAnnotationId={hoverAnnotationId}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -151,6 +151,26 @@ describe('ReviewTasksPage', () => {
     expect(screen.queryByTestId('task-card-a-open')).not.toBeInTheDocument();
   });
 
+  it('filters by the type facet from the URL, with a removable chip', () => {
+    mockData();
+    renderPage('/reviews/d1/tasks?type=QUESTION');
+    expect(screen.getByTestId('task-card-a-talk')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-card-a-open')).not.toBeInTheDocument();
+    expect(screen.getByTestId('active-filter-chips')).toHaveTextContent('Question');
+  });
+
+  it('offers the facet popover without the status facet (columns speak status)', () => {
+    mockData();
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Filter annotations' }));
+    expect(screen.queryByLabelText('Status')).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByLabelText('Type'));
+    fireEvent.click(screen.getByRole('option', { name: 'Question' }));
+    expect(screen.getByTestId('task-card-a-talk')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-card-a-done')).not.toBeInTheDocument();
+  });
+
   it('resolves author names through the participants, and self by display name', () => {
     mockData();
     vi.mocked(useAnnotations).mockReturnValue({

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -25,12 +25,10 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Divider from '@mui/material/Divider';
-import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import { LayoutGrid, List as ListIcon, Search } from 'lucide-react';
+import { LayoutGrid, List as ListIcon } from 'lucide-react';
 import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useParticipants, useRecordVisit } from '../../api/hooks/useReviews';
@@ -38,6 +36,10 @@ import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
+import type { FilterAuthor } from '../../components/reviews/panel/PanelFilterBar';
+import { PanelFilterBar } from '../../components/reviews/panel/PanelFilterBar';
+import type { AnnotationFilters } from '../../components/reviews/panel/panelFilters';
+import { matchesFilters } from '../../components/reviews/panel/panelFilters';
 import {
   mayResolveAnnotation,
   useResolveWithFeedback,
@@ -46,15 +48,10 @@ import { TaskBoard } from '../../components/reviews/tasks/TaskBoard';
 import { TaskDrawer } from '../../components/reviews/tasks/TaskDrawer';
 import { TaskListRows } from '../../components/reviews/tasks/TaskListRows';
 import type { TaskFilter } from '../../components/reviews/tasks/tasksModel';
-import {
-  columnOf,
-  matchesQuery,
-  parseTaskFilter,
-  taskKeys,
-} from '../../components/reviews/tasks/tasksModel';
+import { columnOf, parseTaskFilter, taskKeys } from '../../components/reviews/tasks/tasksModel';
 import { useTasksViewMode } from '../../components/reviews/tasks/useTasksViewMode';
 import { isOpenWorkflowState } from '../../components/reviews/workflowMeta';
-import { ExtractionStatus } from '../../api/generated';
+import { AnnotationPriority, AnnotationType, ExtractionStatus } from '../../api/generated';
 import { useAuthStore } from '../../stores/authStore';
 
 const FILTERS: { key: TaskFilter; label: string }[] = [
@@ -99,18 +96,45 @@ export function ReviewTasksPage() {
   // The unseen-marker baseline (issue #307): the PREVIOUS visit, stamped once.
   const previousSeenAt = useRecordVisit(documentId);
   const filter = parseTaskFilter(searchParams.get('filter'));
-  const query = searchParams.get('q') ?? '';
+  // The facet filters share the panel's model (#403) and live in the URL like
+  // everything else on this page.
+  const typeParam = searchParams.get('type');
+  const priorityParam = searchParams.get('priority');
+  const facets: AnnotationFilters = {
+    status: 'all',
+    type: Object.values(AnnotationType).includes(typeParam as AnnotationType)
+      ? (typeParam as AnnotationType)
+      : null,
+    priority: Object.values(AnnotationPriority).includes(priorityParam as AnnotationPriority)
+      ? (priorityParam as AnnotationPriority)
+      : null,
+    author: searchParams.get('author'),
+    query: searchParams.get('q') ?? '',
+  };
   const [openTaskId, setOpenTaskId] = useState<string | null>(null);
 
   const { resolveWith } = useResolveWithFeedback(notify);
 
-  const setParam = (key: 'filter' | 'q', value: string | null) => {
+  const setParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(searchParams);
     if (value === null || value === '' || value === 'all') {
       next.delete(key);
     } else {
       next.set(key, value);
     }
+    setSearchParams(next, { replace: true });
+  };
+
+  const setFacets = (nextFacets: AnnotationFilters) => {
+    const next = new URLSearchParams(searchParams);
+    const write = (key: string, value: string | null) => {
+      if (value === null || value === '') next.delete(key);
+      else next.set(key, value);
+    };
+    write('type', nextFacets.type);
+    write('priority', nextFacets.priority);
+    write('author', nextFacets.author);
+    write('q', nextFacets.query);
     setSearchParams(next, { replace: true });
   };
 
@@ -129,9 +153,13 @@ export function ReviewTasksPage() {
       ? annotations.length
       : annotations.filter((annotation) => columnOf(annotation) === key).length;
 
+  const authors: FilterAuthor[] = [
+    ...new Set(annotations.map((annotation) => annotation.authorId)),
+  ].map((id) => ({ id, name: authorNameOf(id) }));
+
   const visible = annotations
     .filter((annotation) => filter === 'all' || columnOf(annotation) === filter)
-    .filter((annotation) => matchesQuery(annotation, authorNameOf(annotation.authorId), query));
+    .filter((annotation) => matchesFilters(annotation, facets, authorNameOf(annotation.authorId)));
 
   const openTask = annotations.find((annotation) => annotation.id === openTaskId) ?? null;
   const keyByAnnotation = taskKeys(annotations);
@@ -212,23 +240,15 @@ export function ReviewTasksPage() {
           />
         ))}
         <Box sx={{ flex: 1 }} />
-        <TextField
-          size="small"
-          placeholder="Search tasks…"
-          value={query}
-          onChange={(event) => setParam('q', event.target.value)}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={14} />
-                </InputAdornment>
-              ),
-              'aria-label': 'Search tasks',
-            },
-          }}
-          sx={{ width: 220 }}
-        />
+        <Box sx={{ width: { xs: '100%', sm: 560, md: 720 } }}>
+          <PanelFilterBar
+            filters={facets}
+            onChange={setFacets}
+            authors={authors}
+            statusFacet={false}
+            searchLabel="Search tasks"
+          />
+        </Box>
       </Stack>
 
       {annotationsQuery.isPending ? (


### PR DESCRIPTION
Third round of the review-surface polish (#403), collected interactively.

- **fix(core): resolved annotations follow the document onto new versions.** `seedPendingPlacements` filtered on OPEN — valid under #248's terminal decisions, broken since #405/#394 (RESOLVED is reopenable and stays a readable record): resolved annotations lost their anchors on upload despite identical text, and reopened ones could never be re-anchored. Every annotation now seeds; regression IT included.
- **Teams unfold in the participants dialog.** New Community endpoint `GET /principals/teams/{teamId}/members` (names only, #292 visibility rule, no email leakage — IT-pinned); team rows grow a chevron revealing members as indented rows, lazily fetched.
- **One anatomy for every annotation surface.** Shared `AnnotationHead`/`AnnotationBadgeRow`/`CommentBubble` power the panel, the hover preview and the focus card — coloured rails and pointer arrows are gone. The focus card gets `min(55vh, 520px)` max height, a drag handle in its header and even spacing all around.
- **Tasks view gains the panel's facet filters.** Type/Priority/Author in the filter popover (status stays with the column chips), URL-persisted, active facets as compact in-field pills (zero layout shift) with cue icons; search field widened.
- **Header polish.** The owner shows prominently (avatar + OWNER label + name via the principal directory), the progress bar explains itself on hover, and the focus drawer drops the doubled outer card chrome (SectionCard frameless variant).

Every item verified in the running app; 476 UI tests, new ITs for the re-anchoring regression and the members endpoint, all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
