### PR TITLE
feat(reviews): permalinks for annotations and comments (#412)

### DIFF
--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -184,4 +184,10 @@ describe('FocusAnnotationCard', () => {
     expect(screen.queryByTestId('resolve-bar')).not.toBeInTheDocument();
     expect(screen.getByTestId('thread-a2')).toBeInTheDocument();
   });
+
+  // Issue #412: the shared copy-link affordance rides the card header.
+  it('offers a copy-link affordance in the header when a permalink builder is wired', () => {
+    renderCard({ buildPermalink: (id) => `https://qnop.example/reviews/d?annotation=${id}` });
+    expect(screen.getByRole('button', { name: 'Copy link to annotation' })).toBeInTheDocument();
+  });
 });

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -37,6 +37,8 @@ import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
+import type { BuildPermalink } from '../useReviewPermalink';
+import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { AnnotationHead } from '../panel/AnnotationHead';
 import { CommentThread } from '../panel/CommentThread';
 import { ResolveBar } from '../panel/ResolveBar';
@@ -68,6 +70,11 @@ interface FocusAnnotationCardProps {
   ownerId?: string;
   /** The previous visit (issue #307) — enables the thread's "new" divider. */
   previousSeenAt?: string | null;
+  /** Builds annotation/comment permalinks (issue #412) — enables the copy affordances. */
+  buildPermalink?: BuildPermalink;
+  /** A comment permalink target (issue #412) — scrolled to + pulsed once the thread loads. */
+  scrollToCommentId?: string | null;
+  onScrolledToComment?: () => void;
 }
 
 /** True when the key event originates in a text field (arrows must move the caret). */
@@ -100,6 +107,9 @@ export function FocusAnnotationCard({
   threadParticipation = 'OPEN',
   ownerId,
   previousSeenAt = null,
+  buildPermalink,
+  scrollToCommentId = null,
+  onScrolledToComment,
 }: FocusAnnotationCardProps) {
   const theme = useTheme();
   const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
@@ -277,6 +287,13 @@ export function FocusAnnotationCard({
                       : 'Annotation'}
                   </Typography>
                   <Box sx={{ flex: 1 }} />
+                  {buildPermalink && (
+                    <CopyLinkButton
+                      url={buildPermalink(annotation.id)}
+                      notify={notify}
+                      label="Copy link to annotation"
+                    />
+                  )}
                   <Tooltip title="Previous annotation (↑)">
                     <span>
                       <IconButton
@@ -337,6 +354,9 @@ export function FocusAnnotationCard({
                     }
                     previousSeenAt={previousSeenAt}
                     skipOpener
+                    buildPermalink={buildPermalink}
+                    scrollToCommentId={scrollToCommentId}
+                    onScrolledToComment={onScrolledToComment}
                   />
                 </Box>
                 {/* Discoverability for the native resize grip underneath. */}

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -414,4 +414,22 @@ describe('AnnotationPanel', () => {
     expect(screen.queryByTestId('resolve-bar')).not.toBeInTheDocument();
     expect(screen.getByTestId('thread-a1')).toBeInTheDocument();
   });
+
+  // Issue #412: the annotation copy-link appears on the expanded card when a
+  // permalink builder is wired, and stays absent without one.
+  it('offers a copy-link affordance on the active annotation with a permalink builder', () => {
+    renderPanel({
+      annotations: [annotation('a1')],
+      activeAnnotationId: 'a1',
+      buildPermalink: (id) => `https://qnop.example/reviews/d?annotation=${id}`,
+    });
+    expect(screen.getByRole('button', { name: 'Copy link to annotation' })).toBeInTheDocument();
+  });
+
+  it('omits the copy-link affordance without a permalink builder', () => {
+    renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });
+    expect(
+      screen.queryByRole('button', { name: 'Copy link to annotation' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -40,6 +40,8 @@ import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
 import { compareAnnotationsByPosition } from '../viewer/anchoring';
 import { isUnseen } from '../newSince';
+import type { BuildPermalink } from '../useReviewPermalink';
+import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { AnnotationListItem } from './AnnotationListItem';
 import { CommentThread } from './CommentThread';
 import { Composer } from './Composer';
@@ -82,6 +84,11 @@ interface AnnotationPanelProps {
   frameless?: boolean;
   /** The previous visit (issue #307) — null hides every unseen cue. */
   previousSeenAt?: string | null;
+  /** Builds annotation/comment permalinks (issue #412) — enables the copy affordances. */
+  buildPermalink?: BuildPermalink;
+  /** A comment permalink target (issue #412) — scrolled to + pulsed in the active thread. */
+  scrollToCommentId?: string | null;
+  onScrolledToComment?: () => void;
 }
 
 /** A collapsible, counted group of annotation cards (prototype sidebar section). */
@@ -216,6 +223,9 @@ export function AnnotationPanel({
   reviewClosed = false,
   frameless = false,
   previousSeenAt = null,
+  buildPermalink,
+  scrollToCommentId = null,
+  onScrolledToComment,
 }: AnnotationPanelProps) {
   const [filters, setFilters] = useState<AnnotationFilters>(EMPTY_FILTERS);
   const userId = useAuthStore((state) => state.userId);
@@ -281,6 +291,18 @@ export function AnnotationPanel({
           onHover={onHover}
         />
         <Collapse in={active} unmountOnExit>
+          {/* The annotation permalink (issue #412) — a quiet right-aligned link
+              under the head card; a sibling of the row's ButtonBase, never
+              nested inside it. */}
+          {buildPermalink && (
+            <Stack direction="row" sx={{ justifyContent: 'flex-end', pt: 0.5 }}>
+              <CopyLinkButton
+                url={buildPermalink(annotation.id)}
+                notify={notify}
+                label="Copy link to annotation"
+              />
+            </Stack>
+          )}
           {!readOnly && mayResolveAnnotation(annotation, userId) && (
             <ResolveBar disabled={resolving} onResolve={(note) => resolveWith(annotation, note)} />
           )}
@@ -298,6 +320,9 @@ export function AnnotationPanel({
             }
             previousSeenAt={previousSeenAt}
             skipOpener
+            buildPermalink={buildPermalink}
+            scrollToCommentId={active ? scrollToCommentId : null}
+            onScrolledToComment={onScrolledToComment}
           />
         </Collapse>
       </Stack>

--- a/qnop-ui/src/components/reviews/panel/CommentBubble.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentBubble.tsx
@@ -24,7 +24,9 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import { shortRelativeTime } from '../../../utils/relativeTime';
+import type { Notify } from '../../admin/layout/useToast';
 import { UserAvatar } from '../../shell/UserAvatar';
+import { CopyLinkButton } from '../permalink/CopyLinkButton';
 
 const AVATAR_SIZE = 26;
 
@@ -42,14 +44,20 @@ interface CommentBubbleProps {
   createdAt: string;
   /** Clamp the body to N lines (the hover preview); unset shows everything. */
   clampLines?: number;
+  /** A stable DOM id on the bubble root — the scroll/pulse target of a comment permalink (#412). */
+  domId?: string;
+  /** The comment's permalink; with `notify` it renders the meta-line copy affordance (issue #412). */
+  permalinkUrl?: string;
+  notify?: Notify;
 }
 
 /**
  * One comment in the social anatomy (issue #403): avatar, a softly rounded
  * bubble carrying the bold author name above the text, and the compact
- * relative timestamp in the meta line underneath (full date in the tooltip).
- * Shared by the thread and the mark's hover preview, so a comment reads
- * identically everywhere.
+ * relative timestamp in the meta line underneath (full date in the tooltip),
+ * where a quiet copy-link affordance joins it in the thread (issue #412; likes
+ * #410 share this line too). Shared by the thread and the mark's hover
+ * preview, so a comment reads identically everywhere.
  */
 export function CommentBubble({
   name,
@@ -58,10 +66,13 @@ export function CommentBubble({
   body,
   createdAt,
   clampLines,
+  domId,
+  permalinkUrl,
+  notify,
 }: CommentBubbleProps) {
   const theme = useTheme();
   return (
-    <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+    <Stack id={domId} direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
       <Box sx={{ position: 'relative', zIndex: 1, pt: 0.25 }}>
         <UserAvatar name={name} size={AVATAR_SIZE} imageUrl={own ? avatarUrl : null} />
       </Box>
@@ -96,13 +107,18 @@ export function CommentBubble({
             {body}
           </Typography>
         </Box>
-        <Typography
-          variant="caption"
-          title={TIME_FORMAT.format(new Date(createdAt))}
-          sx={{ display: 'block', pl: 1.5, mt: 0.25, fontWeight: 600, color: 'text.secondary' }}
-        >
-          {shortRelativeTime(createdAt)}
-        </Typography>
+        <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center', pl: 1.5, mt: 0.25 }}>
+          <Typography
+            variant="caption"
+            title={TIME_FORMAT.format(new Date(createdAt))}
+            sx={{ fontWeight: 600, color: 'text.secondary' }}
+          >
+            {shortRelativeTime(createdAt)}
+          </Typography>
+          {permalinkUrl && notify && (
+            <CopyLinkButton url={permalinkUrl} notify={notify} label="Copy link to comment" />
+          )}
+        </Stack>
       </Box>
     </Stack>
   );

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -267,3 +267,95 @@ describe('CommentThread', () => {
     expect(onReopen).toHaveBeenCalled();
   });
 });
+
+// Issue #412: permalinks. The thread carries a per-comment copy affordance and
+// resolves an incoming comment permalink target — scroll into view + pulse, or
+// a toast when the id is gone.
+describe('CommentThread permalinks (#412)', () => {
+  const TWO_COMMENTS = {
+    isPending: false,
+    isError: false,
+    data: {
+      comments: [
+        {
+          id: 'c1',
+          annotationId: 'a1',
+          authorId: 'me',
+          body: 'first',
+          createdAt: '2026-07-01T10:00:00Z',
+        },
+        {
+          id: 'c2',
+          annotationId: 'a1',
+          authorId: 'other',
+          body: 'second',
+          createdAt: '2026-07-02T10:00:00Z',
+        },
+      ],
+    },
+  } as unknown as ReturnType<typeof useComments>;
+
+  const buildPermalink = (annotationId: string, commentId?: string) =>
+    `https://qnop.example/reviews/d?annotation=${annotationId}${
+      commentId ? `&comment=${commentId}` : ''
+    }`;
+
+  it('renders a copy-link affordance on every comment when a builder is provided', () => {
+    vi.mocked(useComments).mockReturnValue(TWO_COMMENTS);
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <CommentThread annotationId="a1" notify={vi.fn()} buildPermalink={buildPermalink} />
+      </ThemeProvider>,
+    );
+    expect(screen.getAllByRole('button', { name: 'Copy link to comment' })).toHaveLength(2);
+  });
+
+  it('shows no per-comment copy affordance without a builder (e.g. the hover preview)', () => {
+    vi.mocked(useComments).mockReturnValue(TWO_COMMENTS);
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <CommentThread annotationId="a1" notify={vi.fn()} />
+      </ThemeProvider>,
+    );
+    expect(screen.queryByRole('button', { name: 'Copy link to comment' })).not.toBeInTheDocument();
+  });
+
+  it('scrolls a comment permalink target into view and consumes it once', () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    vi.mocked(useComments).mockReturnValue(TWO_COMMENTS);
+    const notify = vi.fn();
+    const onScrolledToComment = vi.fn();
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <CommentThread
+          annotationId="a1"
+          notify={notify}
+          scrollToCommentId="c2"
+          onScrolledToComment={onScrolledToComment}
+        />
+      </ThemeProvider>,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(onScrolledToComment).toHaveBeenCalledTimes(1);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('degrades an unknown comment permalink target to a toast', () => {
+    vi.mocked(useComments).mockReturnValue(TWO_COMMENTS);
+    const notify = vi.fn();
+    const onScrolledToComment = vi.fn();
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <CommentThread
+          annotationId="a1"
+          notify={notify}
+          scrollToCommentId="ghost"
+          onScrolledToComment={onScrolledToComment}
+        />
+      </ThemeProvider>,
+    );
+    expect(notify).toHaveBeenCalledWith('This comment no longer exists.', 'error');
+    expect(onScrolledToComment).toHaveBeenCalledTimes(1);
+  });
+});

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -36,6 +36,7 @@ import { isSubmitShortcut, submitShortcutLabel } from '../../../utils/platform';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { isNewComment } from '../newSince';
+import type { BuildPermalink } from '../useReviewPermalink';
 import { CommentBubble } from './CommentBubble';
 import { UserAvatar } from '../../shell/UserAvatar';
 
@@ -61,6 +62,14 @@ interface CommentThreadProps {
   previousSeenAt?: string | null;
   /** True when the surrounding card already renders the opening annotation (issue #403). */
   skipOpener?: boolean;
+  /** Builds a per-comment permalink (issue #412) — enables the meta-line copy affordance. */
+  buildPermalink?: BuildPermalink;
+  /**
+   * A comment permalink target (issue #412): once the thread has loaded, its bubble is scrolled
+   * into view and pulsed once. An unknown id degrades to a toast. Consumed via `onScrolledToComment`.
+   */
+  scrollToCommentId?: string | null;
+  onScrolledToComment?: () => void;
 }
 
 /**
@@ -83,6 +92,9 @@ export function CommentThread({
   onReopen,
   previousSeenAt = null,
   skipOpener = false,
+  buildPermalink,
+  scrollToCommentId = null,
+  onScrolledToComment,
 }: CommentThreadProps) {
   const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
@@ -91,6 +103,7 @@ export function CommentThread({
   const commentsQuery = useComments(annotationId);
   const addComment = useAddComment(annotationId);
   const [draft, setDraft] = useState('');
+  const pulseColor = alpha(theme.qnop.brand.blue, 0.5);
 
   const submit = () => {
     const body = draft.trim();
@@ -111,13 +124,56 @@ export function CommentThread({
     });
   };
 
-  const comments = commentsQuery.data?.comments ?? [];
+  const comments = useMemo(() => commentsQuery.data?.comments ?? [], [commentsQuery.data]);
   // With the opening annotation living in the head card (issue #403), the
   // timeline carries only the replies.
   const visibleComments = skipOpener ? comments.slice(1) : comments;
   const firstNewCommentId = visibleComments.find((comment) =>
     isNewComment(comment, previousSeenAt, userId),
   )?.id;
+
+  // A comment permalink target (issue #412): once the thread has loaded, scroll
+  // its bubble into view (reduced-motion aware) and pulse it once. The opening
+  // comment already shows in the head card, so it needs no scroll; an unknown
+  // id degrades to a toast. Handled once per target so a re-render never
+  // re-scrolls or re-toasts.
+  const handledScrollRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!scrollToCommentId || commentsQuery.isPending) return;
+    if (handledScrollRef.current === scrollToCommentId) return;
+    handledScrollRef.current = scrollToCommentId;
+
+    const index = comments.findIndex((comment) => comment.id === scrollToCommentId);
+    if (index === -1) {
+      notify('This comment no longer exists.', 'error');
+    } else if (!(skipOpener && index === 0)) {
+      const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      const el = document.getElementById(`comment-${scrollToCommentId}`);
+      el?.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'center' });
+      // A one-shot ring in the unseen-marker blue, driven imperatively so it
+      // outlives the parent clearing the target; skipped under reduced motion
+      // and where the Web Animations API is unavailable (jsdom).
+      if (!reduced) {
+        el?.animate?.(
+          [
+            { boxShadow: `0 0 0 3px ${pulseColor}` },
+            { boxShadow: '0 0 0 3px transparent', offset: 0.6 },
+            { boxShadow: '0 0 0 0 transparent' },
+          ],
+          { duration: 1200, easing: 'ease-out' },
+        );
+      }
+    }
+    onScrolledToComment?.();
+  }, [
+    scrollToCommentId,
+    commentsQuery.isPending,
+    comments,
+    skipOpener,
+    notify,
+    onScrolledToComment,
+    pulseColor,
+  ]);
 
   return (
     <Box sx={{ position: 'relative', mt: 0.5, ml: 1.5, pl: 0 }}>
@@ -178,6 +234,9 @@ export function CommentThread({
                 avatarUrl={avatarUrl}
                 body={comment.body}
                 createdAt={comment.createdAt}
+                domId={`comment-${comment.id}`}
+                permalinkUrl={buildPermalink?.(annotationId, comment.id)}
+                notify={notify}
               />
             </Fragment>
           );

--- a/qnop-ui/src/components/reviews/permalink/CopyLinkButton.test.tsx
+++ b/qnop-ui/src/components/reviews/permalink/CopyLinkButton.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import { CopyLinkButton } from './CopyLinkButton';
+
+const URL = 'https://qnop.example/reviews/doc-1?annotation=a1';
+const originalClipboard = navigator.clipboard;
+
+function renderButton(notify = vi.fn()) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <CopyLinkButton url={URL} notify={notify} />
+    </ThemeProvider>,
+  );
+  return notify;
+}
+
+afterEach(() => {
+  Object.assign(navigator, { clipboard: originalClipboard });
+});
+
+describe('CopyLinkButton', () => {
+  it('writes the url to the clipboard and confirms with a success toast', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const notify = renderButton();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(URL));
+    await waitFor(() => expect(notify).toHaveBeenCalledWith('Link copied.', 'success'));
+  });
+
+  it('degrades to an error toast when the clipboard is unavailable', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('insecure context'));
+    Object.assign(navigator, { clipboard: { writeText } });
+    const notify = renderButton();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+
+    await waitFor(() => expect(notify).toHaveBeenCalledWith('Could not copy the link.', 'error'));
+  });
+});
+
+describe('CopyLinkButton — event isolation', () => {
+  it('does not bubble the click to an enclosing handler (would toggle the card)', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const onParentClick = vi.fn();
+    // Models the clickable annotation card the affordance sits inside; a role
+    // button (not a native one) avoids nesting two real buttons in the test.
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label="card"
+          onClick={onParentClick}
+          onKeyDown={() => {}}
+        >
+          <CopyLinkButton url={URL} notify={vi.fn()} />
+        </div>
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/components/reviews/permalink/CopyLinkButton.tsx
+++ b/qnop-ui/src/components/reviews/permalink/CopyLinkButton.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { MouseEvent } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { Link as LinkIcon } from 'lucide-react';
+import { copyToClipboard } from '../../../utils/clipboard';
+import type { Notify } from '../../admin/layout/useToast';
+
+interface CopyLinkButtonProps {
+  /** The absolute permalink to copy. */
+  url: string;
+  notify: Notify;
+  /** Tooltip + accessible label; the meta variant distinguishes annotation vs comment. */
+  label?: string;
+  iconSize?: number;
+}
+
+/**
+ * The quiet "copy link" affordance (issue #412): a small link icon that writes
+ * an absolute permalink to the clipboard and confirms with a toast. It stops
+ * event propagation so it can sit inside a clickable annotation card without
+ * toggling it, and degrades to an error toast when the clipboard is
+ * unavailable (an insecure context) rather than throwing.
+ */
+export function CopyLinkButton({
+  url,
+  notify,
+  label = 'Copy link',
+  iconSize = 13,
+}: CopyLinkButtonProps) {
+  const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    const ok = await copyToClipboard(url);
+    notify(ok ? 'Link copied.' : 'Could not copy the link.', ok ? 'success' : 'error');
+  };
+  return (
+    <Tooltip title={label}>
+      <IconButton
+        size="small"
+        aria-label={label}
+        onClick={handleCopy}
+        sx={{ color: 'text.secondary' }}
+      >
+        <LinkIcon size={iconSize} aria-hidden />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
@@ -33,6 +33,8 @@ import { useAuthStore } from '../../../stores/authStore';
 import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
 import { ToneBadge } from '../../admin/ToneBadge';
+import type { BuildPermalink } from '../useReviewPermalink';
+import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { CommentThread } from '../panel/CommentThread';
 import { ResolveBar } from '../panel/ResolveBar';
 import {
@@ -62,6 +64,8 @@ interface TaskDrawerProps {
   onClose: () => void;
   /** Jumps to the review page with this annotation active (deep link). */
   onShowInDocument: (annotationId: string) => void;
+  /** Builds annotation/comment permalinks (issue #412) — enables the copy affordances. */
+  buildPermalink?: BuildPermalink;
 }
 
 /**
@@ -83,6 +87,7 @@ export function TaskDrawer({
   ownerId,
   onClose,
   onShowInDocument,
+  buildPermalink,
 }: TaskDrawerProps) {
   const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
@@ -190,15 +195,23 @@ export function TaskDrawer({
               “{annotation.anchor.textQuote.quote}”
             </Typography>
           )}
-          <Button
-            size="small"
-            variant="text"
-            startIcon={<ExternalLink size={13} />}
-            onClick={() => onShowInDocument(annotation.id)}
-            sx={{ mt: 1 }}
-          >
-            Show in document
-          </Button>
+          <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', mt: 1 }}>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<ExternalLink size={13} />}
+              onClick={() => onShowInDocument(annotation.id)}
+            >
+              Show in document
+            </Button>
+            {buildPermalink && (
+              <CopyLinkButton
+                url={buildPermalink(annotation.id)}
+                notify={notify}
+                label="Copy link to annotation"
+              />
+            )}
+          </Stack>
         </Box>
 
         <Box sx={{ flex: 1, overflowY: 'auto', px: 2, py: 1 }}>
@@ -214,6 +227,7 @@ export function TaskDrawer({
             }
             previousSeenAt={previousSeenAt}
             skipOpener
+            buildPermalink={buildPermalink}
           />
         </Box>
 

--- a/qnop-ui/src/components/reviews/useReviewPermalink.test.tsx
+++ b/qnop-ui/src/components/reviews/useReviewPermalink.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { useReviewPermalink, type PermalinkView } from './useReviewPermalink';
+
+function wrapperFor(entry: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path="/reviews/:documentId" element={<>{children}</>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+}
+
+function buildAt(entry: string, view?: PermalinkView) {
+  return renderHook(() => useReviewPermalink(view), { wrapper: wrapperFor(entry) }).result.current;
+}
+
+const origin = window.location.origin;
+
+describe('useReviewPermalink', () => {
+  it('keeps the pretty route segment as-is, so a slug URL yields a slug permalink (#411)', () => {
+    const build = buildAt('/reviews/supply-contract');
+    expect(build('a1')).toBe(`${origin}/reviews/supply-contract?annotation=a1`);
+  });
+
+  it('carries the current document view so a link reopens the same surface', () => {
+    const build = buildAt('/reviews/doc-1', 'focus');
+    expect(build('a1')).toBe(`${origin}/reviews/doc-1?annotation=a1&view=focus`);
+  });
+
+  it('adds the comment param only when a comment id is given', () => {
+    const build = buildAt('/reviews/doc-1', 'panel');
+    expect(build('a1', 'c9')).toBe(`${origin}/reviews/doc-1?annotation=a1&comment=c9&view=panel`);
+  });
+
+  it('omits the view when none is passed (recipient keeps their preference)', () => {
+    const build = buildAt('/reviews/doc-1');
+    expect(build('a1', 'c9')).toBe(`${origin}/reviews/doc-1?annotation=a1&comment=c9`);
+  });
+});

--- a/qnop-ui/src/components/reviews/useReviewPermalink.ts
+++ b/qnop-ui/src/components/reviews/useReviewPermalink.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+
+/** The document view a permalink should reopen in (issue #412). */
+export type PermalinkView = 'panel' | 'focus';
+
+/** Builds an absolute permalink to an annotation, optionally to one comment. */
+export type BuildPermalink = (annotationId: string, commentId?: string) => string;
+
+/**
+ * A builder for shareable annotation/comment permalinks (issue #412). The URL
+ * carries the pretty route segment as-is — a slug when the page was opened by
+ * slug (issue #411) — plus `?annotation=` (and `?comment=` for a single
+ * comment) and the current document view, so a copied link reopens the exact
+ * target the sharer sees. It only builds URLs; the server still enforces
+ * access, and the link carries no extra authorization (anti-enumeration
+ * unchanged).
+ *
+ * Call at the page level (inside the route), where `useParams` is available;
+ * pass the returned builder down to the copy-link affordances.
+ */
+export function useReviewPermalink(view?: PermalinkView): BuildPermalink {
+  const { documentId = '' } = useParams();
+  return useCallback(
+    (annotationId, commentId) => {
+      const params = new URLSearchParams();
+      params.set('annotation', annotationId);
+      if (commentId) params.set('comment', commentId);
+      if (view) params.set('view', view);
+      return `${window.location.origin}/reviews/${documentId}?${params.toString()}`;
+    },
+    [documentId, view],
+  );
+}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -35,6 +35,7 @@ import {
   useRenderedDocument,
 } from '../../api/hooks/useDocuments';
 import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotations';
+import { useComments } from '../../api/hooks/useComments';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import { useAuthStore } from '../../stores/authStore';
 
@@ -361,6 +362,49 @@ describe('DocumentReviewPage deep link', () => {
     seedHappyPath();
     renderPage('/reviews/doc-1?annotation=a1');
     expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  // Issue #412: a comment permalink opens the annotation AND scrolls its thread
+  // to the referenced comment once the thread has loaded.
+  it('scrolls to the comment named by ?comment= on the deep-linked annotation', () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    seedHappyPath();
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        comments: [
+          {
+            id: 'op',
+            annotationId: 'a1',
+            authorId: 'u1',
+            body: 'opener',
+            createdAt: '2026-07-01T10:00:00Z',
+          },
+          {
+            id: 'c9',
+            annotationId: 'a1',
+            authorId: 'u1',
+            body: 'the reply',
+            createdAt: '2026-07-02T10:00:00Z',
+          },
+        ],
+      },
+    } as unknown as ReturnType<typeof useComments>);
+
+    renderPage('/reviews/doc-1?annotation=a1&comment=c9');
+
+    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  // Issue #412: an annotation that no longer exists degrades to a toast rather
+  // than a silently empty page; the review itself still opens.
+  it('degrades an unknown ?annotation= target to a toast', () => {
+    seedHappyPath();
+    renderPage('/reviews/doc-1?annotation=does-not-exist');
+    expect(screen.getByText('This annotation no longer exists.')).toBeInTheDocument();
   });
 });
 

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -50,6 +50,7 @@ import { ErrorBoundary } from '../../components/errors/ErrorBoundary';
 import { ReviewHubHead } from '../../components/reviews/hub/ReviewHubHead';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
+import { useReviewPermalink } from '../../components/reviews/useReviewPermalink';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
 import {
   DEFAULT_PANEL_FRACTION,
@@ -154,15 +155,23 @@ export function DocumentReviewPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlView]);
   const [listOpen, setListOpen] = useState(false);
-  // Deep link from the tasks view (issue #393): ?annotation= seeds the active
-  // annotation once; the param is consumed so in-page selection owns the state.
+  // Deep link (issues #393/#412): ?annotation= seeds the active annotation and
+  // ?comment= seeds a comment scroll target once; both params are consumed so
+  // in-page selection owns the state afterwards. The original ?annotation= is
+  // kept in a ref to validate the target once the annotations settle.
   const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(() =>
     searchParams.get('annotation'),
   );
+  const [scrollToCommentId, setScrollToCommentId] = useState<string | null>(() =>
+    searchParams.get('comment'),
+  );
+  const clearScrollToComment = useCallback(() => setScrollToCommentId(null), []);
+  const deepLinkAnnotationRef = useRef<string | null>(searchParams.get('annotation'));
   useEffect(() => {
-    if (!searchParams.has('annotation')) return;
+    if (!searchParams.has('annotation') && !searchParams.has('comment')) return;
     const next = new URLSearchParams(searchParams);
     next.delete('annotation');
+    next.delete('comment');
     setSearchParams(next, { replace: true });
   }, [searchParams, setSearchParams]);
   // Card↔mark linking (prototype): hovering either side lights up the other.
@@ -221,6 +230,21 @@ export function DocumentReviewPage() {
   // to the mark elements the highlight layer renders.
   const focusMode = viewMode === 'focus';
   const activeAnnotation = annotations.find((a) => a.id === activeAnnotationId);
+  // Permalinks (issue #412): the builder carries the current view so a copied
+  // link reopens the same surface; it only builds URLs, the server still gates
+  // access. A deep-linked annotation that no longer exists degrades to a toast
+  // once the annotations settle (validated once via the ref above).
+  const buildPermalink = useReviewPermalink(focusMode ? 'focus' : 'panel');
+  useEffect(() => {
+    const target = deepLinkAnnotationRef.current;
+    if (!target || annotationsQuery.isPending || annotationsQuery.isError) return;
+    deepLinkAnnotationRef.current = null;
+    if (!annotations.some((a) => a.id === target)) {
+      notify('This annotation no longer exists.', 'error');
+      setActiveAnnotationId(null);
+      setScrollToCommentId(null);
+    }
+  }, [annotations, annotationsQuery.isPending, annotationsQuery.isError, notify]);
   const composingPending = Boolean(pending && !pending.menuPosition);
   const focusSpotlight = !focusMode
     ? null
@@ -525,6 +549,9 @@ export function DocumentReviewPage() {
                   readOnly={!isLatestVersion}
                   reviewClosed={!isOpenWorkflowState(document.workflowState)}
                   previousSeenAt={previousSeenAt}
+                  buildPermalink={buildPermalink}
+                  scrollToCommentId={scrollToCommentId}
+                  onScrolledToComment={clearScrollToComment}
                 />
               </ErrorBoundary>
             </Box>
@@ -558,6 +585,9 @@ export function DocumentReviewPage() {
               readOnly={!isLatestVersion}
               reviewClosed={!isOpenWorkflowState(document.workflowState)}
               previousSeenAt={previousSeenAt}
+              buildPermalink={buildPermalink}
+              scrollToCommentId={scrollToCommentId}
+              onScrolledToComment={clearScrollToComment}
             />
           </ErrorBoundary>
         </FocusDrawer>
@@ -576,6 +606,9 @@ export function DocumentReviewPage() {
           threadParticipation={document.threadParticipation ?? 'OPEN'}
           ownerId={document.ownerId}
           previousSeenAt={previousSeenAt}
+          buildPermalink={buildPermalink}
+          scrollToCommentId={scrollToCommentId}
+          onScrolledToComment={clearScrollToComment}
         />
       )}
       {focusMode && composingPending && pending && (

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -219,6 +219,19 @@ describe('ReviewTasksPage', () => {
     expect(screen.getByTestId('review-page')).toBeInTheDocument();
   });
 
+  // Issue #412: the drawer is the third thread surface — it carries the
+  // annotation copy-link alongside its "Show in document" deep link.
+  it('offers an annotation copy-link in the drawer header', () => {
+    mockData();
+    renderPage();
+
+    fireEvent.click(screen.getByTestId('task-card-a-open'));
+    const drawer = screen.getByTestId('task-drawer');
+    expect(
+      within(drawer).getByRole('button', { name: 'Copy link to annotation' }),
+    ).toBeInTheDocument();
+  });
+
   it('honours the stored list preference', () => {
     localStorage.setItem('qnop-tasks-view', 'list');
     mockData();

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -35,6 +35,7 @@ import { useRecordVisit } from '../../api/hooks/useReviews';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
+import { useReviewPermalink } from '../../components/reviews/useReviewPermalink';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
 import type { FilterAuthor } from '../../components/reviews/panel/PanelFilterBar';
@@ -78,6 +79,9 @@ export function ReviewTasksPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { toast, notify, clear } = useToast();
+  // Permalinks from the tasks drawer open the document in the recipient's own
+  // view preference — the sharer is on the tasks surface, not panel/focus (#412).
+  const buildPermalink = useReviewPermalink();
   const userId = useAuthStore((state) => state.userId);
   const ownDisplayName = useAuthStore((state) => state.displayName);
 
@@ -298,6 +302,7 @@ export function ReviewTasksPage() {
         ownerId={document.ownerId}
         onClose={() => setOpenTaskId(null)}
         onShowInDocument={showInDocument}
+        buildPermalink={buildPermalink}
       />
       <AdminToast toast={toast} onClose={clear} />
     </Stack>

--- a/qnop-ui/src/utils/clipboard.test.ts
+++ b/qnop-ui/src/utils/clipboard.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyToClipboard } from './clipboard';
+
+const original = navigator.clipboard;
+afterEach(() => {
+  Object.assign(navigator, { clipboard: original });
+});
+
+describe('copyToClipboard', () => {
+  it('returns true when the write succeeds', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    await expect(copyToClipboard('hello')).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('returns false instead of throwing when the clipboard is unavailable', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    await expect(copyToClipboard('hello')).resolves.toBe(false);
+  });
+});

--- a/qnop-ui/src/utils/clipboard.ts
+++ b/qnop-ui/src/utils/clipboard.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Copies text to the clipboard, resolving to whether it succeeded rather than
+ * throwing: `navigator.clipboard` is undefined in insecure contexts and its
+ * write can reject, so every caller can surface a plain success/failure toast
+ * without a try/catch of its own.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Adds shareable, copy-to-clipboard **permalinks** for annotations and individual comments across every review thread surface. Frontend-only — the server still gates access and the links carry no extra authorization (anti-enumeration unchanged).

Closes #412.

### URL scheme
- Annotation: `?annotation={id}`
- Comment: `?annotation={id}&comment={commentId}`
- Composes with `?view=panel|focus` and slug URLs (#411): the builder keeps the pretty route segment as-is and carries the current document view, so a copied link reopens the same surface.

### What's included
- **`useReviewPermalink`** — builds slug-preferring absolute URLs.
- **`CopyLinkButton`** — a quiet copy affordance with a confirmation toast, wired onto:
  - the panel's expanded annotation card,
  - the focus card header,
  - the task drawer header (next to "Show in document"),
  - and every comment's meta line (shares that line with likes, #410).
  - Stops event propagation so it never toggles the card it sits in.
- **Comment deep link** — the active annotation's thread scrolls to the referenced comment and pulses it once (reduced-motion aware, via the Web Animations API); the opening comment already shows in the head card, so it needs no scroll.
- **Graceful degradation** — unknown annotation/comment ids degrade to a toast ("This annotation/comment no longer exists.") while the review still opens; the deep-link params are consumed from the URL.

### Design note
The copy affordance is not placed inside the shared `AnnotationHead`: in the panel that head is rendered inside a `ButtonBase` (`<button>`), so a nested interactive control would be invalid, and the head's badge row already occupies both corners. It is therefore placed per surface (a right-aligned link under the panel's expanded card, the focus/drawer headers, the comment meta line), keeping the affordance on all three thread surfaces without nesting or overlap.

### Not in scope
Cross-version pinning, notifications/mentions (per the issue).

## Test plan
- [x] `useReviewPermalink`: slug-preferring URL, `?view=` preserved, `?comment=` optional.
- [x] `CopyLinkButton`: writes the url + success toast; error toast when the clipboard is unavailable; stops event propagation.
- [x] `CommentThread`: per-comment copy affordance present with a builder / absent without (hover preview); scrolls a target into view and consumes it once; unknown id → toast.
- [x] Affordance present on all three thread surfaces (panel / focus / task drawer).
- [x] Page-level deep-link wiring (per #306): `?annotation=&comment=` opens + scrolls; unknown `?annotation=` → toast.
- [x] `tsc`, `eslint`, `prettier`, full `vitest` (518 tests) green.
- [x] Manual browser check: affordances render on all surfaces; copy → "Link copied." toast; `?annotation=&comment=&view=panel` full-load opens the annotation, shows the thread, consumes the params, preserves the slug + view; unknown-id degradation toast fires (console-verified).

🤖 Co-Author: Claude (Fable 5) via Claude Code