### PR TITLE
feat(reviews): document-scoped (global) annotations without a text anchor (#395)

### DIFF
--- a/docs/adr/0009-multi-layer-annotation-anchoring.md
+++ b/docs/adr/0009-multi-layer-annotation-anchoring.md
@@ -47,3 +47,12 @@ PENDING → PLACED | MOVED | ORPHANED | FAILED
 - **Text-quote as the sole/primary strategy with layout as a mere fallback.** Rejected: images have no quote; geometry must be a first-class, always-present layer.
 - **Synchronous re-anchoring at upload.** Rejected: blocks the upload for large documents/many annotations; async with a `PENDING` lifecycle is the chosen shape ([ADR-0033](0033-durable-async-job-execution-on-postgres.md)).
 - **Auto-placing low-confidence matches.** Rejected: a mis-attached objection on a contract is worse than a visible orphan.
+
+## Amendment — document-scoped annotations (2026-07-06, issue #395)
+
+The region anchor is the universal base layer for *located* annotations. This amendment adds the explicit **unlocated** case: an annotation may be created **without any anchor** — a document-scoped remark ("unify terminology across the contract") that pins to no passage.
+
+- **Modeled as an annotation with no `AnnotationPlacement` row at all** — not a placement carrying a null anchor. It is implicitly valid on every version, never enters re-anchoring, and is never `PENDING`/`ORPHANED`.
+- **Identity, thread, status and the FINALIZED gate are unchanged** — an OPEN document-scoped annotation still blocks FINALIZED (it is counted like any other OPEN annotation), and a document-scoped annotation contributes no pending placement.
+- **No new discriminator field is needed.** An orphaned annotation keeps its anchor (a placement row with status `ORPHANED`), so in the `AnnotationView` a **null anchor ⇒ document-scoped**; the client reads that signal directly.
+- **Out of scope:** converting a document-scoped annotation into a located one (re-anchor UI is [#326] territory).

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4372,16 +4372,22 @@ components:
         - LOW
     AnnotationCreateRequest:
       type: object
-      description: Create an annotation anchored to a region of a version.
+      description: >-
+        Create an annotation. With an anchor it is located on a region of the
+        version and re-anchors across versions (ADR-0009); without an anchor it
+        is document-scoped (issue #395) — a general remark valid on every
+        version, never placed and never orphaned.
       required:
         - versionNumber
-        - anchor
         - comment
       properties:
         versionNumber:
           type: integer
           minimum: 1
-          description: The 1-based version the annotation is drawn on.
+          description: >-
+            The 1-based version the annotation is authored on. For a located
+            annotation it is the version the region is drawn on; a document-scoped
+            annotation carries no placement on it.
         anchor:
           $ref: '#/components/schemas/Anchor'
         comment:

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -76,7 +76,9 @@ public class AnnotationController implements AnnotationsApi {
             request.getVersionNumber(),
             CurrentUser.requireUserId(),
             CurrentUser.isAdmin(),
-            mapper.writeValueAsString(request.getAnchor()),
+            // A document-scoped annotation (issue #395) carries no anchor; keep it a Java null
+            // rather than the JSON literal "null" so the service creates no placement for it.
+            request.getAnchor() == null ? null : mapper.writeValueAsString(request.getAnchor()),
             request.getComment(),
             request.getType() == null ? null : request.getType().getValue(),
             request.getPriority() == null ? null : request.getPriority().getValue());

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -93,6 +93,23 @@ class AnnotationApiIT extends SeededIntegrationTest {
     return JsonPath.read(json, "$.id");
   }
 
+  /** Creates an anchor-free, document-scoped annotation (issue #395) on the latest version. */
+  private String createDocumentScopedAnnotation(UUID documentId, UUID actor) throws Exception {
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        "{\"versionNumber\":1,\"comment\":\"unify terminology across the"
+                            + " contract\"}"))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return JsonPath.read(json, "$.id");
+  }
+
   @Test
   void participantCreatesAnAnnotationPlacedOnTheVersion() throws Exception {
     UUID documentId = seedDocumentWithVersion();
@@ -126,6 +143,51 @@ class AnnotationApiIT extends SeededIntegrationTest {
         .andExpect(jsonPath("$.annotations.length()").value(1))
         .andExpect(jsonPath("$.annotations[0].placementStatus").value("PLACED"))
         .andExpect(jsonPath("$.annotations[0].anchor.region.box.width").value(0.3));
+  }
+
+  @Test
+  void createsADocumentScopedAnnotationWithoutAnAnchor() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+
+    // A general remark that pins to no passage (issue #395): the anchor is omitted, so no
+    // placement is created — the view carries neither an anchor nor a placement status.
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"versionNumber\":1,\"comment\":\"unify terminology across the contract\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.status").value("OPEN"))
+        .andExpect(jsonPath("$.authorId").value(AUDITOR_ID.toString()))
+        .andExpect(jsonPath("$.anchor").doesNotExist())
+        .andExpect(jsonPath("$.placementStatus").doesNotExist())
+        .andExpect(jsonPath("$.commentCount").value(1));
+  }
+
+  @Test
+  void documentScopedAnnotationAppearsOnEveryVersionWithoutAPlacement() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    createDocumentScopedAnnotation(documentId, AUDITOR_ID);
+
+    // A second version is uploaded: a located annotation would re-anchor, but a document-scoped
+    // one has no placement to carry forward — it stays valid on every version, never PENDING or
+    // ORPHANED (issue #395, ADR-0009).
+    versions.save(
+        new DocumentVersion(
+            documentId, 2, "sha256/bb/cafebabe", "cafebabe", "application/pdf", 2345L, MEMBER_ID));
+
+    for (String version : new String[] {"1", "2"}) {
+      mockMvc
+          .perform(
+              as(
+                  get("/api/v1/documents/" + documentId + "/annotations").param("version", version),
+                  MEMBER_ID))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.annotations.length()").value(1))
+          .andExpect(jsonPath("$.annotations[0].anchor").doesNotExist())
+          .andExpect(jsonPath("$.annotations[0].placementStatus").doesNotExist());
+    }
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
@@ -281,6 +281,42 @@ class ReviewWorkflowControllerIT extends SeededIntegrationTest {
   }
 
   @Test
+  void documentScopedAnnotationBlocksFinalizeWhileOpenThenFinalizesWithoutAPlacement()
+      throws Exception {
+    Document document = inReviewOwnedByMember();
+    DocumentVersion version =
+        new DocumentVersion(
+            document.getId(), 1, "s3://key", "hash", "application/pdf", 10, MEMBER_ID);
+    version.attachRenderedDocument("{\"surfaces\":[]}"); // READY (issue #323 finalize precondition)
+    versions.save(version);
+    // A document-scoped annotation (issue #395) — no placement row at all.
+    Annotation annotation = annotations.save(new Annotation(document.getId(), MEMBER2_ID));
+
+    // OPEN → the FINALIZED gate counts it like any other open annotation.
+    mockMvc
+        .perform(
+            post(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(MEMBER_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetState\":\"FINALIZED\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("open")));
+
+    // Resolved → it contributes no pending placement, so FINALIZED succeeds without one ever
+    // existing (it is never PENDING/ORPHANED, ADR-0009 as amended by #395).
+    annotation.resolve();
+    annotations.save(annotation);
+    mockMvc
+        .perform(
+            post(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(MEMBER_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetState\":\"FINALIZED\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.state").value("FINALIZED"));
+  }
+
+  @Test
   void finalizeIsBlockedWhenTheOnlyVersionFailedExtraction() throws Exception {
     Document document = inReviewOwnedByMember();
     DocumentVersion version =

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -125,11 +125,12 @@ public class AnnotationService {
       Instant createdAt) {}
 
   /**
-   * Creates an annotation on {@code versionNumber}, placed immediately, seeded with its mandatory
-   * first comment — an annotation without text must not exist (issue #301). Only the LATEST version
-   * accepts new annotations (issue #306) — older versions are a read-only record; the guard answers
-   * 409 {@code VERSION_READ_ONLY} so a client racing a concurrent re-upload gets a stable, mappable
-   * signal.
+   * Creates an annotation on {@code versionNumber}, seeded with its mandatory first comment — an
+   * annotation without text must not exist (issue #301). With an {@code anchorJson} it is placed
+   * immediately; without one it is document-scoped (issue #395) — no placement, valid on every
+   * version. Only the LATEST version accepts new annotations (issue #306) — older versions are a
+   * read-only record; the guard answers 409 {@code VERSION_READ_ONLY} so a client racing a
+   * concurrent re-upload gets a stable, mappable signal.
    */
   @Transactional
   public AnnotationView create(
@@ -166,10 +167,16 @@ public class AnnotationService {
     Annotation created = new Annotation(documentId, author);
     created.classify(typeOf(type), priorityOf(priority));
     Annotation annotation = annotations.saveAndFlush(created);
-    AnnotationPlacement placement =
-        new AnnotationPlacement(annotation.getId(), version.getId(), anchorJson);
-    placement.markPlaced(anchorJson);
-    placements.save(placement);
+    // A located annotation is placed immediately on the version it was drawn on. A document-scoped
+    // annotation (issue #395) carries no anchor and gets no placement at all — it stays valid on
+    // every version, never re-anchored and never orphaned (ADR-0009). The null placement flows
+    // through to a view with a null anchor/placementStatus, the client's document-scope signal.
+    AnnotationPlacement placement = null;
+    if (anchorJson != null) {
+      placement = new AnnotationPlacement(annotation.getId(), version.getId(), anchorJson);
+      placement.markPlaced(anchorJson);
+      placements.save(placement);
+    }
 
     comments.save(new Comment(annotation.getId(), author, firstComment));
     int commentCount = 1;

--- a/qnop-ui/src/components/reviews/WholeDocumentChip.tsx
+++ b/qnop-ui/src/components/reviews/WholeDocumentChip.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { FileText } from 'lucide-react';
+
+interface WholeDocumentChipProps {
+  /** Shortens the label to "Whole doc" for tight rows. */
+  compact?: boolean;
+}
+
+/**
+ * The scope marker for a document-scoped annotation (issue #395): a quiet pill
+ * that reads as "this remark is about the whole document", taking the slot a
+ * located annotation uses for its page reference. Deliberately neutral — scope
+ * is metadata, not a status — so it never competes with the status/priority
+ * cues. One component so the card, list row, drawer and panel stay identical.
+ */
+export function WholeDocumentChip({ compact = false }: WholeDocumentChipProps) {
+  const theme = useTheme();
+  return (
+    <Tooltip title="Applies to the whole document — not pinned to a passage">
+      <Stack
+        direction="row"
+        spacing={0.5}
+        data-testid="whole-document-chip"
+        sx={{
+          alignItems: 'center',
+          flexShrink: 0,
+          px: 0.75,
+          py: 0.25,
+          borderRadius: 99,
+          bgcolor: theme.qnop.surface2,
+          color: 'text.secondary',
+        }}
+      >
+        <FileText size={11} aria-hidden />
+        <Typography
+          component="span"
+          sx={{ fontSize: 11, fontWeight: 500, lineHeight: 1, whiteSpace: 'nowrap' }}
+        >
+          {compact ? 'Whole doc' : 'Whole document'}
+        </Typography>
+      </Stack>
+    </Tooltip>
+  );
+}

--- a/qnop-ui/src/components/reviews/annotationScope.test.ts
+++ b/qnop-ui/src/components/reviews/annotationScope.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AnnotationView } from '../../api/generated';
+import { PlacementStatus } from '../../api/generated';
+import { isDocumentScoped } from './annotationScope';
+
+const REGION_ANCHOR = { region: { surfaceIndex: 0, box: { x: 0, y: 0, width: 0.1, height: 0.1 } } };
+
+describe('isDocumentScoped (#395)', () => {
+  it('is true when the annotation carries no anchor', () => {
+    expect(isDocumentScoped({ anchor: undefined })).toBe(true);
+  });
+
+  it('is false for a located annotation', () => {
+    expect(isDocumentScoped({ anchor: REGION_ANCHOR } as AnnotationView)).toBe(false);
+  });
+
+  it('is false for an orphaned annotation — it keeps its anchor', () => {
+    // The key invariant: orphaned retains its anchor (placement status ORPHANED), so it never
+    // looks document-scoped.
+    expect(
+      isDocumentScoped({
+        anchor: REGION_ANCHOR,
+        placementStatus: PlacementStatus.Orphaned,
+      } as AnnotationView),
+    ).toBe(false);
+  });
+});

--- a/qnop-ui/src/components/reviews/annotationScope.ts
+++ b/qnop-ui/src/components/reviews/annotationScope.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { AnnotationView } from '../../api/generated';
+
+/**
+ * A document-scoped annotation (issue #395): a general remark that pins to no
+ * passage, so it carries no anchor and no placement on any version — valid
+ * everywhere, never orphaned (ADR-0009 amendment). The signal is unambiguous
+ * because an *orphaned* annotation keeps its anchor (a placement whose status is
+ * ORPHANED), so a missing anchor uniquely marks the document-scoped case.
+ */
+export function isDocumentScoped(annotation: Pick<AnnotationView, 'anchor'>): boolean {
+  return !annotation.anchor;
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
@@ -27,6 +27,8 @@ import { useTheme } from '@mui/material/styles';
 import { MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
+import { isDocumentScoped } from '../annotationScope';
+import { WholeDocumentChip } from '../WholeDocumentChip';
 import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
 import { PlacementStatusChip } from './PlacementStatusChip';
 import { STATUS_CUES } from './statusCues';
@@ -86,7 +88,11 @@ export function AnnotationBadgeRow({ annotation, unseen = false }: AnnotationBad
         spacing={1}
         sx={{ alignItems: 'center', ml: 'auto', color: 'text.secondary' }}
       >
-        {region && <Typography variant="caption">Page {region.surfaceIndex + 1}</Typography>}
+        {isDocumentScoped(annotation) ? (
+          <WholeDocumentChip compact />
+        ) : (
+          region && <Typography variant="caption">Page {region.surfaceIndex + 1}</Typography>
+        )}
         <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
           <MessageSquare size={13} aria-hidden />
           <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>

--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -28,6 +28,7 @@ import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
 import { shortRelativeTime } from '../../../utils/relativeTime';
 import { UserAvatar } from '../../shell/UserAvatar';
+import { isDocumentScoped } from '../annotationScope';
 import { AnnotationBadgeRow } from './AnnotationBadgeRow';
 
 const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
@@ -96,9 +97,13 @@ export function AnnotationHead({ annotation, unseen = false }: AnnotationHeadPro
           </Typography>
         </Box>
       ) : (
-        <Typography variant="body2" color="text.secondary">
-          {fallbackLabel}
-        </Typography>
+        // A document-scoped annotation (issue #395) has no passage; its scope reads from the
+        // "Whole document" chip in the badge row above, so no fallback line is needed here.
+        !isDocumentScoped(annotation) && (
+          <Typography variant="body2" color="text.secondary">
+            {fallbackLabel}
+          </Typography>
+        )
       )}
       {openerText && (
         <Typography

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -147,7 +147,9 @@ function AnnotationListItemBase({
     (participant, index, all) => all.findIndex((other) => other.id === participant.id) === index,
   );
 
-  const fallbackLabel = region ? 'Region annotation' : 'No placement on this version';
+  // No region means no placement at all → a document-scoped annotation (issue #395); an orphaned
+  // annotation keeps its anchor, so it never lands here.
+  const fallbackLabel = region ? 'Region annotation' : 'Whole document';
 
   return (
     <ButtonBase

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -139,26 +139,24 @@ describe('AnnotationPanel', () => {
     ).toBeInTheDocument();
   });
 
-  it('lists placed annotations and separates unplaced ones', () => {
+  it('separates document-scoped annotations into their own group (#395)', () => {
     renderPanel({
       annotations: [
         annotation('placed-1'),
-        annotation('orphaned-1', {
-          anchor: undefined,
-          placementStatus: PlacementStatus.Orphaned,
-        }),
+        // A document-scoped annotation: no anchor and no placement (issue #395).
+        annotation('doc-1', { anchor: undefined, placementStatus: undefined }),
       ],
-      // The unplaced annotation is expanded: placement cues are
-      // expanded-state details; collapsed rows stay a single dense line.
-      activeAnnotationId: 'orphaned-1',
+      activeAnnotationId: 'doc-1',
     });
 
     expect(screen.getByText('Annotations (2)')).toBeInTheDocument();
-    expect(screen.getByText('Not placed on this version')).toBeInTheDocument();
-    expect(screen.getByText('“quoted text”')).toBeInTheDocument();
-    // The collapsed placed row shows the page as a compact caption.
+    // The anchor-free annotation groups under "Whole document", not the "anchor lost" bucket.
+    expect(screen.getByText('Whole document')).toBeInTheDocument();
+    expect(screen.queryByText('Not placed on this version')).not.toBeInTheDocument();
+    // The located annotation's collapsed row still shows its page.
     expect(screen.getByText('p. 1')).toBeInTheDocument();
-    expect(screen.getByText('Orphaned')).toBeInTheDocument();
+    // The active document-scoped annotation carries the whole-document chip.
+    expect(screen.getByTestId('whole-document-chip')).toBeInTheDocument();
   });
 
   it('toggles the active annotation and reveals its thread', () => {

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -159,6 +159,27 @@ describe('AnnotationPanel', () => {
     expect(screen.getByTestId('whole-document-chip')).toBeInTheDocument();
   });
 
+  it('offers a New task action for a whole-document note when writable (#395)', () => {
+    const onNewDocumentNote = vi.fn();
+    renderPanel({ onNewDocumentNote });
+
+    fireEvent.click(screen.getByRole('button', { name: 'New task' }));
+    expect(onNewDocumentNote).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides New task on a read-only or closed review, or without a handler (#395)', () => {
+    renderPanel({ onNewDocumentNote: vi.fn(), readOnly: true });
+    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+    cleanup();
+
+    renderPanel({ onNewDocumentNote: vi.fn(), reviewClosed: true });
+    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+    cleanup();
+
+    renderPanel({});
+    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+  });
+
   it('toggles the active annotation and reveals its thread', () => {
     const props = renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });
 

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -159,25 +159,25 @@ describe('AnnotationPanel', () => {
     expect(screen.getByTestId('whole-document-chip')).toBeInTheDocument();
   });
 
-  it('offers a New task action for a whole-document note when writable (#395)', () => {
+  it('offers a Global annotation action for a whole-document remark when writable (#395)', () => {
     const onNewDocumentNote = vi.fn();
     renderPanel({ onNewDocumentNote });
 
-    fireEvent.click(screen.getByRole('button', { name: 'New task' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Global annotation' }));
     expect(onNewDocumentNote).toHaveBeenCalledTimes(1);
   });
 
-  it('hides New task on a read-only or closed review, or without a handler (#395)', () => {
+  it('hides Global annotation on a read-only or closed review, or without a handler (#395)', () => {
     renderPanel({ onNewDocumentNote: vi.fn(), readOnly: true });
-    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Global annotation' })).not.toBeInTheDocument();
     cleanup();
 
     renderPanel({ onNewDocumentNote: vi.fn(), reviewClosed: true });
-    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Global annotation' })).not.toBeInTheDocument();
     cleanup();
 
     renderPanel({});
-    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Global annotation' })).not.toBeInTheDocument();
   });
 
   it('toggles the active annotation and reveals its thread', () => {
@@ -266,7 +266,7 @@ describe('AnnotationPanel', () => {
   it('collapses a section on click', () => {
     renderPanel({ annotations: [annotation('a1')] });
 
-    const header = screen.getByRole('button', { name: /On this version/ });
+    const header = screen.getByRole('button', { name: /Anchored to the document/ });
     expect(header).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByTestId('annotation-item-a1')).toBeVisible();
 

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -93,8 +93,9 @@ interface AnnotationPanelProps {
   onScrolledToComment?: () => void;
   /**
    * Opens the "new whole-document task" dialog (issue #395) — a general remark that needs no
-   * selection. When set (and the review is writable) a quiet "New task" button rides the panel
-   * header, so document-scoped tasks can also be raised from the document and focus views.
+   * selection. When set (and the review is writable) a quiet "Global annotation" button rides the
+   * panel header, so document-scoped annotations can also be raised from the document and focus
+   * views.
    */
   onNewDocumentNote?: () => void;
 }
@@ -357,7 +358,7 @@ export function AnnotationPanel({
             startIcon={<Plus size={15} />}
             onClick={onNewDocumentNote}
           >
-            New task
+            Global annotation
           </Button>
         ) : undefined
       }
@@ -390,17 +391,6 @@ export function AnnotationPanel({
             No annotations match this filter.
           </Typography>
         )}
-        {located.length > 0 && (
-          <PanelSection
-            title="On this version"
-            subtitle="Anchored to the document"
-            icon={<Link2 size={13} aria-hidden />}
-            count={located.length}
-            newCount={located.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
-          >
-            {located.map(renderItem)}
-          </PanelSection>
-        )}
         {documentScoped.length > 0 && (
           <PanelSection
             title="Whole document"
@@ -410,6 +400,17 @@ export function AnnotationPanel({
             newCount={documentScoped.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
           >
             {documentScoped.map(renderItem)}
+          </PanelSection>
+        )}
+        {located.length > 0 && (
+          <PanelSection
+            title="Anchored to the document"
+            subtitle="Placed on this version"
+            icon={<Link2 size={13} aria-hidden />}
+            count={located.length}
+            newCount={located.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
+          >
+            {located.map(renderItem)}
           </PanelSection>
         )}
       </Stack>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -22,12 +22,13 @@
 import { useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import ButtonBase from '@mui/material/ButtonBase';
 import Collapse from '@mui/material/Collapse';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { ChevronRight, FileText, Link2, NotebookPen } from 'lucide-react';
+import { ChevronRight, FileText, Link2, NotebookPen, Plus } from 'lucide-react';
 import type {
   AnnotationPriority,
   AnnotationType,
@@ -90,6 +91,12 @@ interface AnnotationPanelProps {
   /** A comment permalink target (issue #412) — scrolled to + pulsed in the active thread. */
   scrollToCommentId?: string | null;
   onScrolledToComment?: () => void;
+  /**
+   * Opens the "new whole-document task" dialog (issue #395) — a general remark that needs no
+   * selection. When set (and the review is writable) a quiet "New task" button rides the panel
+   * header, so document-scoped tasks can also be raised from the document and focus views.
+   */
+  onNewDocumentNote?: () => void;
 }
 
 /** A collapsible, counted group of annotation cards (prototype sidebar section). */
@@ -227,6 +234,7 @@ export function AnnotationPanel({
   buildPermalink,
   scrollToCommentId = null,
   onScrolledToComment,
+  onNewDocumentNote,
 }: AnnotationPanelProps) {
   const [filters, setFilters] = useState<AnnotationFilters>(EMPTY_FILTERS);
   const userId = useAuthStore((state) => state.userId);
@@ -339,6 +347,20 @@ export function AnnotationPanel({
       title={`Annotations (${annotations.length})`}
       description="Marks and their discussion on this version."
       frameless={frameless}
+      action={
+        // Raise a whole-document task without a selection (issue #395) — a quiet peer to the
+        // text-selection gesture, offered while the latest version is open for review.
+        onNewDocumentNote && !readOnly && !reviewClosed ? (
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<Plus size={15} />}
+            onClick={onNewDocumentNote}
+          >
+            New task
+          </Button>
+        ) : undefined
+      }
     >
       <Stack spacing={1.5}>
         {annotations.length > 0 && (

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -27,7 +27,7 @@ import Collapse from '@mui/material/Collapse';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { ChevronRight, Link2, NotebookPen, Unlink } from 'lucide-react';
+import { ChevronRight, FileText, Link2, NotebookPen } from 'lucide-react';
 import type {
   AnnotationPriority,
   AnnotationType,
@@ -40,6 +40,7 @@ import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
 import { compareAnnotationsByPosition } from '../viewer/anchoring';
 import { isUnseen } from '../newSince';
+import { isDocumentScoped } from '../annotationScope';
 import type { BuildPermalink } from '../useReviewPermalink';
 import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { AnnotationListItem } from './AnnotationListItem';
@@ -256,16 +257,19 @@ export function AnnotationPanel({
   // Sort + status-filter once per (annotations, filter) change, not on every
   // render (e.g. a hover or selection): the list can be large and the sort is
   // O(n log n) (issue #334).
-  const { placed, unplaced, hiddenByFilter } = useMemo(() => {
+  const { located, documentScoped, hiddenByFilter } = useMemo(() => {
     const matches = (annotation: AnnotationView) =>
       matchesFilters(annotation, filters, authorNameOf(annotation));
     const sorted = [...annotations].sort(compareAnnotationsByPosition);
-    const placedItems = sorted.filter((a) => a.anchor && matches(a));
-    const unplacedItems = sorted.filter((a) => !a.anchor && matches(a));
+    // Located annotations anchor to a passage; document-scoped ones (issue #395) apply to the
+    // whole document — no anchor, never orphaned — and group on their own.
+    const locatedItems = sorted.filter((a) => !isDocumentScoped(a) && matches(a));
+    const documentScopedItems = sorted.filter((a) => isDocumentScoped(a) && matches(a));
     return {
-      placed: placedItems,
-      unplaced: unplacedItems,
-      hiddenByFilter: annotations.length > 0 && placedItems.length + unplacedItems.length === 0,
+      located: locatedItems,
+      documentScoped: documentScopedItems,
+      hiddenByFilter:
+        annotations.length > 0 && locatedItems.length + documentScopedItems.length === 0,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- authorNameOf derives from the inputs below
   }, [annotations, filters, userId, displayName]);
@@ -364,26 +368,26 @@ export function AnnotationPanel({
             No annotations match this filter.
           </Typography>
         )}
-        {placed.length > 0 && (
+        {located.length > 0 && (
           <PanelSection
             title="On this version"
             subtitle="Anchored to the document"
             icon={<Link2 size={13} aria-hidden />}
-            count={placed.length}
-            newCount={placed.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
+            count={located.length}
+            newCount={located.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
           >
-            {placed.map(renderItem)}
+            {located.map(renderItem)}
           </PanelSection>
         )}
-        {unplaced.length > 0 && (
+        {documentScoped.length > 0 && (
           <PanelSection
-            title="Not placed on this version"
-            subtitle="Anchor lost — needs manual handling"
-            icon={<Unlink size={13} aria-hidden />}
-            count={unplaced.length}
-            newCount={unplaced.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
+            title="Whole document"
+            subtitle="General remarks — not pinned to a passage"
+            icon={<FileText size={13} aria-hidden />}
+            count={documentScoped.length}
+            newCount={documentScoped.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
           >
-            {unplaced.map(renderItem)}
+            {documentScoped.map(renderItem)}
           </PanelSection>
         )}
       </Stack>

--- a/qnop-ui/src/components/reviews/panel/Composer.tsx
+++ b/qnop-ui/src/components/reviews/panel/Composer.tsx
@@ -35,46 +35,59 @@ import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
 
 /**
  * The composer for a freshly drawn anchor — rendered in the panel, and in
- * focus mode inside the overlay card. The first comment is mandatory (issue
- * #301) — an annotation without text must not exist, so creating stays
- * disabled (button and submit shortcut) until the trimmed comment is
- * non-empty.
+ * focus mode inside the overlay card. Also runs anchor-free (`pendingAnchor`
+ * null) for a document-scoped remark (issue #395), where the surrounding
+ * dialog owns the heading, so it renders `frameless` and drops its own frame
+ * and passage line. The first comment is mandatory (issue #301) — an
+ * annotation without text must not exist, so creating stays disabled (button
+ * and submit shortcut) until the trimmed comment is non-empty.
  */
 export function Composer({
   pendingAnchor,
   creating,
   onCreate,
   onCancel,
+  frameless = false,
 }: {
-  pendingAnchor: Anchor;
+  /** The drawn region, or null for a document-scoped annotation (issue #395). */
+  pendingAnchor: Anchor | null;
   creating: boolean;
   onCreate: (comment: string, type?: AnnotationType, priority?: AnnotationPriority) => void;
   onCancel: () => void;
+  /** Drops the card frame and heading/passage line — for hosting inside a dialog. */
+  frameless?: boolean;
 }) {
   const theme = useTheme();
   const [comment, setComment] = useState('');
   const [type, setType] = useState<AnnotationType | ''>('');
   const [priority, setPriority] = useState<AnnotationPriority | ''>('');
   const canCreate = !creating && comment.trim().length > 0;
-  const quote = pendingAnchor.textQuote?.quote;
+  const quote = pendingAnchor?.textQuote?.quote;
   const create = () => onCreate(comment, type || undefined, priority || undefined);
   return (
-    <Paper variant="outlined" sx={{ p: 1.5 }} data-testid="annotation-composer">
+    <Paper
+      variant={frameless ? 'elevation' : 'outlined'}
+      elevation={0}
+      sx={{ p: frameless ? 0 : 1.5, bgcolor: 'transparent' }}
+      data-testid="annotation-composer"
+    >
       <Stack spacing={1}>
-        <Typography variant="subtitle2">New annotation</Typography>
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{
-            fontStyle: quote ? 'italic' : 'normal',
-            display: '-webkit-box',
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {quote ? `“${quote}”` : `Region on page ${pendingAnchor.region.surfaceIndex + 1}`}
-        </Typography>
+        {!frameless && <Typography variant="subtitle2">New annotation</Typography>}
+        {!frameless && pendingAnchor && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{
+              fontStyle: quote ? 'italic' : 'normal',
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {quote ? `“${quote}”` : `Region on page ${pendingAnchor.region.surfaceIndex + 1}`}
+          </Typography>
+        )}
         <TextField
           multiline
           minRows={5}

--- a/qnop-ui/src/components/reviews/tasks/NewTaskDialog.tsx
+++ b/qnop-ui/src/components/reviews/tasks/NewTaskDialog.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { FileText } from 'lucide-react';
+import type { AnnotationPriority, AnnotationType } from '../../../api/generated';
+import { useCreateAnnotation } from '../../../api/hooks/useAnnotations';
+import { apiErrorCode } from '../../../utils/apiError';
+import type { Notify } from '../../admin/layout/useToast';
+import { Composer } from '../panel/Composer';
+
+interface NewTaskDialogProps {
+  open: boolean;
+  documentId: string;
+  /** The latest version — the authoring context; a document-scoped task gets no placement on it. */
+  versionNumber: number;
+  notify: Notify;
+  onClose: () => void;
+}
+
+/**
+ * Creates a document-scoped annotation from the tasks view (issue #395): a
+ * general remark that needs no text selection. It reuses the panel's `Composer`
+ * (frameless) so the comment + optional type/priority read identically to a
+ * located annotation; the request simply carries no anchor, which the server
+ * takes as document-scoped.
+ */
+export function NewTaskDialog({
+  open,
+  documentId,
+  versionNumber,
+  notify,
+  onClose,
+}: NewTaskDialogProps) {
+  const createAnnotation = useCreateAnnotation(documentId);
+
+  const handleCreate = (comment: string, type?: AnnotationType, priority?: AnnotationPriority) => {
+    // No anchor → the server creates no placement: a document-scoped annotation (issue #395).
+    createAnnotation.mutate(
+      { versionNumber, comment, type, priority },
+      {
+        onSuccess: () => {
+          notify('Task created.');
+          onClose();
+        },
+        onError: (error) =>
+          notify(
+            apiErrorCode(error) === 'REVIEW_CLOSED'
+              ? 'This review is closed — no new tasks can be added.'
+              : 'Could not create the task.',
+            'error',
+          ),
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          <FileText size={18} aria-hidden />
+          New task
+        </Stack>
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          A general remark that applies to the whole document — it is not pinned to a passage and
+          stays valid on every version.
+        </Typography>
+        <Composer
+          pendingAnchor={null}
+          frameless
+          creating={createAnnotation.isPending}
+          onCreate={handleCreate}
+          onCancel={onClose}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/reviews/tasks/NewTaskDialog.tsx
+++ b/qnop-ui/src/components/reviews/tasks/NewTaskDialog.tsx
@@ -41,11 +41,12 @@ interface NewTaskDialogProps {
 }
 
 /**
- * Creates a document-scoped annotation from the tasks view (issue #395): a
- * general remark that needs no text selection. It reuses the panel's `Composer`
- * (frameless) so the comment + optional type/priority read identically to a
- * located annotation; the request simply carries no anchor, which the server
- * takes as document-scoped.
+ * Creates a document-scoped ("global") annotation (issue #395): a general
+ * remark that applies to the whole document and needs no text selection,
+ * raisable from the tasks, document and focus views. It reuses the panel's
+ * `Composer` (frameless) so the comment + optional type/priority read
+ * identically to a located annotation; the request simply carries no anchor,
+ * which the server takes as document-scoped.
  */
 export function NewTaskDialog({
   open,
@@ -62,14 +63,14 @@ export function NewTaskDialog({
       { versionNumber, comment, type, priority },
       {
         onSuccess: () => {
-          notify('Task created.');
+          notify('Annotation created.');
           onClose();
         },
         onError: (error) =>
           notify(
             apiErrorCode(error) === 'REVIEW_CLOSED'
-              ? 'This review is closed — no new tasks can be added.'
-              : 'Could not create the task.',
+              ? 'This review is closed — no new annotations can be added.'
+              : 'Could not create the annotation.',
             'error',
           ),
       },
@@ -81,7 +82,7 @@ export function NewTaskDialog({
       <DialogTitle>
         <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
           <FileText size={18} aria-hidden />
-          New task
+          New global annotation
         </Stack>
       </DialogTitle>
       <DialogContent>

--- a/qnop-ui/src/components/reviews/tasks/TaskCard.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskCard.tsx
@@ -33,6 +33,8 @@ import { ToneBadge } from '../../admin/ToneBadge';
 import { useAuthStore } from '../../../stores/authStore';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { isUnseen } from '../newSince';
+import { isDocumentScoped } from '../annotationScope';
+import { WholeDocumentChip } from '../WholeDocumentChip';
 import { tokens } from '../../../theme/tokens';
 import { STATUS_CUES } from '../panel/statusCues';
 import { PRIORITY_CUES, TYPE_CUES, taskTitle } from './tasksModel';
@@ -156,14 +158,18 @@ export function TaskCard({
           </Stack>
         )}
         <Box sx={{ flex: 1 }} />
-        {page !== null && (
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ fontVariantNumeric: 'tabular-nums' }}
-          >
-            p. {page}
-          </Typography>
+        {isDocumentScoped(annotation) ? (
+          <WholeDocumentChip compact />
+        ) : (
+          page !== null && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ fontVariantNumeric: 'tabular-nums' }}
+            >
+              p. {page}
+            </Typography>
+          )
         )}
       </Stack>
 

--- a/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
@@ -33,6 +33,8 @@ import { useAuthStore } from '../../../stores/authStore';
 import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
 import { ToneBadge } from '../../admin/ToneBadge';
+import { isDocumentScoped } from '../annotationScope';
+import { WholeDocumentChip } from '../WholeDocumentChip';
 import type { BuildPermalink } from '../useReviewPermalink';
 import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { CommentThread } from '../panel/CommentThread';
@@ -167,6 +169,7 @@ export function TaskDrawer({
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mt: 1, flexWrap: 'wrap' }}>
             <ToneBadge tone={statusCue.tone} label={statusCue.label} />
             <PlacementStatusChip status={annotation.placementStatus} />
+            {isDocumentScoped(annotation) && <WholeDocumentChip />}
             {page !== null && (
               <Typography variant="caption" color="text.secondary">
                 p. {page}

--- a/qnop-ui/src/components/reviews/tasks/TaskListRows.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskListRows.tsx
@@ -32,6 +32,7 @@ import { AnnotationStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { tokens } from '../../../theme/tokens';
+import { isDocumentScoped } from '../annotationScope';
 import { STATUS_CUES } from '../panel/statusCues';
 import { PRIORITY_CUES, TYPE_CUES, columnOf, taskTitle } from './tasksModel';
 
@@ -123,9 +124,11 @@ export function TaskListRows({ annotations, taskKeyOf, authorNameOf, onOpen }: T
                 {taskTitle(annotation)}
               </Typography>
               <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
-                {annotation.anchor?.textQuote?.quote
-                  ? `“${annotation.anchor.textQuote.quote}”`
-                  : 'No text anchor'}
+                {isDocumentScoped(annotation)
+                  ? 'Whole document'
+                  : annotation.anchor?.textQuote?.quote
+                    ? `“${annotation.anchor.textQuote.quote}”`
+                    : 'No text anchor'}
                 {page !== null && ` · p. ${page}`}
                 {` · ${authorNameOf(annotation.authorId)}`}
               </Typography>

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -256,6 +256,15 @@ describe('DocumentReviewPage', () => {
     expect(screen.getByText('Moved')).toBeInTheDocument();
   });
 
+  // Issue #395: a whole-document task can be raised from the panel too, not only the tasks view.
+  it('opens the New task dialog from the annotations panel', () => {
+    seedHappyPath();
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New task' }));
+    expect(screen.getByText(/applies to the whole document/i)).toBeInTheDocument();
+  });
+
   it('announces a still-processing version and keeps annotating disabled', () => {
     seedHappyPath(ExtractionStatus.Pending);
     renderPage();

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -256,12 +256,13 @@ describe('DocumentReviewPage', () => {
     expect(screen.getByText('Moved')).toBeInTheDocument();
   });
 
-  // Issue #395: a whole-document task can be raised from the panel too, not only the tasks view.
-  it('opens the New task dialog from the annotations panel', () => {
+  // Issue #395: a whole-document ("global") annotation can be raised from the panel too, not only
+  // the tasks view.
+  it('opens the global annotation dialog from the annotations panel', () => {
     seedHappyPath();
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'New task' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Global annotation' }));
     expect(screen.getByText(/applies to the whole document/i)).toBeInTheDocument();
   });
 

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -71,6 +71,7 @@ import { useAnchorElement } from '../../components/reviews/focus/useAnchorElemen
 import { useRecordVisit } from '../../api/hooks/useReviews';
 import { useViewMode } from '../../components/reviews/focus/useViewMode';
 import { columnOf } from '../../components/reviews/tasks/tasksModel';
+import { NewTaskDialog } from '../../components/reviews/tasks/NewTaskDialog';
 import { Composer } from '../../components/reviews/panel/Composer';
 import { WorkflowBadge } from '../../components/reviews/WorkflowBadge';
 import { AnonymousBadge } from '../../components/reviews/AnonymousBadge';
@@ -156,6 +157,9 @@ export function DocumentReviewPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlView]);
   const [listOpen, setListOpen] = useState(false);
+  // The "new whole-document task" dialog (issue #395), reachable from the panel in both the
+  // document and focus views — the same anchor-free create the tasks view offers.
+  const [newNoteOpen, setNewNoteOpen] = useState(false);
   // Deep link (issues #393/#412): ?annotation= seeds the active annotation and
   // ?comment= seeds a comment scroll target once; both params are consumed so
   // in-page selection owns the state afterwards. The original ?annotation= is
@@ -555,6 +559,7 @@ export function DocumentReviewPage() {
                   buildPermalink={buildPermalink}
                   scrollToCommentId={scrollToCommentId}
                   onScrolledToComment={clearScrollToComment}
+                  onNewDocumentNote={() => setNewNoteOpen(true)}
                 />
               </ErrorBoundary>
             </Box>
@@ -591,6 +596,7 @@ export function DocumentReviewPage() {
               buildPermalink={buildPermalink}
               scrollToCommentId={scrollToCommentId}
               onScrolledToComment={clearScrollToComment}
+              onNewDocumentNote={() => setNewNoteOpen(true)}
             />
           </ErrorBoundary>
         </FocusDrawer>
@@ -663,6 +669,13 @@ export function DocumentReviewPage() {
           <ListItemText>Create annotation</ListItemText>
         </MenuItem>
       </Menu>
+      <NewTaskDialog
+        open={newNoteOpen}
+        documentId={documentId}
+        versionNumber={knownLatest}
+        notify={notify}
+        onClose={() => setNewNoteOpen(false)}
+      />
       <AdminToast toast={toast} onClose={clear} />
     </Stack>
   );

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -51,6 +51,7 @@ import { ReviewHubHead } from '../../components/reviews/hub/ReviewHubHead';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
 import { useReviewPermalink } from '../../components/reviews/useReviewPermalink';
+import { isDocumentScoped } from '../../components/reviews/annotationScope';
 import { AnnotationPanel } from '../../components/reviews/panel/AnnotationPanel';
 import {
   DEFAULT_PANEL_FRACTION,
@@ -318,9 +319,11 @@ export function DocumentReviewPage() {
   const handleFocusSelect = useCallback(
     (id: string | null) => {
       setActiveAnnotationId(id);
-      // A placed annotation continues in the spotlight; unplaced ones keep their
-      // thread inside the drawer (no mark to spotlight).
-      if (id && annotations.find((a) => a.id === id)?.anchor) setListOpen(false);
+      if (!id) return;
+      const selected = annotations.find((a) => a.id === id);
+      // A located annotation closes the drawer to reveal its floating card; a document-scoped one
+      // (issue #395) has no mark to float by, so it stays in the drawer where its thread expands.
+      if (selected) setListOpen(isDocumentScoped(selected));
     },
     [annotations],
   );

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -242,12 +242,12 @@ describe('ReviewTasksPage', () => {
     expect(screen.queryByTestId('task-board')).not.toBeInTheDocument();
   });
 
-  // Issue #395: document-scoped tasks.
-  it('creates a document-scoped task from the New task dialog, with no anchor', () => {
+  // Issue #395: document-scoped ("global") annotations.
+  it('creates a document-scoped annotation from the dialog, with no anchor', () => {
     mockData();
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'New task' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Global annotation' }));
     const dialog = screen.getByRole('dialog');
     fireEvent.change(within(dialog).getByLabelText('Annotation comment'), {
       target: { value: 'Unify terminology across the contract' },
@@ -264,7 +264,7 @@ describe('ReviewTasksPage', () => {
     expect(payload.anchor).toBeUndefined();
   });
 
-  it('hides New task on a closed review', () => {
+  it('hides the Global annotation action on a closed review', () => {
     mockData();
     vi.mocked(useDocument).mockReturnValue({
       isPending: false,
@@ -279,7 +279,7 @@ describe('ReviewTasksPage', () => {
     } as never);
     renderPage();
 
-    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Global annotation' })).not.toBeInTheDocument();
   });
 
   it('marks a document-scoped task with the whole-document chip', () => {

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -41,8 +41,10 @@ vi.mock('../../api/hooks/useDocuments', () => ({
   useDocument: vi.fn(),
   useDocumentVersions: vi.fn(),
 }));
+const { createMutate } = vi.hoisted(() => ({ createMutate: vi.fn() }));
 vi.mock('../../api/hooks/useAnnotations', () => ({
   useAnnotations: vi.fn(),
+  useCreateAnnotation: vi.fn().mockReturnValue({ mutate: createMutate, isPending: false }),
   useResolveAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useReopenAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
 }));
@@ -238,5 +240,58 @@ describe('ReviewTasksPage', () => {
     renderPage();
     expect(screen.getByTestId('task-row-a-open')).toBeInTheDocument();
     expect(screen.queryByTestId('task-board')).not.toBeInTheDocument();
+  });
+
+  // Issue #395: document-scoped tasks.
+  it('creates a document-scoped task from the New task dialog, with no anchor', () => {
+    mockData();
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New task' }));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.change(within(dialog).getByLabelText('Annotation comment'), {
+      target: { value: 'Unify terminology across the contract' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: /Create annotation/ }));
+
+    expect(createMutate).toHaveBeenCalledTimes(1);
+    const [payload] = createMutate.mock.calls[0];
+    expect(payload).toMatchObject({
+      versionNumber: 2,
+      comment: 'Unify terminology across the contract',
+    });
+    // No anchor is sent → the server takes it as document-scoped.
+    expect(payload.anchor).toBeUndefined();
+  });
+
+  it('hides New task on a closed review', () => {
+    mockData();
+    vi.mocked(useDocument).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        id: 'd1',
+        title: 'Supply Contract',
+        ownerId: 'owner-1',
+        latestVersionNumber: 2,
+        workflowState: 'FINALIZED',
+      },
+    } as never);
+    renderPage();
+
+    expect(screen.queryByRole('button', { name: 'New task' })).not.toBeInTheDocument();
+  });
+
+  it('marks a document-scoped task with the whole-document chip', () => {
+    mockData();
+    vi.mocked(useAnnotations).mockReturnValue({
+      isPending: false,
+      data: {
+        annotations: [annotation('a-doc', { anchor: undefined, placementStatus: undefined })],
+      },
+    } as never);
+    renderPage();
+
+    expect(screen.getByTestId('whole-document-chip')).toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -22,13 +22,14 @@
 import { useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import { LayoutGrid, List as ListIcon } from 'lucide-react';
+import { LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
 import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useRecordVisit } from '../../api/hooks/useReviews';
@@ -46,6 +47,7 @@ import {
   mayResolveAnnotation,
   useResolveWithFeedback,
 } from '../../components/reviews/panel/resolve';
+import { NewTaskDialog } from '../../components/reviews/tasks/NewTaskDialog';
 import { TaskBoard } from '../../components/reviews/tasks/TaskBoard';
 import { TaskDrawer } from '../../components/reviews/tasks/TaskDrawer';
 import { TaskListRows } from '../../components/reviews/tasks/TaskListRows';
@@ -120,6 +122,7 @@ export function ReviewTasksPage() {
     query: searchParams.get('q') ?? '',
   };
   const [openTaskId, setOpenTaskId] = useState<string | null>(null);
+  const [newTaskOpen, setNewTaskOpen] = useState(false);
 
   const { resolveWith } = useResolveWithFeedback(notify);
 
@@ -215,6 +218,20 @@ export function ReviewTasksPage() {
       <PageHeader
         title={document.title}
         titleAdornment={<Chip size="small" variant="outlined" label="Tasks" />}
+        action={
+          // A document-scoped task (issue #395) needs no selection — offered while the review is
+          // open and has a version to author against; the server refuses a closed review anyway.
+          isOpenWorkflowState(document.workflowState) && latestVersion >= 1 ? (
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<Plus size={16} />}
+              onClick={() => setNewTaskOpen(true)}
+            >
+              New task
+            </Button>
+          ) : undefined
+        }
       />
       <ReviewViewTabs
         documentId={routeSegment}
@@ -303,6 +320,13 @@ export function ReviewTasksPage() {
         onClose={() => setOpenTaskId(null)}
         onShowInDocument={showInDocument}
         buildPermalink={buildPermalink}
+      />
+      <NewTaskDialog
+        open={newTaskOpen}
+        documentId={documentId}
+        versionNumber={latestVersion}
+        notify={notify}
+        onClose={() => setNewTaskOpen(false)}
       />
       <AdminToast toast={toast} onClose={clear} />
     </Stack>

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -228,7 +228,7 @@ export function ReviewTasksPage() {
               startIcon={<Plus size={16} />}
               onClick={() => setNewTaskOpen(true)}
             >
-              New task
+              Global annotation
             </Button>
           ) : undefined
         }


### PR DESCRIPTION
## Summary

Lets a reviewer raise an annotation with **no anchor** — a general remark that pins to no passage. It is document-scoped: valid on every version, never placed, never orphaned (ADR-0009 amendment, part of the #393 tasks integration).

Closes #395.

### The key design call — no new field
The anchor lives on a per-version `AnnotationPlacement`, not on the `Annotation`. A document-scoped annotation is simply **an annotation with no placement row at all**, distinct from an *orphaned* one (which keeps its anchor, status `ORPHANED`). So in the view a **null anchor uniquely means document-scoped** — no discriminator field needed. List, the FINALIZED gate and version-upload seeding already handle the placement-less case correctly.

### Backend (surgical)
- `AnnotationCreateRequest.anchor` is no longer `required` in the OpenAPI contract; a present anchor is still `@Valid`-validated, so malformed anchors are still rejected.
- The controller passes a Java `null` (not the JSON literal `"null"`) when the anchor is absent; the service then creates **no placement**.
- Unchanged and confirmed by ITs: a document-scoped OPEN annotation blocks FINALIZED, contributes no pending placement, and appears on every version's list.

### Frontend
- A **"Global annotation"** create affordance (dialog reusing the panel `Composer`, anchor-free) — offered from the **tasks, document and focus views** while the latest version is open for review. The document/focus views share the same `AnnotationPanel` (side panel + focus drawer), so one quiet header button covers both.
- A shared **"Whole document"** chip marks these on the board card, list row, task drawer and panel head (taking the page-reference slot). The panel groups them under a **"Whole document"** section that leads, ahead of the located **"Anchored to the document"** group (renamed from "On this version"). The viewer paints no marker.
- In focus mode a document-scoped annotation has no mark to float a card by, so selecting it keeps the list drawer open where its thread expands.
- `isDocumentScoped` centralises the null-anchor signal.

### Not in scope
Converting a document-scoped annotation into a located one (re-anchor UI is #326).

## Test plan
- [x] ITs: create-without-anchor (anchor/placementStatus absent); appears on every version, never PENDING/ORPHANED; malformed anchor still 400; the FINALIZED gate blocks a document-scoped OPEN annotation and finalizes after resolve **without any placement**.
- [x] FE: the dialog posts no anchor; the "Global annotation" affordance shows/hides by writability and appears in tasks/document/focus; the whole-document chip and panel group; the `isDocumentScoped` discriminator.
- [x] `./gradlew spotlessCheck` + ArchUnit, `tsc`, `eslint`, full `vitest` (527) green.
- [x] Manual browser check against the running backend: creating a global annotation from all three views succeeds (no anchor), shows the "Whole document" chip on card/drawer/panel, groups whole-document first, and the located group reads "Anchored to the document".

🤖 Co-Author: Claude (Opus 4.8, 1M context) via Claude Code