### PR TITLE
test(ui): admin-surface coverage — wave 3 of #352

### DIFF
--- a/qnop-ui/src/pages/admin/BrandingPage.test.tsx
+++ b/qnop-ui/src/pages/admin/BrandingPage.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ServerConfigBranding, ServerConfigResponse } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { BrandingPage } from './BrandingPage';
+
+const BRANDING: ServerConfigBranding = {
+  logoLight: { source: 'DEFAULT', url: '/branding/logo-light.svg?v=aaa' },
+  logoDark: { source: 'CUSTOM', url: '/branding/logo-dark.svg?v=bbb' },
+  logomark: { source: 'DEFAULT', url: '/branding/logomark.svg?v=ccc' },
+};
+
+const CONFIG: Partial<ServerConfigResponse> = { branding: BRANDING };
+
+// Mutable state the useConfig mock reads, so each test can drive a branch.
+const configState = vi.hoisted(() => ({
+  data: undefined as Partial<ServerConfigResponse> | undefined,
+  isLoading: false,
+  isError: false,
+}));
+
+vi.mock('../../api/hooks/useConfig', () => ({
+  useConfig: () => configState,
+}));
+
+// Stub the child card to its user-visible label so we assert the loaded slots
+// without pulling in the real component's upload/cropper internals.
+vi.mock('../../components/admin/branding/BrandingSlotCard', () => ({
+  BrandingSlotCard: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+beforeEach(() => {
+  configState.data = CONFIG;
+  configState.isLoading = false;
+  configState.isError = false;
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+const renderPage = () => render(<BrandingPage />, { wrapper });
+
+const SLOT_LABELS = ['Logo (light)', 'Logo (dark)', 'Logomark'];
+
+describe('BrandingPage', () => {
+  it('shows skeletons and no slot cards while the config is loading', () => {
+    configState.isLoading = true;
+    configState.data = undefined;
+
+    const { container } = renderPage();
+
+    expect(container.querySelectorAll('.MuiSkeleton-root').length).toBe(3);
+    for (const label of SLOT_LABELS) {
+      expect(screen.queryByText(label)).toBeNull();
+    }
+  });
+
+  it('surfaces an error alert when the config could not be loaded', () => {
+    configState.isError = true;
+    configState.data = undefined;
+
+    renderPage();
+
+    expect(screen.getByText('The branding configuration could not be loaded.')).toBeTruthy();
+    for (const label of SLOT_LABELS) {
+      expect(screen.queryByText(label)).toBeNull();
+    }
+  });
+
+  it('renders a card for each of the three branding slots once loaded', () => {
+    renderPage();
+
+    for (const label of SLOT_LABELS) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
+});

--- a/qnop-ui/src/pages/admin/OidcProvidersPage.test.tsx
+++ b/qnop-ui/src/pages/admin/OidcProvidersPage.test.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { OidcProviderDto } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { OidcProvidersPage } from './OidcProvidersPage';
+
+const { updateMutate, deleteMutate, useOidcProvidersMock } = vi.hoisted(() => ({
+  updateMutate: vi.fn(),
+  deleteMutate: vi.fn(),
+  useOidcProvidersMock: vi.fn(),
+}));
+
+const PROVIDERS: OidcProviderDto[] = [
+  {
+    id: 'p-1',
+    name: 'Keycloak',
+    providerType: 'OIDC',
+    enabled: true,
+    clientId: 'qnop',
+    hasClientSecret: true,
+    scope: 'openid profile email',
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'p-2',
+    name: 'GitHub',
+    providerType: 'GITHUB',
+    enabled: false,
+    clientId: 'gh-app',
+    hasClientSecret: true,
+    scope: 'read:user user:email',
+    createdAt: '2026-01-02T00:00:00Z',
+  },
+];
+
+vi.mock('../../api/hooks/useOidcProviders', () => ({
+  useOidcProviders: () => useOidcProvidersMock(),
+  useUpdateOidcProvider: () => ({ mutateAsync: updateMutate }),
+  useDeleteOidcProvider: () => ({ mutateAsync: deleteMutate }),
+}));
+
+vi.mock('../../components/admin/oidc/OidcProvidersTable', () => ({
+  OidcProvidersTable: ({
+    providers,
+    onToggleEnabled,
+    onDelete,
+  }: {
+    providers: OidcProviderDto[];
+    onToggleEnabled: (p: OidcProviderDto) => void;
+    onDelete: (p: OidcProviderDto) => void;
+  }) => (
+    <div>
+      {providers.map((provider) => (
+        <div key={provider.id}>
+          <span>{provider.name}</span>
+          <button onClick={() => onToggleEnabled(provider)}>toggle-{provider.id}</button>
+          <button onClick={() => onDelete(provider)}>delete-{provider.id}</button>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/admin/oidc/OidcProviderFormDialog', () => ({
+  OidcProviderFormDialog: ({ open, mode }: { open: boolean; mode: string }) =>
+    open ? <div>form-dialog-open:{mode}</div> : null,
+}));
+
+vi.mock('../../components/admin/ConfirmDialog', () => ({
+  ConfirmDialog: ({ open, onConfirm }: { open: boolean; onConfirm: () => void }) =>
+    open ? <button onClick={onConfirm}>confirm-delete</button> : null,
+}));
+
+beforeEach(() => {
+  updateMutate.mockReset().mockResolvedValue(undefined);
+  deleteMutate.mockReset().mockResolvedValue(undefined);
+  useOidcProvidersMock.mockReset().mockReturnValue({
+    data: { providers: PROVIDERS },
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+  });
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+const renderPage = () => render(<OidcProvidersPage />, { wrapper });
+
+describe('OidcProvidersPage', () => {
+  it('lists the configured providers', () => {
+    renderPage();
+
+    expect(screen.getByText('Keycloak')).toBeTruthy();
+    expect(screen.getByText('GitHub')).toBeTruthy();
+  });
+
+  it('shows an error alert when the providers cannot be loaded', () => {
+    useOidcProvidersMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+    });
+    renderPage();
+
+    expect(screen.getByText('The providers could not be loaded.')).toBeTruthy();
+    expect(screen.queryByText('Keycloak')).toBeNull();
+  });
+
+  it('toggles a provider and surfaces a success toast', async () => {
+    renderPage();
+
+    // Keycloak is enabled → toggling requests `enabled: false`.
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-p-1' }));
+
+    await waitFor(() =>
+      expect(updateMutate).toHaveBeenCalledWith({ id: 'p-1', request: { enabled: false } }),
+    );
+    expect(await screen.findByText('Keycloak disabled.')).toBeTruthy();
+  });
+
+  it('reports a failed toggle as an error toast', async () => {
+    updateMutate.mockRejectedValue(new Error('boom'));
+    renderPage();
+
+    // GitHub is disabled → toggling requests `enabled: true`.
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-p-2' }));
+
+    await waitFor(() =>
+      expect(updateMutate).toHaveBeenCalledWith({ id: 'p-2', request: { enabled: true } }),
+    );
+    const alert = await screen.findByText('The change could not be saved.');
+    expect(alert.closest('.MuiAlert-colorError')).toBeTruthy();
+  });
+
+  it('deletes a provider after confirmation and surfaces a success toast', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'delete-p-2' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'confirm-delete' }));
+
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith('p-2'));
+    expect(await screen.findByText('GitHub deleted.')).toBeTruthy();
+  });
+
+  it('reports a failed delete as an error toast', async () => {
+    deleteMutate.mockRejectedValue(new Error('boom'));
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'delete-p-1' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'confirm-delete' }));
+
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith('p-1'));
+    const alert = await screen.findByText('The provider could not be deleted.');
+    expect(alert.closest('.MuiAlert-colorError')).toBeTruthy();
+  });
+
+  it('opens the create dialog from the "Add provider" button', () => {
+    renderPage();
+
+    expect(screen.queryByText(/form-dialog-open/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add provider' }));
+
+    expect(screen.getByText('form-dialog-open:create')).toBeTruthy();
+  });
+});

--- a/qnop-ui/src/pages/admin/SettingsPage.test.tsx
+++ b/qnop-ui/src/pages/admin/SettingsPage.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { buildTheme } from '../../theme/theme';
+import { SettingsPage } from './SettingsPage';
+
+// SettingsPage is a thin composition wrapper: it delegates to
+// ApplicationSettingsForm, whose own hooks are out of scope here. Stub the
+// child so the test asserts only the page's own composition.
+vi.mock('../../components/admin/settings/ApplicationSettingsForm', () => ({
+  ApplicationSettingsForm: () => <div data-testid="application-settings-form" />,
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+const renderPage = () => render(<SettingsPage />, { wrapper });
+
+describe('SettingsPage', () => {
+  it('renders the page header title and description', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy();
+    expect(screen.getByText('Workspace, uploads, usage tracking and authentication.')).toBeTruthy();
+  });
+
+  it('delegates to the application settings form', () => {
+    renderPage();
+
+    expect(screen.getByTestId('application-settings-form')).toBeTruthy();
+  });
+});

--- a/qnop-ui/src/pages/admin/TeamDetailPage.test.tsx
+++ b/qnop-ui/src/pages/admin/TeamDetailPage.test.tsx
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { AdminTeamDetail, AdminTeamMember } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { TeamDetailPage } from './TeamDetailPage';
+
+const { teamState, setRoleMutate, removeMemberMutate } = vi.hoisted(() => ({
+  teamState: { data: undefined, isLoading: false, isError: false } as {
+    data: AdminTeamDetail | undefined;
+    isLoading: boolean;
+    isError: boolean;
+  },
+  setRoleMutate: vi.fn(),
+  removeMemberMutate: vi.fn(),
+}));
+
+vi.mock('../../api/hooks/useTeams', () => ({
+  useTeam: () => teamState,
+  useSetTeamMemberRole: () => ({ mutate: setRoleMutate }),
+  useRemoveTeamMember: () => ({ mutate: removeMemberMutate }),
+}));
+
+// The heavy member/team dialogs pull in their own api hooks and search UI;
+// stub them down to markers that expose the props the page wires in.
+vi.mock('../../components/admin/teams/AddMemberDialog', () => ({
+  AddMemberDialog: (props: {
+    open: boolean;
+    teamId: string;
+    existingMemberIds: string[];
+    onClose: () => void;
+  }) =>
+    props.open ? (
+      <div data-testid="add-member-dialog">
+        <span data-testid="add-team-id">{props.teamId}</span>
+        <span data-testid="add-existing">{props.existingMemberIds.join(',')}</span>
+        <button type="button" onClick={props.onClose}>
+          close-add
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../components/admin/teams/TeamFormDialog', () => ({
+  TeamFormDialog: (props: {
+    open: boolean;
+    mode: string;
+    team?: { name: string };
+    onClose: () => void;
+  }) =>
+    props.open ? (
+      <div data-testid="team-form-dialog">
+        <span data-testid="edit-mode">{props.mode}</span>
+        <span data-testid="edit-name">{props.team?.name}</span>
+        <button type="button" onClick={props.onClose}>
+          close-edit
+        </button>
+      </div>
+    ) : null,
+}));
+
+const LEAD: AdminTeamMember = {
+  userId: 'u1',
+  displayName: 'Ada Lovelace',
+  email: 'ada@example.com',
+  teamRole: 'LEAD',
+  joinedAt: '2026-01-01T10:00:00Z',
+};
+
+const MEMBER: AdminTeamMember = {
+  userId: 'u2',
+  displayName: 'Alan Turing',
+  email: 'alan@example.com',
+  teamRole: 'MEMBER',
+  joinedAt: '2026-02-01T10:00:00Z',
+};
+
+function makeTeam(overrides: Partial<AdminTeamDetail> = {}): AdminTeamDetail {
+  return {
+    id: 't1',
+    name: 'Platform',
+    description: 'Owns the ingest pipeline.',
+    enabled: true,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-03-01T00:00:00Z',
+    members: [LEAD, MEMBER],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  setRoleMutate.mockReset();
+  removeMemberMutate.mockReset();
+  teamState.data = makeTeam();
+  teamState.isLoading = false;
+  teamState.isError = false;
+});
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <MemoryRouter initialEntries={['/admin/teams/t1']}>
+          <Routes>
+            <Route path="/admin/teams/:id" element={<TeamDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('TeamDetailPage', () => {
+  it('shows the loading placeholder while the team query is in flight', () => {
+    teamState.data = undefined;
+    teamState.isLoading = true;
+    renderPage();
+
+    expect(screen.getByText('Loading…')).toBeTruthy();
+  });
+
+  it('renders an error alert with a way back to the team list on failure', () => {
+    teamState.data = undefined;
+    teamState.isError = true;
+    renderPage();
+
+    expect(screen.getByText(/This team could not be loaded\./)).toBeTruthy();
+    const back = screen.getByRole('link', { name: 'Back to teams' });
+    expect(back.getAttribute('href')).toBe('/admin/teams');
+  });
+
+  it('renders the header, description and every member row', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Platform' })).toBeTruthy();
+    expect(screen.getByText('Owns the ingest pipeline.')).toBeTruthy();
+    expect(screen.getByText('Ada Lovelace')).toBeTruthy();
+    expect(screen.getByText('ada@example.com')).toBeTruthy();
+    expect(screen.getByText('Alan Turing')).toBeTruthy();
+    expect(screen.getByText('alan@example.com')).toBeTruthy();
+  });
+
+  it('renders the empty-state row when the team has no members', () => {
+    teamState.data = makeTeam({ members: [] });
+    renderPage();
+
+    expect(screen.getByText('No members yet. Add the first one.')).toBeTruthy();
+  });
+
+  it('demotes a lead to member through the row menu', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for Ada Lovelace' }));
+    fireEvent.click(await screen.findByText('Make member'));
+
+    expect(setRoleMutate).toHaveBeenCalledWith({
+      teamId: 't1',
+      userId: 'u1',
+      teamRole: 'MEMBER',
+    });
+  });
+
+  it('promotes a member to lead through the row menu', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for Alan Turing' }));
+    fireEvent.click(await screen.findByText('Make lead'));
+
+    expect(setRoleMutate).toHaveBeenCalledWith({
+      teamId: 't1',
+      userId: 'u2',
+      teamRole: 'LEAD',
+    });
+  });
+
+  it('removes a member after confirming the destructive dialog', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for Ada Lovelace' }));
+    fireEvent.click(await screen.findByText('Remove from team'));
+
+    expect(await screen.findByText('Remove Ada Lovelace from this team?')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(removeMemberMutate).toHaveBeenCalledWith({ teamId: 't1', userId: 'u1' });
+  });
+
+  it('does not remove a member when the confirmation is cancelled', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for Alan Turing' }));
+    fireEvent.click(await screen.findByText('Remove from team'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('Remove Alan Turing from this team?')).toBeNull(),
+    );
+    expect(removeMemberMutate).not.toHaveBeenCalled();
+  });
+
+  it('opens the add-member dialog wired with the team id and existing members', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add member' }));
+
+    expect(await screen.findByTestId('add-member-dialog')).toBeTruthy();
+    expect(screen.getByTestId('add-team-id').textContent).toBe('t1');
+    expect(screen.getByTestId('add-existing').textContent).toBe('u1,u2');
+
+    fireEvent.click(screen.getByRole('button', { name: 'close-add' }));
+    await waitFor(() => expect(screen.queryByTestId('add-member-dialog')).toBeNull());
+  });
+
+  it('opens the edit dialog in edit mode with the current team seeded', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(await screen.findByTestId('team-form-dialog')).toBeTruthy();
+    expect(screen.getByTestId('edit-mode').textContent).toBe('edit');
+    expect(screen.getByTestId('edit-name').textContent).toBe('Platform');
+
+    fireEvent.click(screen.getByRole('button', { name: 'close-edit' }));
+    await waitFor(() => expect(screen.queryByTestId('team-form-dialog')).toBeNull());
+  });
+
+  it('renders a team with no description without crashing', () => {
+    teamState.data = makeTeam({ description: '' });
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Platform' })).toBeTruthy();
+    expect(screen.queryByText('Owns the ingest pipeline.')).toBeNull();
+  });
+});

--- a/qnop-ui/src/pages/admin/TeamsPage.test.tsx
+++ b/qnop-ui/src/pages/admin/TeamsPage.test.tsx
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { AdminTeamListResponse, AdminTeamSummary } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { TeamsPage } from './TeamsPage';
+
+type TeamsHookResult = {
+  data: AdminTeamListResponse | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+};
+
+const { teamsRef, deleteMutate, navigateSpy } = vi.hoisted(() => ({
+  teamsRef: {
+    current: {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    } as TeamsHookResult,
+  },
+  deleteMutate: vi.fn(),
+  navigateSpy: vi.fn(),
+}));
+
+const TEAMS: AdminTeamSummary[] = [
+  {
+    id: 'team-1',
+    name: 'Alpha',
+    description: 'First team',
+    enabled: true,
+    memberCount: 3,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+  },
+  {
+    id: 'team-2',
+    name: 'Beta',
+    description: '',
+    enabled: false,
+    memberCount: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+  },
+];
+
+const LIST: AdminTeamListResponse = { items: TEAMS, total: TEAMS.length, page: 0, size: 20 };
+
+const setTeams = (partial: Partial<TeamsHookResult>) => {
+  teamsRef.current = { ...teamsRef.current, ...partial };
+};
+
+vi.mock('../../api/hooks/useTeams', () => ({
+  useTeams: () => teamsRef.current,
+  useDeleteTeam: () => ({ mutateAsync: deleteMutate, isPending: false }),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => navigateSpy,
+}));
+
+// Stub the create/edit dialog: it owns its own mutations, so here we only expose
+// enough of the page's orchestration (open flag, mode, target team) to assert on.
+vi.mock('../../components/admin/teams/TeamFormDialog', () => ({
+  TeamFormDialog: (props: {
+    open: boolean;
+    mode: 'create' | 'edit';
+    team?: AdminTeamSummary;
+    onClose: () => void;
+  }) =>
+    props.open ? (
+      <div data-testid="team-form-dialog">
+        <span>form-mode:{props.mode}</span>
+        {props.team ? <span>form-team:{props.team.name}</span> : null}
+        <button type="button" onClick={props.onClose}>
+          close-form
+        </button>
+      </div>
+    ) : null,
+}));
+
+// Stub the confirm dialog so we can drive the page's confirmDelete handler.
+vi.mock('../../components/admin/ConfirmDialog', () => ({
+  ConfirmDialog: (props: {
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    onConfirm: () => void;
+    onClose: () => void;
+  }) =>
+    props.open ? (
+      <div role="dialog" aria-label="confirm-delete">
+        <p>{props.message}</p>
+        <button type="button" onClick={props.onConfirm}>
+          {props.confirmLabel}
+        </button>
+        <button type="button" onClick={props.onClose}>
+          cancel-confirm
+        </button>
+      </div>
+    ) : null,
+}));
+
+beforeEach(() => {
+  teamsRef.current = { data: LIST, isLoading: false, isFetching: false, isError: false };
+  deleteMutate.mockReset().mockResolvedValue(undefined);
+  navigateSpy.mockReset();
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+const renderPage = () => render(<TeamsPage />, { wrapper });
+
+const openRowMenu = async (teamName: string) => {
+  fireEvent.click(screen.getByRole('button', { name: `Actions for ${teamName}` }));
+  return screen.findByRole('menu');
+};
+
+describe('TeamsPage', () => {
+  it('renders a row per team with description, member count and status', () => {
+    renderPage();
+
+    expect(screen.getByText('Alpha')).toBeTruthy();
+    expect(screen.getByText('First team')).toBeTruthy();
+    expect(screen.getByText('Beta')).toBeTruthy();
+    // Alpha is active, Beta is disabled.
+    expect(screen.getByText('Active')).toBeTruthy();
+    expect(screen.getByText('Disabled')).toBeTruthy();
+    // Beta has no description → em dash placeholder.
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+
+  it('shows the loading hint while the first page is loading', () => {
+    setTeams({ data: undefined, isLoading: true });
+    renderPage();
+
+    expect(screen.getByText('Loading…')).toBeTruthy();
+  });
+
+  it('shows a background-fetch progress bar', () => {
+    setTeams({ isFetching: true });
+    renderPage();
+
+    expect(screen.getByRole('progressbar')).toBeTruthy();
+  });
+
+  it('renders an error alert instead of the table when the list fails', () => {
+    setTeams({ data: undefined, isError: true });
+    renderPage();
+
+    expect(screen.getByText('The team list could not be loaded.')).toBeTruthy();
+    // The table header is not rendered in the error branch.
+    expect(screen.queryByText('Members')).toBeNull();
+  });
+
+  it('shows the empty-state row when there are no teams', () => {
+    setTeams({ data: { items: [], total: 0, page: 0, size: 20 } });
+    renderPage();
+
+    expect(screen.getByText('No teams found.')).toBeTruthy();
+  });
+
+  it('opens the create dialog in create mode', () => {
+    renderPage();
+
+    expect(screen.queryByTestId('team-form-dialog')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Create team' }));
+
+    expect(screen.getByTestId('team-form-dialog')).toBeTruthy();
+    expect(screen.getByText('form-mode:create')).toBeTruthy();
+  });
+
+  it('closes the create dialog via its onClose', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create team' }));
+    fireEvent.click(screen.getByRole('button', { name: 'close-form' }));
+
+    expect(screen.queryByTestId('team-form-dialog')).toBeNull();
+  });
+
+  it('opens the edit dialog seeded with the chosen team', async () => {
+    renderPage();
+
+    await openRowMenu('Alpha');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
+
+    expect(screen.getByText('form-mode:edit')).toBeTruthy();
+    expect(screen.getByText('form-team:Alpha')).toBeTruthy();
+  });
+
+  it('navigates to a team detail page when its row is clicked', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByText('Alpha'));
+
+    expect(navigateSpy).toHaveBeenCalledWith('/admin/teams/team-1');
+  });
+
+  it('deletes a team and surfaces a success toast', async () => {
+    renderPage();
+
+    await openRowMenu('Alpha');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+    // The confirmation names the team being deleted.
+    expect(screen.getByText(/Delete .*Alpha.* and all its memberships/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith('team-1'));
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Alpha');
+    expect(alert.textContent).toContain('deleted');
+    expect(alert.className).toContain('MuiAlert-colorSuccess');
+  });
+
+  it('surfaces an error toast when the delete fails', async () => {
+    deleteMutate.mockRejectedValueOnce(new Error('boom'));
+    renderPage();
+
+    await openRowMenu('Beta');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith('team-2'));
+    const alert = await screen.findByText('Could not delete the team.');
+    expect(alert.closest('.MuiAlert-colorError')).toBeTruthy();
+  });
+
+  it('dismisses the delete confirmation without calling the mutation', async () => {
+    renderPage();
+
+    await openRowMenu('Alpha');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'cancel-confirm' }));
+
+    expect(screen.queryByRole('dialog', { name: 'confirm-delete' })).toBeNull();
+    expect(deleteMutate).not.toHaveBeenCalled();
+  });
+
+  it('reveals a clear button while searching and resets the field', () => {
+    renderPage();
+
+    const input = screen.getByPlaceholderText('Search by name or description') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'alpha' } });
+    expect(input.value).toBe('alpha');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+    expect(input.value).toBe('');
+  });
+});

--- a/qnop-ui/src/pages/admin/UsersPage.test.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.test.tsx
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { AdminUserListResponse, AdminUserSummary } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { useAuthStore } from '../../stores/authStore';
+import { UsersPage } from './UsersPage';
+
+// The four page-owned mutations plus a mutable query-state object so each test
+// can steer loading / error / empty / populated list responses.
+const { updateMutate, deleteMutate, resetMutate, generateMutate, queryState } = vi.hoisted(() => ({
+  updateMutate: vi.fn(),
+  deleteMutate: vi.fn(),
+  resetMutate: vi.fn(),
+  generateMutate: vi.fn(),
+  queryState: {
+    data: undefined as AdminUserListResponse | undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+  },
+}));
+
+vi.mock('../../api/hooks/useAdminUsers', () => ({
+  useAdminUsers: () => queryState,
+  useUpdateUser: () => ({ mutateAsync: updateMutate }),
+  useDeleteUser: () => ({ mutateAsync: deleteMutate }),
+  useSendUserPasswordReset: () => ({ mutateAsync: resetMutate }),
+  useGenerateUserPassword: () => ({ mutateAsync: generateMutate }),
+}));
+
+// Stub the heavy child table down to one button per callback so the PAGE's own
+// orchestration (which mutation runs, which dialog opens, which toast shows) is
+// what gets exercised — the table's own rendering is covered by its own test.
+vi.mock('../../components/admin/users/UsersTable', () => ({
+  UsersTable: ({
+    users,
+    onSort,
+    onEdit,
+    onResetPassword,
+    onGeneratePassword,
+    onToggleEnabled,
+    onDelete,
+  }: {
+    users: AdminUserSummary[];
+    onSort: (field: string) => void;
+    onEdit: (user: AdminUserSummary) => void;
+    onResetPassword: (user: AdminUserSummary) => void;
+    onGeneratePassword: (user: AdminUserSummary) => void;
+    onToggleEnabled: (user: AdminUserSummary) => void;
+    onDelete: (user: AdminUserSummary) => void;
+  }): ReactNode => (
+    <div data-testid="users-table">
+      {users.length === 0 && <span>stub-no-users</span>}
+      <button onClick={() => onSort('role')}>stub-sort-role</button>
+      {users.map((user) => (
+        <div key={user.id}>
+          <span>{user.displayName}</span>
+          <button onClick={() => onEdit(user)}>edit-{user.id}</button>
+          <button onClick={() => onResetPassword(user)}>reset-{user.id}</button>
+          <button onClick={() => onGeneratePassword(user)}>generate-{user.id}</button>
+          <button onClick={() => onToggleEnabled(user)}>toggle-{user.id}</button>
+          <button onClick={() => onDelete(user)}>delete-{user.id}</button>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/admin/users/UserFormDialog', () => ({
+  UserFormDialog: ({
+    open,
+    mode,
+    user,
+    onClose,
+  }: {
+    open: boolean;
+    mode: 'create' | 'edit';
+    user?: AdminUserSummary;
+    onClose: () => void;
+  }): ReactNode =>
+    open ? (
+      <div>
+        <span>stub-user-form-{mode}</span>
+        {user && <span>stub-editing-{user.displayName}</span>}
+        <button onClick={onClose}>stub-close-form</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../components/admin/users/ResetLinkDialog', () => ({
+  ResetLinkDialog: ({
+    open,
+    displayName,
+    url,
+  }: {
+    open: boolean;
+    displayName: string;
+    url: string;
+  }): ReactNode =>
+    open ? (
+      <div>
+        stub-reset-link {displayName} {url}
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../components/admin/users/GeneratedPasswordDialog', () => ({
+  GeneratedPasswordDialog: ({
+    open,
+    displayName,
+    password,
+  }: {
+    open: boolean;
+    displayName: string;
+    password: string;
+  }): ReactNode =>
+    open ? (
+      <div>
+        stub-generated {displayName} {password}
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../components/admin/ConfirmDialog', () => ({
+  ConfirmDialog: ({
+    open,
+    message,
+    onConfirm,
+    onClose,
+  }: {
+    open: boolean;
+    message: string;
+    onConfirm: () => void;
+    onClose: () => void;
+  }): ReactNode =>
+    open ? (
+      <div role="dialog">
+        <p>{message}</p>
+        <button onClick={onConfirm}>stub-confirm-delete</button>
+        <button onClick={onClose}>stub-cancel-delete</button>
+      </div>
+    ) : null,
+}));
+
+const ADA: AdminUserSummary = {
+  id: 'ada',
+  displayName: 'Ada Admin',
+  email: 'ada@example.com',
+  role: 'ADMIN',
+  source: 'INTERNAL',
+  enabled: true,
+  passwordChangeRequired: false,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const BEN: AdminUserSummary = {
+  id: 'ben',
+  displayName: 'Ben Member',
+  email: 'ben@example.com',
+  role: 'MEMBER',
+  source: 'INTERNAL',
+  enabled: false,
+  passwordChangeRequired: false,
+  createdAt: '2026-01-02T00:00:00Z',
+};
+
+const LIST: AdminUserListResponse = { items: [ADA, BEN], total: 2, page: 0, size: 20 };
+
+/** A minimal axios-shaped error carrying the API's uniform `code` envelope. */
+function conflictError(code: string, status = 409) {
+  return { isAxiosError: true, response: { status, data: { code } } };
+}
+
+beforeEach(() => {
+  updateMutate.mockReset().mockResolvedValue({});
+  deleteMutate.mockReset().mockResolvedValue(undefined);
+  resetMutate.mockReset().mockResolvedValue({ emailSent: true });
+  generateMutate.mockReset().mockResolvedValue({ password: 'hunter2' });
+  queryState.data = LIST;
+  queryState.isLoading = false;
+  queryState.isFetching = false;
+  queryState.isError = false;
+  useAuthStore.setState({ userId: 'me' });
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+const renderPage = () => render(<UsersPage />, { wrapper });
+
+describe('UsersPage', () => {
+  it('renders the header and the current page of users', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Users' })).toBeTruthy();
+    expect(screen.getByText('Ada Admin')).toBeTruthy();
+    expect(screen.getByText('Ben Member')).toBeTruthy();
+  });
+
+  it('shows the loading placeholder while the first page is loading', () => {
+    queryState.isLoading = true;
+    renderPage();
+
+    expect(screen.getByText('Loading…')).toBeTruthy();
+  });
+
+  it('shows an error alert instead of the table when the list fails to load', () => {
+    queryState.isError = true;
+    renderPage();
+
+    expect(screen.getByText('The user list could not be loaded.')).toBeTruthy();
+    expect(screen.queryByTestId('users-table')).toBeNull();
+  });
+
+  it('renders the empty-state row when there are no users', () => {
+    queryState.data = { items: [], total: 0, page: 0, size: 20 };
+    renderPage();
+
+    expect(screen.getByText('stub-no-users')).toBeTruthy();
+  });
+
+  it('opens the create dialog from the Add user button', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add user' }));
+
+    expect(screen.getByText('stub-user-form-create')).toBeTruthy();
+  });
+
+  it('opens the edit dialog seeded with the chosen user', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'edit-ada' }));
+
+    expect(screen.getByText('stub-user-form-edit')).toBeTruthy();
+    expect(screen.getByText('stub-editing-Ada Admin')).toBeTruthy();
+  });
+
+  it('clears the search box via its clear button', () => {
+    renderPage();
+
+    const search = screen.getByLabelText('Search users') as HTMLInputElement;
+    fireEvent.change(search, { target: { value: 'ada' } });
+    expect(search.value).toBe('ada');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+    expect(search.value).toBe('');
+  });
+
+  it('toggles a user by patching the inverse enabled flag', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-ada' }));
+
+    await waitFor(() =>
+      expect(updateMutate).toHaveBeenCalledWith({ id: 'ada', request: { enabled: false } }),
+    );
+  });
+
+  it('maps a LAST_ADMIN conflict on toggle to its curated toast', async () => {
+    updateMutate.mockRejectedValue(conflictError('LAST_ADMIN'));
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-ada' }));
+
+    expect(await screen.findByText('At least one enabled admin must remain.')).toBeTruthy();
+  });
+
+  it('falls back to a generic toast when a toggle error carries no known code', async () => {
+    updateMutate.mockRejectedValue(new Error('boom'));
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-ben' }));
+
+    expect(await screen.findByText('Could not update Ben Member.')).toBeTruthy();
+  });
+
+  it('confirms a delete and reports success', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'delete-ben' }));
+    // The confirm dialog opens with the target's name in its message.
+    expect(screen.getByRole('dialog')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'stub-confirm-delete' }));
+
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith('ben'));
+    expect(await screen.findByText('User “Ben Member” deleted.')).toBeTruthy();
+  });
+
+  it('surfaces a delete failure as an error toast', async () => {
+    deleteMutate.mockRejectedValue(new Error('nope'));
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'delete-ben' }));
+    fireEvent.click(screen.getByRole('button', { name: 'stub-confirm-delete' }));
+
+    expect(await screen.findByText('Could not delete the user.')).toBeTruthy();
+  });
+
+  it('reports an emailed password reset as a success toast', async () => {
+    resetMutate.mockResolvedValue({ emailSent: true });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'reset-ben' }));
+
+    await waitFor(() => expect(resetMutate).toHaveBeenCalledWith('ben'));
+    expect(
+      await screen.findByText('Password reset emailed to ben@example.com. Sessions revoked.'),
+    ).toBeTruthy();
+  });
+
+  it('shows the reset-link dialog when email delivery falls back to a link', async () => {
+    resetMutate.mockResolvedValue({ emailSent: false, resetUrl: 'https://q/reset?t=1' });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'reset-ada' }));
+
+    expect(await screen.findByText(/stub-reset-link Ada Admin/)).toBeTruthy();
+    expect(screen.getByText(/https:\/\/q\/reset\?t=1/)).toBeTruthy();
+  });
+
+  it('warns when a reset returns neither an email nor a link', async () => {
+    resetMutate.mockResolvedValue({ emailSent: false });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'reset-ada' }));
+
+    expect(
+      await screen.findByText('Reset triggered for Ada Admin, but no link was returned.'),
+    ).toBeTruthy();
+  });
+
+  it('surfaces a failed reset as an error toast', async () => {
+    resetMutate.mockRejectedValue(new Error('down'));
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'reset-ada' }));
+
+    expect(await screen.findByText('The reset could not be triggered.')).toBeTruthy();
+  });
+
+  it('shows the generated password in its dialog', async () => {
+    generateMutate.mockResolvedValue({ password: 's3cr3t' });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'generate-ada' }));
+
+    await waitFor(() => expect(generateMutate).toHaveBeenCalledWith('ada'));
+    expect(await screen.findByText(/stub-generated Ada Admin s3cr3t/)).toBeTruthy();
+  });
+
+  it('surfaces a failed password generation as an error toast', async () => {
+    generateMutate.mockRejectedValue(new Error('nope'));
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'generate-ada' }));
+
+    expect(await screen.findByText('A password could not be generated.')).toBeTruthy();
+  });
+});

--- a/qnop-ui/vitest.config.ts
+++ b/qnop-ui/vitest.config.ts
@@ -45,6 +45,17 @@ export default defineConfig({
         'src/components/shell/navConfig.tsx',
         // Auth screens — the critical entry flow (issue #352, wave 1).
         'src/pages/auth/**/*.tsx',
+        // Admin screens — users, teams, settings, branding and OIDC (issue
+        // #352, wave 3). The pages own the orchestration/state; their heavy
+        // child dialogs/tables/forms stay on their own component tests. (The
+        // mail admin pages carry their own tests but predate this gate and are
+        // not yet at the 80% bar, so they stay off the allowlist for now.)
+        'src/pages/admin/UsersPage.tsx',
+        'src/pages/admin/TeamsPage.tsx',
+        'src/pages/admin/TeamDetailPage.tsx',
+        'src/pages/admin/SettingsPage.tsx',
+        'src/pages/admin/BrandingPage.tsx',
+        'src/pages/admin/OidcProvidersPage.tsx',
         // The viewer's pure anchor-building logic (#250) plus the document
         // surface (issue #352, wave 2): the pdf.js loader/canvas wiring and the
         // scrollable page stack with its scroll spy and rubber-band selection.


### PR DESCRIPTION
## Summary

Wave 3 of the frontend test-coverage effort (#352): the **administration screens** (waves 1 & 2 shipped auth #434 and the document viewer #436). **54 tests** across the six admin pages, each **mocking its api hooks** (mutation spies via `vi.hoisted`) and **stubbing its heavy child dialogs/tables/forms** so the page's own orchestration and state — not the leaf components — is what's exercised.

### Covered in this wave
- **UsersPage** (18) — list / loading / error / empty; add & edit dialogs; toggle-enabled (`LAST_ADMIN` 409 vs. generic fallback); delete confirm; reset-password (emailed / link-fallback / neither / error); generate-password — success **and** error paths, asserting mutation args and the resulting toasts.
- **TeamsPage** (13) — render / loading / fetching / error / empty; create & edit dialogs; row navigation to the detail route; delete confirm success and error; search clear.
- **TeamDetailPage** (11) — loading / not-found; member rows; role toggle both directions; remove-member confirm **and** cancel; add-member and rename dialogs.
- **SettingsPage** (2) — the thin composition (header + delegated settings form).
- **BrandingPage** (3) — loading skeletons, error alert, and the three loaded slots.
- **OidcProvidersPage** (7) — error alert; toggle-enabled and delete confirm (success and error toasts); open the create dialog.

### Coverage
- **54 new tests**, full suite **634 passing**.
- Adds the five named admin pages plus `TeamDetailPage` to the coverage `include` allowlist.
- **Thresholds stay at 80** — global **~88% statements / 82% branches / 84% functions / 89% lines**.
- The **mail admin pages** (`EmailServerPage`, `MailTemplate*`) carry their own tests but predate this gate and sit below the 80% branch bar, so they stay off the allowlist for now (a separate cleanup, not this wave's scope).

### Test plan
- [x] `vitest run --coverage` — 634 pass, gate green at 80
- [x] `tsc -b --noEmit` — clean (fixed an `AdminUserListResponse` fixture missing `page`/`size`)
- [x] `eslint` — clean
- [x] `prettier --check` — clean
- [ ] CI green

### Follow-up (last wave open on #352)
- Shell/router: `AppShell` persistence + mobile drawer, router guards

Refs #352

🤖 Co-Author: Claude (Opus 4.x) via Claude Code