### PR TITLE
test(ui): auth-flow coverage — wave 1 of #352

### DIFF
--- a/qnop-ui/package.json
+++ b/qnop-ui/package.json
@@ -63,6 +63,7 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.62.1",
     "vite": "8.1.2",
-    "vitest": "4.1.9"
+    "vitest": "4.1.9",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.2(@types/node@24.13.2))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.9)
 
 packages:
 
@@ -2091,6 +2094,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2775,6 +2781,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest@4.1.9:
     resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
@@ -5080,6 +5091,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -5759,6 +5772,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.2
       fsevents: 2.3.3
+
+  vitest-axe@0.1.0(vitest@4.1.9):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.12.1
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.2(@types/node@24.13.2))
 
   vitest@4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.2(@types/node@24.13.2)):
     dependencies:

--- a/qnop-ui/src/api/auth.test.ts
+++ b/qnop-ui/src/api/auth.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AxiosError, type AxiosResponse } from 'axios';
+import { apiErrorCode, apiErrorMessage } from '../utils/apiError';
+import { authApi, authPasswordResetApi, authRegistrationApi } from './config';
+import { changePassword, forgotPassword, register, resetPassword, verifyEmail } from './auth';
+
+vi.mock('./config', () => ({
+  authApi: { changePassword: vi.fn() },
+  authRegistrationApi: { register: vi.fn(), verifyEmail: vi.fn() },
+  authPasswordResetApi: { forgotPassword: vi.fn(), resetPassword: vi.fn() },
+}));
+
+const registerFn = vi.mocked(authRegistrationApi.register);
+const verifyEmailFn = vi.mocked(authRegistrationApi.verifyEmail);
+const forgotPasswordFn = vi.mocked(authPasswordResetApi.forgotPassword);
+const resetPasswordFn = vi.mocked(authPasswordResetApi.resetPassword);
+const changePasswordFn = vi.mocked(authApi.changePassword);
+
+function axiosError(status: number, data?: unknown): AxiosError {
+  return new AxiosError('boom', 'ERR', undefined, undefined, { status, data } as AxiosResponse);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('auth API wrappers', () => {
+  it('register forwards the fields under registerRequest and resolves on 200', async () => {
+    registerFn.mockResolvedValue({ status: 200 } as never);
+    const input = { username: 'jo', email: 'jo@x.io', password: 'pw', displayName: 'Jo' };
+
+    await expect(register(input)).resolves.toBeUndefined();
+    expect(registerFn).toHaveBeenCalledWith({ registerRequest: input });
+  });
+
+  it('verifyEmail forwards the token', async () => {
+    verifyEmailFn.mockResolvedValue({ status: 200 } as never);
+
+    await verifyEmail('tok-123');
+
+    expect(verifyEmailFn).toHaveBeenCalledWith({ token: 'tok-123' });
+  });
+
+  it('forgotPassword wraps the email in the request body', async () => {
+    forgotPasswordFn.mockResolvedValue({ status: 200 } as never);
+
+    await forgotPassword('jo@x.io');
+
+    expect(forgotPasswordFn).toHaveBeenCalledWith({ forgotPasswordRequest: { email: 'jo@x.io' } });
+  });
+
+  it('resetPassword forwards the token and new password', async () => {
+    resetPasswordFn.mockResolvedValue({ status: 200 } as never);
+
+    await resetPassword('tok', 'new-pass');
+
+    expect(resetPasswordFn).toHaveBeenCalledWith({
+      resetPasswordRequest: { token: 'tok', newPassword: 'new-pass' },
+    });
+  });
+
+  it('changePassword forwards the current and new password', async () => {
+    changePasswordFn.mockResolvedValue({ status: 204 } as never);
+
+    await changePassword('old', 'new');
+
+    expect(changePasswordFn).toHaveBeenCalledWith({
+      changePasswordRequest: { currentPassword: 'old', newPassword: 'new' },
+    });
+  });
+
+  it('propagates a 409 conflict so the caller can read the code', async () => {
+    registerFn.mockRejectedValue(axiosError(409, { code: 'EMAIL_TAKEN' }));
+
+    const error = await register({
+      username: 'jo',
+      email: 'taken@x.io',
+      password: 'pw',
+      displayName: 'Jo',
+    }).catch((e: unknown) => e);
+
+    expect(apiErrorCode(error)).toBe('EMAIL_TAKEN');
+  });
+
+  it('a 429 propagates and extracts the rate-limit message', async () => {
+    forgotPasswordFn.mockRejectedValue(axiosError(429));
+
+    const error = await forgotPassword('jo@x.io').catch((e: unknown) => e);
+
+    expect(apiErrorMessage(error, 'fallback')).toBe('Too many attempts. Please try again later.');
+  });
+
+  it('a 400 with an expired token surfaces the link-expired message', async () => {
+    resetPasswordFn.mockRejectedValue(axiosError(400, { code: 'INVALID_TOKEN' }));
+
+    const error = await resetPassword('stale', 'new-pass').catch((e: unknown) => e);
+
+    expect(apiErrorMessage(error, 'fallback')).toBe(
+      'The request is invalid or the link has expired.',
+    );
+  });
+
+  it('a 400 password-policy failure surfaces the caller fallback', async () => {
+    changePasswordFn.mockRejectedValue(axiosError(400, { code: 'VALIDATION_ERROR' }));
+
+    const error = await changePassword('old', 'weak').catch((e: unknown) => e);
+
+    expect(apiErrorMessage(error, 'too weak')).toBe('too weak');
+  });
+
+  it('a network error (no response) falls back to the caller message', async () => {
+    registerFn.mockRejectedValue(new AxiosError('Network Error', 'ERR_NETWORK'));
+
+    const error = await register({
+      username: 'jo',
+      email: 'jo@x.io',
+      password: 'pw',
+      displayName: 'Jo',
+    }).catch((e: unknown) => e);
+
+    expect(apiErrorMessage(error, 'try again')).toBe('try again');
+  });
+});

--- a/qnop-ui/src/pages/auth/ChangePasswordPage.test.tsx
+++ b/qnop-ui/src/pages/auth/ChangePasswordPage.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { axe } from 'vitest-axe';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { changePassword } from '../../api/auth';
+import { useAuthStore } from '../../stores/authStore';
+import { ChangePasswordPage } from './ChangePasswordPage';
+
+vi.mock('../../api/auth', () => ({ changePassword: vi.fn() }));
+const changePasswordFn = vi.mocked(changePassword);
+
+const AXE_OPTIONS = { rules: { region: { enabled: false } } };
+const STRONG = 'brand-new-strong-pw';
+
+function withRedirectProbes() {
+  return (
+    <Routes>
+      <Route path="/change-password" element={<ChangePasswordPage />} />
+      <Route path="/login" element={<div>login screen</div>} />
+      <Route path="/" element={<div>home screen</div>} />
+    </Routes>
+  );
+}
+
+function fillForm() {
+  fireEvent.change(screen.getByLabelText(/^Current password/), { target: { value: 'old-pw' } });
+  fireEvent.change(screen.getByLabelText(/^New password/), { target: { value: STRONG } });
+  fireEvent.change(screen.getByLabelText(/^Confirm new password/), { target: { value: STRONG } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({ accessToken: null, source: null, passwordChangeRequired: false });
+});
+
+describe('ChangePasswordPage', () => {
+  it('redirects to /login without a session', () => {
+    renderWithProviders(withRedirectProbes(), { initialEntries: ['/change-password'] });
+
+    expect(screen.getByText('login screen')).toBeInTheDocument();
+  });
+
+  it('redirects an external (OIDC) account to home', () => {
+    useAuthStore.setState({ accessToken: 'tok', source: 'EXTERNAL' });
+    renderWithProviders(withRedirectProbes(), { initialEntries: ['/change-password'] });
+
+    expect(screen.getByText('home screen')).toBeInTheDocument();
+  });
+
+  it('changes the password, clears the session and confirms success', async () => {
+    useAuthStore.setState({ accessToken: 'tok', source: null });
+    changePasswordFn.mockResolvedValue();
+    renderWithProviders(<ChangePasswordPage />);
+
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Change password' }));
+
+    expect(await screen.findByText(/your password has been changed/i)).toBeInTheDocument();
+    expect(changePasswordFn).toHaveBeenCalledWith('old-pw', STRONG);
+    expect(useAuthStore.getState().accessToken).toBeNull();
+  });
+
+  it('surfaces an error when the current password is wrong', async () => {
+    useAuthStore.setState({ accessToken: 'tok', source: null });
+    changePasswordFn.mockRejectedValue(new Error('bad'));
+    renderWithProviders(<ChangePasswordPage />);
+
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Change password' }));
+
+    expect(await screen.findByText(/the current password is wrong/i)).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    useAuthStore.setState({ accessToken: 'tok', source: null });
+    const { container } = renderWithProviders(<ChangePasswordPage />);
+
+    expect(await axe(container, AXE_OPTIONS)).toHaveNoViolations();
+  });
+});

--- a/qnop-ui/src/pages/auth/ForgotPasswordPage.test.tsx
+++ b/qnop-ui/src/pages/auth/ForgotPasswordPage.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { AxiosError, type AxiosResponse } from 'axios';
+import { axe } from 'vitest-axe';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { forgotPassword } from '../../api/auth';
+import { ForgotPasswordPage } from './ForgotPasswordPage';
+
+vi.mock('../../api/auth', () => ({ forgotPassword: vi.fn() }));
+const forgotPasswordFn = vi.mocked(forgotPassword);
+
+const AXE_OPTIONS = { rules: { region: { enabled: false } } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ForgotPasswordPage', () => {
+  it('submits the email and shows the uniform acknowledgement', async () => {
+    forgotPasswordFn.mockResolvedValue();
+    renderWithProviders(<ForgotPasswordPage />);
+
+    fireEvent.change(screen.getByLabelText(/work email/i), { target: { value: 'jo@x.io' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send link' }));
+
+    expect(await screen.findByText(/reset link is on its way/i)).toBeInTheDocument();
+    expect(forgotPasswordFn).toHaveBeenCalledWith('jo@x.io');
+  });
+
+  it('surfaces a rate-limit error and keeps the form on screen', async () => {
+    forgotPasswordFn.mockRejectedValue(
+      new AxiosError('x', 'ERR', undefined, undefined, { status: 429 } as AxiosResponse),
+    );
+    renderWithProviders(<ForgotPasswordPage />);
+
+    fireEvent.change(screen.getByLabelText(/work email/i), { target: { value: 'jo@x.io' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send link' }));
+
+    expect(
+      await screen.findByText('Too many attempts. Please try again later.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send link' })).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderWithProviders(<ForgotPasswordPage />);
+
+    expect(await axe(container, AXE_OPTIONS)).toHaveNoViolations();
+  });
+});

--- a/qnop-ui/src/pages/auth/RegisterPage.test.tsx
+++ b/qnop-ui/src/pages/auth/RegisterPage.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { AxiosError, type AxiosResponse } from 'axios';
+import { axe } from 'vitest-axe';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { register } from '../../api/auth';
+import { useConfig } from '../../api/hooks/useConfig';
+import { RegisterPage } from './RegisterPage';
+
+vi.mock('../../api/auth', () => ({ register: vi.fn() }));
+vi.mock('../../api/hooks/useConfig', () => ({ useConfig: vi.fn() }));
+
+const registerFn = vi.mocked(register);
+const useConfigMock = vi.mocked(useConfig);
+
+const AXE_OPTIONS = { rules: { region: { enabled: false } } };
+const STRONG = 'brand-new-strong-pw';
+
+function mockConfig(selfRegistrationEnabled: boolean, isLoading = false) {
+  useConfigMock.mockReturnValue({
+    data: selfRegistrationEnabled ? { auth: { selfRegistrationEnabled } } : { auth: {} },
+    isLoading,
+  } as unknown as ReturnType<typeof useConfig>);
+}
+
+function fillValidForm() {
+  fireEvent.change(screen.getByLabelText(/full name/i), { target: { value: 'Jo Doe' } });
+  fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'jo' } });
+  fireEvent.change(screen.getByLabelText(/work email/i), { target: { value: 'jo@x.io' } });
+  fireEvent.change(screen.getByLabelText(/^Password/), { target: { value: STRONG } });
+  fireEvent.click(screen.getByRole('checkbox'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('RegisterPage', () => {
+  it('redirects to /login when self-registration is disabled', () => {
+    mockConfig(false);
+    renderWithProviders(
+      <Routes>
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/login" element={<div>login screen</div>} />
+      </Routes>,
+      { initialEntries: ['/register'] },
+    );
+
+    expect(screen.getByText('login screen')).toBeInTheDocument();
+  });
+
+  it('keeps submit disabled until the terms and a strong password are provided', () => {
+    mockConfig(true);
+    renderWithProviders(<RegisterPage />);
+
+    const submit = screen.getByRole('button', { name: 'Create account' });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/^Password/), { target: { value: STRONG } });
+    expect(submit).toBeDisabled(); // terms still unchecked
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(submit).toBeEnabled();
+  });
+
+  it('registers with the entered details and shows the confirmation notice', async () => {
+    mockConfig(true);
+    registerFn.mockResolvedValue();
+    renderWithProviders(<RegisterPage />);
+
+    fillValidForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(await screen.findByText(/sent you a confirmation email/i)).toBeInTheDocument();
+    expect(registerFn).toHaveBeenCalledWith({
+      displayName: 'Jo Doe',
+      username: 'jo',
+      email: 'jo@x.io',
+      password: STRONG,
+    });
+  });
+
+  it('surfaces a generic error when registration fails', async () => {
+    mockConfig(true);
+    registerFn.mockRejectedValue(
+      new AxiosError('x', 'ERR', undefined, undefined, {
+        status: 409,
+        data: { code: 'EMAIL_TAKEN' },
+      } as AxiosResponse),
+    );
+    renderWithProviders(<RegisterPage />);
+
+    fillValidForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(
+      await screen.findByText('Registration failed. Please try again later.'),
+    ).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    mockConfig(true);
+    const { container } = renderWithProviders(<RegisterPage />);
+
+    expect(await axe(container, AXE_OPTIONS)).toHaveNoViolations();
+  });
+});

--- a/qnop-ui/src/pages/auth/ResetPasswordPage.test.tsx
+++ b/qnop-ui/src/pages/auth/ResetPasswordPage.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { AxiosError, type AxiosResponse } from 'axios';
+import { axe } from 'vitest-axe';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { resetPassword } from '../../api/auth';
+import { ResetPasswordPage } from './ResetPasswordPage';
+
+vi.mock('../../api/auth', () => ({ resetPassword: vi.fn() }));
+const resetPasswordFn = vi.mocked(resetPassword);
+
+const AXE_OPTIONS = { rules: { region: { enabled: false } } };
+const STRONG = 'brand-new-strong-pw';
+const withToken = { initialEntries: ['/reset-password?token=reset-tok'] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ResetPasswordPage', () => {
+  it('rejects a link with no token and points to requesting a new one', () => {
+    renderWithProviders(<ResetPasswordPage />, { initialEntries: ['/reset-password'] });
+
+    expect(screen.getByText(/this link is invalid or incomplete/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save password' })).not.toBeInTheDocument();
+  });
+
+  it('warns when the two passwords do not match', () => {
+    renderWithProviders(<ResetPasswordPage />, withToken);
+
+    fireEvent.change(screen.getByLabelText(/^New password/), { target: { value: STRONG } });
+    fireEvent.change(screen.getByLabelText(/^Confirm password/), {
+      target: { value: 'different' },
+    });
+
+    expect(screen.getByText(/passwords don't match/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save password' })).toBeDisabled();
+  });
+
+  it('submits the token and new password, then confirms success', async () => {
+    resetPasswordFn.mockResolvedValue();
+    renderWithProviders(<ResetPasswordPage />, withToken);
+
+    fireEvent.change(screen.getByLabelText(/^New password/), { target: { value: STRONG } });
+    fireEvent.change(screen.getByLabelText(/^Confirm password/), { target: { value: STRONG } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save password' }));
+
+    expect(await screen.findByText(/your password has been changed/i)).toBeInTheDocument();
+    expect(resetPasswordFn).toHaveBeenCalledWith('reset-tok', STRONG);
+  });
+
+  it('surfaces the link-expired message on a 400', async () => {
+    resetPasswordFn.mockRejectedValue(
+      new AxiosError('x', 'ERR', undefined, undefined, {
+        status: 400,
+        data: { code: 'INVALID_TOKEN' },
+      } as AxiosResponse),
+    );
+    renderWithProviders(<ResetPasswordPage />, withToken);
+
+    fireEvent.change(screen.getByLabelText(/^New password/), { target: { value: STRONG } });
+    fireEvent.change(screen.getByLabelText(/^Confirm password/), { target: { value: STRONG } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save password' }));
+
+    expect(
+      await screen.findByText('The request is invalid or the link has expired.'),
+    ).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderWithProviders(<ResetPasswordPage />, withToken);
+
+    expect(await axe(container, AXE_OPTIONS)).toHaveNoViolations();
+  });
+});

--- a/qnop-ui/src/pages/auth/VerifyEmailPage.test.tsx
+++ b/qnop-ui/src/pages/auth/VerifyEmailPage.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { verifyEmail } from '../../api/auth';
+import { VerifyEmailPage } from './VerifyEmailPage';
+
+vi.mock('../../api/auth', () => ({ verifyEmail: vi.fn() }));
+const verifyEmailFn = vi.mocked(verifyEmail);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('VerifyEmailPage', () => {
+  it('verifies the token from the link and confirms success', async () => {
+    verifyEmailFn.mockResolvedValue();
+    renderWithProviders(<VerifyEmailPage />, {
+      initialEntries: ['/verify-email?token=good-token'],
+    });
+
+    expect(await screen.findByText(/your email address is confirmed/i)).toBeInTheDocument();
+    expect(verifyEmailFn).toHaveBeenCalledWith('good-token');
+  });
+
+  it('shows an error when the token is rejected', async () => {
+    verifyEmailFn.mockRejectedValue(new Error('invalid'));
+    renderWithProviders(<VerifyEmailPage />, { initialEntries: ['/verify-email?token=stale'] });
+
+    expect(await screen.findByText(/link is invalid or expired/i)).toBeInTheDocument();
+  });
+
+  it('shows an error and never calls the API when no token is present', () => {
+    renderWithProviders(<VerifyEmailPage />, { initialEntries: ['/verify-email'] });
+
+    expect(screen.getByText(/link is invalid or expired/i)).toBeInTheDocument();
+    expect(verifyEmailFn).not.toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/test/renderWithProviders.tsx
+++ b/qnop-ui/src/test/renderWithProviders.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { render, type RenderResult } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router-dom';
+import { buildTheme } from '../theme/theme';
+
+interface RenderOptions {
+  /** Initial history entries — e.g. `['/reset-password?token=abc']` to seed the URL. */
+  initialEntries?: string[];
+}
+
+/**
+ * Renders a component inside the providers every screen needs (issue #352): a
+ * fresh {@link QueryClient} with retries off (so a mocked rejection surfaces at
+ * once), the MUI theme, and a {@link MemoryRouter} for `Link`/`Navigate`/search
+ * params. A new QueryClient per call keeps tests isolated.
+ */
+export function renderWithProviders(
+  ui: ReactNode,
+  { initialEntries = ['/'] }: RenderOptions = {},
+): RenderResult {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}

--- a/qnop-ui/src/test/setup.ts
+++ b/qnop-ui/src/test/setup.ts
@@ -20,8 +20,12 @@
  */
 
 import '@testing-library/jest-dom/vitest';
-import { afterEach, vi } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
+import * as axeMatchers from 'vitest-axe/matchers';
+
+// Registers the `toHaveNoViolations` matcher for the form accessibility checks (issue #352).
+expect.extend(axeMatchers);
 
 afterEach(() => {
   cleanup();

--- a/qnop-ui/src/test/vitest-axe.d.ts
+++ b/qnop-ui/src/test/vitest-axe.d.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+// Types the `toHaveNoViolations` matcher registered in src/test/setup.ts (issue #352).
+import 'vitest';
+
+interface AxeMatchers<R = unknown> {
+  toHaveNoViolations(): R;
+}
+
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface Assertion<T = unknown> extends AxeMatchers<T> {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface AsymmetricMatchersContaining extends AxeMatchers {}
+}

--- a/qnop-ui/vitest.config.ts
+++ b/qnop-ui/vitest.config.ts
@@ -27,10 +27,13 @@ export default defineConfig({
       // setup, queryClient), presentational stubs (pages, AppShell) and the
       // bootstrap (main, router) are covered by component/visual/E2E tests as
       // their real screens land (#102/#103), not by markup assertions here.
+      // Scope grows per the #352 coverage waves (auth → viewer → admin → shell),
+      // each wave adding its slice here alongside the tests that cover it.
       include: [
         'src/stores/**/*.ts',
         'src/utils/**/*.ts',
         'src/api/refresh.ts',
+        'src/api/auth.ts',
         'src/api/hooks/**/*.ts',
         // Auth guards are logic (unit-tested); the presentational auth
         // components (AuthLayout, OidcButtons, PasswordField, the strength
@@ -40,6 +43,8 @@ export default defineConfig({
         'src/components/auth/RoleRoute.tsx',
         'src/components/auth/AuthHydrationBoundary.tsx',
         'src/components/shell/navConfig.tsx',
+        // Auth screens — the critical entry flow (issue #352, wave 1).
+        'src/pages/auth/**/*.tsx',
         // The viewer's pure anchor-building logic (#250); the presentational
         // viewer/panel components are covered by component tests, and the
         // pdf.js wiring (usePdfDocument, SurfacePage canvas) by E2E later.


### PR DESCRIPTION
## Summary

Wave 1 of the frontend test-coverage effort (#352): the **critical auth entry flow**. This is the first of several waves the issue enumerates (auth → viewer → admin → shell/router).

Adds a shared `renderWithProviders` helper (fresh `QueryClient` with retries off, MUI theme, `MemoryRouter` for `Link`/`Navigate`/search params) and wires **`vitest-axe`** so every form gets a `toHaveNoViolations` accessibility assertion.

### Covered in this wave
- **`api/auth.ts`** wrappers — request shaping plus `409` / `429` / `400` / network error propagation and message extraction.
- **RegisterPage** — self-registration guard (redirects to `/login` when disabled), submit gating (terms + strong password), success notice, failure path, a11y.
- **VerifyEmailPage** — token-from-link success, rejected token, missing token (never calls the API).
- **ForgotPasswordPage** — uniform acknowledgement, rate-limit (`429`) surface, a11y.
- **ResetPasswordPage** — missing-token guard, password-mismatch guard, success, link-expired `400`, a11y.
- **ChangePasswordPage** — unauth → `/login` and OIDC → home redirects, success + session clear, wrong-password error, a11y.

### Coverage
- **47 new tests**, full suite **558 passing**.
- Grows the coverage `include` allowlist by its wave-1 slice (`api/auth.ts`, `pages/auth/**`) alongside the tests that cover it.
- **Thresholds kept at 80** (not lowered to the issue's 70 floor) — the scoped `include` sits at **~88% statements / 84% branches / 84% functions / 89% lines**.

### Test plan
- [x] `vitest run --coverage` — 558 pass, gate green at 80
- [x] `tsc -b --noEmit` — clean
- [x] `eslint` — clean
- [x] `prettier --check` — clean
- [ ] CI green

### Follow-up waves (still open on #352)
- Viewer: `DocumentViewer`, `PageCanvas`, `RegionSelectLayer`, `usePdfDocument`
- Admin pages: Users / Teams / Settings / Branding / OidcProviders
- Shell/router: `AppShell` persistence + mobile drawer, router guards

Refs #352

🤖 Co-Author: Claude (Opus 4.x) via Claude Code