### PR TITLE
test(review): concurrency, extraction-failure cascade & annotation-decision authz ITs (#351)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/document/DocumentExtractionFailureIT.java
+++ b/qnop-app/src/test/java/io/qnop/document/DocumentExtractionFailureIT.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.document;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.User;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.job.JobQueuePoller;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+/**
+ * The downstream cascade of a FAILED extraction (issue #351). {@code DocumentIngestIT} already
+ * proves a corrupt upload lands {@code extractionStatus FAILED} and its {@code /rendered}
+ * representation answers {@code 409 EXTRACTION_FAILED}. This IT covers the rest of the cascade:
+ *
+ * <ul>
+ *   <li>a version diff that touches a FAILED version is refused with {@code 409 EXTRACTION_FAILED}
+ *       (the diff needs the extracted text of both sides, exactly like {@code /rendered});
+ *   <li>re-anchoring never runs against a FAILED version — the extraction failure marks the
+ *       version's pending placements {@code FAILED} instead of chaining a re-anchor job, so an
+ *       annotation carried onto a corrupt new version rests at {@code FAILED}, never {@code
+ *       PLACED}/{@code MOVED}/{@code ORPHANED}.
+ * </ul>
+ *
+ * <p>Tests drive the durable job queue with {@code poller.poll()} (the scheduled tick is disabled
+ * in ITs). Requires Docker (Testcontainers Postgres + MinIO).
+ */
+@AutoConfigureMockMvc
+class DocumentExtractionFailureIT extends AbstractIntegrationTest {
+
+  private static final String QUOTE = "the payment terms are thirty days";
+
+  /** A PDF header the magic-byte check accepts, but PDFBox cannot parse — extraction FAILS. */
+  private static final byte[] CORRUPT_PDF = "%PDF-1.7 garbage that PDFBox cannot parse".getBytes();
+
+  @Autowired MockMvc mockMvc;
+  @Autowired UserRepository users;
+  @Autowired DocumentRepository documents;
+  @Autowired PasswordEncoder passwordEncoder;
+  @Autowired JobQueuePoller poller;
+
+  private final List<UUID> createdDocuments = new ArrayList<>();
+  private final List<UUID> createdUsers = new ArrayList<>();
+
+  @AfterEach
+  void cleanup() {
+    createdDocuments.forEach(id -> documents.findById(id).ifPresent(documents::delete));
+    createdUsers.forEach(id -> users.findById(id).ifPresent(users::delete));
+  }
+
+  @Test
+  @DisplayName("a diff that touches a FAILED version is refused with 409 EXTRACTION_FAILED")
+  void diffAgainstAFailedVersionIsConflict() throws Exception {
+    UUID owner = createUser();
+    UUID documentId = upload(owner, "the original clause stands");
+    poller.poll(); // extract v1 → READY
+
+    addVersion(owner, documentId, CORRUPT_PDF);
+    poller.poll(); // extract v2 → FAILED (chains nothing)
+
+    mockMvc
+        .perform(get("/api/v1/documents/{id}/versions", documentId).with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.versions[0].extractionStatus").value("READY"))
+        .andExpect(jsonPath("$.versions[1].extractionStatus").value("FAILED"));
+
+    // v1 is READY, v2 is FAILED: the diff cannot render the FAILED side.
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/diff", documentId)
+                .param("from", "1")
+                .param("to", "2")
+                .with(asUser(owner)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("EXTRACTION_FAILED"));
+  }
+
+  @Test
+  @DisplayName("re-anchoring skips a FAILED version, leaving the carried placement FAILED")
+  void reanchorSkipsAFailedVersionLeavingThePlacementFailed() throws Exception {
+    UUID owner = createUser();
+    UUID documentId = upload(owner, "whereas " + QUOTE + " from invoice", "a second line");
+    poller.poll(); // extract v1 (no placements yet → no re-anchor job)
+
+    mockMvc
+        .perform(
+            post("/api/v1/documents/{id}/annotations", documentId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(annotationBody())
+                .with(asUser(owner)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.placementStatus").value("PLACED"));
+
+    // v2 is corrupt. Uploading it eagerly seeds a PENDING placement to be re-anchored...
+    addVersion(owner, documentId, CORRUPT_PDF);
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("version", "2")
+                .with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("PENDING"));
+
+    // ...but v2's extraction FAILS, so the failure marks the placement FAILED and chains no
+    // re-anchor job — the annotation is never re-placed onto the unreadable version.
+    poller.poll(); // extract v2 → FAILED
+
+    mockMvc
+        .perform(get("/api/v1/documents/{id}/versions", documentId).with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.versions[1].extractionStatus").value("FAILED"));
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("version", "2")
+                .with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("FAILED"));
+
+    // No re-anchor job was chained: a further poll is a no-op and the placement stays FAILED.
+    poller.poll();
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/annotations", documentId)
+                .param("version", "2")
+                .with(asUser(owner)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("FAILED"));
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  /** The annotation drawn on v1: region + the quote with its real prefix/suffix context. */
+  private static String annotationBody() {
+    return """
+        {"versionNumber":1,"anchor":{
+          "region":{"surfaceIndex":0,"box":{"x":0.1,"y":0.1,"width":0.5,"height":0.05}},
+          "textQuote":{"quote":"%s","prefix":"whereas ","suffix":" from invoice"},
+          "textPosition":{"start":8,"end":%d}},
+         "comment":"please double-check this clause"}
+        """
+        .formatted(QUOTE, 8 + QUOTE.length());
+  }
+
+  private UUID upload(UUID owner, String... lines) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                multipart("/api/v1/documents")
+                    .file(pdfFile(pdf(lines)))
+                    .param("title", "Extraction failure IT")
+                    .with(asUser(owner)))
+            .andExpect(status().isCreated())
+            .andReturn();
+    UUID id =
+        UUID.fromString(JsonPath.read(result.getResponse().getContentAsString(), "$.documentId"));
+    createdDocuments.add(id);
+    return id;
+  }
+
+  private void addVersion(UUID owner, UUID documentId, byte[] bytes) throws Exception {
+    mockMvc
+        .perform(
+            multipart("/api/v1/documents/{id}/versions", documentId)
+                .file(pdfFile(bytes))
+                .with(asUser(owner)))
+        .andExpect(status().isCreated());
+  }
+
+  private UUID createUser() {
+    String name = "extfail-" + UUID.randomUUID();
+    User user =
+        User.internal(name, name + "@example.com", name, passwordEncoder.encode("irrelevant-pw"));
+    user.setEnabled(true);
+    UUID id = users.saveAndFlush(user).getId();
+    createdUsers.add(id);
+    return id;
+  }
+
+  private static RequestPostProcessor asUser(UUID userId) {
+    return jwt().jwt(j -> j.subject(userId.toString()));
+  }
+
+  private static MockMultipartFile pdfFile(byte[] bytes) {
+    return new MockMultipartFile("file", "doc.pdf", "application/pdf", bytes);
+  }
+
+  /** One LETTER page with one text line per given string. */
+  private static byte[] pdf(String... lines) throws IOException {
+    try (PDDocument document = new PDDocument()) {
+      PDPage page = new PDPage(PDRectangle.LETTER);
+      document.addPage(page);
+      try (PDPageContentStream content = new PDPageContentStream(document, page)) {
+        content.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+        float y = 700;
+        for (String line : lines) {
+          content.beginText();
+          content.newLineAtOffset(72, y);
+          content.showText(line);
+          content.endText();
+          y -= 20;
+        }
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      document.save(out);
+      return out.toByteArray();
+    }
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationApiIT.java
@@ -20,6 +20,7 @@
  */
 package io.qnop.review;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -32,6 +33,7 @@ import io.qnop.entity.Document;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ReviewParticipant;
 import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.repository.ReviewParticipantRepository;
@@ -56,6 +58,7 @@ class AnnotationApiIT extends SeededIntegrationTest {
   @Autowired private DocumentRepository documents;
   @Autowired private DocumentVersionRepository versions;
   @Autowired private ReviewParticipantRepository participants;
+  @Autowired private AuditEventRepository auditEvents;
 
   /** A DRAFT document owned by MEMBER with AUDITOR + MEMBER2 as reviewers and one version. */
   private UUID seedDocumentWithVersion() {
@@ -248,7 +251,12 @@ class AnnotationApiIT extends SeededIntegrationTest {
     // in the thread or uploads a new version, but never closes the concern.
     mockMvc
         .perform(as(post("/api/v1/annotations/" + annotationId + "/resolve"), MEMBER_ID))
-        .andExpect(status().isForbidden());
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("ANNOTATION_ACTION_FORBIDDEN"));
+
+    // The refused decision leaves no audit trail — nobody "resolved" anything (issue #351).
+    assertThat(auditEvents.findByDocumentIdOrderByCreatedAtDesc(documentId))
+        .noneMatch(event -> "annotation.resolved".equals(event.getEventType()));
   }
 
   @Test
@@ -259,7 +267,33 @@ class AnnotationApiIT extends SeededIntegrationTest {
     // MEMBER2 is a participant (so the annotation is visible) but not the author.
     mockMvc
         .perform(as(post("/api/v1/annotations/" + annotationId + "/resolve"), MEMBER2_ID))
-        .andExpect(status().isForbidden());
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("ANNOTATION_ACTION_FORBIDDEN"));
+
+    assertThat(auditEvents.findByDocumentIdOrderByCreatedAtDesc(documentId))
+        .noneMatch(event -> "annotation.resolved".equals(event.getEventType()));
+  }
+
+  @Test
+  void theAuthorsResolveIsAuditedWithTheAuthorAsActor() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    // AUDITOR authors an annotation on a document owned by someone else (MEMBER) and,
+    // as the author, may decide (resolve) it — the audit event must attribute the act to
+    // the author, not the document owner (issue #351).
+    String annotationId = createAnnotation(documentId, AUDITOR_ID);
+
+    mockMvc
+        .perform(as(post("/api/v1/annotations/" + annotationId + "/resolve"), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("RESOLVED"));
+
+    assertThat(auditEvents.findByDocumentIdOrderByCreatedAtDesc(documentId))
+        .anySatisfy(
+            event -> {
+              assertThat(event.getEventType()).isEqualTo("annotation.resolved");
+              assertThat(event.getActorId()).isEqualTo(AUDITOR_ID);
+              assertThat(event.getDetail()).contains(annotationId);
+            });
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowConcurrencyIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowConcurrencyIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.Document;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * The owner fires the SAME workflow transition on one document twice at once (issue #351) — the
+ * endpoint is owner-only, so both racing requests authenticate as the owner. The transition path
+ * loads the document with a pessimistic write lock ({@code DocumentRepository.findByIdForUpdate},
+ * ADR-0030/#324), so the two requests serialize rather than overwriting each other: the winner
+ * commits {@code DRAFT → IN_REVIEW} (200); the loser then re-reads the fresh {@code IN_REVIEW}
+ * state, from which {@code IN_REVIEW} is no longer a legal manual edge, and the state machine
+ * refuses it with {@code 409 INVALID_TRANSITION}. The observable guarantee — exactly one 200 and
+ * one 409, never a double-apply or a 500 — is what protects the review workflow under concurrency.
+ *
+ * <p>Note: the original ticket assumed the loser would fail on an {@code @Version} optimistic-lock
+ * collision; the shipped design instead serializes on the row lock and denies via the state
+ * machine, so the loser's 409 carries {@code INVALID_TRANSITION} (not an optimistic-lock code —
+ * that path is never reached and has no HTTP mapping). This test asserts the real behaviour.
+ *
+ * <p>The base class is deliberately not {@code @Transactional}, so each request commits on its own
+ * connection — the winner's commit is visible to the loser's {@code SELECT … FOR UPDATE}. Requires
+ * Docker (Testcontainers Postgres).
+ */
+class ReviewWorkflowConcurrencyIT extends SeededIntegrationTest {
+
+  private static final int WORKERS = 2;
+
+  @Autowired private DocumentRepository documents;
+
+  @Test
+  void competingTransitionsYieldExactlyOneWinnerAndOneConflict() throws Exception {
+    UUID documentId = documents.save(new Document(MEMBER_ID, "Concurrent transition race")).getId();
+
+    ExecutorService pool = Executors.newFixedThreadPool(WORKERS);
+    CyclicBarrier startLine = new CyclicBarrier(WORKERS);
+    try {
+      List<Future<MvcResult>> futures = new ArrayList<>();
+      for (int i = 0; i < WORKERS; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  startLine.await(5, TimeUnit.SECONDS);
+                  return mockMvc
+                      .perform(
+                          post("/api/v1/documents/" + documentId + "/workflow")
+                              .header("Authorization", "Bearer " + token(MEMBER_ID))
+                              .contentType(MediaType.APPLICATION_JSON)
+                              .content("{\"targetState\":\"IN_REVIEW\"}"))
+                      .andReturn();
+                }));
+      }
+
+      int okCount = 0;
+      int conflictCount = 0;
+      for (Future<MvcResult> future : futures) {
+        MvcResult result = future.get(15, TimeUnit.SECONDS);
+        int status = result.getResponse().getStatus();
+        if (status == 200) {
+          okCount++;
+          assertThat(JsonPath.<String>read(result.getResponse().getContentAsString(), "$.state"))
+              .isEqualTo("IN_REVIEW");
+        } else if (status == 409) {
+          conflictCount++;
+          assertThat(JsonPath.<String>read(result.getResponse().getContentAsString(), "$.code"))
+              .isEqualTo("INVALID_TRANSITION");
+        } else {
+          throw new AssertionError("Unexpected status " + status);
+        }
+      }
+
+      assertThat(okCount).isEqualTo(1);
+      assertThat(conflictCount).isEqualTo(1);
+    } finally {
+      pool.shutdownNow();
+    }
+
+    // The race commits the transition exactly once: the document rests in the winner's target.
+    assertThat(documents.findById(documentId).orElseThrow().getWorkflowState())
+        .isEqualTo(WorkflowState.IN_REVIEW.name());
+  }
+}


### PR DESCRIPTION
## Summary

Completes the remaining priority-2 integration tests from #351. The other two parts of that issue are already on `main`: the `AnchorResolver` boundary edge cases (#430) and the version-diff cache-race fix + `VersionDiffConcurrencyIT` (#431). This PR adds the last three.

### `ReviewWorkflowConcurrencyIT` (part 1)
Two competing `DRAFT → IN_REVIEW` transitions on one document, fired concurrently. They race through the **pessimistic write lock** (`DocumentRepository.findByIdForUpdate`, ADR-0030 / #324): the winner commits and returns **200**; the loser re-reads the fresh `IN_REVIEW` state, from which `IN_REVIEW` is no longer a legal manual edge, and the state machine denies it with **409 `INVALID_TRANSITION`** — never a double-apply, never a 500.

> ⚠️ **Deviation from the ticket's premise (intentional).** The issue assumed the loser fails on an `@Version` optimistic-lock collision. The shipped design instead **serializes on the row lock** and denies via the state machine, so the loser's 409 carries `INVALID_TRANSITION`. There is no HTTP mapping for `OptimisticLockingFailureException` on this path — that path is never reached. Reverting the pessimistic lock to force an optimistic-lock 409 would undo ADR-0030, so the test asserts the **real, shipped guarantee** (exactly one 200 + one 409, no corruption).

### `DocumentExtractionFailureIT` (part 3)
Extends the FAILED-extraction cascade beyond what `DocumentIngestIT` already covers (corrupt upload → `FAILED`, `/rendered` → 409 `EXTRACTION_FAILED`):
- a **version diff** touching a FAILED version → **409 `EXTRACTION_FAILED`**;
- **re-anchoring skips a FAILED version** — the extraction failure marks the carried-forward placement `FAILED` (not `PLACED`/`ORPHANED`) and chains **no** re-anchor job, so a further `poller.poll()` is a no-op.

### `AnnotationApiIT` (part 4)
The annotation "decision" in this codebase is author-only **resolve**/**reopen** (there is no accept/reject endpoint — that only exists in stale client codegen). Strengthened coverage:
- the author's resolve is **audited with the author as actor** (`annotation.resolved`), even though the author is not the document owner;
- the owner and another-reviewer 403s now assert the exact **`ANNOTATION_ACTION_FORBIDDEN`** code and verify **no resolve audit trail** is written.

## Test plan
- [x] `./gradlew spotlessApply` + `:qnop-app:compileTestJava` green
- [x] Adversarial review of all three files against production code (endpoints, error codes, lock semantics, placement lifecycle, audit actor) — no bugs found
- [ ] CI runs the Testcontainers ITs (Docker unavailable locally, so these run in CI only)

Closes #351.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code