### PR TITLE
fix(security): list explicit CORS allowed-headers instead of "*" (#336)

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -257,7 +257,10 @@ public class SecurityConfiguration {
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowedOrigins(properties.cors().allowedOrigins());
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-    config.setAllowedHeaders(List.of("*"));
+    // Explicit headers, not "*": the CORS spec forbids the wildcard together with
+    // allowCredentials=true, so browsers reject "*" for credentialed requests (issue #336).
+    // These cover the SPA's calls: JSON bodies, the Bearer token, and the CSRF header.
+    config.setAllowedHeaders(List.of("Content-Type", "Authorization", "X-XSRF-TOKEN"));
     config.setAllowCredentials(true);
     config.setMaxAge(3_600L);
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/qnop-app/src/test/java/io/qnop/web/security/SecurityConfigurationTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/security/SecurityConfigurationTest.java
@@ -23,12 +23,15 @@ package io.qnop.web.security;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.security.QnopProperties;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
@@ -40,6 +43,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 class SecurityConfigurationTest extends AbstractIntegrationTest {
 
   @LocalServerPort int port;
+  @Autowired QnopProperties properties;
 
   private HttpResponse<String> get(String path) throws Exception {
     HttpRequest request =
@@ -70,5 +74,35 @@ class SecurityConfigurationTest extends AbstractIntegrationTest {
     assertThat(response.headers().firstValue("Content-Security-Policy")).isPresent();
     assertThat(response.headers().firstValue("Referrer-Policy"))
         .hasValue("strict-origin-when-cross-origin");
+  }
+
+  @Test
+  void credentialedPreflightAllowsTheExplicitHeadersNotAWildcard() throws Exception {
+    // The CORS spec forbids allowed-headers "*" together with allowCredentials=true; browsers
+    // reject the combination for credentialed requests. The preflight must therefore echo the
+    // explicit headers the SPA uses, never "*" (issue #336).
+    String origin = properties.cors().allowedOrigins().get(0);
+    HttpRequest preflight =
+        HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/v1/auth/login"))
+            .method("OPTIONS", HttpRequest.BodyPublishers.noBody())
+            .header("Origin", origin)
+            .header("Access-Control-Request-Method", "POST")
+            .header("Access-Control-Request-Headers", "content-type,authorization,x-xsrf-token")
+            .build();
+
+    HttpResponse<String> response =
+        HttpClient.newHttpClient().send(preflight, BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.headers().firstValue("Access-Control-Allow-Origin")).hasValue(origin);
+    assertThat(response.headers().firstValue("Access-Control-Allow-Credentials")).hasValue("true");
+
+    String allowedHeaders =
+        response.headers().firstValue("Access-Control-Allow-Headers").orElse("");
+    assertThat(allowedHeaders).doesNotContain("*");
+    assertThat(allowedHeaders.toLowerCase(Locale.ROOT))
+        .contains("content-type")
+        .contains("authorization")
+        .contains("x-xsrf-token");
   }
 }


### PR DESCRIPTION
## Summary

Closes #336. `SecurityConfiguration.corsConfigurationSource` set `allowedHeaders("*")` together with `allowCredentials(true)`. The CORS spec forbids this combination — browsers reject a `*` `Access-Control-Allow-Headers` for **credentialed** requests, so a cross-origin call carrying `Authorization` or `X-XSRF-TOKEN` can be blocked.

Replaced `"*"` with the explicit headers the SPA sends:

- `Content-Type` — JSON (and multipart) request bodies
- `Authorization` — the Bearer access token
- `X-XSRF-TOKEN` — the CSRF token header (matches `CookieCsrfTokenRepository` / the frontend's `CSRF_HEADER`)

## Test plan
- [x] New `credentialedPreflightAllowsTheExplicitHeadersNotAWildcard` in `SecurityConfigurationTest` — drives a real credentialed `OPTIONS` preflight against the live server and asserts `Access-Control-Allow-Headers` contains the three headers and **not** `*`, with `Access-Control-Allow-Credentials: true`. Origin is read from `QnopProperties` so it can't drift from config.
- [x] Local: `spotlessApply`, `:qnop-app:compileJava/compileTestJava`, `ArchitectureRulesTest` green. The preflight IT runs under Testcontainers in CI (Docker).

🤖 Co-Author: Claude (Opus 4.8) via Claude Code