### PR TITLE
fix(compose): mount the local Postgres volume at /var/lib/postgresql (#407)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ set -a; source .env; set +a
 cd qnop-ui && pnpm install && pnpm dev
 ```
 
+> **Postgres 18 data volume.** `postgres:18` stores its cluster under
+> `/var/lib/postgresql/<major>/docker` and refuses a mount at the old
+> `…/data` path, so compose mounts `qnop_pgdata:/var/lib/postgresql` (issue #407).
+> A `qnop_pgdata` volume created before this change won't start — the simplest fix
+> is a fresh volume (`docker compose down -v`, then `docker compose up -d`); to keep
+> existing data instead, copy the old cluster's `18/` directory into it (recipe in
+> issue #407).
+
 ## Repository layout
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
     ports:
       - '${QNOP_DB_PORT:-5432}:5432'
     volumes:
-      - qnop_pgdata:/var/lib/postgresql/data
+      # postgres:18+ stores data under /var/lib/postgresql/<major>/docker and refuses any mount
+      # at the legacy /var/lib/postgresql/data — mount the parent instead (issue #407).
+      - qnop_pgdata:/var/lib/postgresql
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U ${QNOP_DB_USERNAME:-qnop} -d ${QNOP_DB_NAME:-qnop}']
       interval: 10s


### PR DESCRIPTION
## Summary

Closes #407. Since the Renovate digest bump in `8eb48d5`, `docker compose up` cannot start the local Postgres:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" ...
       there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
```

`postgres:18` places data under `/var/lib/postgresql/<major>/docker` and **refuses any mount at the legacy `/var/lib/postgresql/data`** (even an empty one — [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)). Our compose mounted `qnop_pgdata:/var/lib/postgresql/data`, so the container exited 1 every start.

**Fix:** mount the parent — `qnop_pgdata:/var/lib/postgresql` (upstream's suggested configuration). Added a README note for migrating an existing `qnop_pgdata` volume (start fresh, or copy the old `18/` cluster dir in).

## Test plan
- [x] `docker compose config -q` validates the file (no daemon needed).
- [ ] Manual: `docker compose down -v && docker compose up -d` starts Postgres healthy (needs a local Docker daemon — not available in this environment; the change matches upstream's documented mount and the issue's verified repro).

> Note: CI doesn't cover this path — `docker-compose.smoke.yml` runs Postgres with no volume, which is why CI stayed green while local setups broke.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code