### PR TITLE
feat(reviews): Document/Focus tab merge & focus-view polish round (#403)

### DIFF
--- a/qnop-ui/src/api/hooks/useAnnotations.ts
+++ b/qnop-ui/src/api/hooks/useAnnotations.ts
@@ -65,7 +65,10 @@ export function useCreateAnnotation(documentId: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: annotationKeys.all });
       queryClient.invalidateQueries({ queryKey: ['reviews'] });
-      queryClient.invalidateQueries({ queryKey: documentKeys.all });
+      // Detail only (workflow chip / counts) — NEVER documentKeys.all: that
+      // sweeps in the rendered/original binaries and reloading the PDF
+      // remounts the viewer, snapping the scroll back to page 1 (issue #403).
+      queryClient.invalidateQueries({ queryKey: documentKeys.detail(documentId) });
     },
   });
 }
@@ -82,10 +85,12 @@ export function useReopenAnnotation() {
       const response = await annotationsApi.reopenAnnotation({ annotationId: vars.annotationId });
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (updated) => {
       queryClient.invalidateQueries({ queryKey: annotationKeys.all });
       queryClient.invalidateQueries({ queryKey: ['reviews'] });
-      queryClient.invalidateQueries({ queryKey: documentKeys.all });
+      // Detail only — see useCreateAnnotation: touching documentKeys.all
+      // reloads the PDF and costs the reader their scroll position.
+      queryClient.invalidateQueries({ queryKey: documentKeys.detail(updated.documentId) });
     },
   });
 }
@@ -107,13 +112,14 @@ export function useResolveAnnotation() {
       });
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (updated) => {
       queryClient.invalidateQueries({ queryKey: annotationKeys.all });
       queryClient.invalidateQueries({ queryKey: commentKeys.all });
       queryClient.invalidateQueries({ queryKey: ['reviews'] });
-      // The derived workflow pair (#405) surfaces on the document detail too
-      // (the header's status chip reads document.workflowState).
-      queryClient.invalidateQueries({ queryKey: documentKeys.all });
+      // The derived workflow pair (#405) surfaces on the document detail
+      // (the header's status chip reads document.workflowState) — detail
+      // only, so the PDF/rendered caches stay put (issue #403).
+      queryClient.invalidateQueries({ queryKey: documentKeys.detail(updated.documentId) });
     },
   });
 }

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -146,7 +146,7 @@ describe('FocusAnnotationCard', () => {
     expect(style.minWidth).toBe('320px');
     expect(style.minHeight).toBe('220px');
     expect(style.maxWidth).toContain('640px');
-    expect(style.maxHeight).toContain('55vh');
+    expect(style.maxHeight).toContain('64vh');
   });
 
   it('drags by the header — buttons excluded — and offsets the card', () => {

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -38,7 +38,6 @@ import { AnnotationStatus } from '../../../api/generated';
 import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
 import type { BuildPermalink } from '../useReviewPermalink';
-import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { AnnotationHead } from '../panel/AnnotationHead';
 import { CommentThread } from '../panel/CommentThread';
 import { ResolveBar } from '../panel/ResolveBar';
@@ -287,13 +286,6 @@ export function FocusAnnotationCard({
                       : 'Annotation'}
                   </Typography>
                   <Box sx={{ flex: 1 }} />
-                  {buildPermalink && (
-                    <CopyLinkButton
-                      url={buildPermalink(annotation.id)}
-                      notify={notify}
-                      label="Copy link to annotation"
-                    />
-                  )}
                   <Tooltip title="Previous annotation (↑)">
                     <span>
                       <IconButton
@@ -329,8 +321,13 @@ export function FocusAnnotationCard({
                     own tail — clean out of the card. */}
                 <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0 }}>
                   <Box sx={{ px: 1.5, pt: 1.25 }}>
-                    {/* The same root post the panel's expanded card shows. */}
-                    <AnnotationHead annotation={annotation} />
+                    {/* The same root post the panel's expanded card shows —
+                        including the author row's copy-link (issue #412). */}
+                    <AnnotationHead
+                      annotation={annotation}
+                      permalinkUrl={buildPermalink?.(annotation.id)}
+                      notify={notify}
+                    />
                   </Box>
 
                   {!readOnly && mayResolveAnnotation(annotation, userId) && (

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -242,13 +242,13 @@ export function FocusAnnotationCard({
                   // native grip, hard-bounded so the card can neither
                   // collapse below usability nor swallow the document.
                   resize: 'both',
-                  width: 380,
+                  width: 460,
                   minWidth: 320,
                   maxWidth: 'min(640px, calc(100vw - 48px))',
                   minHeight: 220,
-                  // Tall threads scroll inside; the card itself stays a
+                  // Tall content scrolls inside; the card itself stays a
                   // modest share of the screen (issue #403).
-                  maxHeight: 'min(55vh, 520px)',
+                  maxHeight: 'min(64vh, 600px)',
                 }}
               >
                 <Stack
@@ -323,42 +323,48 @@ export function FocusAnnotationCard({
                   </IconButton>
                 </Stack>
 
-                <Box sx={{ px: 1.5, pt: 1.25, flexShrink: 0 }}>
-                  {/* The same root post the panel's expanded card shows. */}
-                  <AnnotationHead annotation={annotation} />
-                </Box>
+                {/* ONE scroll container for everything below the handle
+                    (issue #403): the opening text used to sit in a fixed
+                    block, so a long annotation pushed the thread — and its
+                    own tail — clean out of the card. */}
+                <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0 }}>
+                  <Box sx={{ px: 1.5, pt: 1.25 }}>
+                    {/* The same root post the panel's expanded card shows. */}
+                    <AnnotationHead annotation={annotation} />
+                  </Box>
 
-                {!readOnly && mayResolveAnnotation(annotation, userId) && (
-                  // The bar's flush-right button is the panel's look; inside
-                  // the floating card it breathes like the left side does.
-                  <Box sx={{ pr: 2 }}>
-                    <ResolveBar
-                      disabled={resolving}
-                      onResolve={(note) => resolveWith(annotation, note)}
+                  {!readOnly && mayResolveAnnotation(annotation, userId) && (
+                    // The bar's flush-right button is the panel's look; inside
+                    // the floating card it breathes like the left side does.
+                    <Box sx={{ pr: 2 }}>
+                      <ResolveBar
+                        disabled={resolving}
+                        onResolve={(note) => resolveWith(annotation, note)}
+                      />
+                    </Box>
+                  )}
+
+                  {/* Same breathing room at the bottom as the head keeps at the top. */}
+                  <Box sx={{ pl: 0.5, pr: 2, pb: 1.25 }}>
+                    <CommentThread
+                      annotationId={annotation.id}
+                      documentId={annotation.documentId}
+                      notify={notify}
+                      readOnly={readOnly}
+                      policyReadOnly={policyReadOnly}
+                      closed={annotation.status !== AnnotationStatus.Open}
+                      onReopen={
+                        !readOnly && !reviewClosed && mayReopenAnnotation(annotation, userId)
+                          ? () => reopenWith(annotation)
+                          : undefined
+                      }
+                      previousSeenAt={previousSeenAt}
+                      skipOpener
+                      buildPermalink={buildPermalink}
+                      scrollToCommentId={scrollToCommentId}
+                      onScrolledToComment={onScrolledToComment}
                     />
                   </Box>
-                )}
-
-                {/* Same breathing room at the bottom as the head keeps at the top. */}
-                <Box sx={{ overflowY: 'auto', flex: 1, minHeight: 0, pl: 0.5, pr: 2, pb: 1.25 }}>
-                  <CommentThread
-                    annotationId={annotation.id}
-                    documentId={annotation.documentId}
-                    notify={notify}
-                    readOnly={readOnly}
-                    policyReadOnly={policyReadOnly}
-                    closed={annotation.status !== AnnotationStatus.Open}
-                    onReopen={
-                      !readOnly && !reviewClosed && mayReopenAnnotation(annotation, userId)
-                        ? () => reopenWith(annotation)
-                        : undefined
-                    }
-                    previousSeenAt={previousSeenAt}
-                    skipOpener
-                    buildPermalink={buildPermalink}
-                    scrollToCommentId={scrollToCommentId}
-                    onScrolledToComment={onScrolledToComment}
-                  />
                 </Box>
                 {/* Discoverability for the native resize grip underneath. */}
                 <Box

--- a/qnop-ui/src/components/reviews/focus/FocusDrawer.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusDrawer.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import { FocusDrawer } from './FocusDrawer';
+
+function renderDrawer() {
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <FocusDrawer open onClose={vi.fn()}>
+        <div>panel content</div>
+      </FocusDrawer>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('FocusDrawer resizing (issue #403)', () => {
+  it('exposes a keyboard-operable separator that widens and narrows the drawer', () => {
+    renderDrawer();
+    const handle = screen.getByTestId('focus-drawer-resize-handle');
+    const before = Number(handle.getAttribute('aria-valuenow'));
+
+    // The handle sits on the leading edge: ArrowLeft grows the drawer.
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    expect(Number(handle.getAttribute('aria-valuenow'))).toBe(before + 24);
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    expect(Number(handle.getAttribute('aria-valuenow'))).toBe(before);
+  });
+
+  it('persists the chosen width as a personal preference', () => {
+    renderDrawer();
+    fireEvent.keyDown(screen.getByTestId('focus-drawer-resize-handle'), { key: 'ArrowLeft' });
+
+    expect(Number(localStorage.getItem('qnop-focus-drawer-width'))).toBeGreaterThan(0);
+  });
+
+  it('never resizes below the minimum width', () => {
+    localStorage.setItem('qnop-focus-drawer-width', '381');
+    renderDrawer();
+    const handle = screen.getByTestId('focus-drawer-resize-handle');
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+
+    expect(Number(handle.getAttribute('aria-valuenow'))).toBe(380);
+  });
+});

--- a/qnop-ui/src/components/reviews/focus/FocusDrawer.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusDrawer.tsx
@@ -19,9 +19,42 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useRef, useState, type KeyboardEvent, type PointerEvent, type ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
-import type { ReactNode } from 'react';
+import { alpha, useTheme } from '@mui/material/styles';
+
+/** Never narrower than the panel needs to breathe, never the whole viewport. */
+const MIN_WIDTH = 380;
+const DEFAULT_WIDTH = 520;
+const KEYBOARD_STEP = 24;
+const WIDTH_KEY = 'qnop-focus-drawer-width';
+
+/** Keeps a slice of the document visible even on generous drags. */
+function maxWidth(): number {
+  return Math.max(MIN_WIDTH, Math.min(900, window.innerWidth - 240));
+}
+
+function clampWidth(width: number): number {
+  return Math.min(Math.max(width, MIN_WIDTH), maxWidth());
+}
+
+function storedWidth(): number {
+  try {
+    const value = Number(localStorage.getItem(WIDTH_KEY));
+    return Number.isFinite(value) && value >= MIN_WIDTH ? clampWidth(value) : DEFAULT_WIDTH;
+  } catch {
+    return DEFAULT_WIDTH;
+  }
+}
+
+function persistWidth(width: number) {
+  try {
+    localStorage.setItem(WIDTH_KEY, String(width));
+  } catch {
+    // best-effort persistence
+  }
+}
 
 interface FocusDrawerProps {
   open: boolean;
@@ -33,16 +66,98 @@ interface FocusDrawerProps {
  * Focus mode's temporary home of the annotation list (issue #291): the full
  * panel — filters, sections, the orphaned group — slides in on demand and
  * disappears again, keeping the document at full width the rest of the time.
+ * The width is a personal working preference (issue #403): a grab handle on
+ * the leading edge resizes it (pointer drag, or arrow keys on the focused
+ * separator) and the choice persists in localStorage.
  */
 export function FocusDrawer({ open, onClose, children }: FocusDrawerProps) {
+  const theme = useTheme();
+  const [width, setWidth] = useState<number>(storedWidth);
+  const [resizing, setResizing] = useState(false);
+  // The live value for the pointer-up persist — state updates lag the drag.
+  const widthRef = useRef(width);
+
+  const applyWidth = (next: number) => {
+    const clamped = clampWidth(next);
+    widthRef.current = clamped;
+    setWidth(clamped);
+    return clamped;
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    setResizing(true);
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture?.(event.pointerId)) return;
+    // Anchored right: the drawer spans from the pointer to the viewport edge.
+    applyWidth(window.innerWidth - event.clientX);
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    setResizing(false);
+    persistWidth(widthRef.current);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // The handle sits on the LEADING edge: left grows the drawer, right shrinks it.
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    persistWidth(applyWidth(width + (event.key === 'ArrowLeft' ? KEYBOARD_STEP : -KEYBOARD_STEP)));
+  };
+
   return (
     <Drawer
       anchor="right"
       open={open}
       onClose={onClose}
-      slotProps={{ paper: { sx: { width: { xs: '100%', sm: 420 } } } }}
+      slotProps={{ paper: { sx: { width: { xs: '100%', sm: width }, overflow: 'visible' } } }}
     >
-      <Box sx={{ p: 2, overflowY: 'auto' }}>{children}</Box>
+      <Box
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize the annotation drawer"
+        aria-valuemin={MIN_WIDTH}
+        aria-valuenow={Math.round(width)}
+        tabIndex={0}
+        data-testid="focus-drawer-resize-handle"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onKeyDown={handleKeyDown}
+        sx={{
+          position: 'absolute',
+          left: -5,
+          top: 0,
+          bottom: 0,
+          width: 10,
+          zIndex: 1,
+          display: { xs: 'none', sm: 'flex' },
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'col-resize',
+          touchAction: 'none',
+          '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
+          // The visible grip: a quiet hairline that wakes on hover/drag.
+          '&::after': {
+            content: '""',
+            width: '3px',
+            height: 48,
+            borderRadius: 2,
+            bgcolor: resizing ? theme.qnop.brand.blue : theme.palette.divider,
+            transition: 'background-color 120ms ease, height 120ms ease',
+          },
+          '&:hover::after': {
+            bgcolor: resizing ? theme.qnop.brand.blue : alpha(theme.qnop.brand.blue, 0.6),
+            height: 72,
+          },
+          '@media (prefers-reduced-motion: reduce)': { '&::after': { transition: 'none' } },
+        }}
+      />
+      <Box sx={{ p: 2, overflowY: 'auto', height: '100%' }}>{children}</Box>
     </Drawer>
   );
 }

--- a/qnop-ui/src/components/reviews/focus/FocusScrimLayer.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusScrimLayer.tsx
@@ -33,15 +33,17 @@ interface FocusScrimLayerProps {
 }
 
 /**
- * The focus mode's per-page scrim (issue #291): the page dims under a soft
- * veil while the spotlit passage stays untouched — the hole is cut with a
- * clip-path, never a filter over the mark, so the anchored text keeps its
- * full contrast (the marks themselves paint on the layer above). The clipped
- * region is also transparent to pointer events, so the spotlit passage stays
- * selectable while the veil catches dismiss clicks. Moving the spotlight
- * (prev/next) morphs the clip smoothly — clip-path animates on the
- * compositor; `prefers-reduced-motion` snaps instead, and
- * `prefers-reduced-transparency` drops the blur.
+ * The focus mode's per-page scrim (issue #291): the page softens under a
+ * light blur — deliberately NO darkening (issue #403); sharpness alone
+ * separates the spotlit passage — while the spotlit region stays untouched.
+ * The hole is cut with a clip-path, never a filter over the mark, so the
+ * anchored text keeps its full contrast (the marks themselves paint on the
+ * layer above). The clipped region is also transparent to pointer events, so
+ * the spotlit passage stays selectable while the veil catches dismiss clicks.
+ * Moving the spotlight (prev/next) morphs the clip smoothly — clip-path
+ * animates on the compositor; `prefers-reduced-motion` snaps instead, and
+ * `prefers-reduced-transparency` swaps the blur for a whisper of tint so the
+ * spotlight keeps SOME cue.
  */
 export function FocusScrimLayer({ spotlight, onDismiss, surfaceIndex }: FocusScrimLayerProps) {
   return (
@@ -53,9 +55,11 @@ export function FocusScrimLayer({ spotlight, onDismiss, surfaceIndex }: FocusScr
         inset: 0,
         pointerEvents: 'auto',
         cursor: 'pointer',
-        bgcolor: 'rgba(1, 32, 66, 0.32)',
-        backdropFilter: 'blur(1.5px)',
-        '@media (prefers-reduced-transparency: reduce)': { backdropFilter: 'none' },
+        backdropFilter: 'blur(1px)',
+        '@media (prefers-reduced-transparency: reduce)': {
+          backdropFilter: 'none',
+          bgcolor: 'rgba(1, 32, 66, 0.14)',
+        },
         clipPath: spotlight ? holePolygon(spotlight) : undefined,
         transition: `clip-path ${tokens.motion.durSlow}ms ${tokens.motion.easeInOut}`,
         animation: 'qnopScrimIn 200ms ease-out',

--- a/qnop-ui/src/components/reviews/hub/ReviewViewTabs.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewViewTabs.test.tsx
@@ -46,14 +46,10 @@ describe('ReviewViewTabs', () => {
   it('links every view and marks the active one', () => {
     renderTabs({ active: 'tasks' });
 
-    expect(screen.getByTestId('review-view-tab-document')).toHaveAttribute(
-      'href',
-      '/reviews/d1?view=panel',
-    );
-    expect(screen.getByTestId('review-view-tab-focus')).toHaveAttribute(
-      'href',
-      '/reviews/d1?view=focus',
-    );
+    // No ?view= param — the stored panel/focus preference decides (issue #403).
+    expect(screen.getByTestId('review-view-tab-document')).toHaveAttribute('href', '/reviews/d1');
+    // Focus is a toolbar-level presentation of the Document tab, not a tab (issue #403).
+    expect(screen.queryByTestId('review-view-tab-focus')).not.toBeInTheDocument();
     expect(screen.getByTestId('review-view-tab-compare')).toHaveAttribute(
       'href',
       '/reviews/d1/compare',

--- a/qnop-ui/src/components/reviews/hub/ReviewViewTabs.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewViewTabs.tsx
@@ -27,11 +27,11 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import type { LucideIcon } from 'lucide-react';
-import { FileText, Focus, GitCompareArrows, SquareKanban } from 'lucide-react';
+import { FileText, GitCompareArrows, SquareKanban } from 'lucide-react';
 import { tokens } from '../../../theme/tokens';
 
-/** The review's four ways of working (issue #398). */
-export type ReviewView = 'document' | 'focus' | 'tasks' | 'compare';
+/** The review's three ways of working (issue #398; focus folded into Document, issue #403). */
+export type ReviewView = 'document' | 'tasks' | 'compare';
 
 interface ReviewViewTabsProps {
   documentId: string;
@@ -47,10 +47,10 @@ const TABS: { view: ReviewView; label: string; icon: LucideIcon; href: (id: stri
     {
       view: 'document',
       label: 'Document',
+      // No ?view= param: the stored panel/focus preference decides (issue #403).
       icon: FileText,
-      href: (id) => `/reviews/${id}?view=panel`,
+      href: (id) => `/reviews/${id}`,
     },
-    { view: 'focus', label: 'Focus', icon: Focus, href: (id) => `/reviews/${id}?view=focus` },
     { view: 'tasks', label: 'Tasks', icon: SquareKanban, href: (id) => `/reviews/${id}/tasks` },
     {
       view: 'compare',
@@ -63,7 +63,9 @@ const TABS: { view: ReviewView; label: string; icon: LucideIcon; href: (id: stri
 /**
  * The review's view switcher (issue #398, prototype `rh-tab`): one labeled,
  * always-visible strip under the hub head on every review page — Document,
- * Focus, Tasks (with the open-count pill), Compare. Every tab is a plain
+ * Tasks (with the open-count pill), Compare. The former Focus tab folded
+ * into Document as a toolbar-level presentation switch (issue #403), so the
+ * strip navigates between surfaces, not layouts. Every tab is a plain
  * link (router tabs, not ARIA tabpanels), so the strip is stateless and
  * identical everywhere; the active tab carries the prototype's 2px accent
  * underline. Icon-only navigation was the discoverability problem this

--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -114,25 +114,34 @@ export function AnnotationHead({
           >
             {authorName}
           </Typography>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            noWrap
-            component="p"
-            title={DATE_FORMAT.format(new Date(annotation.createdAt))}
-            sx={{ lineHeight: 1.4 }}
-          >
-            Started this discussion · {shortRelativeTime(annotation.createdAt)}
-          </Typography>
+          <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', minWidth: 0 }}>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              noWrap
+              component="p"
+              title={DATE_FORMAT.format(new Date(annotation.createdAt))}
+              sx={{ lineHeight: 1.4 }}
+            >
+              Started this discussion · {shortRelativeTime(annotation.createdAt)}
+            </Typography>
+            {permalinkUrl && notify && (
+              // Directly after the timestamp, exactly like a comment row's
+              // link. The negative margin keeps the icon button from growing
+              // the caption line beyond the avatar's height.
+              <Box
+                className="annotation-hover-actions"
+                sx={{ display: 'flex', flexShrink: 0, my: '-3px' }}
+              >
+                <CopyLinkButton
+                  url={permalinkUrl}
+                  notify={notify}
+                  label="Copy link to annotation"
+                />
+              </Box>
+            )}
+          </Stack>
         </Box>
-        {permalinkUrl && notify && (
-          // Inline after the author block, exactly like a comment row's link
-          // after its timestamp (no ml:auto — Stack spacing margins would
-          // override it anyway).
-          <Box className="annotation-hover-actions" sx={{ display: 'flex', flexShrink: 0 }}>
-            <CopyLinkButton url={permalinkUrl} notify={notify} label="Copy link to annotation" />
-          </Box>
-        )}
       </Stack>
       <AnnotationBadgeRow annotation={annotation} unseen={unseen} />
       {/* The anchored passage, styled as a real quotation. */}

--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -25,6 +25,8 @@ import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import type { AnnotationView } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
+import type { Notify } from '../../admin/layout/useToast';
+import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { useAuthStore } from '../../../stores/authStore';
 import { shortRelativeTime } from '../../../utils/relativeTime';
 import { UserAvatar } from '../../shell/UserAvatar';
@@ -44,6 +46,9 @@ interface AnnotationHeadProps {
   annotation: AnnotationView;
   /** Adds the "New" badge (issue #307). */
   unseen?: boolean;
+  /** With `notify`, the author row carries the hover-revealed copy-link (issue #412). */
+  permalinkUrl?: string;
+  notify?: Notify;
 }
 
 /**
@@ -55,7 +60,12 @@ interface AnnotationHeadProps {
  * expanded card and the focus mode's floating card, so the head reads
  * identically on both.
  */
-export function AnnotationHead({ annotation, unseen = false }: AnnotationHeadProps) {
+export function AnnotationHead({
+  annotation,
+  unseen = false,
+  permalinkUrl,
+  notify,
+}: AnnotationHeadProps) {
   const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
   const displayName = useAuthStore((state) => state.displayName);
@@ -75,7 +85,24 @@ export function AnnotationHead({ annotation, unseen = false }: AnnotationHeadPro
     : 'No placement on this version';
 
   return (
-    <Stack spacing={1.25} data-testid="annotation-head-card">
+    <Stack
+      spacing={1.25}
+      data-testid="annotation-head-card"
+      sx={{
+        // The same quiet reveal the comment rows use (issue #412): the
+        // copy-link stays invisible until the card is hovered or focused;
+        // pointer-less devices see it permanently.
+        '& .annotation-hover-actions': {
+          opacity: 0,
+          transition: 'opacity 120ms ease',
+          '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+          '@media (hover: none)': { opacity: 1 },
+        },
+        '&:hover .annotation-hover-actions, &:focus-within .annotation-hover-actions': {
+          opacity: 1,
+        },
+      }}
+    >
       {/* The thread starter, front and centre — this is their discussion. */}
       <Stack direction="row" spacing={1.25} sx={{ alignItems: 'center', minWidth: 0 }}>
         <UserAvatar name={authorName} size={AUTHOR_AVATAR_SIZE} imageUrl={own ? avatarUrl : null} />
@@ -98,6 +125,14 @@ export function AnnotationHead({ annotation, unseen = false }: AnnotationHeadPro
             Started this discussion · {shortRelativeTime(annotation.createdAt)}
           </Typography>
         </Box>
+        {permalinkUrl && notify && (
+          // Inline after the author block, exactly like a comment row's link
+          // after its timestamp (no ml:auto — Stack spacing margins would
+          // override it anyway).
+          <Box className="annotation-hover-actions" sx={{ display: 'flex', flexShrink: 0 }}>
+            <CopyLinkButton url={permalinkUrl} notify={notify} label="Copy link to annotation" />
+          </Box>
+        )}
       </Stack>
       <AnnotationBadgeRow annotation={annotation} unseen={unseen} />
       {/* The anchored passage, styled as a real quotation. */}

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -32,12 +32,37 @@ import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { tokens } from '../../../theme/tokens';
+import { shortRelativeTime } from '../../../utils/relativeTime';
 import { hasNewComments, isUnseen } from '../newSince';
+import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
 import { AnnotationHead } from './AnnotationHead';
 import { STATUS_CUES } from './statusCues';
 
 /** Up to this many participant avatars stack in the collapsed row. */
 const MAX_AVATARS = 3;
+
+/** Status tile + gap — the meta line indents to align under the title. */
+const TILE_INDENT = '34px';
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+/**
+ * One-line plain-text excerpt of a Markdown body (issue #403): a collapsed
+ * document-scoped annotation shows what it SAYS instead of a generic "Whole
+ * document" label, so four general remarks stop reading identically. Cheap
+ * marker stripping only — the full body renders properly once expanded.
+ */
+function plainExcerpt(markdown: string): string {
+  return markdown
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^[#>\-*\d.\s]+/gm, '')
+    .replace(/[`*_~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 interface DiscussionParticipant {
   id: string;
@@ -129,6 +154,14 @@ function AnnotationListItemBase({
   const region = annotation.anchor?.region;
   const statusCue = STATUS_CUES[annotation.status];
   const StatusIcon = statusCue.icon;
+  const typeCue = annotation.type ? TYPE_CUES[annotation.type] : null;
+  const priorityCue = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
+  const viewerAvatarUrl = useAuthStore((state) => state.avatarUrl);
+  const viewerName = useAuthStore((state) => state.displayName);
+  const authorName =
+    annotation.authorId === viewerId
+      ? (viewerName ?? 'You')
+      : (annotation.authorDisplayName ?? 'Participant');
 
   // Participants: the annotation author plus every commenter already known to
   // the cache (enabled: false never fetches — rows stay cheap; the stack
@@ -187,64 +220,129 @@ function AnnotationListItemBase({
       {active ? (
         <AnnotationHead annotation={annotation} unseen={unseen} />
       ) : (
-        <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
-          <Tooltip title={statusCue.label}>
-            <Box sx={{ display: 'flex', color: statusCue.color(theme), flexShrink: 0 }}>
-              <StatusIcon size={15} aria-label={statusCue.label} />
-            </Box>
-          </Tooltip>
-          {unseen && (
-            <Tooltip title="New since your last visit">
+        <Stack spacing={0.5} sx={{ minWidth: 0 }}>
+          {/* Title line: status tile, the content itself, participants. */}
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+            <Tooltip title={statusCue.label}>
               <Box
-                data-testid="unseen-dot"
                 sx={{
-                  width: 7,
-                  height: 7,
-                  borderRadius: '50%',
-                  bgcolor: theme.qnop.brand.blue,
+                  position: 'relative',
+                  width: 26,
+                  height: 26,
+                  borderRadius: '8px',
+                  display: 'grid',
+                  placeItems: 'center',
+                  bgcolor: alpha(statusCue.color(theme), 0.12),
+                  color: statusCue.color(theme),
                   flexShrink: 0,
                 }}
-              />
+              >
+                <StatusIcon size={14} aria-label={statusCue.label} />
+                {unseen && (
+                  <Tooltip title="New since your last visit">
+                    <Box
+                      data-testid="unseen-dot"
+                      sx={{
+                        position: 'absolute',
+                        top: -3,
+                        right: -3,
+                        width: 9,
+                        height: 9,
+                        borderRadius: '50%',
+                        bgcolor: theme.qnop.brand.blue,
+                        border: '2px solid',
+                        borderColor: 'background.paper',
+                      }}
+                    />
+                  </Tooltip>
+                )}
+              </Box>
             </Tooltip>
-          )}
-          <Typography
-            variant="body2"
-            noWrap
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              color: 'text.secondary',
-              fontStyle: quote ? 'italic' : 'normal',
-            }}
-          >
-            {quote ? `“${quote}”` : fallbackLabel}
-          </Typography>
+            <Typography
+              variant="body2"
+              noWrap
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                color: annotation.status === 'RESOLVED' ? 'text.secondary' : 'text.primary',
+                fontStyle: quote ? 'italic' : 'normal',
+              }}
+            >
+              {quote ? `“${quote}”` : plainExcerpt(annotation.firstComment ?? '') || fallbackLabel}
+            </Typography>
+            <ParticipantAvatars participants={participants} />
+          </Stack>
+          {/* Meta line: who, when, what kind — then the counters. */}
           <Stack
             direction="row"
-            spacing={0.5}
-            data-testid="comment-count"
-            sx={{
-              alignItems: 'center',
-              color: freshComments ? theme.qnop.brand.blue : 'text.secondary',
-              fontWeight: freshComments ? 600 : undefined,
-              flexShrink: 0,
-            }}
+            spacing={0.75}
+            sx={{ alignItems: 'center', minWidth: 0, pl: TILE_INDENT, color: 'text.secondary' }}
           >
-            <MessageSquare size={13} aria-hidden />
-            <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
-              {annotation.commentCount}
+            <UserAvatar
+              name={authorName}
+              size={16}
+              imageUrl={annotation.authorId === viewerId ? viewerAvatarUrl : null}
+            />
+            <Typography variant="caption" noWrap sx={{ fontWeight: 500, flexShrink: 1 }}>
+              {authorName}
             </Typography>
-          </Stack>
-          {region && (
             <Typography
               variant="caption"
-              color="text.secondary"
-              sx={{ flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}
+              title={DATE_FORMAT.format(new Date(annotation.createdAt))}
+              sx={{ flexShrink: 0, color: 'text.disabled' }}
             >
-              p. {region.surfaceIndex + 1}
+              {shortRelativeTime(annotation.createdAt)}
             </Typography>
-          )}
-          <ParticipantAvatars participants={participants} />
+            {typeCue && (
+              <Stack
+                direction="row"
+                spacing={0.4}
+                sx={{ alignItems: 'center', color: typeCue.color(theme), flexShrink: 0 }}
+              >
+                <typeCue.icon size={11} aria-hidden />
+                <Typography variant="caption">{typeCue.label}</Typography>
+              </Stack>
+            )}
+            {priorityCue && (
+              <Tooltip title={`${priorityCue.label} priority`}>
+                <Box
+                  sx={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: '50%',
+                    bgcolor: priorityCue.color(theme),
+                    flexShrink: 0,
+                  }}
+                />
+              </Tooltip>
+            )}
+            <Box sx={{ flex: 1 }} />
+            <Stack
+              direction="row"
+              spacing={0.5}
+              data-testid="comment-count"
+              sx={{
+                alignItems: 'center',
+                color: freshComments ? theme.qnop.brand.blue : 'text.secondary',
+                fontWeight: freshComments ? 600 : undefined,
+                flexShrink: 0,
+              }}
+            >
+              <MessageSquare size={12} aria-hidden />
+              <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
+                {annotation.commentCount}
+              </Typography>
+            </Stack>
+            {region && (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}
+              >
+                p. {region.surfaceIndex + 1}
+              </Typography>
+            )}
+          </Stack>
         </Stack>
       )}
     </ButtonBase>

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -30,6 +30,7 @@ import { MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
+import type { Notify } from '../../admin/layout/useToast';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { tokens } from '../../../theme/tokens';
 import { shortRelativeTime } from '../../../utils/relativeTime';
@@ -122,6 +123,9 @@ interface AnnotationListItemProps {
    * referentially stable for {@link memo} (issue #333).
    */
   onSelect: (annotationId: string | null) => void;
+  /** The annotation permalink (issue #412) — shown in the expanded head's author row. */
+  permalinkUrl?: string;
+  notify?: Notify;
   onHover?: (annotationId: string | null) => void;
 }
 
@@ -145,6 +149,8 @@ function AnnotationListItemBase({
   linked = false,
   onSelect,
   onHover,
+  permalinkUrl,
+  notify,
 }: AnnotationListItemProps) {
   const theme = useTheme();
   const viewerId = useAuthStore((state) => state.userId);
@@ -186,6 +192,9 @@ function AnnotationListItemBase({
 
   return (
     <ButtonBase
+      // Expanded, the card hosts real buttons (the head's copy-link) — a
+      // <button> may not nest, so the active card is a div with button role.
+      component={active ? 'div' : 'button'}
       onClick={() => onSelect(active ? null : annotation.id)}
       onMouseEnter={() => onHover?.(annotation.id)}
       onMouseLeave={() => onHover?.(null)}
@@ -218,7 +227,12 @@ function AnnotationListItemBase({
       }}
     >
       {active ? (
-        <AnnotationHead annotation={annotation} unseen={unseen} />
+        <AnnotationHead
+          annotation={annotation}
+          unseen={unseen}
+          permalinkUrl={permalinkUrl}
+          notify={notify}
+        />
       ) : (
         <Stack spacing={0.5} sx={{ minWidth: 0 }}>
           {/* Title line: status tile, the content itself, participants. */}

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -43,7 +43,6 @@ import { compareAnnotationsByPosition } from '../viewer/anchoring';
 import { isUnseen } from '../newSince';
 import { isDocumentScoped } from '../annotationScope';
 import type { BuildPermalink } from '../useReviewPermalink';
-import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { AnnotationListItem } from './AnnotationListItem';
 import type { UploadedAttachment } from '../markdown/useCommentAttachmentUpload';
 import { CommentThread } from './CommentThread';
@@ -306,20 +305,10 @@ export function AnnotationPanel({
           linked={annotation.id === hoverAnnotationId}
           onSelect={onSelect}
           onHover={onHover}
+          permalinkUrl={buildPermalink?.(annotation.id)}
+          notify={notify}
         />
         <Collapse in={active} unmountOnExit>
-          {/* The annotation permalink (issue #412) — a quiet right-aligned link
-              under the head card; a sibling of the row's ButtonBase, never
-              nested inside it. */}
-          {buildPermalink && (
-            <Stack direction="row" sx={{ justifyContent: 'flex-end', pt: 0.5 }}>
-              <CopyLinkButton
-                url={buildPermalink(annotation.id)}
-                notify={notify}
-                label="Copy link to annotation"
-              />
-            </Stack>
-          )}
           {!readOnly && mayResolveAnnotation(annotation, userId) && (
             <ResolveBar disabled={resolving} onResolve={(note) => resolveWith(annotation, note)} />
           )}

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.test.tsx
@@ -151,15 +151,12 @@ describe('DocumentViewer', () => {
     });
   });
 
-  it('brings an off-screen hovered mark into view', () => {
+  it('never scrolls on hover — skimming the panel must not move the page (issue #403)', () => {
     const { update } = renderViewer({ annotations: [{ id: 'a1' }] as AnnotationView[] });
 
     update({ hoverAnnotationId: 'a1' });
 
-    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'center',
-    });
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
   });
 
   it('forwards a mark selection from the page stack', () => {

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.test.tsx
@@ -146,9 +146,38 @@ describe('DocumentViewer', () => {
     update({ activeAnnotationId: 'a1' });
 
     expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
+      behavior: 'auto',
       block: 'center',
     });
+  });
+
+  it('retries the deep-link scroll until the mark has rendered (issue #403)', () => {
+    // "Show in document" / ?annotation= seeds the active id BEFORE the
+    // annotations arrive — the first pass finds no mark and must not give up.
+    const { update } = renderViewer({
+      annotations: [] as AnnotationView[],
+      activeAnnotationId: 'a1',
+    });
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    update({ annotations: [{ id: 'a1' }] as AnnotationView[] });
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('scrolls once per selection — a data refetch never yanks the reader back', () => {
+    const { update } = renderViewer({ annotations: [{ id: 'a1' }] as AnnotationView[] });
+    update({ activeAnnotationId: 'a1' });
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+
+    // Annotations refresh (same id, new identity) — no second scroll.
+    update({ annotations: [{ id: 'a1' }] as AnnotationView[] });
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+
+    // Deselect + reselect scrolls again.
+    update({ activeAnnotationId: null });
+    update({ activeAnnotationId: 'a1' });
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(2);
   });
 
   it('never scrolls on hover — skimming the panel must not move the page (issue #403)', () => {

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -167,21 +167,6 @@ export function DocumentViewer({
       ?.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'center' });
   }, [activeAnnotationId]);
 
-  // Hovering a panel card brings its mark into view — but only when it is
-  // off-screen, so hovering an already-visible mark never causes scroll jumps.
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!hoverAnnotationId || !container) return;
-    const mark = document.getElementById(`annotation-highlight-${hoverAnnotationId}`);
-    if (!mark) return;
-    const markRect = mark.getBoundingClientRect();
-    const viewRect = container.getBoundingClientRect();
-    if (markRect.top < viewRect.top + 24 || markRect.bottom > viewRect.bottom - 8) {
-      const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      mark.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'center' });
-    }
-  }, [hoverAnnotationId]);
-
   const pageWidth = Math.max(0, (containerWidth - 2 * PAGE_GUTTER_PX) * zoom);
   const pageCount = surfaces?.length ?? pdf.numPages;
   // Only a PANEL-card hover stages the mark's spotlight treatment; hovering

--- a/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/DocumentViewer.tsx
@@ -156,16 +156,29 @@ export function DocumentViewer({
     };
   }, [onVisiblePageChange]);
 
-  // A panel click (or the focus card's prev/next walk, #291) scrolls the
-  // possibly off-screen highlight into view. scrollIntoView ignores the CSS
-  // scroll-behavior override, so reduced motion is honoured explicitly.
+  // A panel click, the focus card's prev/next walk (#291) or a deep link (the
+  // tasks view's "Show in document", ?annotation= permalinks — issue #403)
+  // scrolls the possibly off-screen highlight into view. On a fresh navigation
+  // the marks are NOT there yet — data arrives after the first render, and the
+  // page stack itself waits for the measured containerWidth — so the effect
+  // retries on every data/layout pass until the mark exists, but scrolls only
+  // once per id (the ref), so later refetches never yank the reader back.
+  const scrolledToAnnotationRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!activeAnnotationId) return;
-    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    document
-      .getElementById(`annotation-highlight-${activeAnnotationId}`)
-      ?.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'center' });
-  }, [activeAnnotationId]);
+    if (!activeAnnotationId) {
+      scrolledToAnnotationRef.current = null; // re-selecting scrolls again
+      return;
+    }
+    if (scrolledToAnnotationRef.current === activeAnnotationId) return;
+    const mark = document.getElementById(`annotation-highlight-${activeAnnotationId}`);
+    if (!mark) return; // marks not rendered yet — retry once the data lands
+    scrolledToAnnotationRef.current = activeAnnotationId;
+    // Instant by design: "show in document" means a jump, and Chromium can
+    // wedge smooth container scrolls started while the page stack is still
+    // settling — the animation then silently never moves. Instant is
+    // deterministic and needs no reduced-motion branch.
+    mark.scrollIntoView({ behavior: 'auto', block: 'center' });
+  }, [activeAnnotationId, annotations, surfaces, containerWidth]);
 
   const pageWidth = Math.max(0, (containerWidth - 2 * PAGE_GUTTER_PX) * zoom);
   const pageCount = surfaces?.length ?? pdf.numPages;

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -30,8 +30,17 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { BoxSelect, ChevronDown, ChevronUp, NotebookPen, TextCursor } from 'lucide-react';
+import {
+  BoxSelect,
+  ChevronDown,
+  ChevronUp,
+  Focus,
+  NotebookPen,
+  PanelRight,
+  TextCursor,
+} from 'lucide-react';
 import type { DocumentVersionSummary } from '../../../api/generated';
+import type { ReviewViewMode } from '../focus/useViewMode';
 import { ExtractionStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { ZoomControls } from './ZoomControls';
@@ -55,8 +64,12 @@ interface ViewerToolbarProps {
   canAnnotate: boolean;
   zoom: number;
   onZoomChange: (zoom: number) => void;
-  /** True in focus mode (issue #291) — shows the annotation drawer's entry point. */
-  focusMode: boolean;
+  /**
+   * The surface's presentation (issue #403): side panel or spotlight focus.
+   * Both live inside the Document tab; this toolbar hosts the switch.
+   */
+  viewMode: ReviewViewMode;
+  onViewModeChange: (mode: ReviewViewMode) => void;
   /** Shown on the list button in focus mode — the drawer's entry point. */
   annotationCount: number;
   onOpenAnnotationList: () => void;
@@ -82,10 +95,12 @@ export function ViewerToolbar({
   canAnnotate,
   zoom,
   onZoomChange,
-  focusMode,
+  viewMode,
+  onViewModeChange,
   annotationCount,
   onOpenAnnotationList,
 }: ViewerToolbarProps) {
+  const focusMode = viewMode === 'focus';
   return (
     <Paper
       variant="outlined"
@@ -176,6 +191,39 @@ export function ViewerToolbar({
         <Divider orientation="vertical" flexItem />
 
         <ZoomControls zoom={zoom} onZoomChange={onZoomChange} />
+
+        <Divider orientation="vertical" flexItem />
+
+        {/* Panel vs. focus is a presentation of THIS tab (issue #403), so the
+            switch lives here rather than in the page-level tab strip. */}
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={viewMode}
+          onChange={(_event, next: ReviewViewMode | null) => next && onViewModeChange(next)}
+          aria-label="Document layout"
+        >
+          <ToggleButton value="panel" aria-label="Panel view" sx={{ gap: 0.5, px: 1 }}>
+            <Tooltip title="Document beside the annotation panel">
+              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                <PanelRight size={15} />
+                <Typography variant="caption" sx={{ fontWeight: 600, lineHeight: 1 }}>
+                  Panel
+                </Typography>
+              </Stack>
+            </Tooltip>
+          </ToggleButton>
+          <ToggleButton value="focus" aria-label="Focus view" sx={{ gap: 0.5, px: 1 }}>
+            <Tooltip title="Full-width document with the spotlight overlay">
+              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                <Focus size={15} />
+                <Typography variant="caption" sx={{ fontWeight: 600, lineHeight: 1 }}>
+                  Focus
+                </Typography>
+              </Stack>
+            </Tooltip>
+          </ToggleButton>
+        </ToggleButtonGroup>
 
         {focusMode && (
           <Tooltip title="Show the annotation list">

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -343,16 +343,28 @@ describe('DocumentReviewPage focus mode', () => {
     expect(screen.getByText(/Annotations \(/)).toBeInTheDocument();
   });
 
-  it('switches back to panel mode via the Document view tab and stores it', () => {
+  it('switches back to panel mode via the toolbar switch and stores it', () => {
     localStorage.setItem('qnop-review-view-mode', 'focus');
     seedHappyPath();
     renderPage();
 
-    // The view tabs (issue #398) navigate — ?view=panel syncs into the mode.
-    fireEvent.click(screen.getByTestId('review-view-tab-document'));
+    // Panel vs. focus lives in the viewer toolbar now (issue #403); the switch
+    // routes through ?view=, which syncs into the stored preference.
+    fireEvent.click(screen.getByRole('button', { name: 'Panel view' }));
 
     expect(screen.getByRole('complementary', { name: 'Annotations' })).toBeInTheDocument();
     expect(localStorage.getItem('qnop-review-view-mode')).toBe('panel');
+  });
+
+  it('switches into focus mode via the toolbar switch', () => {
+    localStorage.setItem('qnop-review-view-mode', 'panel');
+    seedHappyPath();
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Focus view' }));
+
+    expect(screen.queryByRole('complementary', { name: 'Annotations' })).not.toBeInTheDocument();
+    expect(localStorage.getItem('qnop-review-view-mode')).toBe('focus');
   });
 
   it('activates focus mode through the ?view= deep link', () => {

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -69,7 +69,7 @@ import {
 } from '../../components/reviews/focus/spotlightModel';
 import { useAnchorElement } from '../../components/reviews/focus/useAnchorElement';
 import { useRecordVisit } from '../../api/hooks/useReviews';
-import { useViewMode } from '../../components/reviews/focus/useViewMode';
+import { useViewMode, type ReviewViewMode } from '../../components/reviews/focus/useViewMode';
 import { columnOf } from '../../components/reviews/tasks/tasksModel';
 import { NewTaskDialog } from '../../components/reviews/tasks/NewTaskDialog';
 import { Composer } from '../../components/reviews/panel/Composer';
@@ -158,6 +158,19 @@ export function DocumentReviewPage() {
     // setViewMode is a stable setter-like callback; syncing on param change only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlView]);
+  // The toolbar's panel/focus switch (issue #403) goes through the URL, so the
+  // address stays shareable and the ?view= sync above remains the single path
+  // into the stored preference.
+  const switchViewMode = (mode: ReviewViewMode) => {
+    setSearchParams(
+      (params) => {
+        const next = new URLSearchParams(params);
+        next.set('view', mode);
+        return next;
+      },
+      { replace: true },
+    );
+  };
   const [listOpen, setListOpen] = useState(false);
   // The "new whole-document task" dialog (issue #395), reachable from the panel in both the
   // document and focus views — the same anchor-free create the tasks view offers.
@@ -307,7 +320,12 @@ export function DocumentReviewPage() {
       {
         onSuccess: (created) => {
           setPending(null);
-          setActiveAnnotationId(created.id);
+          // In the panel the fresh annotation expands in place — helpful. In
+          // focus mode activating it would re-open the overlay on the spot the
+          // writer just left: the scrim (blur) stays up and the card's focus
+          // trap yanks the viewport to a mark that hasn't rendered yet (issue
+          // #403). Creating is a closing gesture there: page stays put, sharp.
+          if (!focusMode) setActiveAnnotationId(created.id);
           notify('Annotation created.');
         },
         onError: (error) =>
@@ -390,7 +408,7 @@ export function DocumentReviewPage() {
       />
       <ReviewViewTabs
         documentId={routeSegment}
-        active={focusMode ? 'focus' : 'document'}
+        active="document"
         openTaskCount={annotations.filter((a) => columnOf(a) !== 'done').length}
         compareEnabled={
           (versionsQuery.data?.versions.filter(
@@ -422,7 +440,8 @@ export function DocumentReviewPage() {
               canAnnotate={canAnnotate}
               zoom={zoom}
               onZoomChange={setZoom}
-              focusMode={focusMode}
+              viewMode={viewMode}
+              onViewModeChange={switchViewMode}
               annotationCount={annotations.length}
               onOpenAnnotationList={() => setListOpen(true)}
             />
@@ -628,11 +647,7 @@ export function DocumentReviewPage() {
           open={Boolean(pendingMarkEl)}
           anchorEl={pendingMarkEl}
           placement="right-start"
-          sx={(theme) => ({
-            zIndex: theme.zIndex.modal,
-            width: 380,
-            maxWidth: 'calc(100vw - 32px)',
-          })}
+          sx={(theme) => ({ zIndex: theme.zIndex.modal })}
           modifiers={[
             { name: 'offset', options: { offset: [0, 16] } },
             { name: 'flip', options: { fallbackPlacements: ['left-start', 'bottom', 'top'] } },
@@ -640,13 +655,28 @@ export function DocumentReviewPage() {
           ]}
         >
           {/* Same floating-surface treatment as the focus card: bordered
-              Paper under one soft ambient shadow. */}
+              Paper under one soft ambient shadow. The Composer's own Paper is
+              deliberately transparent (it normally sits on the panel), so this
+              wrapper supplies the opaque surface — floating over the document
+              it must never shine through (issue #403). */}
           <Box
-            sx={{
-              boxShadow: (theme) =>
-                theme.qnop.mode === 'dark' ? 'none' : '0 16px 48px rgba(1,32,66,0.14)',
+            sx={(theme) => ({
+              position: 'relative',
+              boxShadow: theme.qnop.mode === 'dark' ? 'none' : '0 16px 48px rgba(1,32,66,0.14)',
               borderRadius: '10px',
-            }}
+              bgcolor: 'background.paper',
+              overflow: 'hidden',
+              // Writer-resizable (issue #403), like the focus card — but only
+              // horizontally: height stays content-driven (the textarea grows
+              // as you type), so width is the axis worth grabbing.
+              resize: 'horizontal',
+              width: 380,
+              minWidth: 320,
+              maxWidth: 'min(720px, calc(100vw - 48px))',
+              // The inner outlined Paper draws the border; align its corners
+              // with this surface so the edge reads as ONE rounded frame.
+              '& > .MuiPaper-root': { borderRadius: '10px' },
+            })}
           >
             <Composer
               pendingAnchor={pending.anchor}
@@ -654,6 +684,20 @@ export function DocumentReviewPage() {
               onCreate={handleCreate}
               onCancel={() => setPending(null)}
               onUploadAttachment={uploadAttachment}
+            />
+            {/* Discoverability for the native resize grip underneath. */}
+            <Box
+              aria-hidden
+              sx={(theme) => ({
+                position: 'absolute',
+                right: 2,
+                bottom: 2,
+                width: 11,
+                height: 11,
+                pointerEvents: 'none',
+                clipPath: 'polygon(100% 0, 100% 100%, 0 100%)',
+                background: `repeating-linear-gradient(135deg, transparent 0 2.5px, ${theme.palette.divider} 2.5px 4px)`,
+              })}
             />
           </Box>
         </Popper>


### PR DESCRIPTION
## Summary

A polish round on the review surfaces (part of #403), built on the merged #448 state.

### One Document tab
- The **Focus tab is gone** — the strip navigates surfaces (Document, Tasks, Compare) and a labeled **Panel | Focus** toolbar switch (same `ToggleButtonGroup` language as the text/region tool) picks the presentation. It routes through `?view=` (shareable), and the stored preference decides when arriving without a param.

### Panel list
- Collapsed annotation rows become **two-line cards**: tinted status tile (unseen dot on its corner), a title that shows the content — quote, or a plain-text excerpt of the opening comment instead of four identical "Whole document" labels — and a meta line with author, relative time, type cue, priority dot, and counters.

### Focus view
- Annotation **drawer**: wider default (520px) and resizable (pointer drag with capture + arrow keys on the focusable separator, hard bounds, width persisted).
- Floating **card**: opens at 460px; everything below the handle scrolls as one container — long opening texts no longer push the thread out of the card; max height up to `min(64vh, 600px)`.
- **Scrim**: no more dark veil — a light 1px blur alone separates the spotlit passage; `prefers-reduced-transparency` falls back to a subtle tint.
- **Composer popup**: opaque floating surface (its transparent panel-Paper used to shine through over the document) and horizontally resizable with the grip indicator.
- **Creating** from focus mode is a closing gesture: the fresh annotation no longer re-activates the overlay (blur stuck on + focus-trap scroll yank).

### Calmer scrolling
- Hovering a panel row no longer scrolls the document — the click owns bringing a mark into view (hover keeps the visual link).
- `create/resolve/reopen` mutations invalidate the document **detail** only instead of `documentKeys.all`, which reloaded the PDF binary and remounted the viewer back to page 1 on every annotation.

### Annotation permalink in the author row (follow-up to #412)
- The opening annotation carries its copy-link **like a comment row does**: hover/focus-revealed, directly after the timestamp ("Started this discussion · 3d 🔗"), always visible on pointer-less devices.
- Replaces both previous placements (floating link under the panel's expanded card, focus card's handle row) — the head anatomy is now identical in both views. The expanded panel card hosts real buttons, so it renders as a `div[role=button]` instead of nesting `<button>` in `<button>`.

## Test plan
- [x] `pnpm test:run` — 706 tests (updated: tab strip, page view-switch, viewer hover/click scroll; new: drawer resize/persist/clamp), `pnpm lint`, `pnpm typecheck`, `pnpm build`
- [x] Manual browser walkthrough (light + dark): tab strip, Panel↔Focus round trip incl. deep link, drawer drag + reload persistence, long-annotation card scroll to the thread tail, region→create flow (popup solid, resizable; page stays put and sharp afterwards), hover vs. click scrolling
- [x] Permalink: hover/focus reveal on the head in panel + focus views, copy toast, card stays expanded on click (propagation stopped)

Part of #403.

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
