### PR TITLE
test(ui): document-viewer coverage — wave 2 of #352

### DIFF
--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.test.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+import type { AnnotationView, RenderedSurface } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { DocumentViewer, type DocumentViewerHandle } from './DocumentViewer';
+import type { ViewerTool } from './ViewerToolbar';
+
+// Stub the page stack: DocumentViewer's own logic (page count, scroll spy,
+// imperative scroll, mark linking) is what's under test — the pdf.js pixel path
+// belongs to PageCanvas / E2E. Page 0 hosts every annotation's highlight anchor
+// so the scroll-into-view effects have a target by id.
+vi.mock('./SurfacePage', () => ({
+  SurfacePage: ({
+    pageIndex,
+    annotations,
+    onSelectAnnotation,
+  }: {
+    pageIndex: number;
+    annotations: { id: string }[];
+    onSelectAnnotation: (id: string) => void;
+  }) => (
+    <div data-testid={`surface-${pageIndex}`}>
+      {pageIndex === 0 &&
+        annotations.map((a) => <span key={a.id} id={`annotation-highlight-${a.id}`} />)}
+      <button onClick={() => onSelectAnnotation('a1')}>select-{pageIndex}</button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  // The page stack renders only once the container reports a width. The effect
+  // reads `clientWidth` synchronously (the ResizeObserver stub never fires), and
+  // jsdom returns 0 for it — so give the container a fixed width to lay out.
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get: () => 800,
+  });
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth;
+  vi.clearAllMocks();
+});
+
+function baseProps() {
+  return {
+    pdf: { numPages: 3 } as unknown as PDFDocumentProxy,
+    zoom: 1,
+    annotations: [] as AnnotationView[],
+    activeAnnotationId: null as string | null,
+    onSelectAnnotation: vi.fn(),
+    onVisiblePageChange: vi.fn(),
+    tool: 'text' as ViewerTool,
+    canAnnotate: false,
+    pendingAnchor: null,
+    onTextSelected: vi.fn(),
+    onRegionSelected: vi.fn(),
+  };
+}
+
+function renderViewer(overrides: Record<string, unknown> = {}) {
+  const props = { ...baseProps(), ...overrides };
+  const view = render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <DocumentViewer {...props} />
+    </ThemeProvider>,
+  );
+  const update = (next: Record<string, unknown>) =>
+    view.rerender(
+      <ThemeProvider theme={buildTheme('light')}>
+        <DocumentViewer {...props} {...next} />
+      </ThemeProvider>,
+    );
+  return { props, update };
+}
+
+describe('DocumentViewer', () => {
+  it('renders one page per pdf page when the server has no surfaces yet', () => {
+    renderViewer();
+
+    expect(screen.getAllByTestId(/^surface-/)).toHaveLength(3);
+  });
+
+  it('renders one page per server surface once extraction has produced them', () => {
+    const surfaces = [{ index: 0 }, { index: 1 }] as RenderedSurface[];
+    renderViewer({ surfaces });
+
+    expect(screen.getAllByTestId(/^surface-/)).toHaveLength(2);
+  });
+
+  it('scrolls the requested page into view through the imperative handle', () => {
+    const handle: { current: DocumentViewerHandle | null } = { current: null };
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <DocumentViewer {...baseProps()} ref={handle} />
+      </ThemeProvider>,
+    );
+
+    act(() => handle.current?.scrollToPage(1));
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  });
+
+  it('reports the current page to the toolbar on mount and on scroll', async () => {
+    const { props } = renderViewer();
+
+    expect(props.onVisiblePageChange).toHaveBeenCalledWith(0);
+
+    fireEvent.scroll(screen.getByLabelText('Document pages'));
+
+    await waitFor(() => expect(props.onVisiblePageChange.mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it('scrolls an off-screen active annotation into view once it becomes active', () => {
+    // The mark is activated after the page stack has laid out (real flow: a panel
+    // click on an already-loaded document), so the highlight anchor exists by then.
+    const { update } = renderViewer({ annotations: [{ id: 'a1' }] as AnnotationView[] });
+
+    update({ activeAnnotationId: 'a1' });
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+    });
+  });
+
+  it('brings an off-screen hovered mark into view', () => {
+    const { update } = renderViewer({ annotations: [{ id: 'a1' }] as AnnotationView[] });
+
+    update({ hoverAnnotationId: 'a1' });
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'center',
+    });
+  });
+
+  it('forwards a mark selection from the page stack', () => {
+    const { props } = renderViewer({ annotations: [{ id: 'a1' }] as AnnotationView[] });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /^select-0$/ })[0]);
+
+    expect(props.onSelectAnnotation).toHaveBeenCalledWith('a1');
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/PageCanvas.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/PageCanvas.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+import { PageCanvas } from './PageCanvas';
+
+// A controllable IntersectionObserver: the setup.ts stub never fires, but the
+// canvas only renders once its observer reports the page as visible.
+let intersect: (() => void) | null = null;
+const realIO = window.IntersectionObserver;
+
+beforeEach(() => {
+  window.IntersectionObserver = class {
+    constructor(private cb: IntersectionObserverCallback) {}
+    observe = () => {
+      intersect = () =>
+        this.cb([{ isIntersecting: true } as IntersectionObserverEntry], this as never);
+    };
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = () => [];
+  } as unknown as typeof IntersectionObserver;
+});
+
+afterEach(() => {
+  window.IntersectionObserver = realIO;
+  intersect = null;
+  vi.clearAllMocks();
+});
+
+/** A pdf.js page 100×200 at scale 1 (aspect 0.5), with a spyable render task. */
+function fakePdf() {
+  // A fresh cancel spy per document: testing-library's auto-cleanup unmounts the
+  // previous test's canvas (and cancels its render) after our clearAllMocks runs,
+  // so a shared spy would carry that stray call into the next test.
+  const cancel = vi.fn();
+  const page = {
+    getViewport: vi.fn(({ scale }: { scale: number }) => ({
+      width: 100 * scale,
+      height: 200 * scale,
+    })),
+    render: vi.fn(() => ({ promise: Promise.resolve(), cancel })),
+  };
+  const pdf = { getPage: vi.fn().mockResolvedValue(page) } as unknown as PDFDocumentProxy;
+  return { pdf, page, cancel };
+}
+
+describe('PageCanvas', () => {
+  it('renders nothing until the page scrolls into view', () => {
+    const { pdf } = fakePdf();
+    render(<PageCanvas pdf={pdf} pageIndex={0} width={300} ariaLabel="Page 1" />);
+
+    expect(pdf.getPage).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
+  });
+
+  it('renders the pdf.js page and sizes the canvas by width × devicePixelRatio', async () => {
+    const { pdf, page } = fakePdf();
+    const onAspect = vi.fn();
+    render(
+      <PageCanvas pdf={pdf} pageIndex={0} width={300} ariaLabel="Page 1" onAspect={onAspect} />,
+    );
+
+    act(() => intersect?.());
+
+    await waitFor(() => expect(pdf.getPage).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(page.render).toHaveBeenCalledOnce());
+
+    // Aspect from the base (scale-1) viewport: 100 / 200.
+    expect(onAspect).toHaveBeenCalledWith(0.5);
+    // Render viewport at scale (300/100)*dpr — dpr is 1 under jsdom.
+    const canvas = screen.getByLabelText('Page 1') as HTMLCanvasElement;
+    expect(canvas.width).toBe(300);
+    expect(canvas.height).toBe(600);
+  });
+
+  it('cancels the in-flight render when it unmounts', async () => {
+    const { pdf, page, cancel } = fakePdf();
+    const { unmount } = render(
+      <PageCanvas pdf={pdf} pageIndex={2} width={300} ariaLabel="Page 3" />,
+    );
+
+    act(() => intersect?.());
+    await waitFor(() => expect(page.render).toHaveBeenCalledOnce());
+
+    unmount();
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import { RegionSelectLayer } from './RegionSelectLayer';
+
+// The surface Box the handlers read via `currentTarget.getBoundingClientRect()`:
+// 200×100 anchored at the origin, so clientX/clientY map to unit fractions of
+// 200/100. jsdom returns an all-zero rect otherwise (every coordinate NaN).
+const RECT = { left: 0, top: 0, width: 200, height: 100 } as DOMRect;
+
+function renderLayer(enabled = true) {
+  const onRegionSelected = vi.fn();
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <RegionSelectLayer surfaceIndex={0} enabled={enabled} onRegionSelected={onRegionSelected} />
+    </ThemeProvider>,
+  );
+  const layer = screen.getByTestId('region-layer-0');
+  layer.getBoundingClientRect = () => RECT;
+  // jsdom leaves pointer capture unimplemented; the drag start calls it.
+  layer.setPointerCapture = vi.fn();
+  return { layer, onRegionSelected };
+}
+
+function drag(layer: HTMLElement, from: [number, number], to: [number, number]) {
+  fireEvent.pointerDown(layer, { button: 0, pointerId: 1, clientX: from[0], clientY: from[1] });
+  fireEvent.pointerMove(layer, { pointerId: 1, clientX: to[0], clientY: to[1] });
+  fireEvent.pointerUp(layer, { pointerId: 1, clientX: to[0], clientY: to[1] });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('RegionSelectLayer', () => {
+  it('normalizes a drag into a page-relative box and reports the drop position', () => {
+    const { layer, onRegionSelected } = renderLayer();
+
+    drag(layer, [50, 25], [150, 75]);
+
+    expect(onRegionSelected).toHaveBeenCalledWith(
+      0,
+      { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+      { left: 150, top: 75 },
+    );
+  });
+
+  it('clamps coordinates that fall outside the surface to the unit range', () => {
+    const { layer, onRegionSelected } = renderLayer();
+
+    // The pointer-up runs past the right/bottom edge: 300/200 → clamped to 1/1.
+    drag(layer, [50, 25], [300, 200]);
+
+    expect(onRegionSelected).toHaveBeenCalledWith(
+      0,
+      { x: 0.25, y: 0.25, width: 0.75, height: 0.75 },
+      { left: 300, top: 200 },
+    );
+  });
+
+  it('draws a preview rectangle while dragging and clears it on drop', () => {
+    const { layer } = renderLayer();
+
+    expect(layer.querySelector('div')).toBeNull();
+
+    fireEvent.pointerDown(layer, { button: 0, pointerId: 1, clientX: 50, clientY: 25 });
+    fireEvent.pointerMove(layer, { pointerId: 1, clientX: 150, clientY: 75 });
+    expect(layer.querySelector('div')).not.toBeNull();
+
+    fireEvent.pointerUp(layer, { pointerId: 1, clientX: 150, clientY: 75 });
+    expect(layer.querySelector('div')).toBeNull();
+  });
+
+  it('ignores non-primary buttons', () => {
+    const { layer, onRegionSelected } = renderLayer();
+
+    fireEvent.pointerDown(layer, { button: 2, pointerId: 1, clientX: 50, clientY: 25 });
+    fireEvent.pointerUp(layer, { pointerId: 1, clientX: 150, clientY: 75 });
+
+    expect(onRegionSelected).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const { layer, onRegionSelected } = renderLayer(false);
+
+    drag(layer, [50, 25], [150, 75]);
+
+    expect(onRegionSelected).not.toHaveBeenCalled();
+    expect(layer.setPointerCapture).not.toHaveBeenCalled();
+  });
+
+  it('ignores a move or up that never started with a pointer-down', () => {
+    const { layer, onRegionSelected } = renderLayer();
+
+    fireEvent.pointerMove(layer, { pointerId: 1, clientX: 150, clientY: 75 });
+    fireEvent.pointerUp(layer, { pointerId: 1, clientX: 150, clientY: 75 });
+
+    expect(onRegionSelected).not.toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/usePdfDocument.test.ts
+++ b/qnop-ui/src/components/reviews/viewer/usePdfDocument.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+import { usePdfDocument } from './usePdfDocument';
+
+vi.mock('pdfjs-dist', () => ({
+  GlobalWorkerOptions: {},
+  getDocument: vi.fn(),
+}));
+
+const { getDocument } = await import('pdfjs-dist');
+const getDocumentMock = vi.mocked(getDocument);
+
+/** A resolved/rejected loading task with a spyable destroy(). */
+function loadingTask(promise: Promise<unknown>) {
+  const destroy = vi.fn().mockResolvedValue(undefined);
+  return { task: { promise, destroy } as never, destroy };
+}
+
+const fakePdf = { numPages: 3 } as PDFDocumentProxy;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('usePdfDocument', () => {
+  it('stays idle and never touches pdf.js without data', () => {
+    const { result } = renderHook(() => usePdfDocument(undefined));
+
+    expect(result.current).toEqual({ pdf: null, error: null });
+    expect(getDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it('parses the bytes and exposes the document, handing pdf.js a copy', async () => {
+    const { task } = loadingTask(Promise.resolve(fakePdf));
+    getDocumentMock.mockReturnValue(task);
+    const data = new Uint8Array([1, 2, 3, 4]).buffer;
+
+    const { result } = renderHook(() => usePdfDocument(data));
+
+    await waitFor(() => expect(result.current.pdf).toBe(fakePdf));
+    expect(result.current.error).toBeNull();
+
+    const arg = getDocumentMock.mock.calls[0][0] as { data: ArrayBuffer };
+    expect(arg.data).not.toBe(data); // a defensive slice, not the cached buffer
+    expect(arg.data.byteLength).toBe(4);
+  });
+
+  it('surfaces the parser error message on a rejected load', async () => {
+    const { task } = loadingTask(Promise.reject(new Error('bad header')));
+    getDocumentMock.mockReturnValue(task);
+    const data = new Uint8Array([1]).buffer;
+
+    const { result } = renderHook(() => usePdfDocument(data));
+
+    await waitFor(() => expect(result.current.error).toBe('bad header'));
+    expect(result.current.pdf).toBeNull();
+  });
+
+  it('falls back to a generic message when the rejection is not an Error', async () => {
+    const { task } = loadingTask(Promise.reject('nope'));
+    getDocumentMock.mockReturnValue(task);
+    const data = new Uint8Array([1]).buffer;
+
+    const { result } = renderHook(() => usePdfDocument(data));
+
+    await waitFor(() => expect(result.current.error).toBe('Failed to parse PDF'));
+  });
+
+  it('destroys the loading task on unmount so the worker handle is released', async () => {
+    const { task, destroy } = loadingTask(Promise.resolve(fakePdf));
+    getDocumentMock.mockReturnValue(task);
+    const data = new Uint8Array([1]).buffer;
+
+    const { result, unmount } = renderHook(() => usePdfDocument(data));
+    await waitFor(() => expect(result.current.pdf).toBe(fakePdf));
+
+    unmount();
+
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('tears down the previous task when the data changes', async () => {
+    const first = loadingTask(Promise.resolve(fakePdf));
+    const second = loadingTask(Promise.resolve(fakePdf));
+    getDocumentMock.mockReturnValueOnce(first.task).mockReturnValueOnce(second.task);
+
+    const { result, rerender } = renderHook(({ data }) => usePdfDocument(data), {
+      initialProps: { data: new Uint8Array([1]).buffer },
+    });
+    await waitFor(() => expect(result.current.pdf).toBe(fakePdf));
+
+    rerender({ data: new Uint8Array([2, 2]).buffer });
+
+    expect(first.destroy).toHaveBeenCalledOnce();
+    expect(getDocumentMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/qnop-ui/vitest.config.ts
+++ b/qnop-ui/vitest.config.ts
@@ -45,10 +45,15 @@ export default defineConfig({
         'src/components/shell/navConfig.tsx',
         // Auth screens — the critical entry flow (issue #352, wave 1).
         'src/pages/auth/**/*.tsx',
-        // The viewer's pure anchor-building logic (#250); the presentational
-        // viewer/panel components are covered by component tests, and the
-        // pdf.js wiring (usePdfDocument, SurfacePage canvas) by E2E later.
+        // The viewer's pure anchor-building logic (#250) plus the document
+        // surface (issue #352, wave 2): the pdf.js loader/canvas wiring and the
+        // scrollable page stack with its scroll spy and rubber-band selection.
+        // SurfacePage and the presentational layers stay on component/E2E tests.
         'src/components/reviews/viewer/anchoring.ts',
+        'src/components/reviews/viewer/usePdfDocument.ts',
+        'src/components/reviews/viewer/PageCanvas.tsx',
+        'src/components/reviews/viewer/DocumentViewer.tsx',
+        'src/components/reviews/viewer/RegionSelectLayer.tsx',
         'src/theme/**/*.ts',
       ],
       thresholds: {


### PR DESCRIPTION
## Summary

Wave 2 of the frontend test-coverage effort (#352): the **document viewer surface** — the second critical flow after auth (wave 1, #434). Adds **22 tests** across the four viewer units the issue calls out, driving them through jsdom with targeted stubs (a controllable `IntersectionObserver`, a mocked `pdfjs-dist`, a stubbed `SurfacePage`, and a `clientWidth`/`scrollIntoView` shim).

### Covered in this wave
- **`usePdfDocument`** — idle without data; parses bytes into a pdf.js document handing the worker a **defensive copy** (not the cached buffer); surfaces the parser message (and a generic fallback) on failure; **destroys** the loading task on unmount / data change.
- **`PageCanvas`** — stays blank until its `IntersectionObserver` reports the page visible; then renders the pdf.js page, reports the **aspect ratio**, sizes the backing store by `width × devicePixelRatio`, and **cancels** the in-flight render on unmount.
- **`RegionSelectLayer`** — rubber-band drag normalized to a page-relative box, **unit-clamped** past the edges, preview shown during the drag and cleared on drop; left-button / `enabled` guards.
- **`DocumentViewer`** — page count from server surfaces or `pdf.numPages`; the `scrollToPage` imperative handle; the **scroll spy** reporting the current page; panel-driven **scroll-into-view** for the active/hovered mark; mark selection.

### Coverage
- **22 new tests**, full suite **580 passing**.
- Grows the coverage `include` allowlist by the wave-2 viewer slice.
- **Thresholds stay at 80** — scoped `include` sits at **~88% statements / 82% branches / 85% functions / 89% lines**; the viewer dir itself is **~94% / 82% / 89% / 98%**.
- `SurfacePage` and the presentational layers (`HighlightLayer`, `TextSpanLayer`, `AnnotationHoverCard` — already component-tested) stay off the gate.

### Test plan
- [x] `vitest run --coverage` — 580 pass, gate green at 80
- [x] `tsc -b --noEmit` — clean
- [x] `eslint` — clean
- [x] `prettier --check` — clean
- [ ] CI green

### Follow-up waves (still open on #352)
- Admin pages: Users / Teams / Settings / Branding / OidcProviders (only their API hooks are tested today)
- Shell/router: `AppShell` persistence + mobile drawer, router guards

Refs #352

🤖 Co-Author: Claude (Opus 4.x) via Claude Code