### PR TITLE
feat: review slug URLs & new-review wizard polish (#411, #415)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -3986,6 +3986,13 @@ components:
           $ref: '#/components/schemas/ParticipantKind'
         displayName:
           type: string
+        avatarUrl:
+          type: string
+          nullable: true
+          description: |
+            URL of the user's profile picture (with a cache-busting `?v=` token);
+            null for teams and for users without one — the UI then renders the
+            initials avatar (or the team glyph).
       required:
         - id
         - kind

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1991,6 +1991,42 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /documents/by-slug/{slug}:
+    get:
+      tags:
+        - Documents
+      summary: Resolve a document by its slug
+      description: |
+        Resolves a review by its optional human-readable slug (issue #411).
+        Matching ignores case. Unknown slugs and slugs on documents the caller
+        may not see both answer 404, so slugs are as non-enumerable as ids.
+      operationId: getDocumentBySlug
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          description: The review slug (kebab-case, 3-64 characters).
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 64
+      responses:
+        '200':
+          description: The document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown slug, or the caller is not a participant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /documents/{documentId}/visit:
     post:
       tags:
@@ -3811,6 +3847,14 @@ components:
         title:
           type: string
           maxLength: 500
+        slug:
+          type: string
+          nullable: true
+          minLength: 3
+          maxLength: 64
+          description: >-
+            Optional human-readable identifier chosen at creation (issue #411):
+            kebab-case, unique ignoring case, immutable. Null when none was set.
         ownerId:
           type: string
           format: uuid
@@ -3966,6 +4010,14 @@ components:
         title:
           type: string
           maxLength: 500
+        slug:
+          type: string
+          nullable: true
+          minLength: 3
+          maxLength: 64
+          description: >-
+            Optional human-readable identifier chosen at creation (issue #411):
+            kebab-case, unique ignoring case, immutable. Null when none was set.
         ownerId:
           type: string
           format: uuid

--- a/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
@@ -21,6 +21,7 @@
 package io.qnop.web;
 
 import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.api.v1.model.FieldError;
 import io.qnop.service.document.DocumentValidationException;
 import io.qnop.service.review.AnnotationActionForbiddenException;
 import io.qnop.service.review.AnnotationNotFoundException;
@@ -28,6 +29,7 @@ import io.qnop.service.review.DocumentNotFoundException;
 import io.qnop.service.review.NotDocumentOwnerException;
 import io.qnop.service.review.WorkflowTransitionException;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -44,7 +46,17 @@ public class DocumentExceptionHandler {
 
   @ExceptionHandler(DocumentValidationException.class)
   public ResponseEntity<ErrorResponse> onDocumentError(DocumentValidationException ex) {
-    return error(ex.getStatus(), ex.getCode(), ex.getMessage());
+    ErrorResponse body =
+        new ErrorResponse()
+            .code(ex.getCode())
+            .message(ex.getMessage())
+            .timestamp(OffsetDateTime.now());
+    if (ex.getField() != null) {
+      // Field-scoped rejections (e.g. the slug, issue #411) carry the fieldErrors
+      // detail so forms can attach the message to the offending input.
+      body.fieldErrors(List.of(new FieldError().field(ex.getField()).message(ex.getMessage())));
+    }
+    return ResponseEntity.status(ex.getStatus()).body(body);
   }
 
   @ExceptionHandler(DocumentNotFoundException.class)

--- a/qnop-app/src/main/java/io/qnop/web/DocumentUploadController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentUploadController.java
@@ -61,10 +61,11 @@ public class DocumentUploadController {
   public ResponseEntity<DocumentUploadResponse> createDocument(
       @RequestParam("title") String title,
       @RequestParam("file") MultipartFile file,
-      @RequestParam(value = "dueAt", required = false) String dueAt) {
+      @RequestParam(value = "dueAt", required = false) String dueAt,
+      @RequestParam(value = "slug", required = false) String slug) {
     UploadResult result =
         ingest.createDocument(
-            CurrentUser.requireUserId(), title, sourceOf(file), parseDueAt(dueAt));
+            CurrentUser.requireUserId(), title, sourceOf(file), parseDueAt(dueAt), slug);
     return ResponseEntity.status(HttpStatus.CREATED).body(DocumentUploadResponse.of(result));
   }
 

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -141,6 +141,7 @@ public class DocumentsController implements DocumentsApi {
     return new DocumentSummary()
         .id(view.id())
         .title(view.title())
+        .slug(view.slug())
         .ownerId(view.ownerId())
         .workflowState(view.workflowState())
         .latestVersionNumber(view.latestVersionNumber())
@@ -210,6 +211,13 @@ public class DocumentsController implements DocumentsApi {
   }
 
   @Override
+  public ResponseEntity<DocumentResponse> getDocumentBySlug(String slug) {
+    DocumentView view =
+        documents.getDocumentBySlug(slug, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.ok(toResponse(view));
+  }
+
+  @Override
   public ResponseEntity<VisitResponse> recordVisit(UUID documentId) {
     Instant previous =
         visits.recordVisit(documentId, CurrentUser.requireUserId(), CurrentUser.isAdmin());
@@ -234,6 +242,7 @@ public class DocumentsController implements DocumentsApi {
     return new DocumentResponse()
         .id(view.id())
         .title(view.title())
+        .slug(view.slug())
         .ownerId(view.ownerId())
         .workflowState(view.workflowState())
         .latestVersionNumber(view.latestVersionNumber())

--- a/qnop-app/src/main/java/io/qnop/web/PrincipalsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/PrincipalsController.java
@@ -27,7 +27,11 @@ import io.qnop.api.v1.model.PrincipalListResponse;
 import io.qnop.api.v1.model.PrincipalView;
 import io.qnop.service.PrincipalDirectoryService;
 import io.qnop.service.TeamNotFoundException;
+import io.qnop.service.avatar.AvatarService;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,47 +40,55 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * The assignable-principal directory (issue #292): enabled users and teams for picking review
- * participants — display names only, available to every authenticated user.
+ * participants — display names plus the users' avatar URLs, available to every authenticated user.
  */
 @RestController
 public class PrincipalsController implements PrincipalsApi {
 
   private final PrincipalDirectoryService directory;
+  private final AvatarService avatars;
 
-  public PrincipalsController(PrincipalDirectoryService directory) {
+  public PrincipalsController(PrincipalDirectoryService directory, AvatarService avatars) {
     this.directory = directory;
+    this.avatars = avatars;
   }
 
   @Override
   public ResponseEntity<PrincipalListResponse> searchPrincipals(String q, Integer size) {
     CurrentUser.requireUserId();
-    return ResponseEntity.ok(
-        new PrincipalListResponse()
-            .principals(
-                directory.search(q, size == null ? 20 : size).stream()
-                    .map(
-                        view ->
-                            new PrincipalView()
-                                .id(view.id())
-                                .kind(view.team() ? ParticipantKind.TEAM : ParticipantKind.USER)
-                                .displayName(view.displayName()))
-                    .toList()));
+    return ResponseEntity.ok(toResponse(directory.search(q, size == null ? 20 : size)));
   }
 
   @Override
   public ResponseEntity<PrincipalListResponse> listTeamMembers(UUID teamId) {
     CurrentUser.requireUserId();
-    return ResponseEntity.ok(
-        new PrincipalListResponse()
-            .principals(
-                directory.teamMembers(teamId).stream()
-                    .map(
-                        view ->
-                            new PrincipalView()
-                                .id(view.id())
-                                .kind(ParticipantKind.USER)
-                                .displayName(view.displayName()))
-                    .toList()));
+    return ResponseEntity.ok(toResponse(directory.teamMembers(teamId)));
+  }
+
+  private PrincipalListResponse toResponse(List<PrincipalDirectoryService.PrincipalView> views) {
+    // One batched lookup for the page of user principals, so building avatar
+    // URLs never streams image bytes (same pattern as the admin user list).
+    Map<UUID, Instant> avatarTimestamps =
+        avatars.updatedAt(
+            views.stream()
+                .filter(view -> !view.team())
+                .map(PrincipalDirectoryService.PrincipalView::id)
+                .toList());
+    return new PrincipalListResponse()
+        .principals(
+            views.stream()
+                .map(
+                    view ->
+                        new PrincipalView()
+                            .id(view.id())
+                            .kind(view.team() ? ParticipantKind.TEAM : ParticipantKind.USER)
+                            .displayName(view.displayName())
+                            .avatarUrl(
+                                view.team()
+                                    ? null
+                                    : AvatarUrls.forUser(
+                                        view.id(), avatarTimestamps.get(view.id()))))
+                .toList());
   }
 
   @ExceptionHandler(TeamNotFoundException.class)

--- a/qnop-app/src/test/java/io/qnop/document/DocumentSlugIT.java
+++ b/qnop-app/src/test/java/io/qnop/document/DocumentSlugIT.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.document;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.UserRepository;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+/**
+ * Review slugs (issue #411): optional kebab-case identifier chosen at creation, unique ignoring
+ * case, resolvable via {@code GET /documents/by-slug/{slug}} with the same anti-enumeration 404 as
+ * the id route. Requires Docker.
+ */
+@AutoConfigureMockMvc
+class DocumentSlugIT extends AbstractIntegrationTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired UserRepository users;
+  @Autowired DocumentRepository documents;
+  @Autowired PasswordEncoder passwordEncoder;
+
+  private final List<UUID> createdDocuments = new ArrayList<>();
+  private final List<UUID> createdUsers = new ArrayList<>();
+
+  @AfterEach
+  void cleanup() {
+    createdDocuments.forEach(id -> documents.findById(id).ifPresent(documents::delete));
+    createdUsers.forEach(id -> users.findById(id).ifPresent(users::delete));
+  }
+
+  @Test
+  @DisplayName("create with slug: normalized, echoed on metadata, resolvable case-insensitively")
+  void slugRoundTrip() throws Exception {
+    UUID owner = createUser();
+
+    // Mixed case + surrounding whitespace normalizes to the canonical lowercase form.
+    UUID documentId = createDocument(owner, "  Q3-Contract-Review  ");
+
+    mockMvc
+        .perform(get("/api/v1/documents/{id}", documentId).with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.slug").value("q3-contract-review"));
+
+    // Lookup ignores case too.
+    mockMvc
+        .perform(get("/api/v1/documents/by-slug/{slug}", "Q3-CONTRACT-REVIEW").with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(documentId.toString()))
+        .andExpect(jsonPath("$.slug").value("q3-contract-review"));
+  }
+
+  @Test
+  @DisplayName("a document without a slug answers null and is unaffected")
+  void slugIsOptional() throws Exception {
+    UUID owner = createUser();
+    UUID documentId = createDocument(owner, null);
+
+    mockMvc
+        .perform(get("/api/v1/documents/{id}", documentId).with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.slug").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("taken slug → 409 SLUG_TAKEN with the slug field error, even as a case variant")
+  void slugUniquenessIgnoresCase() throws Exception {
+    UUID owner = createUser();
+    createDocument(owner, "unique-review");
+
+    mockMvc
+        .perform(
+            multipart("/api/v1/documents")
+                .file(pdfFile(pdf("dup")))
+                .param("title", "Duplicate slug")
+                .param("slug", "UNIQUE-Review")
+                .with(asUser(owner)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("SLUG_TAKEN"))
+        .andExpect(jsonPath("$.fieldErrors[0].field").value("slug"));
+  }
+
+  @Test
+  @DisplayName("malformed and UUID-shaped slugs → 400 VALIDATION_ERROR on the slug field")
+  void slugShapeIsValidated() throws Exception {
+    UUID owner = createUser();
+
+    for (String bad :
+        new String[] {
+          "has_underscore",
+          "double--hyphen",
+          "-leading",
+          "trailing-",
+          "ab", // below the 3-character minimum
+          "x".repeat(65), // above the 64-character maximum
+          UUID.randomUUID().toString() // UUID-shaped slugs would shadow id routes
+        }) {
+      mockMvc
+          .perform(
+              multipart("/api/v1/documents")
+                  .file(pdfFile(pdf("bad slug")))
+                  .param("title", "Bad slug")
+                  .param("slug", bad)
+                  .with(asUser(owner)))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+          .andExpect(jsonPath("$.fieldErrors[0].field").value("slug"));
+    }
+  }
+
+  @Test
+  @DisplayName("by-slug is as non-enumerable as by-id: stranger and unknown slug both get 404")
+  void bySlugAntiEnumeration() throws Exception {
+    UUID owner = createUser();
+    UUID stranger = createUser();
+    createDocument(owner, "hidden-review");
+
+    mockMvc
+        .perform(get("/api/v1/documents/by-slug/{slug}", "hidden-review").with(asUser(stranger)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+
+    mockMvc
+        .perform(get("/api/v1/documents/by-slug/{slug}", "no-such-slug").with(asUser(owner)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private UUID createDocument(UUID owner, String slug) throws Exception {
+    var request =
+        multipart("/api/v1/documents")
+            .file(pdfFile(pdf("slug IT")))
+            .param("title", "Slug IT")
+            .with(asUser(owner));
+    if (slug != null) {
+      request = request.param("slug", slug);
+    }
+    MvcResult result = mockMvc.perform(request).andExpect(status().isCreated()).andReturn();
+    UUID id =
+        UUID.fromString(JsonPath.read(result.getResponse().getContentAsString(), "$.documentId"));
+    createdDocuments.add(id);
+    return id;
+  }
+
+  private UUID createUser() {
+    String name = "slug-" + UUID.randomUUID();
+    User user =
+        User.internal(name, name + "@example.com", name, passwordEncoder.encode("irrelevant-pw"));
+    user.setEnabled(true);
+    UUID id = users.saveAndFlush(user).getId();
+    createdUsers.add(id);
+    return id;
+  }
+
+  private static RequestPostProcessor asUser(UUID userId) {
+    return jwt().jwt(j -> j.subject(userId.toString()));
+  }
+
+  private static MockMultipartFile pdfFile(byte[] bytes) {
+    return new MockMultipartFile("file", "doc.pdf", "application/pdf", bytes);
+  }
+
+  private static byte[] pdf(String line) throws IOException {
+    try (PDDocument document = new PDDocument()) {
+      PDPage page = new PDPage(PDRectangle.LETTER);
+      document.addPage(page);
+      try (PDPageContentStream content = new PDPageContentStream(document, page)) {
+        content.beginText();
+        content.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+        content.newLineAtOffset(72, 700);
+        content.showText(line);
+        content.endText();
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      document.save(out);
+      return out.toByteArray();
+    }
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/DocumentOverviewApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DocumentOverviewApiIT.java
@@ -267,7 +267,12 @@ class DocumentOverviewApiIT extends SeededIntegrationTest {
     mockMvc
         .perform(as(get("/api/v1/principals?q=alpha"), MEMBER2_ID))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.principals[?(@.displayName == 'Alpha')].kind").value("TEAM"));
+        .andExpect(jsonPath("$.principals[?(@.displayName == 'Alpha')].kind").value("TEAM"))
+        // Teams (and users without a profile picture) carry a null avatarUrl.
+        .andExpect(
+            jsonPath(
+                "$.principals[?(@.displayName == 'Alpha')].avatarUrl",
+                org.hamcrest.Matchers.contains(org.hamcrest.Matchers.nullValue())));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/AdminUserControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/AdminUserControllerIT.java
@@ -35,6 +35,9 @@ import io.qnop.bootstrap.AbstractIntegrationTest;
 import io.qnop.entity.User;
 import io.qnop.entity.UserRole;
 import io.qnop.repository.UserRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -70,6 +73,7 @@ class AdminUserControllerIT extends AbstractIntegrationTest {
   @Autowired MockMvc mockMvc;
   @Autowired UserRepository userRepository;
   @Autowired PasswordEncoder passwordEncoder;
+  @Autowired ApplicationSettingsService settings;
 
   @Test
   void anonymousIsUnauthorized() throws Exception {
@@ -265,8 +269,12 @@ class AdminUserControllerIT extends AbstractIntegrationTest {
     createUser("root", UserRole.ADMIN);
     User target = createUser("member", UserRole.MEMBER);
     String token = adminToken();
+    // This test owns the no-SMTP fallback path. The seed may leave SMTP enabled
+    // (Mailpit, issue #401), so switch the master toggle off here instead of
+    // depending on class order; @Transactional rolls the change back.
+    settings.update(Map.of(ApplicationSettingKey.SMTP_ENABLED.getKey(), "false"), null);
 
-    // No SMTP is configured in the IT, so the email is "skipped" and the fallback link is returned.
+    // With SMTP off the email is "skipped" and the fallback link is returned.
     mockMvc
         .perform(
             post("/api/v1/admin/users/{id}/password-reset", target.getId())

--- a/qnop-core/src/main/java/io/qnop/entity/Document.java
+++ b/qnop-core/src/main/java/io/qnop/entity/Document.java
@@ -87,6 +87,14 @@ public class Document {
   @Column(name = "due_at")
   private Instant dueAt;
 
+  /**
+   * Optional friendly URL slug (issue #411): kebab-case, globally unique case-insensitively, never
+   * UUID-shaped — the format and uniqueness are pinned in Liquibase; normalisation and the
+   * UUID-shape guard live in the service.
+   */
+  @Column(name = "slug", length = 64, updatable = false)
+  private String slug;
+
   @Version
   @Column(name = "version", nullable = false)
   private long version;
@@ -143,6 +151,15 @@ public class Document {
   /** The optional completion deadline, or {@code null} when none is set (issue #295). */
   public Instant getDueAt() {
     return dueAt;
+  }
+
+  public String getSlug() {
+    return slug;
+  }
+
+  /** Set once at creation (the column is not updatable); {@code null} means no friendly URL. */
+  public void setSlug(String slug) {
+    this.slug = slug;
   }
 
   /** Sets or clears ({@code null}) the optional completion deadline (issue #295). */

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -48,6 +48,12 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
   /** Documents owned by the given user. */
   List<Document> findByOwnerId(UUID ownerId);
 
+  /** Resolves a review by its human-readable slug (issue #411) — uniqueness is per LOWER(slug). */
+  Optional<Document> findBySlugIgnoreCase(String slug);
+
+  /** True when the slug is already claimed, ignoring case (issue #411). */
+  boolean existsBySlugIgnoreCase(String slug);
+
   /**
    * The documents visible to a user for the reviews overview (issue #292): owned, joined as a
    * direct participant, or joined through membership in a participating team. {@code q} must be

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentAccessService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentAccessService.java
@@ -84,12 +84,26 @@ public class DocumentAccessService {
     return new DocumentView(
         document.getId(),
         document.getTitle(),
+        document.getSlug(),
         document.getOwnerId(),
         document.getWorkflowState(),
         latest,
         document.getCreatedAt(),
         document.getUpdatedAt(),
         document.getDueAt());
+  }
+
+  /**
+   * Resolves a review by its human-readable slug (issue #411). An unknown slug and a slug on a
+   * document the actor may not see both answer 404, so slugs are as non-enumerable as ids.
+   */
+  @Transactional(readOnly = true)
+  public DocumentView getDocumentBySlug(String slug, UUID actor, boolean admin) {
+    Document document =
+        documents
+            .findBySlugIgnoreCase(slug)
+            .orElseThrow(() -> DocumentValidationException.notFound("no such document: " + slug));
+    return getDocument(document.getId(), actor, admin);
   }
 
   /** All versions of a visible document, oldest first. */
@@ -204,6 +218,7 @@ public class DocumentAccessService {
   public record DocumentView(
       UUID id,
       String title,
+      String slug,
       UUID ownerId,
       String workflowState,
       int latestVersionNumber,

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -41,10 +41,13 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -71,6 +74,14 @@ public class DocumentIngestService {
   static final String PDF_CONTENT_TYPE = "application/pdf";
   private static final byte[] PDF_MAGIC = "%PDF-".getBytes(StandardCharsets.US_ASCII);
   private static final int MAX_TITLE_LENGTH = 500;
+
+  private static final int MIN_SLUG_LENGTH = 3;
+  private static final int MAX_SLUG_LENGTH = 64;
+  private static final Pattern SLUG_PATTERN = Pattern.compile("^[a-z0-9]+(-[a-z0-9]+)*$");
+  // A slug must never look like a UUID: routes and links resolve UUID-shaped
+  // segments as document ids, so a UUID-shaped slug would be unreachable.
+  private static final Pattern UUID_SHAPE =
+      Pattern.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
 
   private final DocumentRepository documents;
   private final DocumentVersionRepository versions;
@@ -105,27 +116,45 @@ public class DocumentIngestService {
 
   /**
    * Creates a new document owned by {@code actor} with the upload as version 1. An optional {@code
-   * dueAt} completion deadline (issue #295) must be in the future when set at creation.
+   * dueAt} completion deadline (issue #295) must be in the future when set at creation, and an
+   * optional {@code slug} (issue #411) must be kebab-case, 3–64 characters, not UUID-shaped, and
+   * globally unique ignoring case.
    */
-  public UploadResult createDocument(UUID actor, String title, UploadSource upload, Instant dueAt) {
+  public UploadResult createDocument(
+      UUID actor, String title, UploadSource upload, Instant dueAt, String slug) {
     String cleanTitle = requireTitle(title);
     Instant validDueAt = requireFutureOrNull(dueAt);
+    String cleanSlug = normalizeSlug(slug);
+    if (cleanSlug != null && documents.existsBySlugIgnoreCase(cleanSlug)) {
+      throw DocumentValidationException.slugTaken("slug is already in use: " + cleanSlug);
+    }
     long maxBytes = maxUploadBytes();
     validateUpload(upload, maxBytes);
 
     StagedObject staged = stageUpload(upload, maxBytes);
-    UploadResult result =
-        transactionTemplate.execute(
-            status -> {
-              Document document = new Document(actor, cleanTitle);
-              document.setDueAt(validDueAt);
-              document = documents.save(document);
-              DocumentVersion version = saveVersionAndEnqueue(document.getId(), 1, staged, actor);
-              return new UploadResult(
-                  document.getId(),
-                  version.getVersionNumber(),
-                  version.getExtractionStatus().name());
-            });
+    UploadResult result;
+    try {
+      result =
+          transactionTemplate.execute(
+              status -> {
+                Document document = new Document(actor, cleanTitle);
+                document.setDueAt(validDueAt);
+                document.setSlug(cleanSlug);
+                document = documents.save(document);
+                DocumentVersion version = saveVersionAndEnqueue(document.getId(), 1, staged, actor);
+                return new UploadResult(
+                    document.getId(),
+                    version.getVersionNumber(),
+                    version.getExtractionStatus().name());
+              });
+    } catch (DataIntegrityViolationException e) {
+      // The unique index backstops the pre-check against a concurrent create
+      // racing the same slug; without a slug the violation is not ours to map.
+      if (cleanSlug != null) {
+        throw DocumentValidationException.slugTaken("slug is already in use: " + cleanSlug);
+      }
+      throw e;
+    }
     storage.commit(staged.key());
     return result;
   }
@@ -242,6 +271,27 @@ public class DocumentIngestService {
       throw DocumentValidationException.invalidRequest("dueAt must be in the future");
     }
     return dueAt;
+  }
+
+  /**
+   * Normalizes and validates the optional review slug (issue #411): trims and lowercases, then
+   * enforces the kebab-case shape the DB CHECK constraint mirrors. Blank means "no slug".
+   */
+  private static String normalizeSlug(String slug) {
+    if (slug == null || slug.isBlank()) {
+      return null;
+    }
+    String normalized = slug.trim().toLowerCase(Locale.ROOT);
+    if (normalized.length() < MIN_SLUG_LENGTH
+        || normalized.length() > MAX_SLUG_LENGTH
+        || !SLUG_PATTERN.matcher(normalized).matches()) {
+      throw DocumentValidationException.invalidField(
+          "slug", "slug must be 3-64 characters of lowercase letters, digits and single hyphens");
+    }
+    if (UUID_SHAPE.matcher(normalized).matches()) {
+      throw DocumentValidationException.invalidField("slug", "slug must not look like a UUID");
+    }
+    return normalized;
   }
 
   private long maxUploadBytes() {

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
@@ -105,6 +105,7 @@ public class DocumentOverviewService {
                   return new DocumentSummaryView(
                       document.getId(),
                       document.getTitle(),
+                      document.getSlug(),
                       document.getOwnerId(),
                       document.getWorkflowState(),
                       maxVersions.getOrDefault(document.getId(), 0),
@@ -142,6 +143,7 @@ public class DocumentOverviewService {
   public record DocumentSummaryView(
       UUID id,
       String title,
+      String slug,
       UUID ownerId,
       String workflowState,
       int latestVersionNumber,

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentUpdateService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentUpdateService.java
@@ -85,6 +85,7 @@ public class DocumentUpdateService {
     return new DocumentView(
         document.getId(),
         document.getTitle(),
+        document.getSlug(),
         document.getOwnerId(),
         document.getWorkflowState(),
         latest,

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentValidationException.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentValidationException.java
@@ -29,11 +29,17 @@ public class DocumentValidationException extends RuntimeException {
 
   private final int status;
   private final String code;
+  private final String field;
 
   public DocumentValidationException(int status, String code, String message) {
+    this(status, code, message, null);
+  }
+
+  public DocumentValidationException(int status, String code, String message, String field) {
     super(message);
     this.status = status;
     this.code = code;
+    this.field = field;
   }
 
   public int getStatus() {
@@ -42,6 +48,11 @@ public class DocumentValidationException extends RuntimeException {
 
   public String getCode() {
     return code;
+  }
+
+  /** The offending request field, when the rejection maps onto exactly one (issue #411). */
+  public String getField() {
+    return field;
   }
 
   /** Unknown document/version — also used to hide documents from non-participants (404). */
@@ -68,6 +79,16 @@ public class DocumentValidationException extends RuntimeException {
 
   public static DocumentValidationException invalidRequest(String detail) {
     return new DocumentValidationException(400, "VALIDATION_ERROR", detail);
+  }
+
+  /** A single-field rejection, surfaced as {@code fieldErrors} on the envelope (issue #411). */
+  public static DocumentValidationException invalidField(String field, String detail) {
+    return new DocumentValidationException(400, "VALIDATION_ERROR", detail, field);
+  }
+
+  /** The requested slug is already in use — uniqueness is case-insensitive (issue #411). */
+  public static DocumentValidationException slugTaken(String detail) {
+    return new DocumentValidationException(409, "SLUG_TAKEN", detail, "slug");
   }
 
   /** Mutating review activity happens on the LATEST version only (issue #306). */

--- a/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
@@ -50,6 +50,12 @@ databaseChangeLog:
               - column:
                   name: due_at
                   type: TIMESTAMP WITH TIME ZONE
+              # Optional friendly URL slug (issue #411); nullable, globally unique
+              # case-insensitively (see the lower(slug) index below), format pinned
+              # by the CHECK — kebab-case, never UUID-shaped, 3-64 chars.
+              - column:
+                  name: slug
+                  type: VARCHAR(64)
               - column:
                   name: version
                   type: BIGINT
@@ -72,6 +78,14 @@ databaseChangeLog:
             tableName: document
             columns:
               - column: { name: workflow_state }
+        - sql:
+            comment: >-
+              Slug rules (issue #411) — case-insensitive global uniqueness and the
+              kebab-case format, both not expressible in Liquibase primitives.
+            sql: |
+              CREATE UNIQUE INDEX ux_document_slug_lower ON document (LOWER(slug)) WHERE slug IS NOT NULL;
+              ALTER TABLE document ADD CONSTRAINT ck_document_slug
+                CHECK (slug IS NULL OR (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$' AND length(slug) BETWEEN 3 AND 64));
 
   - changeSet:
       id: 0011-document-version

--- a/qnop-ui/src/api/hooks/useDocuments.ts
+++ b/qnop-ui/src/api/hooks/useDocuments.ts
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   DocumentResponse,
   DocumentVersionListResponse,
@@ -34,6 +34,7 @@ const EXTRACTION_POLL_MS = 2500;
 export const documentKeys = {
   all: ['documents'] as const,
   detail: (documentId: string) => [...documentKeys.all, 'detail', documentId] as const,
+  bySlug: (slug: string) => [...documentKeys.all, 'by-slug', slug] as const,
   versions: (documentId: string) => [...documentKeys.all, 'versions', documentId] as const,
   rendered: (documentId: string, versionNumber: number) =>
     [...documentKeys.all, 'rendered', documentId, versionNumber] as const,
@@ -49,6 +50,25 @@ export function useDocument(documentId: string) {
       const response = await documentsApi.getDocument({ documentId });
       return response.data;
     },
+  });
+}
+
+/**
+ * Resolves a review by its human-readable slug (issue #411). Seeds the detail
+ * cache with the response so the page's `useDocument` renders without a second
+ * round-trip. Slugs are immutable, so a resolved mapping stays fresh.
+ */
+export function useDocumentBySlug(slug: string, enabled: boolean) {
+  const queryClient = useQueryClient();
+  return useQuery<DocumentResponse>({
+    queryKey: documentKeys.bySlug(slug),
+    queryFn: async () => {
+      const response = await documentsApi.getDocumentBySlug({ slug });
+      queryClient.setQueryData(documentKeys.detail(response.data.id), response.data);
+      return response.data;
+    },
+    enabled,
+    staleTime: Infinity,
   });
 }
 

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -183,12 +183,14 @@ export function useCreateReview() {
       title: string;
       file: File;
       dueAt?: string | null;
+      slug?: string | null;
       onProgress?: (fraction: number) => void;
     }) => {
       const form = new FormData();
       form.append('title', input.title);
       form.append('file', input.file);
       if (input.dueAt) form.append('dueAt', input.dueAt);
+      if (input.slug) form.append('slug', input.slug);
       const response = await axiosInstance.post<UploadResult>('/documents', form, {
         onUploadProgress: (event) => {
           if (event.total) input.onProgress?.(event.loaded / event.total);

--- a/qnop-ui/src/components/reviews/ReviewParamGate.test.tsx
+++ b/qnop-ui/src/components/reviews/ReviewParamGate.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { useDocumentBySlug } from '../../api/hooks/useDocuments';
+import { ReviewParamGate } from './ReviewParamGate';
+import { useReviewDocumentId } from './reviewDocumentId';
+
+vi.mock('../../api/hooks/useDocuments', () => ({
+  useDocumentBySlug: vi.fn(),
+}));
+
+const DOC_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+function Probe() {
+  return <div data-testid="probe">{useReviewDocumentId()}</div>;
+}
+
+function renderGate(segment: string) {
+  render(
+    <MemoryRouter initialEntries={[`/reviews/${segment}`]}>
+      <Routes>
+        <Route
+          path="/reviews/:documentId"
+          element={
+            <ReviewParamGate>
+              <Probe />
+            </ReviewParamGate>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useDocumentBySlug).mockReturnValue({
+    isPending: true,
+    isError: false,
+    data: undefined,
+  } as never);
+});
+
+describe('ReviewParamGate', () => {
+  it('passes a UUID segment straight through without resolving', () => {
+    renderGate(DOC_ID);
+    expect(screen.getByTestId('probe')).toHaveTextContent(DOC_ID);
+    expect(vi.mocked(useDocumentBySlug)).toHaveBeenCalledWith(DOC_ID, false);
+  });
+
+  it('shows a spinner while a slug segment resolves', () => {
+    renderGate('q3-contract-review');
+    expect(screen.getByLabelText('Resolving review')).toBeInTheDocument();
+    expect(screen.queryByTestId('probe')).not.toBeInTheDocument();
+    expect(vi.mocked(useDocumentBySlug)).toHaveBeenCalledWith('q3-contract-review', true);
+  });
+
+  it('renders children with the canonical id once the slug resolves', () => {
+    vi.mocked(useDocumentBySlug).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: { id: DOC_ID, slug: 'q3-contract-review' },
+    } as never);
+    renderGate('q3-contract-review');
+    expect(screen.getByTestId('probe')).toHaveTextContent(DOC_ID);
+  });
+
+  it('shows the not-found state for an unknown slug', () => {
+    vi.mocked(useDocumentBySlug).mockReturnValue({
+      isPending: false,
+      isError: true,
+      data: undefined,
+    } as never);
+    renderGate('no-such-review');
+    expect(screen.getByText('Review not found')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to reviews' })).toHaveAttribute(
+      'href',
+      '/reviews',
+    );
+  });
+});
+
+describe('useReviewDocumentId', () => {
+  it('falls back to the raw route segment without a gate (unit-test rendering)', () => {
+    render(
+      <MemoryRouter initialEntries={['/reviews/d1']}>
+        <Routes>
+          <Route path="/reviews/:documentId" element={<Probe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('probe')).toHaveTextContent('d1');
+  });
+});

--- a/qnop-ui/src/components/reviews/ReviewParamGate.tsx
+++ b/qnop-ui/src/components/reviews/ReviewParamGate.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { Link as RouterLink, useParams } from 'react-router-dom';
+import { useDocumentBySlug } from '../../api/hooks/useDocuments';
+import { ReviewDocumentIdContext } from './reviewDocumentId';
+
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolves the /reviews/:documentId segment before the page renders (issue
+ * #411): a UUID passes through untouched; anything else is treated as a review
+ * slug and resolved via the by-slug endpoint, so pages only ever work with the
+ * canonical id while the pretty URL stays in the address bar.
+ */
+export function ReviewParamGate({ children }: { children: ReactNode }) {
+  const { documentId: segment = '' } = useParams();
+  const isId = UUID_SHAPE.test(segment);
+  const bySlug = useDocumentBySlug(segment, !isId && segment !== '');
+
+  if (isId) return children;
+
+  if (bySlug.isPending) {
+    return (
+      <Stack sx={{ alignItems: 'center', py: 10 }}>
+        <CircularProgress size={28} aria-label="Resolving review" />
+      </Stack>
+    );
+  }
+
+  if (bySlug.isError || !bySlug.data?.id) {
+    return (
+      <Stack spacing={1} sx={{ alignItems: 'center', py: 10 }}>
+        <Typography variant="h6">Review not found</Typography>
+        <Typography variant="body2" color="text.secondary">
+          No review answers to “{segment}”. The link may be outdated.
+        </Typography>
+        <Button component={RouterLink} to="/reviews" sx={{ mt: 1 }}>
+          Back to reviews
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <ReviewDocumentIdContext.Provider value={bySlug.data.id}>
+      {children}
+    </ReviewDocumentIdContext.Provider>
+  );
+}

--- a/qnop-ui/src/components/reviews/list/ReviewCards.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewCards.tsx
@@ -55,7 +55,7 @@ export function ReviewCards({ reviews, userId, onOpen }: ReviewCardsProps) {
         return (
           <ButtonBase
             key={review.id}
-            onClick={() => onOpen(review.id)}
+            onClick={() => onOpen(review.slug ?? review.id)}
             data-testid={`review-card-${review.id}`}
             sx={{
               display: 'flex',

--- a/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
@@ -78,7 +78,7 @@ export function ReviewsTable({ reviews, userId, onOpen }: ReviewsTableProps) {
                 <TableRow
                   key={review.id}
                   hover
-                  onClick={() => onOpen(review.id)}
+                  onClick={() => onOpen(review.slug ?? review.id)}
                   data-testid={`review-row-${review.id}`}
                   sx={{ cursor: 'pointer', '&:last-child td': { borderBottom: 0 } }}
                 >

--- a/qnop-ui/src/components/reviews/reviewDocumentId.ts
+++ b/qnop-ui/src/components/reviews/reviewDocumentId.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { createContext, useContext } from 'react';
+import { useParams } from 'react-router-dom';
+
+/** Provided by {@code ReviewParamGate} once a slug URL resolved (issue #411). */
+export const ReviewDocumentIdContext = createContext<string | null>(null);
+
+/**
+ * The canonical document id under a /reviews/:documentId route (issue #411).
+ * Inside a {@code ReviewParamGate} this is the resolved id even when the URL
+ * carries a slug; without a gate (unit tests render pages directly) it falls
+ * back to the raw route segment.
+ */
+export function useReviewDocumentId(): string {
+  const resolved = useContext(ReviewDocumentIdContext);
+  const { documentId = '' } = useParams();
+  return resolved ?? documentId;
+}

--- a/qnop-ui/src/components/reviews/wizard/DocumentStep.tsx
+++ b/qnop-ui/src/components/reviews/wizard/DocumentStep.tsx
@@ -38,10 +38,15 @@ interface DocumentStepProps {
   title: string;
   /** Validation error from the last file pick, if any. */
   fileError: string | null;
+  /** Optional review slug (issue #411) — auto-suggested from the title. */
+  slug: string;
+  /** Client- or server-side slug rejection to attach to the field. */
+  slugError: string | null;
   maxSizeMb: number;
   onFilePicked: (file: File) => void;
   onFileCleared: () => void;
   onTitleChange: (title: string) => void;
+  onSlugChange: (slug: string) => void;
 }
 
 /** Step 1 — pick the PDF (dropzone or picker) and name the review. */
@@ -49,10 +54,13 @@ export function DocumentStep({
   file,
   title,
   fileError,
+  slug,
+  slugError,
   maxSizeMb,
   onFilePicked,
   onFileCleared,
   onTitleChange,
+  onSlugChange,
 }: DocumentStepProps) {
   const theme = useTheme();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -177,6 +185,20 @@ export function DocumentStep({
         onChange={(e) => onTitleChange(e.target.value)}
         placeholder="e.g. NDA Acme Corp"
         helperText="Shown in the overview and to every reviewer."
+        fullWidth
+      />
+
+      <TextField
+        label="URL slug (optional)"
+        value={slug}
+        onChange={(e) => onSlugChange(e.target.value)}
+        placeholder="e.g. nda-acme-corp"
+        error={slugError !== null}
+        helperText={
+          slugError ??
+          'A readable address for this review: lowercase letters, digits and hyphens. Cannot be changed later.'
+        }
+        slotProps={{ htmlInput: { 'data-testid': 'wizard-slug-input', maxLength: 64 } }}
         fullWidth
       />
     </Stack>

--- a/qnop-ui/src/components/reviews/wizard/ReviewerStep.tsx
+++ b/qnop-ui/src/components/reviews/wizard/ReviewerStep.tsx
@@ -102,7 +102,11 @@ export function ReviewerStep({ selected, ownUserId, onAdd, onRemove }: ReviewerS
                     <Users size={12} aria-hidden />
                   </Box>
                 ) : (
-                  <UserAvatar name={principal.displayName} size={22} />
+                  <UserAvatar
+                    name={principal.displayName}
+                    size={22}
+                    imageUrl={principal.avatarUrl}
+                  />
                 )}
                 <Typography variant="body2" sx={{ fontSize: 12.5, fontWeight: 500 }}>
                   {principal.displayName}
@@ -140,10 +144,14 @@ export function ReviewerStep({ selected, ownUserId, onAdd, onRemove }: ReviewerS
           }}
         />
         <Box
+          data-testid="principal-list"
           sx={{
             border: `1px solid ${theme.palette.divider}`,
             borderRadius: 2,
-            overflow: 'hidden',
+            // The directory can be long (issue #292) — cap the list to roughly
+            // seven rows and let it scroll instead of stretching the wizard.
+            maxHeight: 'min(48vh, 384px)',
+            overflowY: 'auto',
           }}
         >
           {candidates.length === 0 ? (
@@ -187,7 +195,11 @@ export function ReviewerStep({ selected, ownUserId, onAdd, onRemove }: ReviewerS
                     <Users size={14} aria-hidden />
                   </Box>
                 ) : (
-                  <UserAvatar name={principal.displayName} size={28} />
+                  <UserAvatar
+                    name={principal.displayName}
+                    size={28}
+                    imageUrl={principal.avatarUrl}
+                  />
                 )}
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>

--- a/qnop-ui/src/components/reviews/wizard/SummaryStep.tsx
+++ b/qnop-ui/src/components/reviews/wizard/SummaryStep.tsx
@@ -27,7 +27,9 @@ import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import { FileText, Play, Users } from 'lucide-react';
 import type { PrincipalView } from '../../../api/generated';
+import { ParticipantKind } from '../../../api/generated';
 import { DueDatePicker } from '../DueDatePicker';
+import { UserAvatar } from '../../shell/UserAvatar';
 import { formatFileSize } from './wizardModel';
 
 export type SubmitPhase = 'idle' | 'uploading' | 'finalizing';
@@ -101,11 +103,46 @@ export function SummaryStep({
             None yet — the review starts with you only; reviewers can be added any time.
           </Typography>
         ) : (
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
-            <Users size={16} aria-hidden style={{ color: theme.palette.text.secondary }} />
-            <Typography variant="body2">
-              {reviewers.map((r) => r.displayName).join(', ')}
-            </Typography>
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+            {reviewers.map((reviewer) => (
+              <Stack
+                key={`${reviewer.kind}:${reviewer.id}`}
+                direction="row"
+                spacing={0.75}
+                data-testid={`summary-reviewer-${reviewer.id}`}
+                sx={{
+                  alignItems: 'center',
+                  pl: 0.5,
+                  pr: 1.25,
+                  py: 0.5,
+                  borderRadius: 99,
+                  bgcolor: theme.qnop.surface2,
+                }}
+              >
+                {reviewer.kind === ParticipantKind.Team ? (
+                  <Box
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: '50%',
+                      bgcolor: theme.palette.background.paper,
+                      color: 'text.secondary',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                    }}
+                  >
+                    <Users size={12} aria-hidden />
+                  </Box>
+                ) : (
+                  <UserAvatar name={reviewer.displayName} size={22} imageUrl={reviewer.avatarUrl} />
+                )}
+                <Typography variant="body2" sx={{ fontSize: 12.5, fontWeight: 500 }}>
+                  {reviewer.displayName}
+                </Typography>
+              </Stack>
+            ))}
           </Stack>
         )}
       </SummaryRow>

--- a/qnop-ui/src/components/reviews/wizard/wizardModel.test.ts
+++ b/qnop-ui/src/components/reviews/wizard/wizardModel.test.ts
@@ -20,7 +20,13 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { formatFileSize, titleFromFilename, validateDocumentFile } from './wizardModel';
+import {
+  formatFileSize,
+  suggestSlug,
+  titleFromFilename,
+  validateDocumentFile,
+  validateSlug,
+} from './wizardModel';
 
 function fileOf(name: string, type: string, sizeBytes: number): File {
   const file = new File(['x'], name, { type });
@@ -68,5 +74,54 @@ describe('formatFileSize', () => {
   it('formats kilobytes and never shows 0 KB for tiny files', () => {
     expect(formatFileSize(412 * 1024)).toBe('412 KB');
     expect(formatFileSize(3)).toBe('1 KB');
+  });
+});
+describe('suggestSlug', () => {
+  it('kebab-cases the title', () => {
+    expect(suggestSlug('NDA Acme Corp')).toBe('nda-acme-corp');
+  });
+
+  it('strips diacritics and collapses punctuation runs', () => {
+    expect(suggestSlug('Übergabe — Q3/2026 (final!)')).toBe('ubergabe-q3-2026-final');
+  });
+
+  it('trims leading and trailing separators', () => {
+    expect(suggestSlug('  --Hello World--  ')).toBe('hello-world');
+  });
+
+  it('caps at 64 characters without leaving a dangling hyphen', () => {
+    const suggested = suggestSlug(`${'a'.repeat(63)} tail`);
+    expect(suggested).toHaveLength(63);
+    expect(suggested.endsWith('-')).toBe(false);
+  });
+
+  it('returns empty for titles with no usable characters', () => {
+    expect(suggestSlug('!!! ???')).toBe('');
+  });
+});
+
+describe('validateSlug', () => {
+  it('accepts a kebab-case slug and the empty (optional) value', () => {
+    expect(validateSlug('nda-acme-corp')).toBeNull();
+    expect(validateSlug('')).toBeNull();
+  });
+
+  it('rejects out-of-range lengths', () => {
+    expect(validateSlug('ab')).toBe('The slug must be 3–64 characters long.');
+    expect(validateSlug('x'.repeat(65))).toBe('The slug must be 3–64 characters long.');
+  });
+
+  it('rejects uppercase, underscores, and hyphen runs', () => {
+    const message = 'Only lowercase letters, digits and single hyphens are allowed.';
+    expect(validateSlug('Nda-Acme')).toBe(message);
+    expect(validateSlug('has_underscore')).toBe(message);
+    expect(validateSlug('double--hyphen')).toBe(message);
+    expect(validateSlug('-leading')).toBe(message);
+  });
+
+  it('rejects UUID-shaped slugs, which would shadow id routes', () => {
+    expect(validateSlug('123e4567-e89b-12d3-a456-426614174000')).toBe(
+      'The slug must not look like a document id.',
+    );
   });
 });

--- a/qnop-ui/src/components/reviews/wizard/wizardModel.ts
+++ b/qnop-ui/src/components/reviews/wizard/wizardModel.ts
@@ -41,6 +41,47 @@ export function titleFromFilename(filename: string): string {
   return filename.replace(/\.pdf$/i, '').trim();
 }
 
+export const SLUG_MIN_LENGTH = 3;
+export const SLUG_MAX_LENGTH = 64;
+const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+// A slug must never be UUID-shaped — routes resolve those segments as document ids.
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Suggests a slug from the review title (issue #411): lowercased, diacritics
+ * stripped, everything non-alphanumeric collapsed into single hyphens, capped
+ * at the server's maximum length. May return '' when the title has no usable
+ * characters — the slug stays optional either way.
+ */
+export function suggestSlug(title: string): string {
+  return title
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, SLUG_MAX_LENGTH)
+    .replace(/-+$/, '');
+}
+
+/**
+ * Client-side mirror of the server's slug rules (issue #411; the backend is
+ * authoritative). Empty means "no slug" and is valid.
+ */
+export function validateSlug(slug: string): string | null {
+  if (slug === '') return null;
+  if (slug.length < SLUG_MIN_LENGTH || slug.length > SLUG_MAX_LENGTH) {
+    return `The slug must be ${SLUG_MIN_LENGTH}–${SLUG_MAX_LENGTH} characters long.`;
+  }
+  if (!SLUG_PATTERN.test(slug)) {
+    return 'Only lowercase letters, digits and single hyphens are allowed.';
+  }
+  if (UUID_SHAPE.test(slug)) {
+    return 'The slug must not look like a document id.';
+  }
+  return null;
+}
+
 /** Human-readable file size ("2.4 MB", "412 KB"). */
 export function formatFileSize(bytes: number): string {
   if (bytes >= BYTES_PER_MB) return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -49,6 +49,7 @@ import { BoundaryFallback } from '../../components/errors/BoundaryFallback';
 import { ErrorBoundary } from '../../components/errors/ErrorBoundary';
 import { ReviewHubHead } from '../../components/reviews/hub/ReviewHubHead';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
+import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
 import {
   DEFAULT_PANEL_FRACTION,
@@ -97,7 +98,10 @@ const LEGACY_PANEL_WIDTH_KEY = 'qnop-review-panel-width';
  * search param, defaulting to the latest.
  */
 export function DocumentReviewPage() {
-  const { documentId = '' } = useParams();
+  // The raw segment may be a slug (issue #411) — sibling links keep it, while
+  // all data access below uses the canonical id resolved by the route gate.
+  const { documentId: routeSegment = '' } = useParams();
+  const documentId = useReviewDocumentId();
   const [searchParams, setSearchParams] = useSearchParams();
   const { toast, notify, clear } = useToast();
   const userId = useAuthStore((s) => s.userId);
@@ -345,7 +349,7 @@ export function DocumentReviewPage() {
         }
       />
       <ReviewViewTabs
-        documentId={documentId}
+        documentId={routeSegment}
         active={focusMode ? 'focus' : 'document'}
         openTaskCount={annotations.filter((a) => columnOf(a) !== 'done').length}
         compareEnabled={

--- a/qnop-ui/src/pages/reviews/NewReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/NewReviewPage.tsx
@@ -41,11 +41,13 @@ import { SummaryStep } from '../../components/reviews/wizard/SummaryStep';
 import type { SubmitPhase } from '../../components/reviews/wizard/SummaryStep';
 import { WizardStepsHeader } from '../../components/reviews/wizard/WizardStepsHeader';
 import {
+  suggestSlug,
   titleFromFilename,
   validateDocumentFile,
+  validateSlug,
 } from '../../components/reviews/wizard/wizardModel';
 import { useAuthStore } from '../../stores/authStore';
-import { apiErrorMessage } from '../../utils/apiError';
+import { apiErrorMessage, apiFieldErrors } from '../../utils/apiError';
 
 const STEPS = [{ label: 'Document' }, { label: 'Reviewers' }, { label: 'Summary & start' }];
 const FALLBACK_MAX_SIZE_MB = 50;
@@ -72,6 +74,9 @@ export function NewReviewPage() {
   const [file, setFile] = useState<File | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
   const [title, setTitle] = useState('');
+  const [slug, setSlug] = useState('');
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [slugError, setSlugError] = useState<string | null>(null);
   const [reviewers, setReviewers] = useState<PrincipalView[]>([]);
   const [dueAt, setDueAt] = useState<string | null>(null);
   const [startImmediately, setStartImmediately] = useState(true);
@@ -79,6 +84,15 @@ export function NewReviewPage() {
 
   const maxSizeMb = config?.upload.maxDocumentSizeMb ?? FALLBACK_MAX_SIZE_MB;
   const isSubmitting = submit.phase !== 'idle';
+
+  // Until the user edits the slug themselves it mirrors the title (issue #411).
+  const handleTitleChange = (value: string) => {
+    setTitle(value);
+    if (!slugTouched) {
+      setSlug(suggestSlug(value));
+      setSlugError(null);
+    }
+  };
 
   const handleFilePicked = (picked: File) => {
     const error = validateDocumentFile(picked, maxSizeMb);
@@ -88,7 +102,15 @@ export function NewReviewPage() {
     }
     setFileError(null);
     setFile(picked);
-    if (title.trim() === '') setTitle(titleFromFilename(picked.name));
+    if (title.trim() === '') handleTitleChange(titleFromFilename(picked.name));
+  };
+
+  // Submit-then-validate (house pattern): typing only clears a stale error;
+  // the check runs when leaving step 1 and again server-side on create.
+  const handleSlugChange = (value: string) => {
+    setSlugTouched(value !== '');
+    setSlug(value);
+    setSlugError(null);
   };
 
   const addReviewer = (principal: PrincipalView) =>
@@ -100,8 +122,18 @@ export function NewReviewPage() {
 
   const canProceed = step !== 1 || (file !== null && title.trim() !== '');
 
+  const handleNext = () => {
+    if (step === 1) {
+      const error = validateSlug(slug.trim().toLowerCase());
+      setSlugError(error);
+      if (error) return;
+    }
+    setStep(step + 1);
+  };
+
   const handleCreate = async () => {
     if (!file) return;
+    const cleanSlug = slug.trim().toLowerCase();
     setSubmit({ ...SUBMIT_IDLE, phase: 'uploading' });
     let documentId: string;
     try {
@@ -109,10 +141,20 @@ export function NewReviewPage() {
         title: title.trim(),
         file,
         dueAt,
+        slug: cleanSlug || null,
         onProgress: (fraction) => setSubmit((s) => ({ ...s, progress: fraction })),
       });
       documentId = created.documentId;
     } catch (error) {
+      // A slug rejection (taken or malformed, issue #411) belongs on its field —
+      // jump back to step 1 so the user sees the offending input.
+      const slugFieldError = apiFieldErrors(error).slug;
+      if (slugFieldError) {
+        setSlugError(slugFieldError);
+        setSubmit(SUBMIT_IDLE);
+        setStep(1);
+        return;
+      }
       setSubmit({
         ...SUBMIT_IDLE,
         error: apiErrorMessage(error, 'The upload failed. Please try again.'),
@@ -153,7 +195,7 @@ export function NewReviewPage() {
       setSubmit({ ...SUBMIT_IDLE, partial: { documentId, failures } });
       return;
     }
-    navigate(`/reviews/${documentId}`);
+    navigate(`/reviews/${cleanSlug || documentId}`);
   };
 
   if (submit.partial) {
@@ -193,10 +235,13 @@ export function NewReviewPage() {
             file={file}
             title={title}
             fileError={fileError}
+            slug={slug}
+            slugError={slugError}
             maxSizeMb={maxSizeMb}
             onFilePicked={handleFilePicked}
             onFileCleared={() => setFile(null)}
-            onTitleChange={setTitle}
+            onTitleChange={handleTitleChange}
+            onSlugChange={handleSlugChange}
           />
         )}
         {step === 2 && (
@@ -239,7 +284,7 @@ export function NewReviewPage() {
             variant="contained"
             endIcon={<ChevronRight size={16} />}
             disabled={!canProceed}
-            onClick={() => setStep(step + 1)}
+            onClick={handleNext}
           >
             Next
           </Button>

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -34,6 +34,7 @@ import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useParticipants, useRecordVisit } from '../../api/hooks/useReviews';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
+import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
 import type { FilterAuthor } from '../../components/reviews/panel/PanelFilterBar';
@@ -70,7 +71,10 @@ const FILTERS: { key: TaskFilter; label: string }[] = [
  * task drawer, which reuses the panel's thread and resolve pieces.
  */
 export function ReviewTasksPage() {
-  const { documentId = '' } = useParams();
+  // The raw segment may be a slug (issue #411) — sibling links keep it, while
+  // all data access below uses the canonical id resolved by the route gate.
+  const { documentId: routeSegment = '' } = useParams();
+  const documentId = useReviewDocumentId();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { toast, notify, clear } = useToast();
@@ -175,7 +179,7 @@ export function ReviewTasksPage() {
   };
 
   const showInDocument = (annotationId: string) => {
-    void navigate(`/reviews/${documentId}?annotation=${annotationId}`);
+    void navigate(`/reviews/${routeSegment}?annotation=${annotationId}`);
   };
 
   if (documentQuery.isPending) {
@@ -201,7 +205,7 @@ export function ReviewTasksPage() {
         titleAdornment={<Chip size="small" variant="outlined" label="Tasks" />}
       />
       <ReviewViewTabs
-        documentId={documentId}
+        documentId={routeSegment}
         active="tasks"
         openTaskCount={annotations.filter((annotation) => columnOf(annotation) !== 'done').length}
         compareEnabled={

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -39,6 +39,7 @@ import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useVersionDiff, versionDiffErrorCode } from '../../api/hooks/useVersionDiff';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
+import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
 import { ChangeSummaryPanel } from '../../components/reviews/diff/ChangeSummaryPanel';
 import { ComparePane } from '../../components/reviews/diff/ComparePane';
 import { CompareToolbar } from '../../components/reviews/diff/CompareToolbar';
@@ -56,7 +57,10 @@ import { formatDateTime } from '../../utils/formatDate';
  * invalid or missing parameters normalise to "previous ↔ latest".
  */
 export function VersionComparePage() {
-  const { documentId = '' } = useParams();
+  // The raw segment may be a slug (issue #411) — sibling links keep it, while
+  // all data access below uses the canonical id resolved by the route gate.
+  const { documentId: routeSegment = '' } = useParams();
+  const documentId = useReviewDocumentId();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const documentQuery = useDocument(documentId);
@@ -159,7 +163,7 @@ export function VersionComparePage() {
         titleAdornment={<Chip size="small" variant="outlined" label="Compare versions" />}
       />
       <ReviewViewTabs
-        documentId={documentId}
+        documentId={routeSegment}
         active="compare"
         openTaskCount={openTaskCount}
         compareEnabled={readyNumbers.length >= 2}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -48,6 +48,7 @@ import { ForbiddenPage } from '../pages/errors/ForbiddenPage';
 import { NotFoundPage } from '../pages/errors/NotFoundPage';
 import { NewReviewPage } from '../pages/reviews/NewReviewPage';
 import { ReviewsPage } from '../pages/reviews/ReviewsPage';
+import { ReviewParamGate } from '../components/reviews/ReviewParamGate';
 
 // The template editor pulls in CodeMirror; load it lazily so the rest of the app stays light.
 const MailTemplateEditPage = lazy(() =>
@@ -96,25 +97,31 @@ export const router = createBrowserRouter([
       {
         path: 'reviews/:documentId',
         element: (
-          <LazyBoundary>
-            <DocumentReviewPage />
-          </LazyBoundary>
+          <ReviewParamGate>
+            <LazyBoundary>
+              <DocumentReviewPage />
+            </LazyBoundary>
+          </ReviewParamGate>
         ),
       },
       {
         path: 'reviews/:documentId/compare',
         element: (
-          <LazyBoundary>
-            <VersionComparePage />
-          </LazyBoundary>
+          <ReviewParamGate>
+            <LazyBoundary>
+              <VersionComparePage />
+            </LazyBoundary>
+          </ReviewParamGate>
         ),
       },
       {
         path: 'reviews/:documentId/tasks',
         element: (
-          <LazyBoundary>
-            <ReviewTasksPage />
-          </LazyBoundary>
+          <ReviewParamGate>
+            <LazyBoundary>
+              <ReviewTasksPage />
+            </LazyBoundary>
+          </ReviewParamGate>
         ),
       },
       {


### PR DESCRIPTION
Closes #411, closes #415.

## What

### Review slugs (#411)

A review can optionally be given a human-readable URL slug at creation — `/reviews/q3-contract-review` instead of `/reviews/019f31…`.

**Backend**
- `document.slug` (nullable `VARCHAR(64)`) added to the `0011-document` changeset (pre-prod amend-in-place convention), with a partial unique index on `LOWER(slug)` and a `CHECK` pinning the kebab-case shape (3–64 chars).
- `DocumentIngestService.createDocument` normalizes (trim + lowercase) and validates the optional slug: kebab-case, never UUID-shaped (would shadow id routes), unique ignoring case — the unique index backstops the pre-check against a create race.
- Field-scoped rejections ride the uniform envelope as `fieldErrors` (`SLUG_TAKEN` 409 / `VALIDATION_ERROR` 400 with `field: "slug"`).
- New contract endpoint `GET /documents/by-slug/{slug}` with the same anti-enumeration 404 as the id route; `slug` added to `DocumentResponse` and `DocumentSummary`.

**Frontend**
- Wizard step 1 gains an optional "URL slug" field that mirrors the title (diacritics stripped, kebab-cased) until manually edited; submit-then-validate per the house pattern, server rejections land on the field and jump back to step 1.
- `ReviewParamGate` around the three `/reviews/:documentId` routes resolves non-UUID segments via the by-slug endpoint (seeding the document detail cache) and shows a quiet not-found state for unknown slugs. Pages consume the canonical id through `useReviewDocumentId`; tabs and deep links keep the slug in the address bar.
- The reviews list and the post-create redirect prefer the slug when present.

### New-review wizard polish (#415)

- Step 2's principal directory is capped (~7 rows, viewport-aware) and scrolls internally — a long user list no longer pushes the wizard footer off screen.
- Step 3 renders the selected reviewers as chips with the profile picture (or initials placeholder) and the team glyph, instead of a comma-joined text line.
- `PrincipalView` gains a nullable `avatarUrl`, populated in `PrincipalsController` via one batched `AvatarService.updatedAt` lookup per page (the admin-user-list pattern); step 2's directory rows show the pictures too.

### Test hardening

`AdminUserControllerIT.sendsPasswordReset` silently depended on another test class having left `smtp.enabled=false` behind (the seed points SMTP at Mailpit, #401); the new `DocumentSlugIT` shifted class order and exposed it. The test now switches the toggle off itself (`@Transactional` rolls it back).

## Test plan

- [x] `./gradlew build` (Spotless, ArchUnit, full IT suite incl. new `DocumentSlugIT`: slug round-trip incl. case-insensitive lookup, optional slug, case-variant duplicate → 409 + field error, 7 malformed shapes → 400, by-slug anti-enumeration)
- [x] `pnpm test:run` (490 tests, incl. new `suggestSlug`/`validateSlug` and `ReviewParamGate` suites), `tsc -b`, ESLint, Prettier
- [x] Manual browser pass: create with slug → redirect to slug URL; cold-load of slug URL and `/tasks` sibling; unknown slug → not-found state; duplicate slug → field error on step 1; reviews card opens via slug; step-2 list scrolls; step-3 chips show avatars/placeholders/team glyph
- [x] Dev DB hand-migrated per the pre-prod convention (manual ALTER + `md5sum = NULL` for `0011-document`)

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
