### PR TITLE
feat(platform): observability — job-queue health indicator + Prometheus metrics (#348)

### DIFF
--- a/docs/adr/0037-observability-actuator-health-and-prometheus.md
+++ b/docs/adr/0037-observability-actuator-health-and-prometheus.md
@@ -1,0 +1,22 @@
+# ADR-0037: Observability — Actuator health, job-queue health indicator, Prometheus metrics
+
+- **Status:** Accepted
+- **Date:** 2026-07-05
+- **Deciders:** qnop core team
+
+## Context
+
+The server already boots with Spring Boot Actuator and exposes `/actuator/health` for container probes, but there was no operational visibility into the durable async job queue (ADR-0033) — the one background subsystem whose failure is silent from the outside. A wedged poller/reaper, a growing backlog, or jobs stranded `RUNNING` by a dead worker would not surface until a review's extraction or re-anchoring never completed. There were also no scrapeable metrics. This is the observability foundation flagged for Phase 2 (issue #348); it deliberately stays small and self-hosted (no external APM), consistent with the deferral posture of ADR-0013.
+
+## Decision
+
+- **Health.** A `JobQueueHealthIndicator` contributes the job queue to `/actuator/health`: `DOWN` when a `RUNNING` job is stranded past the reaper's stale threshold (a dead worker or a wedged poller/reaper), otherwise `UP`, with the per-state depth counts as details. It is **not** wired into the liveness/readiness groups, so a stale-queue `DOWN` is an alerting signal, never a pod-restart trigger.
+- **Metrics.** `micrometer-registry-prometheus` (runtime-only) backs `/actuator/prometheus`. A `JobQueueMetrics` `MeterBinder` publishes one `qnop.jobs` gauge per lifecycle `state` (`pending`, `running`, `stale`, `failed`), read live at scrape time.
+- **The counts live behind a service.** `JobService.queueStats()` returns a primitive `QueueStats` record; the actuator components (in the `app` layer) never touch the repository or the entity enum, keeping the ArchUnit layering intact.
+- **Access.** `/actuator/health` stays public (probes) but reveals details only `when_authorized`; every other management endpoint — the Prometheus scrape included — is `ROLE_ADMIN`-only, so an ops Prometheus scrapes with an admin token. No separate management port is introduced yet.
+
+## Consequences
+
+- Operators get queue depth, staleness, and failure counts both as a health signal and as Prometheus time series, with no new infrastructure.
+- Metrics are not anonymously readable; a scrape needs an admin credential (or a future dedicated management port / network policy).
+- **Deferred:** extraction/processing latency histograms — they need a metrics seam into the extraction handler in `qnop-core` (a Micrometer dependency there) and are a clean follow-up now that the registry is in place. Tracked as the remaining part of issue #348.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0034](0034-inter-version-diff.md) | Inter-version diff | Accepted |
 | [0035](0035-esignature-approval-enterprise-feature.md) | E-signature approval as a post-finalization enterprise feature | Accepted |
 | [0036](0036-object-storage-lifecycle-staging-and-reaper.md) | Object-storage lifecycle: staging registry + orphan reaper | Accepted |
+| [0037](0037-observability-actuator-health-and-prometheus.md) | Observability: Actuator health, job-queue health indicator, Prometheus metrics | Accepted |
 
 ## Template
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,9 @@ archunit-junit5 = { group = "com.tngtech.archunit", name = "archunit-junit5", ve
 spring-boot-dependencies = { group = "org.springframework.boot", name = "spring-boot-dependencies", version.ref = "springBoot" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
+# Prometheus scrape registry for Actuator metrics (issue #348, ADR-0013). Version via the BOM;
+# auto-configured at runtime, so it is a runtime-only dependency (no compile-time symbols).
+micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
 liquibase-core = { module = "org.liquibase:liquibase-core" }
 # Spring Boot 4 split LiquibaseAutoConfiguration out of spring-boot-autoconfigure

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
 
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.actuator)
+    // Prometheus scrape registry for the /actuator/prometheus endpoint (issue #348). Runtime-only:
+    // Boot auto-configures it; the metrics/health code uses micrometer-core (via actuator) directly.
+    runtimeOnly(libs.micrometer.registry.prometheus)
     // Servlet security filter chain (io.qnop.web.security, issue #10 / ADR-0022).
     implementation(libs.spring.boot.starter.security)
     // Resource-server filter that validates the bearer JWT on each request, plus

--- a/qnop-app/src/main/java/io/qnop/bootstrap/JobQueueHealthIndicator.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/JobQueueHealthIndicator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import io.qnop.service.job.JobService;
+import io.qnop.service.job.JobService.QueueStats;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Contributes the durable job queue to {@code /actuator/health} (issue #348). Reports {@code DOWN}
+ * when a {@code RUNNING} job is stranded past the stale threshold — a dead worker the reaper has
+ * not reclaimed, or a wedged poller/reaper — otherwise {@code UP}. The queue-depth counts ride
+ * along as details (revealed only to an authenticated admin via {@code show-details:
+ * when_authorized}). This indicator is not part of the liveness/readiness probe groups, so a
+ * stale-queue {@code DOWN} surfaces the condition without triggering a pod restart.
+ */
+@Component
+class JobQueueHealthIndicator implements HealthIndicator {
+
+  private final JobService jobs;
+
+  JobQueueHealthIndicator(JobService jobs) {
+    this.jobs = jobs;
+  }
+
+  @Override
+  public Health health() {
+    QueueStats stats = jobs.queueStats();
+    Health.Builder builder = stats.staleRunning() > 0 ? Health.down() : Health.up();
+    return builder
+        .withDetail("pending", stats.pending())
+        .withDetail("running", stats.running())
+        .withDetail("staleRunning", stats.staleRunning())
+        .withDetail("failed", stats.failed())
+        .build();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/bootstrap/JobQueueMetrics.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/JobQueueMetrics.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.qnop.service.job.JobService;
+import java.util.function.ToDoubleFunction;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes job-queue depth as Prometheus gauges (issue #348): {@code qnop.jobs{state="pending"}}
+ * (the backlog), {@code running}, {@code stale} (in-flight past the stale threshold) and {@code
+ * failed}. Spring Boot binds every {@link MeterBinder} bean to the meter registry, so scraping
+ * {@code /actuator/prometheus} evaluates these gauges live — each reads a fresh snapshot at scrape
+ * time.
+ */
+@Component
+class JobQueueMetrics implements MeterBinder {
+
+  private final JobService jobs;
+
+  JobQueueMetrics(JobService jobs) {
+    this.jobs = jobs;
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    gauge(registry, "pending", stats -> stats.pending());
+    gauge(registry, "running", stats -> stats.running());
+    gauge(registry, "stale", stats -> stats.staleRunning());
+    gauge(registry, "failed", stats -> stats.failed());
+  }
+
+  private void gauge(
+      MeterRegistry registry, String state, ToDoubleFunction<JobService.QueueStats> value) {
+    Gauge.builder("qnop.jobs", jobs, j -> value.applyAsDouble(j.queueStats()))
+        .tag("state", state)
+        .description("Durable job-queue depth by lifecycle state")
+        .register(registry);
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -124,6 +124,10 @@ public class SecurityConfiguration {
             auth ->
                 auth.requestMatchers("/actuator/health", "/actuator/health/**")
                     .permitAll()
+                    // Every other management endpoint (prometheus scrape, health details) is
+                    // ops-only — an admin bearer token, never anonymous (issue #348).
+                    .requestMatchers("/actuator/**")
+                    .hasRole("ADMIN")
                     .requestMatchers(
                         "/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/logout")
                     .permitAll()

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -48,11 +48,16 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        # health is public (probes); prometheus is admin-only (SecurityConfiguration), scraped by
+        # an ops Prometheus with an admin token (issue #348, ADR-0013).
+        include: health,prometheus
   endpoint:
     health:
       probes:
         enabled: true
+      # Anonymous callers (k8s probes) see only UP/DOWN; the job-queue counts and staleness
+      # details are revealed only to an authenticated admin.
+      show-details: when_authorized
 
 # Security & crypto foundation (issue #10, ADR-0022). Secrets come from the
 # QNOP_AUTH_* environment namespace — no secure default is baked in; the

--- a/qnop-app/src/test/java/io/qnop/bootstrap/JobQueueHealthIndicatorTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/JobQueueHealthIndicatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qnop.service.job.JobService;
+import io.qnop.service.job.JobService.QueueStats;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+/** The job-queue health contribution (issue #348): UP unless a RUNNING job is stranded. */
+class JobQueueHealthIndicatorTest {
+
+  private final JobService jobs = mock(JobService.class);
+  private final JobQueueHealthIndicator indicator = new JobQueueHealthIndicator(jobs);
+
+  @Test
+  @DisplayName("UP with the depth counts as details when nothing is stale")
+  void upWhenNoStaleJobs() {
+    when(jobs.queueStats()).thenReturn(new QueueStats(3, 1, 0, 2));
+
+    Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails())
+        .containsEntry("pending", 3L)
+        .containsEntry("running", 1L)
+        .containsEntry("staleRunning", 0L)
+        .containsEntry("failed", 2L);
+  }
+
+  @Test
+  @DisplayName("DOWN when a RUNNING job is stranded past the stale threshold")
+  void downWhenStaleJobsPresent() {
+    when(jobs.queueStats()).thenReturn(new QueueStats(0, 2, 1, 0));
+
+    Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    assertThat(health.getDetails()).containsEntry("staleRunning", 1L);
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/bootstrap/JobQueueMetricsTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/JobQueueMetricsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.qnop.service.job.JobService;
+import io.qnop.service.job.JobService.QueueStats;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** The job-queue depth gauges (issue #348): one {@code qnop.jobs} gauge per lifecycle state. */
+class JobQueueMetricsTest {
+
+  private final JobService jobs = mock(JobService.class);
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+  @Test
+  @DisplayName("binds a qnop.jobs gauge per state, each reading the live snapshot")
+  void bindsQueueDepthGauges() {
+    when(jobs.queueStats()).thenReturn(new QueueStats(5, 2, 1, 3));
+
+    new JobQueueMetrics(jobs).bindTo(registry);
+
+    assertThat(gauge("pending")).isEqualTo(5.0);
+    assertThat(gauge("running")).isEqualTo(2.0);
+    assertThat(gauge("stale")).isEqualTo(1.0);
+    assertThat(gauge("failed")).isEqualTo(3.0);
+  }
+
+  @Test
+  @DisplayName("re-reads the snapshot on each scrape")
+  void gaugesReflectTheLatestSnapshot() {
+    when(jobs.queueStats()).thenReturn(new QueueStats(1, 0, 0, 0));
+    new JobQueueMetrics(jobs).bindTo(registry);
+    assertThat(gauge("pending")).isEqualTo(1.0);
+
+    when(jobs.queueStats()).thenReturn(new QueueStats(9, 0, 0, 0));
+    assertThat(gauge("pending")).isEqualTo(9.0);
+  }
+
+  private double gauge(String state) {
+    Gauge gauge = registry.find("qnop.jobs").tag("state", state).gauge();
+    assertThat(gauge).as("gauge qnop.jobs{state=%s}", state).isNotNull();
+    return gauge.value();
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/bootstrap/ObservabilityIT.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/ObservabilityIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Actuator observability wiring (issue #348): {@code /actuator/health} is public (probes), the
+ * Prometheus scrape is admin-only, and it publishes the job-queue depth gauges.
+ */
+class ObservabilityIT extends SeededIntegrationTest {
+
+  private MockHttpServletRequestBuilder asUser(
+      MockHttpServletRequestBuilder builder, String token) {
+    return builder.header("Authorization", "Bearer " + token);
+  }
+
+  @Test
+  void healthIsPublic() throws Exception {
+    mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
+  }
+
+  @Test
+  void prometheusIsNotReadableAnonymously() throws Exception {
+    mockMvc.perform(get("/actuator/prometheus")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void prometheusIsForbiddenToNonAdmins() throws Exception {
+    mockMvc
+        .perform(asUser(get("/actuator/prometheus"), token(MEMBER_ID)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void adminScrapeExposesTheJobQueueDepthGauge() throws Exception {
+    mockMvc
+        .perform(asUser(get("/actuator/prometheus"), token(ADMIN_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("qnop_jobs")));
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/JobRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/JobRepository.java
@@ -22,6 +22,7 @@ package io.qnop.repository;
 
 import io.qnop.entity.Job;
 import io.qnop.entity.JobStatus;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -29,4 +30,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface JobRepository extends JpaRepository<Job, UUID>, JobRepositoryCustom {
 
   long countByStatus(JobStatus status);
+
+  /**
+   * Jobs in {@code status} untouched since {@code updatedBefore} — used by the health indicator to
+   * count {@code RUNNING} jobs stranded past the stale threshold (a worker that died, or a wedged
+   * poller/reaper), issue #348.
+   */
+  long countByStatusAndUpdatedAtBefore(JobStatus status, Instant updatedBefore);
 }

--- a/qnop-core/src/main/java/io/qnop/service/job/JobService.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobService.java
@@ -150,6 +150,26 @@ public class JobService {
     return repository.reapStaleRunning(now.minus(STALE_AFTER), now);
   }
 
+  /**
+   * A queue-depth snapshot for observability (issue #348): the backlog ({@code pending}), the
+   * in-flight count ({@code running}), how many of those are stranded past the stale threshold
+   * ({@code staleRunning} — a dead worker or a wedged poller/reaper), and the terminal failures
+   * ({@code failed}). Returned as primitives so the web/actuator layer never touches the entity
+   * enum.
+   */
+  public record QueueStats(long pending, long running, long staleRunning, long failed) {}
+
+  /** The current queue-depth snapshot (issue #348), reusing the reaper's stale threshold. */
+  @Transactional(readOnly = true)
+  public QueueStats queueStats() {
+    Instant staleBefore = Instant.now().minus(STALE_AFTER);
+    return new QueueStats(
+        repository.countByStatus(JobStatus.PENDING),
+        repository.countByStatus(JobStatus.RUNNING),
+        repository.countByStatusAndUpdatedAtBefore(JobStatus.RUNNING, staleBefore),
+        repository.countByStatus(JobStatus.FAILED));
+  }
+
   /** Capped exponential backoff: {@code base * 2^(attempts-1)}, clamped to the cap. */
   static Duration backoff(int attempts) {
     int shift = Math.min(Math.max(attempts - 1, 0), 20);

--- a/qnop-core/src/test/java/io/qnop/service/job/JobServiceQueueStatsTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/job/JobServiceQueueStatsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.JobStatus;
+import io.qnop.repository.JobRepository;
+import io.qnop.service.job.JobService.QueueStats;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/** The observability queue-depth snapshot (issue #348). */
+class JobServiceQueueStatsTest {
+
+  private final JobRepository repository = mock(JobRepository.class);
+  private final JobService service = new JobService(repository, mock(JobEnqueuer.class), List.of());
+
+  @Test
+  @DisplayName("assembles the per-state counts, measuring stale RUNNING against the threshold")
+  void queueStatsAssemblesCounts() {
+    when(repository.countByStatus(JobStatus.PENDING)).thenReturn(4L);
+    when(repository.countByStatus(JobStatus.RUNNING)).thenReturn(2L);
+    when(repository.countByStatus(JobStatus.FAILED)).thenReturn(1L);
+    when(repository.countByStatusAndUpdatedAtBefore(eq(JobStatus.RUNNING), any())).thenReturn(1L);
+
+    QueueStats stats = service.queueStats();
+
+    assertThat(stats).isEqualTo(new QueueStats(4, 2, 1, 1));
+  }
+
+  @Test
+  @DisplayName("counts stale RUNNING with a threshold in the past, not the future")
+  void staleThresholdIsInThePast() {
+    ArgumentCaptor<Instant> staleBefore = ArgumentCaptor.forClass(Instant.class);
+    when(repository.countByStatusAndUpdatedAtBefore(eq(JobStatus.RUNNING), staleBefore.capture()))
+        .thenReturn(0L);
+
+    service.queueStats();
+
+    assertThat(staleBefore.getValue()).isBefore(Instant.now());
+  }
+}


### PR DESCRIPTION
Closes #348 (foundation; extraction-latency histograms deferred — see below).

The durable async job queue (ADR-0033) is the one background subsystem whose failure is silent from the outside: a wedged poller/reaper, a growing backlog, or jobs stranded `RUNNING` by a dead worker wouldn't surface until a review's extraction/re-anchoring never completed. This adds the observability foundation (**ADR-0037**), deliberately small and self-hosted (no external APM), consistent with ADR-0013's deferral posture.

## What's added

**Health** — `JobQueueHealthIndicator` contributes the queue to `/actuator/health`:
- `DOWN` when a `RUNNING` job is stranded past the reaper's stale threshold (dead worker / wedged poller-reaper), else `UP`, with per-state depth counts as details.
- **Not** in the liveness/readiness probe groups, so a stale-queue `DOWN` is an alerting signal, never a pod-restart trigger.

**Metrics** — `micrometer-registry-prometheus` (runtime-only) backs `/actuator/prometheus`; `JobQueueMetrics` (`MeterBinder`) publishes one `qnop.jobs` gauge per lifecycle `state` (`pending`, `running`, `stale`, `failed`), read live at scrape time.

**Layering** — `JobService.queueStats()` returns a primitive `QueueStats` record, so the app-layer actuator components never touch the repository or the entity enum (ArchUnit boundaries intact). `JobRepository` gains a stale-`RUNNING` count.

**Access** — `/actuator/health` stays public (details `when_authorized`); every other management endpoint, the Prometheus scrape included, is `ROLE_ADMIN`-only (an ops Prometheus scrapes with an admin token).

## Deferred (tracked in ADR-0037)

Extraction/processing **latency histograms** need a Micrometer seam into the extraction handler in `qnop-core` — a clean follow-up now that the registry is in place. Everything else in the issue (health, queue-staleness indicator, queue-depth metrics) ships here.

## Test plan

- [x] `spotlessApply` + `:qnop-core:compileJava` + `:qnop-app:compileJava` — clean
- [x] `:qnop-core:test` job (`JobServiceQueueStatsTest`) + `:qnop-app:test` `io.qnop.bootstrap.JobQueue*` — pass
- [x] `:qnop-app:test --tests io.qnop.architecture.*` (layering: app→service, no repo/entity leak) — pass
- [x] `ObservabilityIT` (Testcontainers/CI): `/actuator/health` public 200; `/actuator/prometheus` 401 anon, 403 non-admin, 200 + `qnop_jobs` for admin

🤖 Co-Author: Claude (Opus 4.8) via Claude Code