### PR TITLE
fix: hide the reviewer roster from non-owners in anonymous reviews + anonymity marker (#422)

### DIFF
--- a/docs/adr/0038-per-review-privacy.md
+++ b/docs/adr/0038-per-review-privacy.md
@@ -30,9 +30,9 @@ Author identity is resolved **server-side** into a new `authorDisplayName` on `A
 
 Chosen sub-decisions (the open points the issue left to planning):
 
-- **Stable pseudonyms, not one uniform label** — "Participant 2/3" keeps a thread followable (you can tell whether two comments are the same reviewer) without revealing who. The ordinal is assigned by ascending author id over the document's non-owner authors: deterministic, stable across requests and surfaces, and revealing nothing but a count.
+- **Stable pseudonyms, not one uniform label** — "Participant 2/3" keeps a thread followable (you can tell whether two comments are the same reviewer) without revealing who. The ordinal is assigned by ascending user id over the document's non-owner **users** — everyone who authored something *or* is a direct participant (amended for #422) — so the roster and the notes share one numbering; deterministic, stable across requests and surfaces, and revealing nothing but a count.
 - **The owner is exempt from anonymisation** — the owner's *authored* items show the owner's real name, because the owner's identity is already structural and public. This is authorship-exemption only: the owner, *as a viewer*, is still blind to foreign authorship (they see other reviewers as "Participant N" too).
-- **The participant roster stays visible** — anonymity hides *who wrote which note*, the standard blind-review model; it does not hide the invited-reviewers list (that would change the "add reviewers" UX). Hiding the roster too is a possible future tightening, not part of this decision.
+- **The roster is anonymised for non-owners** (amended for #422) — the original decision left the invited-reviewers list visible to everyone, but that lets any participant read off exactly who is reviewing, defeating the anonymity. So in an anonymous review only the owner (and an admin) see who the reviewers are; every other participant sees the roster as the same "Participant N" pseudonyms (users) and nameless "Reviewer team" entries (teams), with principal ids replaced by synthetic tokens (team tokens derive from position, not the real team id, so the roster can't be matched against the principal directory). Enforced server-side on both the participants endpoint and the reviews-overview summary.
 
 The author filter facet disappears entirely in an anonymous review.
 

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationAnonymityIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationAnonymityIT.java
@@ -20,6 +20,7 @@
  */
 package io.qnop.review;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -117,11 +118,12 @@ class AnnotationAnonymityIT extends SeededIntegrationTest {
     UUID documentId = seedDocument(true);
     createAnnotation(documentId, AUDITOR_ID);
 
-    // The foreign reviewer sees a stable pseudonym and NOT the real id or name.
+    // The foreign reviewer sees a stable pseudonym and NOT the real id or name. The ordinal covers
+    // all non-owner participants (issue #422), sorted by id: MEMBER2 (…003) is 1, AUDITOR (…004) 2.
     mockMvc
         .perform(as(get("/api/v1/documents/" + documentId + "/annotations"), MEMBER2_ID))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.annotations[0].authorDisplayName").value("Participant 1"))
+        .andExpect(jsonPath("$.annotations[0].authorDisplayName").value("Participant 2"))
         .andExpect(jsonPath("$.annotations[0].authorId").value(not(AUDITOR_ID.toString())))
         .andExpect(jsonPath("$.annotations[0].authorDisplayName").value(not(realName(AUDITOR_ID))));
   }
@@ -159,11 +161,72 @@ class AnnotationAnonymityIT extends SeededIntegrationTest {
     UUID documentId = seedDocument(true);
     String annotationId = createAnnotation(documentId, AUDITOR_ID);
 
-    // The opening comment (authored by AUDITOR) is pseudonymised for a foreign viewer.
+    // The opening comment (authored by AUDITOR) is pseudonymised for a foreign viewer; AUDITOR is
+    // "Participant 2" under the participant-covering numbering (issue #422).
     mockMvc
         .perform(as(get("/api/v1/annotations/" + annotationId + "/comments"), MEMBER2_ID))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.comments[0].authorDisplayName").value("Participant 1"))
+        .andExpect(jsonPath("$.comments[0].authorDisplayName").value("Participant 2"))
         .andExpect(jsonPath("$.comments[0].authorId").value(not(AUDITOR_ID.toString())));
+  }
+
+  // ── Roster anonymity (issue #422) ────────────────────────────────────────
+
+  @Test
+  void anonymousReviewHidesTheRosterFromForeignReviewers() throws Exception {
+    UUID documentId = seedDocument(true);
+
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/participants"), MEMBER2_ID))
+        .andExpect(status().isOk())
+        // A peer (AUDITOR) is neither their real id nor their real name — a pseudonym instead.
+        .andExpect(
+            jsonPath("$.participants[?(@.principalId == '" + AUDITOR_ID + "')]").doesNotExist())
+        .andExpect(jsonPath("$.participants[*].displayName", hasItem("Participant 2")))
+        .andExpect(jsonPath("$.participants[*].displayName", not(hasItem(realName(AUDITOR_ID)))))
+        // The viewer's own row stays real (they know themselves).
+        .andExpect(
+            jsonPath(
+                "$.participants[?(@.principalId == '" + MEMBER2_ID + "')].displayName",
+                hasItem(realName(MEMBER2_ID))));
+  }
+
+  @Test
+  void anonymousReviewShowsTheRealRosterToTheOwner() throws Exception {
+    UUID documentId = seedDocument(true);
+
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/participants"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath(
+                "$.participants[?(@.principalId == '" + AUDITOR_ID + "')].displayName",
+                hasItem(realName(AUDITOR_ID))));
+  }
+
+  @Test
+  void nonAnonymousReviewShowsTheRealRosterToEveryone() throws Exception {
+    UUID documentId = seedDocument(false);
+
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/participants"), MEMBER2_ID))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath(
+                "$.participants[?(@.principalId == '" + AUDITOR_ID + "')].displayName",
+                hasItem(realName(AUDITOR_ID))));
+  }
+
+  @Test
+  void anonymousReviewHidesTheRosterInTheOverview() throws Exception {
+    UUID documentId = seedDocument(true);
+
+    mockMvc
+        .perform(as(get("/api/v1/documents"), MEMBER2_ID))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath(
+                "$.items[?(@.id == '" + documentId + "')].participants[*].displayName",
+                not(hasItem(realName(AUDITOR_ID)))));
   }
 }

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationAnonymityIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationAnonymityIT.java
@@ -184,11 +184,9 @@ class AnnotationAnonymityIT extends SeededIntegrationTest {
             jsonPath("$.participants[?(@.principalId == '" + AUDITOR_ID + "')]").doesNotExist())
         .andExpect(jsonPath("$.participants[*].displayName", hasItem("Participant 2")))
         .andExpect(jsonPath("$.participants[*].displayName", not(hasItem(realName(AUDITOR_ID)))))
-        // The viewer's own row stays real (they know themselves).
-        .andExpect(
-            jsonPath(
-                "$.participants[?(@.principalId == '" + MEMBER2_ID + "')].displayName",
-                hasItem(realName(MEMBER2_ID))));
+        // The viewer's own row is sorted first and stays real (they know themselves).
+        .andExpect(jsonPath("$.participants[0].principalId").value(MEMBER2_ID.toString()))
+        .andExpect(jsonPath("$.participants[0].displayName").value(realName(MEMBER2_ID)));
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/repository/ReviewParticipantRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ReviewParticipantRepository.java
@@ -34,6 +34,15 @@ public interface ReviewParticipantRepository extends JpaRepository<ReviewPartici
   /** The reviewers (user and team principals) on a document. */
   List<ReviewParticipant> findByDocumentId(UUID documentId);
 
+  /**
+   * The direct-user participant ids on a document (issue #422) — so the anonymity pseudonym ordinal
+   * covers reviewers who joined directly, not only those who authored something. Team participants
+   * carry no user id and are excluded.
+   */
+  @Query(
+      "SELECT p.userId FROM ReviewParticipant p WHERE p.documentId = :documentId AND p.userId IS NOT NULL")
+  List<UUID> findDirectUserIdsByDocumentId(@Param("documentId") UUID documentId);
+
   /** The reviews a given user is a direct participant in. */
   List<ReviewParticipant> findByUserId(UUID userId);
 

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
@@ -29,6 +29,7 @@ import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.repository.ParticipantProjection;
 import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.service.document.ReviewParticipantService.ParticipantView;
+import io.qnop.service.review.ReviewIdentityResolver;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
@@ -58,16 +59,19 @@ public class DocumentOverviewService {
   private final DocumentVersionRepository versions;
   private final AnnotationRepository annotations;
   private final ReviewParticipantRepository participants;
+  private final ReviewIdentityResolver identity;
 
   public DocumentOverviewService(
       DocumentRepository documents,
       DocumentVersionRepository versions,
       AnnotationRepository annotations,
-      ReviewParticipantRepository participants) {
+      ReviewParticipantRepository participants,
+      ReviewIdentityResolver identity) {
     this.documents = documents;
     this.versions = versions;
     this.annotations = annotations;
     this.participants = participants;
+    this.identity = identity;
   }
 
   @Transactional(readOnly = true)
@@ -115,15 +119,29 @@ public class DocumentOverviewService {
                       maxVersions.getOrDefault(document.getId(), 0),
                       count == null ? 0 : Math.toIntExact(count.total()),
                       count == null ? 0 : Math.toIntExact(count.open()),
-                      participantsByDocument.getOrDefault(document.getId(), List.of()).stream()
-                          .map(ParticipantView::of)
-                          .toList(),
+                      rosterFor(
+                          document,
+                          actor,
+                          participantsByDocument.getOrDefault(document.getId(), List.of())),
                       document.getCreatedAt(),
                       document.getUpdatedAt(),
                       document.getDueAt());
                 })
             .toList();
     return new DocumentPage(items, result.getTotalElements(), page, size);
+  }
+
+  /**
+   * The reviewer set for one summary card, anonymised (issue #422) when the review is anonymous and
+   * the caller is not its owner — so the overview never leaks the roster of an anonymous review.
+   */
+  private List<ParticipantView> rosterFor(
+      Document document, UUID actor, List<ParticipantProjection> rows) {
+    if (!document.isAnonymous() || document.getOwnerId().equals(actor)) {
+      return rows.stream().map(ParticipantView::of).toList();
+    }
+    return ReviewParticipantService.anonymiseRoster(
+        document.getId(), rows, identity.forDocument(document.getId(), actor));
   }
 
   private Sort parseSort(String sort) {

--- a/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
@@ -29,7 +29,11 @@ import io.qnop.repository.ParticipantProjection;
 import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.repository.TeamRepository;
 import io.qnop.repository.UserRepository;
+import io.qnop.service.review.ReviewIdentityResolver;
+import io.qnop.service.review.ReviewIdentityResolver.ReviewIdentities;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -49,29 +53,77 @@ public class ReviewParticipantService {
   private final UserRepository users;
   private final TeamRepository teams;
   private final DocumentAccessService access;
+  private final ReviewIdentityResolver identity;
 
   public ReviewParticipantService(
       DocumentRepository documents,
       ReviewParticipantRepository participants,
       UserRepository users,
       TeamRepository teams,
-      DocumentAccessService access) {
+      DocumentAccessService access,
+      ReviewIdentityResolver identity) {
     this.documents = documents;
     this.participants = participants;
     this.users = users;
     this.teams = teams;
     this.access = access;
+    this.identity = identity;
   }
 
-  /** The document's reviewers with display names, oldest first. */
+  /**
+   * The document's reviewers with display names, oldest first. In an anonymous review (issue #413/
+   * #422) only the owner (and an admin) may see who the reviewers are; every other participant sees
+   * the roster anonymised — each reviewer as a stable "Participant N" pseudonym (shared with the
+   * annotation labels) or a nameless "Reviewer team", with the principal id replaced by a synthetic
+   * per-document token so it cannot be correlated back to a real user or team.
+   */
   @Transactional(readOnly = true)
   public List<ParticipantView> list(UUID documentId, UUID actor, boolean admin) {
     if (!access.isVisible(documentId, actor, admin)) {
       throw DocumentValidationException.notFound("document " + documentId);
     }
-    return participants.findViewsByDocumentId(documentId).stream()
-        .map(ParticipantView::of)
-        .toList();
+    Document document =
+        documents
+            .findById(documentId)
+            .orElseThrow(() -> DocumentValidationException.notFound("document " + documentId));
+    List<ParticipantProjection> rows = participants.findViewsByDocumentId(documentId);
+    boolean anonymise = document.isAnonymous() && !admin && !document.getOwnerId().equals(actor);
+    if (!anonymise) {
+      return rows.stream().map(ParticipantView::of).toList();
+    }
+
+    return anonymiseRoster(documentId, rows, identity.forDocument(documentId, actor));
+  }
+
+  /**
+   * Anonymises a document's roster (issue #422): each user reviewer becomes their stable
+   * "Participant N" pseudonym (their own row stays real — they know themselves) with the same
+   * synthetic token used on their annotations; each team becomes a nameless "Reviewer team" whose
+   * token derives from its position, not its real id, so the roster cannot be matched against the
+   * principal directory. Shared by {@link #list} and the reviews overview.
+   */
+  static List<ParticipantView> anonymiseRoster(
+      UUID documentId, List<ParticipantProjection> rows, ReviewIdentities identities) {
+    List<ParticipantView> out = new ArrayList<>(rows.size());
+    int teamIndex = 0;
+    for (ParticipantProjection row : rows) {
+      if (row.teamId() == null) {
+        out.add(
+            new ParticipantView(
+                row.id(),
+                identities.exposedAuthorId(row.userId()),
+                false,
+                identities.displayName(row.userId()),
+                row.createdAt()));
+      } else {
+        teamIndex++;
+        UUID token =
+            UUID.nameUUIDFromBytes(
+                (documentId + ":anonteam:" + teamIndex).getBytes(StandardCharsets.UTF_8));
+        out.add(new ParticipantView(row.id(), token, true, "Reviewer team", row.createdAt()));
+      }
+    }
+    return out;
   }
 
   /** Adds a reviewer (owner-only): exactly one of {@code userId} / {@code teamId}. */

--- a/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
@@ -34,6 +34,7 @@ import io.qnop.service.review.ReviewIdentityResolver.ReviewIdentities;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -100,13 +101,19 @@ public class ReviewParticipantService {
    * "Participant N" pseudonym (their own row stays real — they know themselves) with the same
    * synthetic token used on their annotations; each team becomes a nameless "Reviewer team" whose
    * token derives from its position, not its real id, so the roster cannot be matched against the
-   * principal directory. Shared by {@link #list} and the reviews overview.
+   * principal directory. The caller's own row is sorted first, then the pseudonyms in their
+   * original order. Shared by {@link #list} and the reviews overview.
    */
   static List<ParticipantView> anonymiseRoster(
       UUID documentId, List<ParticipantProjection> rows, ReviewIdentities identities) {
-    List<ParticipantView> out = new ArrayList<>(rows.size());
+    // Caller first, everyone else in their existing (creation) order — a stable sort preserves it.
+    List<ParticipantProjection> ordered =
+        rows.stream()
+            .sorted(Comparator.comparingInt(r -> identities.isSelf(r.userId()) ? 0 : 1))
+            .toList();
+    List<ParticipantView> out = new ArrayList<>(ordered.size());
     int teamIndex = 0;
-    for (ParticipantProjection row : rows) {
+    for (ParticipantProjection row : ordered) {
       if (row.teamId() == null) {
         out.add(
             new ParticipantView(

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewIdentityResolver.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewIdentityResolver.java
@@ -141,6 +141,11 @@ public class ReviewIdentityResolver {
       this.ordinals = ordinals;
     }
 
+    /** Whether {@code userId} is the signed-in caller — used to sort the caller's own row first. */
+    public boolean isSelf(UUID userId) {
+      return userId != null && userId.equals(actor);
+    }
+
     /**
      * The display name to ship for {@code authorId}. Non-anonymous → the real name (or {@code null}
      * for a since-removed user, which the UI renders as a neutral placeholder). Anonymous → the

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewIdentityResolver.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewIdentityResolver.java
@@ -24,6 +24,7 @@ import io.qnop.entity.Document;
 import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.CommentRepository;
 import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.repository.UserDisplayName;
 import io.qnop.repository.UserRepository;
 import java.nio.charset.StandardCharsets;
@@ -54,8 +55,10 @@ import org.springframework.stereotype.Service;
  *       client cannot correlate it back to the participant roster.
  * </ul>
  *
- * <p>The pseudonym ordinal is assigned by ascending author id over the document's non-owner
- * authors: stable across requests and surfaces, deterministic, and revealing nothing but a count.
+ * <p>The pseudonym ordinal is assigned by ascending user id over the document's non-owner users —
+ * everyone who authored something <em>or</em> is a direct participant (issue #422), so the roster
+ * and the annotations share one numbering: stable across requests and surfaces, deterministic, and
+ * revealing nothing but a count.
  */
 @Service
 public class ReviewIdentityResolver {
@@ -63,16 +66,19 @@ public class ReviewIdentityResolver {
   private final DocumentRepository documents;
   private final AnnotationRepository annotations;
   private final CommentRepository comments;
+  private final ReviewParticipantRepository participants;
   private final UserRepository users;
 
   public ReviewIdentityResolver(
       DocumentRepository documents,
       AnnotationRepository annotations,
       CommentRepository comments,
+      ReviewParticipantRepository participants,
       UserRepository users) {
     this.documents = documents;
     this.annotations = annotations;
     this.comments = comments;
+    this.participants = participants;
     this.users = users;
   }
 
@@ -86,20 +92,23 @@ public class ReviewIdentityResolver {
         documents.findById(documentId).orElseThrow(() -> new DocumentNotFoundException(documentId));
     UUID ownerId = document.getOwnerId();
 
-    // Distinct authors across annotations AND comment-only participants — both need a label.
-    Set<UUID> authorIds = new LinkedHashSet<>();
-    authorIds.addAll(annotations.findDistinctAuthorIdsByDocumentId(documentId));
-    authorIds.addAll(comments.findDistinctCommentAuthorIdsByDocumentId(documentId));
+    // Every non-owner user who needs a stable label: annotation authors, comment-only authors, AND
+    // direct participants who never wrote anything (issue #422) — one numbering across the roster
+    // and the notes. Authors who participate via a team are covered by their authorship.
+    Set<UUID> userIds = new LinkedHashSet<>();
+    userIds.addAll(annotations.findDistinctAuthorIdsByDocumentId(documentId));
+    userIds.addAll(comments.findDistinctCommentAuthorIdsByDocumentId(documentId));
+    userIds.addAll(participants.findDirectUserIdsByDocumentId(documentId));
 
     Map<UUID, String> names =
-        authorIds.isEmpty()
+        userIds.isEmpty()
             ? Map.of()
-            : users.findDisplayNamesByIdIn(authorIds).stream()
+            : users.findDisplayNamesByIdIn(userIds).stream()
                 .collect(Collectors.toMap(UserDisplayName::id, UserDisplayName::displayName));
 
     Map<UUID, Integer> ordinals = new HashMap<>();
     int next = 0;
-    for (UUID id : authorIds.stream().filter(id -> !id.equals(ownerId)).sorted().toList()) {
+    for (UUID id : userIds.stream().filter(id -> !id.equals(ownerId)).sorted().toList()) {
       ordinals.put(id, ++next);
     }
 

--- a/qnop-ui/src/components/admin/ToneBadge.tsx
+++ b/qnop-ui/src/components/admin/ToneBadge.tsx
@@ -19,13 +19,23 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 
 export type BadgeTone = 'blue' | 'green' | 'amber' | 'red' | 'neutral';
 
 /** A compact, system-coloured pill driven by the shared `qnop.badge` tones (#104/#105). */
-export function ToneBadge({ tone, label }: { tone: BadgeTone; label: string }) {
+export function ToneBadge({
+  tone,
+  label,
+  icon,
+}: {
+  tone: BadgeTone;
+  label: string;
+  /** Optional leading glyph (e.g. an anonymity eye-off, issue #422). */
+  icon?: ReactNode;
+}) {
   const theme = useTheme();
   const t =
     tone === 'neutral'
@@ -41,6 +51,7 @@ export function ToneBadge({ tone, label }: { tone: BadgeTone; label: string }) {
       sx={{
         display: 'inline-flex',
         alignItems: 'center',
+        gap: 0.5,
         px: 1,
         py: 0.25,
         borderRadius: 1,
@@ -54,6 +65,7 @@ export function ToneBadge({ tone, label }: { tone: BadgeTone; label: string }) {
         borderColor: t.border,
       }}
     >
+      {icon}
       {label}
     </Box>
   );

--- a/qnop-ui/src/components/reviews/AnonymousBadge.tsx
+++ b/qnop-ui/src/components/reviews/AnonymousBadge.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Tooltip from '@mui/material/Tooltip';
+import Box from '@mui/material/Box';
+import { EyeOff } from 'lucide-react';
+import { ToneBadge } from '../admin/ToneBadge';
+
+/**
+ * Flags an anonymous review (issue #422) so every participant knows names are hidden. A neutral
+ * pill with an eye-off glyph, shown next to the workflow badge in the header and on the overview
+ * card.
+ */
+export function AnonymousBadge({ compact = false }: { compact?: boolean }) {
+  return (
+    <Tooltip title="Anonymous review — reviewer names are hidden">
+      <Box component="span" sx={{ display: 'inline-flex' }} data-testid="anonymous-badge">
+        <ToneBadge
+          tone="neutral"
+          label={compact ? 'Anon' : 'Anonymous'}
+          icon={<EyeOff size={12} aria-hidden />}
+        />
+      </Box>
+    </Tooltip>
+  );
+}

--- a/qnop-ui/src/components/reviews/hub/ParticipantsDialog.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ParticipantsDialog.test.tsx
@@ -74,7 +74,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 const notify = vi.fn();
 
-function renderDialog(isOwner: boolean) {
+function renderDialog(isOwner: boolean, anonymised = false) {
   return render(
     <ParticipantsDialog
       documentId={DOC_ID}
@@ -82,6 +82,7 @@ function renderDialog(isOwner: boolean) {
       onClose={vi.fn()}
       isOwner={isOwner}
       ownUserId={ME}
+      anonymised={anonymised}
       notify={notify}
     />,
     { wrapper },
@@ -112,6 +113,19 @@ describe('ParticipantsDialog — read-only for participants', () => {
     expect(screen.getByText('Team Alpha')).toBeInTheDocument();
     expect(screen.queryByPlaceholderText('Add people or teams…')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Remove/ })).not.toBeInTheDocument();
+  });
+
+  it('offers the team unfold to a non-anonymised viewer', async () => {
+    renderDialog(false);
+    expect(await screen.findByText('Team Alpha')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Show members of/ })).toBeInTheDocument();
+  });
+
+  it('hides the team unfold when the roster is anonymised (issue #422)', async () => {
+    renderDialog(false, true);
+    expect(await screen.findByText('Team Alpha')).toBeInTheDocument();
+    // A synthetic team id must not be unfoldable to reveal members.
+    expect(screen.queryByRole('button', { name: /Show members of/ })).not.toBeInTheDocument();
   });
 });
 

--- a/qnop-ui/src/components/reviews/hub/ParticipantsDialog.tsx
+++ b/qnop-ui/src/components/reviews/hub/ParticipantsDialog.tsx
@@ -63,6 +63,8 @@ interface ParticipantsDialogProps {
   isOwner: boolean;
   /** The owner cannot become a participant, so hide them from the picker. */
   ownUserId: string | null;
+  /** True when the roster is anonymised for this viewer (issue #422): teams can't be unfolded. */
+  anonymised?: boolean;
   notify: (message: string, severity?: ToastSeverity) => void;
 }
 
@@ -131,6 +133,7 @@ export function ParticipantsDialog({
   onClose,
   isOwner,
   ownUserId,
+  anonymised = false,
   notify,
 }: ParticipantsDialogProps) {
   const theme = useTheme();
@@ -192,11 +195,14 @@ export function ParticipantsDialog({
             <Stack spacing={0.5} data-testid="participants-list">
               {participants.map((participant) => {
                 const isTeam = participant.kind === ParticipantKind.Team;
-                const expanded = isTeam && expandedTeams.has(participant.principalId);
+                // An anonymised team carries a synthetic id and a hidden name (issue #422), so it
+                // cannot — and must not — be unfolded to reveal its members.
+                const canUnfold = isTeam && !anonymised;
+                const expanded = canUnfold && expandedTeams.has(participant.principalId);
                 return (
                   <Fragment key={participant.id}>
                     <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', py: 0.5 }}>
-                      {isTeam ? (
+                      {canUnfold ? (
                         <IconButton
                           size="small"
                           aria-label={`Show members of ${participant.displayName}`}
@@ -239,7 +245,7 @@ export function ParticipantsDialog({
                         </Tooltip>
                       )}
                     </Stack>
-                    {isTeam && (
+                    {canUnfold && (
                       <Collapse in={expanded} unmountOnExit>
                         <TeamMemberList teamId={participant.principalId} />
                       </Collapse>

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
@@ -107,6 +107,7 @@ function renderHub({
       ownerId={isOwner ? ME : 'owner-far-away'}
       isOwner={isOwner}
       ownUserId={ME}
+      anonymous={false}
       annotations={annotations}
       dueAt={dueAt}
       workflowState={workflowState}

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -68,6 +68,8 @@ interface ReviewHubHeadProps {
   ownerId: string;
   isOwner: boolean;
   ownUserId: string | null;
+  /** True for an anonymous review (issue #422) — the roster is anonymised for non-owners. */
+  anonymous: boolean;
   annotations: AnnotationView[];
   /** The review's optional due date (ISO instant) or null (issue #295). */
   dueAt: string | null;
@@ -89,6 +91,7 @@ export function ReviewHubHead({
   ownerId,
   isOwner,
   ownUserId,
+  anonymous,
   annotations,
   dueAt,
   workflowState,
@@ -381,6 +384,7 @@ export function ReviewHubHead({
         onClose={() => setParticipantsOpen(false)}
         isOwner={isOwner}
         ownUserId={ownUserId}
+        anonymised={anonymous && !isOwner}
         notify={notify}
       />
 

--- a/qnop-ui/src/components/reviews/list/ReviewCards.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewCards.tsx
@@ -30,6 +30,7 @@ import type { DocumentSummary } from '../../../api/generated';
 import { formatRelative } from '../../../utils/formatDate';
 import { DueDateLabel } from '../DueDateLabel';
 import { WorkflowBadge } from '../WorkflowBadge';
+import { AnonymousBadge } from '../AnonymousBadge';
 import { DocumentIcon, ProgressBar, ReviewerStack, RoleBadge } from './ReviewListParts';
 import { progressOf, roleOf } from './reviewListModel';
 
@@ -94,6 +95,7 @@ export function ReviewCards({ reviews, userId, onOpen }: ReviewCardsProps) {
             </Box>
             <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
               <WorkflowBadge state={review.workflowState} />
+              {review.anonymous && <AnonymousBadge compact />}
               {progress && (
                 <Typography
                   variant="caption"

--- a/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
@@ -34,6 +34,7 @@ import type { DocumentSummary } from '../../../api/generated';
 import { formatRelative } from '../../../utils/formatDate';
 import { DueDateLabel } from '../DueDateLabel';
 import { WorkflowBadge } from '../WorkflowBadge';
+import { AnonymousBadge } from '../AnonymousBadge';
 import { DocumentIcon, ProgressBar, ReviewerStack, RoleBadge } from './ReviewListParts';
 import { progressOf, roleOf } from './reviewListModel';
 
@@ -99,7 +100,10 @@ export function ReviewsTable({ reviews, userId, onOpen }: ReviewsTableProps) {
                     <RoleBadge role={roleOf(review, userId)} />
                   </TableCell>
                   <TableCell>
-                    <WorkflowBadge state={review.workflowState} />
+                    <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                      <WorkflowBadge state={review.workflowState} />
+                      {review.anonymous && <AnonymousBadge compact />}
+                    </Stack>
                   </TableCell>
                   <TableCell sx={{ minWidth: 120 }}>
                     {progress ? (

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -71,6 +71,7 @@ import { useViewMode } from '../../components/reviews/focus/useViewMode';
 import { columnOf } from '../../components/reviews/tasks/tasksModel';
 import { Composer } from '../../components/reviews/panel/Composer';
 import { WorkflowBadge } from '../../components/reviews/WorkflowBadge';
+import { AnonymousBadge } from '../../components/reviews/AnonymousBadge';
 import type {
   ScreenPosition,
   TextSelectionOffsets,
@@ -333,13 +334,19 @@ export function DocumentReviewPage() {
           every saved pixel goes to the document and its annotations. */}
       <PageHeader
         title={document.title}
-        titleAdornment={<WorkflowBadge state={document.workflowState} />}
+        titleAdornment={
+          <>
+            <WorkflowBadge state={document.workflowState} />
+            {document.anonymous && <AnonymousBadge />}
+          </>
+        }
         action={
           <ReviewHubHead
             documentId={documentId}
             ownerId={document.ownerId}
             isOwner={document.ownerId === userId}
             ownUserId={userId}
+            anonymous={document.anonymous ?? false}
             annotations={annotations}
             dueAt={document.dueAt ?? null}
             workflowState={document.workflowState}


### PR DESCRIPTION
Closes #422. Follow-up to #413 (per-review privacy); revises the "roster stays visible" scoping note in ADR-0038.

## Bug — the roster leaked in anonymous reviews

Anonymity hid *authorship* but the full reviewer list was still shown to everyone (overview cards, header avatars, the Participants dialog), so any participant could read off who was reviewing. Now, in an anonymous review, **only the owner (and admins) see the real roster**; every other participant sees it anonymised, **server-side**:

- Each **user** reviewer → their stable `Participant N` pseudonym (the viewer's own row stays their real name — they know themselves), with the principal id replaced by the same synthetic token used on their annotations.
- Each **team** → a nameless `Reviewer team`, its token derived from position (not the real team id, so the roster can't be brute-forced against the principal directory); the Participants dialog no longer offers the team unfold.
- The pseudonym ordinal now covers non-owner **users** — authors *and* direct participants — so the roster and the annotation labels share one numbering (`ReviewIdentityResolver`).

Enforced on both `GET /documents/{id}/participants` and the reviews-overview summary (`DocumentSummary.participants`).

## Enhancement — anonymity marker

An **"Anonymous"** badge (eye-off) now appears in the review header (next to the workflow badge) and on the overview cards/table, so every participant immediately knows names are hidden.

## Test plan

- [x] `./gradlew build` (Spotless, ArchUnit, full IT suite; new roster cases in `AnnotationAnonymityIT`: foreign reviewer sees pseudonyms + own real name + no peer id/name; owner and non-anonymous see the real roster; overview roster hidden). Two unrelated flaky ITs (`JobQueueIT` timing, `AdminUserControllerIT.sendsPasswordReset` settings-snapshot ordering) fail intermittently in a full local run but pass in isolation and are untouched by this change.
- [x] `pnpm test:run` (499 tests, incl. the Participants-dialog unfold-hidden case), `tsc -b`, ESLint, Prettier
- [x] Manual browser pass: flipped a real multi-reviewer review anonymous in the dev DB — as a non-owner reviewer the header/cards show the "Anonymous" badge and the roster reads "Participant N" / "Reviewer team" (own name intact, teams not unfoldable); as the owner the roster stays real. Reverted afterwards.

Note: the pseudonym numbering now includes direct participants, so annotation pseudonyms may shift by a position vs. #413 — expected and consistent.

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
