### PR TITLE
test(core): service-layer authorization & logic suites (#349)

### DIFF
--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentAccessServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentAccessServiceTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.api.v1.model.RenderedDocumentResponse;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.service.storage.StorageService;
+import io.qnop.spi.storage.StorageContent;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link DocumentAccessService} (issue #349): the read-side authorization contract.
+ * A document is visible to its owner, any participant (direct or via team — resolved in one repo
+ * query, so indistinguishable here and left to {@code DocumentServingAuthzIT}) and a global admin;
+ * everyone else gets a 404, never a 403. The rendered/original readers enforce the same visibility.
+ */
+@ExtendWith(MockitoExtension.class)
+class DocumentAccessServiceTest {
+
+  @Mock private DocumentRepository documents;
+  @Mock private DocumentVersionRepository versions;
+  @Mock private ReviewParticipantRepository participants;
+  @Mock private StorageService storage;
+
+  private DocumentAccessService service;
+
+  private static final UUID DOC = UUID.randomUUID();
+  private static final UUID OWNER = UUID.randomUUID();
+  private static final UUID PARTICIPANT = UUID.randomUUID();
+  private static final UUID STRANGER = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    service = new DocumentAccessService(documents, versions, participants, storage);
+  }
+
+  private Document ownedDocument() {
+    return new Document(OWNER, "Contract");
+  }
+
+  private DocumentVersion version(int number) {
+    return new DocumentVersion(
+        DOC, number, "storage/key-" + number, "hash-" + number, "application/pdf", 42L, OWNER);
+  }
+
+  // --- getDocument visibility ------------------------------------------------
+
+  @Test
+  @DisplayName("the owner sees the document, with the latest version number resolved")
+  void ownerSeesDocument() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findTopByDocumentIdOrderByVersionNumberDesc(DOC))
+        .thenReturn(Optional.of(version(3)));
+
+    DocumentAccessService.DocumentView view = service.getDocument(DOC, OWNER, false);
+
+    assertThat(view.ownerId()).isEqualTo(OWNER);
+    assertThat(view.workflowState()).isEqualTo("DRAFT");
+    assertThat(view.latestVersionNumber()).isEqualTo(3);
+    // The owner short-circuits authorization — the participant query is never run.
+    verify(participants, never()).existsAccessibleParticipant(any(), any());
+  }
+
+  @Test
+  @DisplayName("a global admin sees any document without a participant lookup")
+  void adminSeesDocument() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findTopByDocumentIdOrderByVersionNumberDesc(DOC)).thenReturn(Optional.empty());
+
+    DocumentAccessService.DocumentView view = service.getDocument(DOC, STRANGER, true);
+
+    assertThat(view.latestVersionNumber()).isZero();
+    verify(participants, never()).existsAccessibleParticipant(any(), any());
+  }
+
+  @Test
+  @DisplayName("a review participant sees the document")
+  void participantSeesDocument() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(participants.existsAccessibleParticipant(any(), eq(PARTICIPANT))).thenReturn(true);
+    when(versions.findTopByDocumentIdOrderByVersionNumberDesc(DOC)).thenReturn(Optional.empty());
+
+    assertThat(service.getDocument(DOC, PARTICIPANT, false).ownerId()).isEqualTo(OWNER);
+  }
+
+  @Test
+  @DisplayName("a non-participant gets 404, not 403 (ids stay non-enumerable)")
+  void nonParticipantGets404() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    // existsAccessibleParticipant defaults to false → not accessible.
+
+    assertThatThrownBy(() -> service.getDocument(DOC, STRANGER, false))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(404));
+  }
+
+  @Test
+  @DisplayName("an unknown document is 404")
+  void unknownDocumentGets404() {
+    when(documents.findById(DOC)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getDocument(DOC, OWNER, false))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(404));
+  }
+
+  @Test
+  @DisplayName("isVisible returns a boolean rather than throwing")
+  void isVisibleReturnsBoolean() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+
+    assertThat(service.isVisible(DOC, OWNER, false)).isTrue();
+    assertThat(service.isVisible(DOC, STRANGER, false)).isFalse();
+  }
+
+  @Test
+  @DisplayName("an unknown or invisible slug is 404")
+  void unknownSlugGets404() {
+    when(documents.findBySlugIgnoreCase("mystery")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getDocumentBySlug("mystery", OWNER, false))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(404));
+  }
+
+  // --- listVersions ----------------------------------------------------------
+
+  @Test
+  @DisplayName("listVersions maps a visible document's versions")
+  void listsVersionsForVisibleDocument() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findByDocumentIdOrderByVersionNumberAsc(DOC)).thenReturn(List.of(version(1)));
+
+    List<DocumentAccessService.DocumentVersionView> list = service.listVersions(DOC, OWNER, false);
+
+    assertThat(list).hasSize(1);
+    assertThat(list.get(0).versionNumber()).isEqualTo(1);
+    assertThat(list.get(0).extractionStatus()).isEqualTo("PENDING");
+  }
+
+  @Test
+  @DisplayName("listVersions enforces visibility (non-participant → 404)")
+  void listVersionsEnforcesVisibility() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+
+    assertThatThrownBy(() -> service.listVersions(DOC, STRANGER, false))
+        .isInstanceOf(DocumentValidationException.class);
+    verify(versions, never()).findByDocumentIdOrderByVersionNumberAsc(any());
+  }
+
+  // --- getRendered -----------------------------------------------------------
+
+  @Test
+  @DisplayName("getRendered parses a READY version's stored representation")
+  void rendersReadyVersion() {
+    DocumentVersion ready = version(1);
+    ready.attachRenderedDocument("{\"surfaces\":[]}");
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findByDocumentIdAndVersionNumber(DOC, 1)).thenReturn(Optional.of(ready));
+
+    RenderedDocumentResponse response = service.getRendered(DOC, 1, OWNER, false);
+
+    assertThat(response).isNotNull();
+    assertThat(response.getSurfaces()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("getRendered is 409 EXTRACTION_FAILED for a failed version")
+  void renderedFailedIs409() {
+    DocumentVersion failed = version(1);
+    failed.markExtractionFailed();
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findByDocumentIdAndVersionNumber(DOC, 1)).thenReturn(Optional.of(failed));
+
+    assertThatThrownBy(() -> service.getRendered(DOC, 1, OWNER, false))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class,
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(409);
+              assertThat(e.getCode()).isEqualTo("EXTRACTION_FAILED");
+            });
+  }
+
+  @Test
+  @DisplayName("getRendered is 409 EXTRACTION_PENDING while extraction has not completed")
+  void renderedPendingIs409() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findByDocumentIdAndVersionNumber(DOC, 1)).thenReturn(Optional.of(version(1)));
+
+    assertThatThrownBy(() -> service.getRendered(DOC, 1, OWNER, false))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class,
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(409);
+              assertThat(e.getCode()).isEqualTo("EXTRACTION_PENDING");
+            });
+  }
+
+  @Test
+  @DisplayName("getRendered fails loudly when the stored JSON does not match the contract")
+  void renderedCorruptJsonThrows() {
+    DocumentVersion ready = version(1);
+    ready.attachRenderedDocument("not-json");
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findByDocumentIdAndVersionNumber(DOC, 1)).thenReturn(Optional.of(ready));
+
+    assertThatThrownBy(() -> service.getRendered(DOC, 1, OWNER, false))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("getRendered enforces visibility before touching the version")
+  void renderedEnforcesVisibility() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+
+    assertThatThrownBy(() -> service.getRendered(DOC, 1, STRANGER, false))
+        .isInstanceOf(DocumentValidationException.class);
+    verify(versions, never()).findByDocumentIdAndVersionNumber(any(), eq(1));
+  }
+
+  // --- getOriginal -----------------------------------------------------------
+
+  @Test
+  @DisplayName("getOriginal streams the stored object with serving metadata")
+  void originalStreamsStoredObject() {
+    DocumentVersion ver = version(1);
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findByDocumentIdAndVersionNumber(DOC, 1)).thenReturn(Optional.of(ver));
+    when(storage.get("storage/key-1"))
+        .thenReturn(
+            Optional.of(
+                new StorageContent(
+                    new ByteArrayInputStream(new byte[] {1, 2, 3}), 3L, "application/pdf")));
+
+    try (DocumentAccessService.OriginalDownload download =
+        service.getOriginal(DOC, 1, OWNER, false)) {
+      assertThat(download.title()).isEqualTo("Contract");
+      assertThat(download.versionNumber()).isEqualTo(1);
+      assertThat(download.contentLength()).isEqualTo(3L);
+      assertThat(download.contentType()).isEqualTo("application/pdf");
+    }
+  }
+
+  @Test
+  @DisplayName("getOriginal fails loudly when the stored object is missing")
+  void originalMissingObjectThrows() {
+    DocumentVersion ver = version(1);
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+    when(versions.findByDocumentIdAndVersionNumber(DOC, 1)).thenReturn(Optional.of(ver));
+    when(storage.get("storage/key-1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getOriginal(DOC, 1, OWNER, false))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("getOriginal enforces visibility before touching storage")
+  void originalEnforcesVisibility() {
+    when(documents.findById(DOC)).thenReturn(Optional.of(ownedDocument()));
+
+    assertThatThrownBy(() -> service.getOriginal(DOC, 1, STRANGER, false))
+        .isInstanceOf(DocumentValidationException.class);
+    verify(storage, never()).get(any());
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentIngestServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentIngestServiceTest.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.job.JobService;
+import io.qnop.service.storage.StagedObject;
+import io.qnop.service.storage.StorageQuotaExceededException;
+import io.qnop.service.storage.StorageService;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Unit tests for {@link DocumentIngestService} (issue #349): the upload validation, staging, and
+ * outbox-enqueue contract exercised entirely against mocked collaborators.
+ *
+ * <p>The service is deliberately not {@code @Transactional} at the method level — only the domain
+ * writes run inside a {@link org.springframework.transaction.support.TransactionTemplate}. Here the
+ * {@link PlatformTransactionManager} is a bare mock: {@code getTransaction} returns {@code null}
+ * and {@code commit}/{@code rollback} are no-ops, so the template simply runs the callback and
+ * propagates whatever it throws — which is exactly what the rollback-mapping tests below rely on.
+ */
+@ExtendWith(MockitoExtension.class)
+class DocumentIngestServiceTest {
+
+  @Mock private DocumentRepository documents;
+  @Mock private DocumentVersionRepository versions;
+  @Mock private StorageService storage;
+  @Mock private JobService jobs;
+  @Mock private ApplicationSettingsService settings;
+  @Mock private DocumentAccessService access;
+  @Mock private AnnotationRepository annotations;
+  @Mock private AnnotationPlacementRepository placements;
+  @Mock private PlatformTransactionManager transactionManager;
+
+  private DocumentIngestService service;
+
+  private static final UUID DOC = UUID.randomUUID();
+  private static final UUID OWNER = UUID.randomUUID();
+  private static final UUID STRANGER = UUID.randomUUID();
+  private static final String PDF_CONTENT_TYPE = "application/pdf";
+  private static final byte[] PDF_BYTES = "%PDF-1.7\n%âã".getBytes(StandardCharsets.UTF_8);
+
+  private DocumentIngestService newService() {
+    return new DocumentIngestService(
+        documents,
+        versions,
+        storage,
+        jobs,
+        settings,
+        access,
+        annotations,
+        placements,
+        transactionManager);
+  }
+
+  // --- request validation (rejected before any storage or settings work) -----
+
+  @Nested
+  @DisplayName("createDocument request validation")
+  class CreateValidation {
+
+    @Test
+    @DisplayName("a blank title is rejected with 400 before any upload work")
+    void blankTitleRejected() {
+      service = newService();
+
+      assertRejected(
+          () -> service.createDocument(OWNER, "   ", pdfUpload(), null, null, false, null), 400);
+      verify(settings, never()).getInteger(any());
+      verify(storage, never()).stage(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("a null title is rejected with 400")
+    void nullTitleRejected() {
+      service = newService();
+
+      assertRejected(
+          () -> service.createDocument(OWNER, null, pdfUpload(), null, null, false, null), 400);
+    }
+
+    @Test
+    @DisplayName("a title over 500 characters is rejected with 400")
+    void overlongTitleRejected() {
+      service = newService();
+      String tooLong = "x".repeat(501);
+
+      assertRejected(
+          () -> service.createDocument(OWNER, tooLong, pdfUpload(), null, null, false, null), 400);
+    }
+
+    @Test
+    @DisplayName("a dueAt in the past is rejected with 400")
+    void pastDueAtRejected() {
+      service = newService();
+      Instant past = Instant.now().minusSeconds(3600);
+
+      assertRejected(
+          () -> service.createDocument(OWNER, "Contract", pdfUpload(), past, null, false, null),
+          400);
+      verify(storage, never()).stage(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("a malformed slug is rejected as a field error (400)")
+    void malformedSlugRejected() {
+      service = newService();
+
+      assertRejected(
+          () -> service.createDocument(OWNER, "Contract", pdfUpload(), null, "ab", false, null),
+          400);
+      verify(documents, never()).existsBySlugIgnoreCase(any());
+    }
+
+    @Test
+    @DisplayName("a UUID-shaped slug is rejected (it would be unreachable as a route)")
+    void uuidShapedSlugRejected() {
+      service = newService();
+
+      assertRejected(
+          () ->
+              service.createDocument(
+                  OWNER, "Contract", pdfUpload(), null, DOC.toString(), false, null),
+          400);
+    }
+
+    @Test
+    @DisplayName("an already-taken slug is 409 SLUG_TAKEN before staging")
+    void takenSlugRejected() {
+      service = newService();
+      when(documents.existsBySlugIgnoreCase("my-slug")).thenReturn(true);
+
+      assertThatThrownBy(
+              () ->
+                  service.createDocument(
+                      OWNER, "Contract", pdfUpload(), null, "my-slug", false, null))
+          .isInstanceOfSatisfying(
+              DocumentValidationException.class,
+              e -> {
+                assertThat(e.getStatus()).isEqualTo(409);
+                assertThat(e.getCode()).isEqualTo("SLUG_TAKEN");
+              });
+      verify(storage, never()).stage(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("an unknown thread-participation policy is a field error (400)")
+    void unknownThreadPolicyRejected() {
+      service = newService();
+
+      assertRejected(
+          () -> service.createDocument(OWNER, "Contract", pdfUpload(), null, null, false, "LOUD"),
+          400);
+    }
+  }
+
+  // --- upload sniffing & size cap --------------------------------------------
+
+  @Nested
+  @DisplayName("createDocument upload checks")
+  class UploadChecks {
+
+    @Test
+    @DisplayName("a declared size over the operator limit is 413 before the stream is opened")
+    void declaredSizeOverLimitRejected() {
+      service = newService();
+      when(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).thenReturn(1);
+      UploadSource huge = upload(PDF_BYTES, 2L * 1024 * 1024);
+
+      assertRejected(
+          () -> service.createDocument(OWNER, "Contract", huge, null, null, false, null), 413);
+      verify(storage, never()).stage(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("content without the %PDF- magic bytes is 415, never staged")
+    void nonPdfMagicRejected() {
+      service = newService();
+      when(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).thenReturn(10);
+      UploadSource notPdf = upload("<html> not a pdf".getBytes(StandardCharsets.UTF_8), 16);
+
+      assertRejected(
+          () -> service.createDocument(OWNER, "Contract", notPdf, null, null, false, null), 415);
+      verify(storage, never()).stage(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("an empty upload is 400")
+    void emptyUploadRejected() {
+      service = newService();
+      when(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).thenReturn(10);
+
+      assertRejected(
+          () ->
+              service.createDocument(
+                  OWNER, "Contract", upload(new byte[0], 0), null, null, false, null),
+          400);
+    }
+
+    @Test
+    @DisplayName("an unreadable upload stream is 400")
+    void unreadableUploadRejected() {
+      service = newService();
+      when(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).thenReturn(10);
+      UploadSource broken =
+          new UploadSource() {
+            @Override
+            public InputStream open() throws IOException {
+              throw new IOException("disk gone");
+            }
+
+            @Override
+            public long declaredSize() {
+              return 8;
+            }
+          };
+
+      assertRejected(
+          () -> service.createDocument(OWNER, "Contract", broken, null, null, false, null), 400);
+    }
+  }
+
+  // --- happy path + staging outcome ------------------------------------------
+
+  @Test
+  @DisplayName("a valid upload stages, saves version 1, enqueues extraction, then commits storage")
+  void createDocumentHappyPath() {
+    service = newService();
+    when(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).thenReturn(10);
+    StagedObject staged = new StagedObject("sha256/ab/" + "c".repeat(64), "hash", 123L);
+    when(storage.stage(any(), eq(PDF_CONTENT_TYPE), anyLong())).thenReturn(staged);
+    when(documents.save(any(Document.class)))
+        .thenAnswer(
+            inv -> {
+              Document saved = inv.getArgument(0);
+              setId(saved, DOC);
+              return saved;
+            });
+    when(versions.save(any(DocumentVersion.class)))
+        .thenAnswer(
+            inv -> {
+              DocumentVersion saved = inv.getArgument(0);
+              setId(saved, UUID.randomUUID());
+              return saved;
+            });
+    Instant dueAt = Instant.now().plusSeconds(86_400);
+
+    DocumentIngestService.UploadResult result =
+        service.createDocument(OWNER, "Contract", pdfUpload(), dueAt, null, false, "OPEN");
+
+    assertThat(result.documentId()).isEqualTo(DOC);
+    assertThat(result.versionNumber()).isEqualTo(1);
+    assertThat(result.extractionStatus()).isEqualTo("PENDING");
+    // Outbox: the extraction job commits with the version row.
+    verify(jobs).enqueue(eq(DocumentIngestService.EXTRACTION_JOB_TYPE), any());
+    // Storage is committed only after the domain transaction succeeds.
+    verify(storage).commit(staged.key());
+  }
+
+  @Test
+  @DisplayName("a storage quota failure maps to 413 and never commits or enqueues")
+  void createDocumentStageQuotaExceeded() {
+    service = newService();
+    when(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).thenReturn(10);
+    when(storage.stage(any(), eq(PDF_CONTENT_TYPE), anyLong()))
+        .thenThrow(new StorageQuotaExceededException(5L * 1024 * 1024));
+
+    assertRejected(
+        () -> service.createDocument(OWNER, "Contract", pdfUpload(), null, null, false, null), 413);
+    verify(documents, never()).save(any());
+    verify(jobs, never()).enqueue(any(), any());
+    verify(storage, never()).commit(any());
+  }
+
+  @Test
+  @DisplayName("a slug race lost to the unique index maps the constraint hit to 409 SLUG_TAKEN")
+  void createDocumentSlugRaceMappedTo409() {
+    service = newService();
+    when(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).thenReturn(10);
+    when(documents.existsBySlugIgnoreCase("my-slug")).thenReturn(false);
+    when(storage.stage(any(), eq(PDF_CONTENT_TYPE), anyLong()))
+        .thenReturn(new StagedObject("sha256/ab/" + "c".repeat(64), "hash", 10L));
+    when(documents.save(any(Document.class)))
+        .thenThrow(new DataIntegrityViolationException("uq_document_slug"));
+
+    assertThatThrownBy(
+            () ->
+                service.createDocument(
+                    OWNER, "Contract", pdfUpload(), null, "my-slug", false, null))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class,
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(409);
+              assertThat(e.getCode()).isEqualTo("SLUG_TAKEN");
+            });
+    verify(storage, never()).commit(any());
+  }
+
+  // --- addVersion authorization + versioning ---------------------------------
+
+  @Nested
+  @DisplayName("addVersion")
+  class AddVersion {
+
+    @Test
+    @DisplayName("the owner appends the next version, enqueues extraction, and commits")
+    void ownerAppendsNextVersion() {
+      service = newService();
+      when(documents.findById(DOC)).thenReturn(Optional.of(new Document(OWNER, "Contract")));
+      when(settings.getInteger(ApplicationSettingKey.UPLOAD_MAX_FILE_SIZE_MB)).thenReturn(10);
+      StagedObject staged = new StagedObject("sha256/ab/" + "c".repeat(64), "hash", 55L);
+      when(storage.stage(any(), eq(PDF_CONTENT_TYPE), anyLong())).thenReturn(staged);
+      when(versions.findTopByDocumentIdOrderByVersionNumberDesc(DOC))
+          .thenReturn(Optional.of(version(2)));
+      when(versions.save(any(DocumentVersion.class)))
+          .thenAnswer(
+              inv -> {
+                DocumentVersion saved = inv.getArgument(0);
+                setId(saved, UUID.randomUUID());
+                return saved;
+              });
+      when(annotations.findByDocumentId(DOC)).thenReturn(List.of());
+
+      DocumentIngestService.UploadResult result = service.addVersion(OWNER, DOC, pdfUpload());
+
+      assertThat(result.versionNumber()).isEqualTo(3);
+      assertThat(result.extractionStatus()).isEqualTo("PENDING");
+      verify(jobs).enqueue(eq(DocumentIngestService.EXTRACTION_JOB_TYPE), any());
+      verify(storage).commit(staged.key());
+    }
+
+    @Test
+    @DisplayName("an unknown document is 404")
+    void unknownDocumentIs404() {
+      service = newService();
+      when(documents.findById(DOC)).thenReturn(Optional.empty());
+
+      assertRejected(() -> service.addVersion(OWNER, DOC, pdfUpload()), 404);
+    }
+
+    @Test
+    @DisplayName("a visible non-owner is told the action is owner-only (403)")
+    void visibleNonOwnerIs403() {
+      service = newService();
+      when(documents.findById(DOC)).thenReturn(Optional.of(new Document(OWNER, "Contract")));
+      when(access.isVisible(DOC, STRANGER, false)).thenReturn(true);
+
+      assertRejected(() -> service.addVersion(STRANGER, DOC, pdfUpload()), 403);
+      verify(storage, never()).stage(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("an invisible non-owner gets the same 404 as an unknown id")
+    void invisibleNonOwnerIs404() {
+      service = newService();
+      when(documents.findById(DOC)).thenReturn(Optional.of(new Document(OWNER, "Contract")));
+      when(access.isVisible(DOC, STRANGER, false)).thenReturn(false);
+
+      assertRejected(() -> service.addVersion(STRANGER, DOC, pdfUpload()), 404);
+    }
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private static void assertRejected(
+      org.assertj.core.api.ThrowableAssert.ThrowingCallable call, int status) {
+    assertThatThrownBy(call)
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(status));
+  }
+
+  private static DocumentVersion version(int number) {
+    return new DocumentVersion(
+        DOC, number, "sha256/ab/key-" + number, "hash-" + number, PDF_CONTENT_TYPE, 42L, OWNER);
+  }
+
+  private static UploadSource pdfUpload() {
+    return upload(PDF_BYTES, PDF_BYTES.length);
+  }
+
+  private static UploadSource upload(byte[] content, long declaredSize) {
+    return new UploadSource() {
+      @Override
+      public InputStream open() {
+        return new ByteArrayInputStream(content);
+      }
+
+      @Override
+      public long declaredSize() {
+        return declaredSize;
+      }
+    };
+  }
+
+  /** Sets the Hibernate-generated primary key that only exists after a real persist. */
+  private static void setId(Object entity, UUID id) {
+    try {
+      Field field = entity.getClass().getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(entity, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("could not seed entity id in test", e);
+    }
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/job/JobQueuePollerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/job/JobQueuePollerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.job;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the durable-queue poller (issue #349). {@link JobQueuePoller}'s only collaborator
+ * is {@link JobService}, so a mock fully isolates the batch-dispatch contract: run each claimed job,
+ * record a handler failure without aborting the batch, and reap stale jobs. The transactional/
+ * ShedLock semantics are inert without a Spring context and are covered by {@code JobQueueIT}.
+ */
+@ExtendWith(MockitoExtension.class)
+class JobQueuePollerTest {
+
+  @Mock private JobService jobService;
+
+  private JobQueuePoller poller;
+
+  @BeforeEach
+  void setUp() {
+    poller = new JobQueuePoller(jobService);
+  }
+
+  @Test
+  @DisplayName("poll runs every claimed job, in claim order")
+  void runsEveryClaimedJobInOrder() {
+    UUID a = UUID.randomUUID();
+    UUID b = UUID.randomUUID();
+    UUID c = UUID.randomUUID();
+    when(jobService.claimBatch()).thenReturn(List.of(a, b, c));
+
+    poller.poll();
+
+    InOrder inOrder = Mockito.inOrder(jobService);
+    inOrder.verify(jobService).runOne(a);
+    inOrder.verify(jobService).runOne(b);
+    inOrder.verify(jobService).runOne(c);
+    verify(jobService, never()).recordFailure(any(), any());
+  }
+
+  @Test
+  @DisplayName("a failing job is recorded and the batch continues")
+  void aFailingJobIsRecordedAndTheBatchContinues() {
+    UUID ok = UUID.randomUUID();
+    UUID boom = UUID.randomUUID();
+    UUID next = UUID.randomUUID();
+    when(jobService.claimBatch()).thenReturn(List.of(ok, boom, next));
+    RuntimeException failure = new IllegalStateException("handler blew up");
+    doThrow(failure).when(jobService).runOne(boom);
+
+    poller.poll();
+
+    verify(jobService).runOne(ok);
+    verify(jobService).recordFailure(eq(boom), any());
+    // The batch is not aborted: the job after the failing one still runs.
+    verify(jobService).runOne(next);
+  }
+
+  @Test
+  @DisplayName("a failure to record the failure is swallowed, not propagated")
+  void aFailureToRecordIsSwallowed() {
+    UUID boom = UUID.randomUUID();
+    UUID next = UUID.randomUUID();
+    when(jobService.claimBatch()).thenReturn(List.of(boom, next));
+    doThrow(new IllegalStateException("handler blew up")).when(jobService).runOne(boom);
+    doThrow(new IllegalStateException("could not record")).when(jobService).recordFailure(eq(boom), any());
+
+    assertThatCode(() -> poller.poll()).doesNotThrowAnyException();
+    // Even when recordFailure itself throws, the next job is still processed.
+    verify(jobService).runOne(next);
+  }
+
+  @Test
+  @DisplayName("an empty batch runs no jobs")
+  void emptyBatchRunsNothing() {
+    when(jobService.claimBatch()).thenReturn(List.of());
+
+    poller.poll();
+
+    verify(jobService, never()).runOne(any());
+    verify(jobService, never()).recordFailure(any(), any());
+  }
+
+  @Test
+  @DisplayName("reap delegates to reapStale and tolerates a positive stale count")
+  void reapDelegatesToReapStale() {
+    when(jobService.reapStale()).thenReturn(3);
+
+    assertThatCode(() -> poller.reap()).doesNotThrowAnyException();
+
+    verify(jobService).reapStale();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/job/JobQueuePollerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/job/JobQueuePollerTest.java
@@ -41,8 +41,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for the durable-queue poller (issue #349). {@link JobQueuePoller}'s only collaborator
- * is {@link JobService}, so a mock fully isolates the batch-dispatch contract: run each claimed job,
- * record a handler failure without aborting the batch, and reap stale jobs. The transactional/
+ * is {@link JobService}, so a mock fully isolates the batch-dispatch contract: run each claimed
+ * job, record a handler failure without aborting the batch, and reap stale jobs. The transactional/
  * ShedLock semantics are inert without a Spring context and are covered by {@code JobQueueIT}.
  */
 @ExtendWith(MockitoExtension.class)
@@ -99,7 +99,9 @@ class JobQueuePollerTest {
     UUID next = UUID.randomUUID();
     when(jobService.claimBatch()).thenReturn(List.of(boom, next));
     doThrow(new IllegalStateException("handler blew up")).when(jobService).runOne(boom);
-    doThrow(new IllegalStateException("could not record")).when(jobService).recordFailure(eq(boom), any());
+    doThrow(new IllegalStateException("could not record"))
+        .when(jobService)
+        .recordFailure(eq(boom), any());
 
     assertThatCode(() -> poller.poll()).doesNotThrowAnyException();
     // Even when recordFailure itself throws, the next job is still processed.

--- a/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.Comment;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.document.DocumentAccessService;
+import io.qnop.service.document.DocumentValidationException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link AnnotationService} (issue #349): the mandatory first comment, visibility
+ * delegated to {@link DocumentAccessService} (non-participant → 404), the latest-version-only guard,
+ * the placement-status list filter, classification authorization, closed-thread comment refusal and
+ * the audit events. Non-strict {@code mock()} wiring keeps the eight collaborators readable; the
+ * identity/anonymity resolver is mocked (its exposed id / display name are nullable in a view).
+ */
+class AnnotationServiceTest {
+
+  private final AnnotationRepository annotations = mock(AnnotationRepository.class);
+  private final AnnotationPlacementRepository placements =
+      mock(AnnotationPlacementRepository.class);
+  private final CommentRepository comments = mock(CommentRepository.class);
+  private final DocumentVersionRepository versions = mock(DocumentVersionRepository.class);
+  private final AuditEventRepository auditEvents = mock(AuditEventRepository.class);
+  private final DocumentAccessService documentAccess = mock(DocumentAccessService.class);
+  private final ReviewWorkflowService workflow = mock(ReviewWorkflowService.class);
+  private final ReviewIdentityResolver identity = mock(ReviewIdentityResolver.class);
+
+  private final AnnotationService service =
+      new AnnotationService(
+          annotations, placements, comments, versions, auditEvents, documentAccess, workflow,
+          identity);
+
+  private final UUID documentId = UUID.randomUUID();
+  private final UUID author = UUID.randomUUID();
+  private final UUID owner = UUID.randomUUID();
+  private final UUID stranger = UUID.randomUUID();
+
+  private DocumentAccessService.DocumentView documentView(UUID ownerId, String threadParticipation) {
+    return new DocumentAccessService.DocumentView(
+        documentId, "Doc", null, false, threadParticipation, ownerId, "IN_REVIEW", 1, null, null,
+        null);
+  }
+
+  /** Stubs the visibility check to succeed with a document owned by {@code ownerId}. */
+  private void visibleDocument(UUID ownerId, String threadParticipation) {
+    when(documentAccess.getDocument(any(), any(), anyBoolean()))
+        .thenReturn(documentView(ownerId, threadParticipation));
+  }
+
+  private void resolvableIdentities() {
+    when(identity.forDocument(any(), any()))
+        .thenReturn(mock(ReviewIdentityResolver.ReviewIdentities.class));
+  }
+
+  private DocumentVersion version(int number) {
+    return new DocumentVersion(
+        documentId, number, "key-" + number, "hash", "application/pdf", 1L, author);
+  }
+
+  // --- create ----------------------------------------------------------------
+
+  @Test
+  @DisplayName("create refuses a blank first comment (an annotation must have text)")
+  void createRejectsBlankFirstComment() {
+    assertThatThrownBy(
+            () -> service.create(documentId, 1, author, false, "{}", "  ", null, null))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(400));
+  }
+
+  @Test
+  @DisplayName("create surfaces the delegated 404 for a non-participant")
+  void createRejectsNonParticipant() {
+    when(documentAccess.getDocument(any(), any(), anyBoolean()))
+        .thenThrow(DocumentValidationException.notFound("no such document"));
+
+    assertThatThrownBy(
+            () -> service.create(documentId, 1, stranger, false, "{}", "hi", null, null))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(404));
+  }
+
+  @Test
+  @DisplayName("create is 404 for an unknown version")
+  void createRejectsUnknownVersion() {
+    visibleDocument(owner, "OPEN");
+    when(versions.findByDocumentIdAndVersionNumber(documentId, 9)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> service.create(documentId, 9, author, false, "{}", "hi", null, null))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(404));
+  }
+
+  @Test
+  @DisplayName("create is 409 VERSION_READ_ONLY for a non-latest version")
+  void createRejectsNonLatestVersion() {
+    visibleDocument(owner, "OPEN");
+    when(versions.findByDocumentIdAndVersionNumber(documentId, 1))
+        .thenReturn(Optional.of(version(1)));
+    when(versions.findTopByDocumentIdOrderByVersionNumberDesc(documentId))
+        .thenReturn(Optional.of(version(2)));
+
+    assertThatThrownBy(
+            () -> service.create(documentId, 1, author, false, "{}", "hi", null, null))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class,
+            e -> {
+              assertThat(e.getStatus()).isEqualTo(409);
+              assertThat(e.getCode()).isEqualTo("VERSION_READ_ONLY");
+            });
+  }
+
+  @Test
+  @DisplayName("create persists the annotation, its first comment (count 1) and the audit")
+  void createPersistsAnnotationCommentAndAudit() {
+    visibleDocument(owner, "OPEN");
+    resolvableIdentities();
+    when(versions.findByDocumentIdAndVersionNumber(documentId, 1))
+        .thenReturn(Optional.of(version(1)));
+    when(versions.findTopByDocumentIdOrderByVersionNumberDesc(documentId))
+        .thenReturn(Optional.of(version(1)));
+    when(annotations.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    AnnotationService.AnnotationView view =
+        service.create(documentId, 1, author, false, "{\"region\":1}", "first note", null, null);
+
+    assertThat(view.commentCount()).isEqualTo(1);
+    verify(placements).save(any());
+    verify(comments).save(any());
+    verify(workflow).annotationRaised(documentId, author);
+    ArgumentCaptor<AuditEvent> audit = ArgumentCaptor.forClass(AuditEvent.class);
+    verify(auditEvents).save(audit.capture());
+    assertThat(audit.getValue().getEventType())
+        .isEqualTo(AnnotationService.AUDIT_ANNOTATION_CREATED);
+  }
+
+  // --- list ------------------------------------------------------------------
+
+  @Test
+  @DisplayName("list requires a version when a placement status is given")
+  void listRejectsPlacementStatusWithoutVersion() {
+    assertThatThrownBy(() -> service.list(documentId, null, "ORPHANED", null, author, false))
+        .isInstanceOfSatisfying(
+            DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(400));
+  }
+
+  @Test
+  @DisplayName("list filters annotations by placement status")
+  void listFiltersByPlacementStatus() {
+    UUID versionId = UUID.randomUUID();
+    DocumentVersion version = mock(DocumentVersion.class);
+    when(version.getId()).thenReturn(versionId);
+    visibleDocument(owner, "OPEN");
+    resolvableIdentities();
+    when(versions.findByDocumentIdAndVersionNumber(documentId, 1))
+        .thenReturn(Optional.of(version));
+    when(annotations.findByDocumentId(documentId))
+        .thenReturn(List.of(new Annotation(documentId, author)));
+    AnnotationPlacement orphaned = new AnnotationPlacement(null, versionId, "{}");
+    orphaned.markOrphaned();
+    when(placements.findByDocumentVersionId(versionId)).thenReturn(List.of(orphaned));
+
+    assertThat(service.list(documentId, 1, "ORPHANED", null, owner, false)).hasSize(1);
+    assertThat(service.list(documentId, 1, "PENDING", null, owner, false)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("list surfaces the delegated 404 for a non-participant")
+  void listRejectsNonParticipant() {
+    when(documentAccess.getDocument(any(), any(), anyBoolean()))
+        .thenThrow(DocumentValidationException.notFound("no such document"));
+
+    assertThatThrownBy(() -> service.list(documentId, null, null, null, stranger, false))
+        .isInstanceOf(DocumentValidationException.class);
+  }
+
+  // --- updateClassification --------------------------------------------------
+
+  @Test
+  @DisplayName("only the owner or the author may classify an annotation")
+  void classifyIsOwnerOrAuthorOnly() {
+    when(annotations.findById(any())).thenReturn(Optional.of(new Annotation(documentId, author)));
+    visibleDocument(owner, "OPEN");
+
+    assertThatThrownBy(
+            () -> service.updateClassification(UUID.randomUUID(), stranger, false, "BUG", null))
+        .isInstanceOf(AnnotationActionForbiddenException.class);
+  }
+
+  @Test
+  @DisplayName("a resolved annotation cannot be reclassified")
+  void classifyRejectsResolvedAnnotation() {
+    Annotation resolved = new Annotation(documentId, author);
+    resolved.resolve();
+    when(annotations.findById(any())).thenReturn(Optional.of(resolved));
+    visibleDocument(owner, "OPEN");
+
+    assertThatThrownBy(
+            () -> service.updateClassification(UUID.randomUUID(), author, false, "BUG", null))
+        .isInstanceOfSatisfying(
+            WorkflowTransitionException.class,
+            e ->
+                assertThat(e.getCode())
+                    .isEqualTo(WorkflowTransitionException.ANNOTATION_ALREADY_RESOLVED));
+  }
+
+  @Test
+  @DisplayName("the author reclassifies an open annotation and it is audited")
+  void classifyUpdatesAndAudits() {
+    when(annotations.findById(any())).thenReturn(Optional.of(new Annotation(documentId, author)));
+    visibleDocument(owner, "OPEN");
+    resolvableIdentities();
+
+    service.updateClassification(UUID.randomUUID(), author, false, null, null);
+
+    ArgumentCaptor<AuditEvent> audit = ArgumentCaptor.forClass(AuditEvent.class);
+    verify(auditEvents, atLeastOnce()).save(audit.capture());
+    assertThat(audit.getValue().getEventType())
+        .isEqualTo(AnnotationService.AUDIT_ANNOTATION_CLASSIFIED);
+  }
+
+  // --- addComment ------------------------------------------------------------
+
+  @Test
+  @DisplayName("addComment surfaces the delegated 404 for a non-participant")
+  void addCommentRejectsNonParticipant() {
+    when(annotations.findById(any())).thenReturn(Optional.of(new Annotation(documentId, author)));
+    when(documentAccess.getDocument(any(), any(), anyBoolean()))
+        .thenThrow(DocumentValidationException.notFound("no such document"));
+
+    assertThatThrownBy(() -> service.addComment(UUID.randomUUID(), stranger, false, "hi"))
+        .isInstanceOf(DocumentValidationException.class);
+  }
+
+  @Test
+  @DisplayName("addComment refuses a resolved annotation's closed thread")
+  void addCommentRejectsClosedThread() {
+    Annotation resolved = new Annotation(documentId, author);
+    resolved.resolve();
+    when(annotations.findById(any())).thenReturn(Optional.of(resolved));
+    visibleDocument(owner, "OPEN");
+
+    assertThatThrownBy(() -> service.addComment(UUID.randomUUID(), author, false, "more"))
+        .isInstanceOfSatisfying(
+            WorkflowTransitionException.class,
+            e ->
+                assertThat(e.getCode())
+                    .isEqualTo(WorkflowTransitionException.ANNOTATION_ALREADY_RESOLVED));
+  }
+
+  @Test
+  @DisplayName("addComment appends to an open thread")
+  void addCommentAppendsToOpenThread() {
+    when(annotations.findById(any())).thenReturn(Optional.of(new Annotation(documentId, author)));
+    visibleDocument(owner, "OPEN");
+    resolvableIdentities();
+    when(comments.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    AnnotationService.CommentView view =
+        service.addComment(UUID.randomUUID(), author, false, "a reply");
+
+    assertThat(view.body()).isEqualTo("a reply");
+    verify(comments).saveAndFlush(any(Comment.class));
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
@@ -50,10 +50,11 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * Unit tests for {@link AnnotationService} (issue #349): the mandatory first comment, visibility
- * delegated to {@link DocumentAccessService} (non-participant → 404), the latest-version-only guard,
- * the placement-status list filter, classification authorization, closed-thread comment refusal and
- * the audit events. Non-strict {@code mock()} wiring keeps the eight collaborators readable; the
- * identity/anonymity resolver is mocked (its exposed id / display name are nullable in a view).
+ * delegated to {@link DocumentAccessService} (non-participant → 404), the latest-version-only
+ * guard, the placement-status list filter, classification authorization, closed-thread comment
+ * refusal and the audit events. Non-strict {@code mock()} wiring keeps the eight collaborators
+ * readable; the identity/anonymity resolver is mocked (its exposed id / display name are nullable
+ * in a view).
  */
 class AnnotationServiceTest {
 
@@ -69,7 +70,13 @@ class AnnotationServiceTest {
 
   private final AnnotationService service =
       new AnnotationService(
-          annotations, placements, comments, versions, auditEvents, documentAccess, workflow,
+          annotations,
+          placements,
+          comments,
+          versions,
+          auditEvents,
+          documentAccess,
+          workflow,
           identity);
 
   private final UUID documentId = UUID.randomUUID();
@@ -77,9 +84,19 @@ class AnnotationServiceTest {
   private final UUID owner = UUID.randomUUID();
   private final UUID stranger = UUID.randomUUID();
 
-  private DocumentAccessService.DocumentView documentView(UUID ownerId, String threadParticipation) {
+  private DocumentAccessService.DocumentView documentView(
+      UUID ownerId, String threadParticipation) {
     return new DocumentAccessService.DocumentView(
-        documentId, "Doc", null, false, threadParticipation, ownerId, "IN_REVIEW", 1, null, null,
+        documentId,
+        "Doc",
+        null,
+        false,
+        threadParticipation,
+        ownerId,
+        "IN_REVIEW",
+        1,
+        null,
+        null,
         null);
   }
 
@@ -104,8 +121,7 @@ class AnnotationServiceTest {
   @Test
   @DisplayName("create refuses a blank first comment (an annotation must have text)")
   void createRejectsBlankFirstComment() {
-    assertThatThrownBy(
-            () -> service.create(documentId, 1, author, false, "{}", "  ", null, null))
+    assertThatThrownBy(() -> service.create(documentId, 1, author, false, "{}", "  ", null, null))
         .isInstanceOfSatisfying(
             DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(400));
   }
@@ -116,8 +132,7 @@ class AnnotationServiceTest {
     when(documentAccess.getDocument(any(), any(), anyBoolean()))
         .thenThrow(DocumentValidationException.notFound("no such document"));
 
-    assertThatThrownBy(
-            () -> service.create(documentId, 1, stranger, false, "{}", "hi", null, null))
+    assertThatThrownBy(() -> service.create(documentId, 1, stranger, false, "{}", "hi", null, null))
         .isInstanceOfSatisfying(
             DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(404));
   }
@@ -128,8 +143,7 @@ class AnnotationServiceTest {
     visibleDocument(owner, "OPEN");
     when(versions.findByDocumentIdAndVersionNumber(documentId, 9)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(
-            () -> service.create(documentId, 9, author, false, "{}", "hi", null, null))
+    assertThatThrownBy(() -> service.create(documentId, 9, author, false, "{}", "hi", null, null))
         .isInstanceOfSatisfying(
             DocumentValidationException.class, e -> assertThat(e.getStatus()).isEqualTo(404));
   }
@@ -143,8 +157,7 @@ class AnnotationServiceTest {
     when(versions.findTopByDocumentIdOrderByVersionNumberDesc(documentId))
         .thenReturn(Optional.of(version(2)));
 
-    assertThatThrownBy(
-            () -> service.create(documentId, 1, author, false, "{}", "hi", null, null))
+    assertThatThrownBy(() -> service.create(documentId, 1, author, false, "{}", "hi", null, null))
         .isInstanceOfSatisfying(
             DocumentValidationException.class,
             e -> {
@@ -195,8 +208,7 @@ class AnnotationServiceTest {
     when(version.getId()).thenReturn(versionId);
     visibleDocument(owner, "OPEN");
     resolvableIdentities();
-    when(versions.findByDocumentIdAndVersionNumber(documentId, 1))
-        .thenReturn(Optional.of(version));
+    when(versions.findByDocumentIdAndVersionNumber(documentId, 1)).thenReturn(Optional.of(version));
     when(annotations.findByDocumentId(documentId))
         .thenReturn(List.of(new Annotation(documentId, author)));
     AnnotationPlacement orphaned = new AnnotationPlacement(null, versionId, "{}");

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
@@ -50,8 +50,8 @@ import org.mockito.ArgumentCaptor;
 /**
  * Unit tests for {@link ReviewWorkflowService} (issue #349): owner-only transition authorization,
  * the finalize guard fed by open-work counts, transition persistence + audit format, and the
- * annotation resolve/reopen author checks. The pessimistic locking mechanism is covered by
- * {@link ReviewWorkflowServiceLockTest}; the state machine itself by {@code ReviewWorkflowMachineTest}.
+ * annotation resolve/reopen author checks. The pessimistic locking mechanism is covered by {@link
+ * ReviewWorkflowServiceLockTest}; the state machine itself by {@code ReviewWorkflowMachineTest}.
  * Non-strict {@code mock()} wiring matches the lock test — the finalize context counts are always
  * computed, so lenient stubbing keeps the tests readable.
  */

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.AnnotationStatus;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.Document;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.document.DocumentAccessService;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link ReviewWorkflowService} (issue #349): owner-only transition authorization,
+ * the finalize guard fed by open-work counts, transition persistence + audit format, and the
+ * annotation resolve/reopen author checks. The pessimistic locking mechanism is covered by
+ * {@link ReviewWorkflowServiceLockTest}; the state machine itself by {@code ReviewWorkflowMachineTest}.
+ * Non-strict {@code mock()} wiring matches the lock test — the finalize context counts are always
+ * computed, so lenient stubbing keeps the tests readable.
+ */
+class ReviewWorkflowServiceTest {
+
+  private final DocumentRepository documents = mock(DocumentRepository.class);
+  private final DocumentVersionRepository versions = mock(DocumentVersionRepository.class);
+  private final AnnotationRepository annotations = mock(AnnotationRepository.class);
+  private final AnnotationPlacementRepository placements =
+      mock(AnnotationPlacementRepository.class);
+  private final CommentRepository comments = mock(CommentRepository.class);
+  private final AuditEventRepository auditEvents = mock(AuditEventRepository.class);
+  private final DocumentAccessService documentAccess = mock(DocumentAccessService.class);
+
+  private final ReviewWorkflowService service =
+      new ReviewWorkflowService(
+          documents, versions, annotations, placements, comments, auditEvents, documentAccess);
+
+  private final UUID documentId = UUID.randomUUID();
+  private final UUID owner = UUID.randomUUID();
+  private final UUID stranger = UUID.randomUUID();
+
+  private Document document(WorkflowState state) {
+    Document document = new Document(owner, "Review");
+    document.setWorkflowState(state);
+    return document;
+  }
+
+  private ArgumentCaptor<AuditEvent> captureAudits() {
+    ArgumentCaptor<AuditEvent> captor = ArgumentCaptor.forClass(AuditEvent.class);
+    verify(auditEvents, atLeastOnce()).save(captor.capture());
+    return captor;
+  }
+
+  // --- status ----------------------------------------------------------------
+
+  @Test
+  @DisplayName("status hides an invisible document behind a 404")
+  void statusRejectsInvisibleDocument() {
+    when(documents.findById(documentId)).thenReturn(Optional.of(document(WorkflowState.IN_REVIEW)));
+    when(documentAccess.isVisible(documentId, stranger, false)).thenReturn(false);
+
+    assertThatThrownBy(() -> service.status(documentId, stranger, false))
+        .isInstanceOf(DocumentNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("status returns the state for a visible document without auditing")
+  void statusReturnsStateForVisibleDocument() {
+    when(documents.findById(documentId)).thenReturn(Optional.of(document(WorkflowState.IN_REVIEW)));
+    when(documentAccess.isVisible(documentId, owner, false)).thenReturn(true);
+
+    assertThat(service.status(documentId, owner, false)).isNotNull();
+    verify(auditEvents, never()).save(any());
+  }
+
+  // --- transition authorization ---------------------------------------------
+
+  @Test
+  @DisplayName("a non-owner cannot transition the workflow")
+  void transitionIsOwnerOnly() {
+    Document draft = document(WorkflowState.DRAFT);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(draft));
+
+    assertThatThrownBy(
+            () -> service.transition(documentId, WorkflowState.IN_REVIEW.name(), stranger))
+        .isInstanceOf(NotDocumentOwnerException.class);
+    assertThat(draft.getWorkflowState()).isEqualTo(WorkflowState.DRAFT.name());
+    verify(auditEvents, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("an unknown target state is an INVALID_TRANSITION")
+  void transitionRejectsUnknownTarget() {
+    when(documents.findByIdForUpdate(documentId))
+        .thenReturn(Optional.of(document(WorkflowState.DRAFT)));
+
+    assertThatThrownBy(() -> service.transition(documentId, "NONSENSE", owner))
+        .isInstanceOfSatisfying(
+            WorkflowTransitionException.class,
+            e -> assertThat(e.getCode()).isEqualTo(WorkflowTransitionException.INVALID_TRANSITION));
+  }
+
+  @Test
+  @DisplayName("an allowed transition mutates the state and audits from→to")
+  void transitionPersistsAndAudits() {
+    Document draft = document(WorkflowState.DRAFT);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(draft));
+
+    service.transition(documentId, WorkflowState.IN_REVIEW.name(), owner);
+
+    assertThat(draft.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
+    AuditEvent audit = captureAudits().getValue();
+    assertThat(audit.getEventType()).isEqualTo(ReviewWorkflowService.AUDIT_WORKFLOW_TRANSITION);
+    assertThat(audit.getDetail()).contains("DRAFT").contains("IN_REVIEW");
+    assertThat(audit.getActorId()).isEqualTo(owner);
+  }
+
+  // --- finalize guard --------------------------------------------------------
+
+  @Test
+  @DisplayName("finalize is allowed once no open work remains")
+  void finalizeAllowedWhenClear() {
+    Document inReview = document(WorkflowState.IN_REVIEW);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(inReview));
+    // open annotations = 0 (default), pending placements = 0 (default), a READY version exists.
+    when(versions.existsByDocumentIdAndExtractionStatus(any(), any())).thenReturn(true);
+
+    service.transition(documentId, WorkflowState.FINALIZED.name(), owner);
+
+    assertThat(inReview.getWorkflowState()).isEqualTo(WorkflowState.FINALIZED.name());
+    verify(auditEvents).save(any());
+  }
+
+  @Test
+  @DisplayName("finalize is blocked by a pending placement")
+  void finalizeBlockedByPendingPlacement() {
+    Document inReview = document(WorkflowState.IN_REVIEW);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(inReview));
+    when(placements.countByDocumentIdAndStatus(any(), any())).thenReturn(1L);
+    when(versions.existsByDocumentIdAndExtractionStatus(any(), any())).thenReturn(true);
+
+    assertThatThrownBy(() -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner))
+        .isInstanceOf(WorkflowTransitionException.class);
+    assertThat(inReview.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
+    verify(auditEvents, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("finalize is blocked without a READY version")
+  void finalizeBlockedWithoutReadyVersion() {
+    Document inReview = document(WorkflowState.IN_REVIEW);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(inReview));
+    // no counts stubbed: 0 open, 0 pending, but existsBy...READY defaults to false.
+
+    assertThatThrownBy(() -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner))
+        .isInstanceOf(WorkflowTransitionException.class);
+    assertThat(inReview.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
+  }
+
+  // --- resolve / reopen ------------------------------------------------------
+
+  @Test
+  @DisplayName("only the author may resolve their annotation")
+  void resolveIsAuthorOnly() {
+    Annotation othersAnnotation = new Annotation(documentId, owner);
+    when(annotations.findById(any())).thenReturn(Optional.of(othersAnnotation));
+    when(documents.findByIdForUpdate(documentId))
+        .thenReturn(Optional.of(document(WorkflowState.IN_REVIEW)));
+
+    assertThatThrownBy(() -> service.resolveAnnotation(UUID.randomUUID(), null, stranger))
+        .isInstanceOf(AnnotationActionForbiddenException.class);
+  }
+
+  @Test
+  @DisplayName("resolving an unknown annotation is 404")
+  void resolveUnknownAnnotationIs404() {
+    when(annotations.findById(any())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.resolveAnnotation(UUID.randomUUID(), null, owner))
+        .isInstanceOf(AnnotationNotFoundException.class);
+    verify(documents, never()).findByIdForUpdate(any());
+  }
+
+  @Test
+  @DisplayName("resolving closes the annotation, records the note and audits annotation.resolved")
+  void resolveClosesAndAudits() {
+    Annotation annotation = new Annotation(documentId, owner);
+    when(annotations.findById(any())).thenReturn(Optional.of(annotation));
+    when(documents.findByIdForUpdate(documentId))
+        .thenReturn(Optional.of(document(WorkflowState.DRAFT)));
+
+    service.resolveAnnotation(UUID.randomUUID(), "looks good now", owner);
+
+    assertThat(annotation.getStatus()).isEqualTo(AnnotationStatus.RESOLVED);
+    verify(comments).save(any());
+    assertThat(captureAudits().getAllValues())
+        .anySatisfy(
+            e ->
+                assertThat(e.getEventType())
+                    .isEqualTo(ReviewWorkflowService.AUDIT_ANNOTATION_RESOLVED));
+  }
+
+  @Test
+  @DisplayName("reopening a still-open annotation is rejected")
+  void reopenRejectsNonResolved() {
+    Annotation open = new Annotation(documentId, owner);
+    when(annotations.findById(any())).thenReturn(Optional.of(open));
+    when(documents.findByIdForUpdate(documentId))
+        .thenReturn(Optional.of(document(WorkflowState.IN_REVIEW)));
+
+    assertThatThrownBy(() -> service.reopenAnnotation(UUID.randomUUID(), owner))
+        .isInstanceOfSatisfying(
+            WorkflowTransitionException.class,
+            e ->
+                assertThat(e.getCode())
+                    .isEqualTo(WorkflowTransitionException.ANNOTATION_NOT_RESOLVED));
+  }
+
+  @Test
+  @DisplayName("reopening a resolved annotation reopens it and audits annotation.reopened")
+  void reopenReopensAndAudits() {
+    Annotation resolved = new Annotation(documentId, owner);
+    resolved.resolve();
+    when(annotations.findById(any())).thenReturn(Optional.of(resolved));
+    when(documents.findByIdForUpdate(documentId))
+        .thenReturn(Optional.of(document(WorkflowState.CHANGES_REQUESTED)));
+    when(annotations.countByDocumentIdAndStatus(any(), any())).thenReturn(1L);
+
+    service.reopenAnnotation(UUID.randomUUID(), owner);
+
+    assertThat(resolved.getStatus()).isEqualTo(AnnotationStatus.OPEN);
+    assertThat(captureAudits().getAllValues())
+        .anySatisfy(
+            e ->
+                assertThat(e.getEventType())
+                    .isEqualTo(ReviewWorkflowService.AUDIT_ANNOTATION_REOPENED));
+  }
+}


### PR DESCRIPTION
Closes #349.

Adds the five priority-1 standalone service test suites called out by the multi-role review of `main` (all mocked-repo unit tests, no Spring context / Testcontainers), bringing the backend service layer to its ≥80% line-coverage target.

## Suites
- **`DocumentAccessServiceTest`** — owner/direct/team/admin visibility; non-participant → 404 (never 403); `getRendered`/`getOriginal`/`listVersions` enforce the same visibility before touching versions or storage.
- **`ReviewWorkflowServiceTest`** — owner-only authz, guard counts blocking FINALIZED, transition persistence, audit-event format, missing-document exceptions.
- **`AnnotationServiceTest`** — create + comment, non-participant → 404, invalid version, placement-status filter, comment-count consistency, audit.
- **`JobQueuePollerTest`** — batch claim, handler exception → `recordFailure()` without aborting the batch, reaper stale-count.
- **`DocumentIngestServiceTest`** *(this session — the missing fifth suite)* — title/`dueAt`/slug/thread-policy validation, magic-byte sniffing (client MIME never trusted), the operator size cap, the happy-path stage→save→enqueue→commit sequence, and both rollback mappings: storage quota → 413 and a slug-race `DataIntegrityViolationException` → 409 `SLUG_TAKEN` (storage never committed). Plus `addVersion` owner authorization (unknown/invisible → 404, visible non-owner → 403).

## Test plan
- [x] `./gradlew :qnop-core:test` green (incl. all five suites)
- [x] `./gradlew spotlessApply` clean (also folded two sibling suites back to google-java-format)
- [ ] CI (full `./gradlew build` + ArchUnit) green

🤖 Co-Author: Claude (Opus 4.8) via Claude Code