### PR TITLE
feat(reviews): task drawer head, resizable drawers & full-screen writing stage (#403)

### DIFF
--- a/qnop-ui/src/components/reviews/ResizableDrawer.test.tsx
+++ b/qnop-ui/src/components/reviews/ResizableDrawer.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { ResizableDrawer } from './ResizableDrawer';
+
+function renderDrawer(overrides: Record<string, unknown> = {}) {
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <ResizableDrawer
+        open
+        onClose={vi.fn()}
+        storageKey="qnop-test-drawer-width"
+        defaultWidth={500}
+        handleAriaLabel="Resize the test drawer"
+        handleTestId="test-drawer-resize-handle"
+        {...overrides}
+      >
+        <div>drawer content</div>
+      </ResizableDrawer>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('ResizableDrawer (issue #403)', () => {
+  it('exposes a keyboard-operable separator that widens and narrows the drawer', () => {
+    renderDrawer();
+    const handle = screen.getByRole('separator', { name: 'Resize the test drawer' });
+    const before = Number(handle.getAttribute('aria-valuenow'));
+
+    // The handle sits on the leading edge: ArrowLeft grows the drawer.
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    expect(Number(handle.getAttribute('aria-valuenow'))).toBe(before + 24);
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    expect(Number(handle.getAttribute('aria-valuenow'))).toBe(before);
+  });
+
+  it('persists the chosen width under its own storage key', () => {
+    renderDrawer();
+    fireEvent.keyDown(screen.getByTestId('test-drawer-resize-handle'), { key: 'ArrowLeft' });
+
+    expect(Number(localStorage.getItem('qnop-test-drawer-width'))).toBe(524);
+  });
+
+  it('starts from the persisted width of ITS surface, not another drawer’s', () => {
+    localStorage.setItem('qnop-test-drawer-width', '600');
+    localStorage.setItem('qnop-other-drawer-width', '444');
+    renderDrawer();
+
+    const handle = screen.getByTestId('test-drawer-resize-handle');
+    expect(Number(handle.getAttribute('aria-valuenow'))).toBe(600);
+  });
+
+  it('never resizes below the minimum width', () => {
+    localStorage.setItem('qnop-test-drawer-width', '381');
+    renderDrawer();
+    const handle = screen.getByTestId('test-drawer-resize-handle');
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+    fireEvent.keyDown(handle, { key: 'ArrowRight' });
+
+    expect(Number(handle.getAttribute('aria-valuenow'))).toBe(380);
+  });
+});

--- a/qnop-ui/src/components/reviews/ResizableDrawer.tsx
+++ b/qnop-ui/src/components/reviews/ResizableDrawer.tsx
@@ -19,40 +19,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useRef, useState, type KeyboardEvent, type PointerEvent, type ReactNode } from 'react';
-import Box from '@mui/material/Box';
+import type { ReactNode } from 'react';
 import Drawer from '@mui/material/Drawer';
-import { alpha, useTheme } from '@mui/material/styles';
+import { ResizeHandle } from './ResizeHandle';
+import { useResizeHandle } from './useResizeHandle';
 
 /** Never narrower than a thread needs to breathe, never the whole viewport. */
 const DEFAULT_MIN_WIDTH = 380;
-const KEYBOARD_STEP = 24;
-
-/** Keeps a slice of the underlying page visible even on generous drags. */
-function maxWidth(minWidth: number): number {
-  return Math.max(minWidth, Math.min(900, window.innerWidth - 240));
-}
-
-function clampWidth(width: number, minWidth: number): number {
-  return Math.min(Math.max(width, minWidth), maxWidth(minWidth));
-}
-
-function storedWidth(storageKey: string, minWidth: number, defaultWidth: number): number {
-  try {
-    const value = Number(localStorage.getItem(storageKey));
-    return Number.isFinite(value) && value >= minWidth ? clampWidth(value, minWidth) : defaultWidth;
-  } catch {
-    return defaultWidth;
-  }
-}
-
-function persistWidth(storageKey: string, width: number) {
-  try {
-    localStorage.setItem(storageKey, String(width));
-  } catch {
-    // best-effort persistence
-  }
-}
 
 interface ResizableDrawerProps {
   open: boolean;
@@ -70,10 +43,9 @@ interface ResizableDrawerProps {
 
 /**
  * A right-anchored drawer whose width is a personal working preference
- * (issue #403): a grab handle on the leading edge resizes it (pointer drag,
- * or arrow keys on the focused separator) and the choice persists per
- * `storageKey`. One mechanism for every review drawer — focus-mode panel and
- * task details resize and remember identically.
+ * (issue #403), resized and persisted through {@link useResizeHandle}. One
+ * mechanism for every review drawer — focus-mode panel and task details
+ * resize and remember identically.
  */
 export function ResizableDrawer({
   open,
@@ -86,96 +58,23 @@ export function ResizableDrawer({
   drawerTestId,
   children,
 }: ResizableDrawerProps) {
-  const theme = useTheme();
-  const [width, setWidth] = useState<number>(() => storedWidth(storageKey, minWidth, defaultWidth));
-  const [resizing, setResizing] = useState(false);
-  // The live value for the pointer-up persist — state updates lag the drag.
-  const widthRef = useRef(width);
-
-  const applyWidth = (next: number) => {
-    const clamped = clampWidth(next, minWidth);
-    widthRef.current = clamped;
-    setWidth(clamped);
-    return clamped;
-  };
-
-  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.currentTarget.setPointerCapture?.(event.pointerId);
-    setResizing(true);
-  };
-
-  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
-    if (!event.currentTarget.hasPointerCapture?.(event.pointerId)) return;
-    // Anchored right: the drawer spans from the pointer to the viewport edge.
-    applyWidth(window.innerWidth - event.clientX);
-  };
-
-  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
-    event.currentTarget.releasePointerCapture?.(event.pointerId);
-    setResizing(false);
-    persistWidth(storageKey, widthRef.current);
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    // The handle sits on the LEADING edge: left grows the drawer, right shrinks it.
-    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
-    event.preventDefault();
-    // widthRef, not state: key-repeat bursts outpace re-renders.
-    persistWidth(
-      storageKey,
-      applyWidth(widthRef.current + (event.key === 'ArrowLeft' ? KEYBOARD_STEP : -KEYBOARD_STEP)),
-    );
-  };
+  const resize = useResizeHandle({ storageKey, defaultWidth, minWidth });
 
   return (
     <Drawer
       anchor="right"
       open={open}
       onClose={onClose}
-      slotProps={{ paper: { sx: { width: { xs: '100%', sm: width }, overflow: 'visible' } } }}
+      slotProps={{
+        paper: { sx: { width: { xs: '100%', sm: resize.width }, overflow: 'visible' } },
+      }}
       data-testid={drawerTestId}
     >
-      <Box
-        role="separator"
-        aria-orientation="vertical"
-        aria-label={handleAriaLabel}
-        aria-valuemin={minWidth}
-        aria-valuenow={Math.round(width)}
-        tabIndex={0}
-        data-testid={handleTestId}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onKeyDown={handleKeyDown}
-        sx={{
-          position: 'absolute',
-          left: -5,
-          top: 0,
-          bottom: 0,
-          width: 10,
-          zIndex: 1,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
-          cursor: 'col-resize',
-          touchAction: 'none',
-          '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
-          // The visible grip: a quiet hairline that wakes on hover/drag.
-          '&::after': {
-            content: '""',
-            width: '3px',
-            height: 48,
-            borderRadius: 2,
-            bgcolor: resizing ? theme.qnop.brand.blue : theme.palette.divider,
-            transition: 'background-color 120ms ease, height 120ms ease',
-          },
-          '&:hover::after': {
-            bgcolor: resizing ? theme.qnop.brand.blue : alpha(theme.qnop.brand.blue, 0.6),
-            height: 72,
-          },
-          '@media (prefers-reduced-motion: reduce)': { '&::after': { transition: 'none' } },
-        }}
+      <ResizeHandle
+        ariaLabel={handleAriaLabel}
+        testId={handleTestId}
+        minWidth={minWidth}
+        state={resize}
       />
       {children}
     </Drawer>

--- a/qnop-ui/src/components/reviews/ResizableDrawer.tsx
+++ b/qnop-ui/src/components/reviews/ResizableDrawer.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState, type KeyboardEvent, type PointerEvent, type ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import { alpha, useTheme } from '@mui/material/styles';
+
+/** Never narrower than a thread needs to breathe, never the whole viewport. */
+const DEFAULT_MIN_WIDTH = 380;
+const KEYBOARD_STEP = 24;
+
+/** Keeps a slice of the underlying page visible even on generous drags. */
+function maxWidth(minWidth: number): number {
+  return Math.max(minWidth, Math.min(900, window.innerWidth - 240));
+}
+
+function clampWidth(width: number, minWidth: number): number {
+  return Math.min(Math.max(width, minWidth), maxWidth(minWidth));
+}
+
+function storedWidth(storageKey: string, minWidth: number, defaultWidth: number): number {
+  try {
+    const value = Number(localStorage.getItem(storageKey));
+    return Number.isFinite(value) && value >= minWidth ? clampWidth(value, minWidth) : defaultWidth;
+  } catch {
+    return defaultWidth;
+  }
+}
+
+function persistWidth(storageKey: string, width: number) {
+  try {
+    localStorage.setItem(storageKey, String(width));
+  } catch {
+    // best-effort persistence
+  }
+}
+
+interface ResizableDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  /** localStorage key for the persisted width — one preference per surface. */
+  storageKey: string;
+  defaultWidth: number;
+  minWidth?: number;
+  /** Accessible name of the resize separator. */
+  handleAriaLabel: string;
+  handleTestId?: string;
+  drawerTestId?: string;
+  children: ReactNode;
+}
+
+/**
+ * A right-anchored drawer whose width is a personal working preference
+ * (issue #403): a grab handle on the leading edge resizes it (pointer drag,
+ * or arrow keys on the focused separator) and the choice persists per
+ * `storageKey`. One mechanism for every review drawer — focus-mode panel and
+ * task details resize and remember identically.
+ */
+export function ResizableDrawer({
+  open,
+  onClose,
+  storageKey,
+  defaultWidth,
+  minWidth = DEFAULT_MIN_WIDTH,
+  handleAriaLabel,
+  handleTestId,
+  drawerTestId,
+  children,
+}: ResizableDrawerProps) {
+  const theme = useTheme();
+  const [width, setWidth] = useState<number>(() => storedWidth(storageKey, minWidth, defaultWidth));
+  const [resizing, setResizing] = useState(false);
+  // The live value for the pointer-up persist — state updates lag the drag.
+  const widthRef = useRef(width);
+
+  const applyWidth = (next: number) => {
+    const clamped = clampWidth(next, minWidth);
+    widthRef.current = clamped;
+    setWidth(clamped);
+    return clamped;
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    setResizing(true);
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture?.(event.pointerId)) return;
+    // Anchored right: the drawer spans from the pointer to the viewport edge.
+    applyWidth(window.innerWidth - event.clientX);
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    setResizing(false);
+    persistWidth(storageKey, widthRef.current);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // The handle sits on the LEADING edge: left grows the drawer, right shrinks it.
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    // widthRef, not state: key-repeat bursts outpace re-renders.
+    persistWidth(
+      storageKey,
+      applyWidth(widthRef.current + (event.key === 'ArrowLeft' ? KEYBOARD_STEP : -KEYBOARD_STEP)),
+    );
+  };
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      slotProps={{ paper: { sx: { width: { xs: '100%', sm: width }, overflow: 'visible' } } }}
+      data-testid={drawerTestId}
+    >
+      <Box
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={handleAriaLabel}
+        aria-valuemin={minWidth}
+        aria-valuenow={Math.round(width)}
+        tabIndex={0}
+        data-testid={handleTestId}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onKeyDown={handleKeyDown}
+        sx={{
+          position: 'absolute',
+          left: -5,
+          top: 0,
+          bottom: 0,
+          width: 10,
+          zIndex: 1,
+          display: { xs: 'none', sm: 'flex' },
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'col-resize',
+          touchAction: 'none',
+          '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
+          // The visible grip: a quiet hairline that wakes on hover/drag.
+          '&::after': {
+            content: '""',
+            width: '3px',
+            height: 48,
+            borderRadius: 2,
+            bgcolor: resizing ? theme.qnop.brand.blue : theme.palette.divider,
+            transition: 'background-color 120ms ease, height 120ms ease',
+          },
+          '&:hover::after': {
+            bgcolor: resizing ? theme.qnop.brand.blue : alpha(theme.qnop.brand.blue, 0.6),
+            height: 72,
+          },
+          '@media (prefers-reduced-motion: reduce)': { '&::after': { transition: 'none' } },
+        }}
+      />
+      {children}
+    </Drawer>
+  );
+}

--- a/qnop-ui/src/components/reviews/ResizeHandle.tsx
+++ b/qnop-ui/src/components/reviews/ResizeHandle.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import { alpha, useTheme } from '@mui/material/styles';
+import type { ResizeHandleState } from './useResizeHandle';
+
+interface ResizeHandleProps {
+  ariaLabel: string;
+  testId?: string;
+  minWidth: number;
+  state: ResizeHandleState;
+}
+
+/**
+ * The grab handle itself: a focusable separator on the surface's leading edge
+ * with a quiet grip hairline that wakes on hover/drag. The host positions it
+ * inside a `position: relative` (or overflow-visible) container.
+ */
+export function ResizeHandle({ ariaLabel, testId, minWidth, state }: ResizeHandleProps) {
+  const theme = useTheme();
+  return (
+    <Box
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      aria-valuemin={minWidth}
+      aria-valuenow={Math.round(state.width)}
+      tabIndex={0}
+      data-testid={testId}
+      {...state.handleProps}
+      sx={{
+        position: 'absolute',
+        left: -5,
+        top: 0,
+        bottom: 0,
+        width: 10,
+        zIndex: 1,
+        display: { xs: 'none', sm: 'flex' },
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'col-resize',
+        touchAction: 'none',
+        '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
+        '&::after': {
+          content: '""',
+          width: '3px',
+          height: 48,
+          borderRadius: 2,
+          bgcolor: state.resizing ? theme.qnop.brand.blue : theme.palette.divider,
+          transition: 'background-color 120ms ease, height 120ms ease',
+        },
+        '&:hover::after': {
+          bgcolor: state.resizing ? theme.qnop.brand.blue : alpha(theme.qnop.brand.blue, 0.6),
+          height: 72,
+        },
+        '@media (prefers-reduced-motion: reduce)': { '&::after': { transition: 'none' } },
+      }}
+    />
+  );
+}

--- a/qnop-ui/src/components/reviews/focus/FocusDrawer.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusDrawer.tsx
@@ -19,42 +19,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useRef, useState, type KeyboardEvent, type PointerEvent, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
-import Drawer from '@mui/material/Drawer';
-import { alpha, useTheme } from '@mui/material/styles';
-
-/** Never narrower than the panel needs to breathe, never the whole viewport. */
-const MIN_WIDTH = 380;
-const DEFAULT_WIDTH = 520;
-const KEYBOARD_STEP = 24;
-const WIDTH_KEY = 'qnop-focus-drawer-width';
-
-/** Keeps a slice of the document visible even on generous drags. */
-function maxWidth(): number {
-  return Math.max(MIN_WIDTH, Math.min(900, window.innerWidth - 240));
-}
-
-function clampWidth(width: number): number {
-  return Math.min(Math.max(width, MIN_WIDTH), maxWidth());
-}
-
-function storedWidth(): number {
-  try {
-    const value = Number(localStorage.getItem(WIDTH_KEY));
-    return Number.isFinite(value) && value >= MIN_WIDTH ? clampWidth(value) : DEFAULT_WIDTH;
-  } catch {
-    return DEFAULT_WIDTH;
-  }
-}
-
-function persistWidth(width: number) {
-  try {
-    localStorage.setItem(WIDTH_KEY, String(width));
-  } catch {
-    // best-effort persistence
-  }
-}
+import { ResizableDrawer } from '../ResizableDrawer';
 
 interface FocusDrawerProps {
   open: boolean;
@@ -66,98 +33,20 @@ interface FocusDrawerProps {
  * Focus mode's temporary home of the annotation list (issue #291): the full
  * panel — filters, sections, the orphaned group — slides in on demand and
  * disappears again, keeping the document at full width the rest of the time.
- * The width is a personal working preference (issue #403): a grab handle on
- * the leading edge resizes it (pointer drag, or arrow keys on the focused
- * separator) and the choice persists in localStorage.
+ * Resizing and width persistence come from the shared {@link ResizableDrawer}
+ * (issue #403).
  */
 export function FocusDrawer({ open, onClose, children }: FocusDrawerProps) {
-  const theme = useTheme();
-  const [width, setWidth] = useState<number>(storedWidth);
-  const [resizing, setResizing] = useState(false);
-  // The live value for the pointer-up persist — state updates lag the drag.
-  const widthRef = useRef(width);
-
-  const applyWidth = (next: number) => {
-    const clamped = clampWidth(next);
-    widthRef.current = clamped;
-    setWidth(clamped);
-    return clamped;
-  };
-
-  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.currentTarget.setPointerCapture?.(event.pointerId);
-    setResizing(true);
-  };
-
-  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
-    if (!event.currentTarget.hasPointerCapture?.(event.pointerId)) return;
-    // Anchored right: the drawer spans from the pointer to the viewport edge.
-    applyWidth(window.innerWidth - event.clientX);
-  };
-
-  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
-    event.currentTarget.releasePointerCapture?.(event.pointerId);
-    setResizing(false);
-    persistWidth(widthRef.current);
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    // The handle sits on the LEADING edge: left grows the drawer, right shrinks it.
-    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
-    event.preventDefault();
-    persistWidth(applyWidth(width + (event.key === 'ArrowLeft' ? KEYBOARD_STEP : -KEYBOARD_STEP)));
-  };
-
   return (
-    <Drawer
-      anchor="right"
+    <ResizableDrawer
       open={open}
       onClose={onClose}
-      slotProps={{ paper: { sx: { width: { xs: '100%', sm: width }, overflow: 'visible' } } }}
+      storageKey="qnop-focus-drawer-width"
+      defaultWidth={520}
+      handleAriaLabel="Resize the annotation drawer"
+      handleTestId="focus-drawer-resize-handle"
     >
-      <Box
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize the annotation drawer"
-        aria-valuemin={MIN_WIDTH}
-        aria-valuenow={Math.round(width)}
-        tabIndex={0}
-        data-testid="focus-drawer-resize-handle"
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onKeyDown={handleKeyDown}
-        sx={{
-          position: 'absolute',
-          left: -5,
-          top: 0,
-          bottom: 0,
-          width: 10,
-          zIndex: 1,
-          display: { xs: 'none', sm: 'flex' },
-          alignItems: 'center',
-          justifyContent: 'center',
-          cursor: 'col-resize',
-          touchAction: 'none',
-          '&:focus-visible': { outline: 'none', boxShadow: theme.qnop.focusRing },
-          // The visible grip: a quiet hairline that wakes on hover/drag.
-          '&::after': {
-            content: '""',
-            width: '3px',
-            height: 48,
-            borderRadius: 2,
-            bgcolor: resizing ? theme.qnop.brand.blue : theme.palette.divider,
-            transition: 'background-color 120ms ease, height 120ms ease',
-          },
-          '&:hover::after': {
-            bgcolor: resizing ? theme.qnop.brand.blue : alpha(theme.qnop.brand.blue, 0.6),
-            height: 72,
-          },
-          '@media (prefers-reduced-motion: reduce)': { '&::after': { transition: 'none' } },
-        }}
-      />
       <Box sx={{ p: 2, overflowY: 'auto', height: '100%' }}>{children}</Box>
-    </Drawer>
+    </ResizableDrawer>
   );
 }

--- a/qnop-ui/src/components/reviews/markdown/FullscreenComposerDialog.tsx
+++ b/qnop-ui/src/components/reviews/markdown/FullscreenComposerDialog.tsx
@@ -29,10 +29,12 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { Minimize2, PenLine } from 'lucide-react';
+import { ResizeHandle } from '../ResizeHandle';
+import { useResizeHandle } from '../useResizeHandle';
 
-/** Reading-comfortable line length for the writing column. */
-const STAGE_MAX_WIDTH = 860;
-const RAIL_WIDTH = 400;
+/** The context rail never crowds the editor, never vanishes. */
+const RAIL_MIN_WIDTH = 320;
+const RAIL_DEFAULT_WIDTH = 400;
 
 interface FullscreenComposerDialogProps {
   open: boolean;
@@ -48,12 +50,12 @@ interface FullscreenComposerDialogProps {
 
 /**
  * The full-screen writing stage (issue #403 follow-up): long thoughts deserve
- * more room than an inline reply box. The editor takes a centred, reading-wide
- * column; the conversation stays visible in a quiet rail on the right — where
- * discussions live everywhere else in the app — so writers keep the thread's
- * context without scrolling the page behind. The host renders the SAME
- * controlled composer inside, so the draft carries over in both directions;
- * Escape or the minimize affordance returns to the inline field.
+ * more room than an inline reply box. The editor fills the whole stage — the
+ * host renders the SAME controlled composer in its frameless `bare` mode, so
+ * the draft carries over in both directions and the composer's footer becomes
+ * the bottom-fixed action bar. The conversation stays visible in a quiet,
+ * resizable rail on the right — where discussions live everywhere else in the
+ * app. Escape or the minimize affordance returns to the inline field.
  */
 export function FullscreenComposerDialog({
   open,
@@ -65,6 +67,12 @@ export function FullscreenComposerDialog({
 }: FullscreenComposerDialogProps) {
   const theme = useTheme();
   const stageRef = useRef<HTMLDivElement>(null);
+  const rail = useResizeHandle({
+    storageKey: 'qnop-stage-rail-width',
+    defaultWidth: RAIL_DEFAULT_WIDTH,
+    minWidth: RAIL_MIN_WIDTH,
+    maxWidth: () => Math.max(RAIL_MIN_WIDTH, Math.min(680, Math.round(window.innerWidth * 0.5))),
+  });
 
   // Writers expect the caret in the field, at the end of their draft — the
   // dialog's default focus lands on the first button instead.
@@ -149,20 +157,23 @@ export function FullscreenComposerDialog({
         </Stack>
 
         <Stack direction="row" sx={{ flex: 1, minHeight: 0 }}>
-          {/* The writing stage: a centred, reading-wide column. */}
-          <Box ref={stageRef} sx={{ flex: 1, minWidth: 0, overflowY: 'auto' }}>
-            <Box sx={{ maxWidth: STAGE_MAX_WIDTH, mx: 'auto', px: { xs: 2, sm: 3 }, py: 3 }}>
-              {children}
-            </Box>
+          {/* The editor owns the whole stage; the host's bare composer brings
+              its own bottom action bar. */}
+          <Box
+            ref={stageRef}
+            sx={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}
+          >
+            {children}
           </Box>
 
-          {/* The conversation, kept in sight — quiet, read-only, on the right
-              where discussions live everywhere else in the app. */}
+          {/* The conversation, kept in sight — quiet, read-only, resizable, on
+              the right where discussions live everywhere else in the app. */}
           {context && (
             <Box
               data-testid="fullscreen-composer-context"
               sx={{
-                width: RAIL_WIDTH,
+                position: 'relative',
+                width: rail.width,
                 flexShrink: 0,
                 display: { xs: 'none', md: 'flex' },
                 flexDirection: 'column',
@@ -172,6 +183,12 @@ export function FullscreenComposerDialog({
                 bgcolor: theme.qnop.surface2,
               }}
             >
+              <ResizeHandle
+                ariaLabel="Resize the context rail"
+                testId="stage-rail-resize-handle"
+                minWidth={RAIL_MIN_WIDTH}
+                state={rail}
+              />
               <Typography
                 variant="overline"
                 sx={{

--- a/qnop-ui/src/components/reviews/markdown/FullscreenComposerDialog.tsx
+++ b/qnop-ui/src/components/reviews/markdown/FullscreenComposerDialog.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, type ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import Fade from '@mui/material/Fade';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { Minimize2, PenLine } from 'lucide-react';
+
+/** Reading-comfortable line length for the writing column. */
+const STAGE_MAX_WIDTH = 860;
+const RAIL_WIDTH = 400;
+
+interface FullscreenComposerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** The stage's heading — "Write a reply", "New annotation", … */
+  title: string;
+  /** Right-hand context rail: the discussion so far, the anchored passage, … */
+  context?: ReactNode;
+  contextTitle?: string;
+  /** The writing surface — a composer the HOST controls, so drafts survive the mode switch. */
+  children: ReactNode;
+}
+
+/**
+ * The full-screen writing stage (issue #403 follow-up): long thoughts deserve
+ * more room than an inline reply box. The editor takes a centred, reading-wide
+ * column; the conversation stays visible in a quiet rail on the right — where
+ * discussions live everywhere else in the app — so writers keep the thread's
+ * context without scrolling the page behind. The host renders the SAME
+ * controlled composer inside, so the draft carries over in both directions;
+ * Escape or the minimize affordance returns to the inline field.
+ */
+export function FullscreenComposerDialog({
+  open,
+  onClose,
+  title,
+  context,
+  contextTitle = 'Discussion',
+  children,
+}: FullscreenComposerDialogProps) {
+  const theme = useTheme();
+  const stageRef = useRef<HTMLDivElement>(null);
+
+  // Writers expect the caret in the field, at the end of their draft — the
+  // dialog's default focus lands on the first button instead.
+  const focusEditor = () => {
+    const input = stageRef.current?.querySelector('textarea');
+    if (!input) return;
+    input.focus();
+    const end = input.value.length;
+    input.setSelectionRange(end, end);
+  };
+
+  return (
+    <Dialog
+      fullScreen
+      open={open}
+      onClose={onClose}
+      slots={{ transition: Fade }}
+      transitionDuration={200}
+      slotProps={{ transition: { onEntered: focusEditor } }}
+      data-testid="fullscreen-composer"
+    >
+      <Stack sx={{ height: '100%' }}>
+        {/* Stage header: what you are writing, and the way back. */}
+        <Stack
+          direction="row"
+          spacing={1.25}
+          sx={{
+            alignItems: 'center',
+            px: 2,
+            py: 1,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Box
+            aria-hidden
+            sx={{
+              width: 30,
+              height: 30,
+              borderRadius: '8px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: theme.qnop.brand.blue,
+              bgcolor: alpha(theme.qnop.brand.blue, 0.1),
+            }}
+          >
+            <PenLine size={15} />
+          </Box>
+          <Typography sx={{ fontWeight: 700, fontSize: '0.9375rem' }}>{title}</Typography>
+          <Box sx={{ flex: 1 }} />
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'text.secondary',
+              display: { xs: 'none', sm: 'inline-flex' },
+              alignItems: 'center',
+              gap: 0.5,
+            }}
+          >
+            <Box
+              component="kbd"
+              sx={{
+                font: 'inherit',
+                px: 0.75,
+                py: 0.1,
+                borderRadius: '5px',
+                border: '1px solid',
+                borderColor: 'divider',
+                bgcolor: theme.qnop.surface2,
+              }}
+            >
+              esc
+            </Box>
+            to exit
+          </Typography>
+          <Tooltip title="Exit full screen">
+            <IconButton size="small" aria-label="Exit full screen" onClick={onClose}>
+              <Minimize2 size={16} />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+
+        <Stack direction="row" sx={{ flex: 1, minHeight: 0 }}>
+          {/* The writing stage: a centred, reading-wide column. */}
+          <Box ref={stageRef} sx={{ flex: 1, minWidth: 0, overflowY: 'auto' }}>
+            <Box sx={{ maxWidth: STAGE_MAX_WIDTH, mx: 'auto', px: { xs: 2, sm: 3 }, py: 3 }}>
+              {children}
+            </Box>
+          </Box>
+
+          {/* The conversation, kept in sight — quiet, read-only, on the right
+              where discussions live everywhere else in the app. */}
+          {context && (
+            <Box
+              data-testid="fullscreen-composer-context"
+              sx={{
+                width: RAIL_WIDTH,
+                flexShrink: 0,
+                display: { xs: 'none', md: 'flex' },
+                flexDirection: 'column',
+                minHeight: 0,
+                borderLeft: '1px solid',
+                borderColor: 'divider',
+                bgcolor: theme.qnop.surface2,
+              }}
+            >
+              <Typography
+                variant="overline"
+                sx={{
+                  px: 2.5,
+                  pt: 1.75,
+                  pb: 0.75,
+                  color: 'text.secondary',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                {contextTitle}
+              </Typography>
+              <Box sx={{ flex: 1, overflowY: 'auto', px: 2.5, pb: 2.5 }}>{context}</Box>
+            </Box>
+          )}
+        </Stack>
+      </Stack>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/reviews/markdown/MarkdownComposer.test.tsx
+++ b/qnop-ui/src/components/reviews/markdown/MarkdownComposer.test.tsx
@@ -31,10 +31,12 @@ import type { UploadedAttachment } from './useCommentAttachmentUpload';
 function Host({
   onSubmit,
   onUploadAttachment,
+  onToggleFullscreen,
   initial = '',
 }: {
   onSubmit?: () => void;
   onUploadAttachment?: (file: File) => Promise<UploadedAttachment>;
+  onToggleFullscreen?: () => void;
   initial?: string;
 }) {
   const [value, setValue] = useState(initial);
@@ -45,6 +47,7 @@ function Host({
         onChange={setValue}
         onSubmit={onSubmit}
         onUploadAttachment={onUploadAttachment}
+        onToggleFullscreen={onToggleFullscreen}
         inputAriaLabel="Test comment"
       />
     </ThemeProvider>
@@ -235,5 +238,19 @@ describe('MarkdownComposer — attachments (issue #446)', () => {
     fireEvent.paste(textarea(), { clipboardData: { files: [file] } });
 
     await waitFor(() => expect(upload).toHaveBeenCalledWith(file));
+  });
+
+  it('offers the full-screen toggle only when the host provides one (issue #403)', () => {
+    render(<Host />);
+    expect(screen.queryByRole('button', { name: 'Full screen' })).not.toBeInTheDocument();
+  });
+
+  it('fires the full-screen toggle', () => {
+    const onToggleFullscreen = vi.fn();
+    render(<Host onToggleFullscreen={onToggleFullscreen} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Full screen' }));
+
+    expect(onToggleFullscreen).toHaveBeenCalledTimes(1);
   });
 });

--- a/qnop-ui/src/components/reviews/markdown/MarkdownComposer.tsx
+++ b/qnop-ui/src/components/reviews/markdown/MarkdownComposer.tsx
@@ -36,7 +36,7 @@ import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme, type Theme } from '@mui/material/styles';
-import { Paperclip } from 'lucide-react';
+import { Maximize2, Minimize2, Paperclip } from 'lucide-react';
 import { isSubmitShortcut } from '../../../utils/platform';
 import { applyMarkdownAction, type MarkdownAction } from './markdownFormatting';
 import { EmojiPickerButton } from './EmojiPickerButton';
@@ -91,6 +91,15 @@ interface MarkdownComposerProps {
   onUploadAttachment?: (file: File) => Promise<UploadedAttachment>;
   /** Right side of the footer row — the send / create actions. */
   actions?: ReactNode;
+  /**
+   * Offered by hosts that can stage the composer full screen (issue #403
+   * follow-up): renders the expand/collapse affordance in the mode row.
+   */
+  onToggleFullscreen?: () => void;
+  /** True on the full-screen instance — flips the affordance to "exit". */
+  fullscreen?: boolean;
+  /** Larger reading type for the full-screen stage. */
+  roomy?: boolean;
 }
 
 /**
@@ -112,9 +121,16 @@ export function MarkdownComposer({
   maxRows = 12,
   disabled = false,
   onUploadAttachment,
+  onToggleFullscreen,
+  fullscreen = false,
+  roomy = false,
   actions,
 }: MarkdownComposerProps) {
   const theme = useTheme();
+  // The full-screen stage reads larger; both the input and the preview's
+  // row-derived heights follow the same metrics.
+  const fontSize = roomy ? 16 : 14;
+  const lineHeight = roomy ? 1.65 : 1.55;
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   // Selection for the controlled-update fallback, applied after the re-render.
@@ -368,7 +384,20 @@ export function MarkdownComposer({
             Preview
           </ButtonBase>
         </Stack>
-        {!previewing && <MarkdownToolbar onAction={handleAction} disabled={disabled} />}
+        <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+          {!previewing && <MarkdownToolbar onAction={handleAction} disabled={disabled} />}
+          {onToggleFullscreen && (
+            <Tooltip title={fullscreen ? 'Exit full screen' : 'Full screen'}>
+              <IconButton
+                size="small"
+                aria-label={fullscreen ? 'Exit full screen' : 'Full screen'}
+                onClick={onToggleFullscreen}
+              >
+                {fullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
       </Stack>
       {previewing ? (
         <Box
@@ -376,8 +405,8 @@ export function MarkdownComposer({
           sx={{
             px: 1.5,
             py: 1.25,
-            minHeight: Math.round(minRows * 14 * 1.55) + 20,
-            maxHeight: Math.round(maxRows * 14 * 1.55) + 20,
+            minHeight: Math.round(minRows * fontSize * lineHeight) + 20,
+            maxHeight: Math.round(maxRows * fontSize * lineHeight) + 20,
             overflowY: 'auto',
           }}
         >
@@ -403,7 +432,7 @@ export function MarkdownComposer({
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           inputProps={{ maxLength: BODY_MAX_LENGTH, 'aria-label': inputAriaLabel }}
-          sx={{ px: 1.5, py: 1.25, fontSize: 14, lineHeight: 1.55 }}
+          sx={{ px: 1.5, py: 1.25, fontSize, lineHeight }}
         />
       )}
       <Stack

--- a/qnop-ui/src/components/reviews/markdown/MarkdownComposer.tsx
+++ b/qnop-ui/src/components/reviews/markdown/MarkdownComposer.tsx
@@ -100,6 +100,12 @@ interface MarkdownComposerProps {
   fullscreen?: boolean;
   /** Larger reading type for the full-screen stage. */
   roomy?: boolean;
+  /**
+   * Editor mode for the full-screen stage (issue #403 follow-up): no frame,
+   * the writing area fills all available height, and the footer becomes the
+   * stage's bottom-fixed action bar. Implies the larger reading type.
+   */
+  bare?: boolean;
 }
 
 /**
@@ -124,13 +130,14 @@ export function MarkdownComposer({
   onToggleFullscreen,
   fullscreen = false,
   roomy = false,
+  bare = false,
   actions,
 }: MarkdownComposerProps) {
   const theme = useTheme();
   // The full-screen stage reads larger; both the input and the preview's
   // row-derived heights follow the same metrics.
-  const fontSize = roomy ? 16 : 14;
-  const lineHeight = roomy ? 1.65 : 1.55;
+  const fontSize = roomy || bare ? 16 : 14;
+  const lineHeight = roomy || bare ? 1.65 : 1.55;
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   // Selection for the controlled-update fallback, applied after the re-render.
@@ -333,15 +340,20 @@ export function MarkdownComposer({
       onDrop={handleDrop}
       sx={{
         position: 'relative',
-        border: '1px solid',
-        borderColor: 'divider',
-        borderRadius: '10px',
         bgcolor: 'background.paper',
-        transition: 'border-color 120ms ease, box-shadow 120ms ease',
-        '&:focus-within': {
-          borderColor: theme.qnop.brand.blue,
-          boxShadow: `0 0 0 2px ${alpha(theme.qnop.brand.blue, 0.18)}`,
-        },
+        // The stage IS the surface (issue #403): no frame, fill the host.
+        ...(bare
+          ? { height: '100%', display: 'flex', flexDirection: 'column', minHeight: 0 }
+          : {
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: '10px',
+              transition: 'border-color 120ms ease, box-shadow 120ms ease',
+              '&:focus-within': {
+                borderColor: theme.qnop.brand.blue,
+                boxShadow: `0 0 0 2px ${alpha(theme.qnop.brand.blue, 0.18)}`,
+              },
+            }),
         '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
       }}
     >
@@ -402,13 +414,17 @@ export function MarkdownComposer({
       {previewing ? (
         <Box
           data-testid="composer-preview"
-          sx={{
-            px: 1.5,
-            py: 1.25,
-            minHeight: Math.round(minRows * fontSize * lineHeight) + 20,
-            maxHeight: Math.round(maxRows * fontSize * lineHeight) + 20,
-            overflowY: 'auto',
-          }}
+          sx={
+            bare
+              ? { flex: 1, minHeight: 0, overflowY: 'auto', px: { xs: 2.5, md: 4 }, py: 2.5 }
+              : {
+                  px: 1.5,
+                  py: 1.25,
+                  minHeight: Math.round(minRows * fontSize * lineHeight) + 20,
+                  maxHeight: Math.round(maxRows * fontSize * lineHeight) + 20,
+                  overflowY: 'auto',
+                }
+          }
         >
           {value.trim() ? (
             <Markdown>{value}</Markdown>
@@ -432,13 +448,41 @@ export function MarkdownComposer({
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           inputProps={{ maxLength: BODY_MAX_LENGTH, 'aria-label': inputAriaLabel }}
-          sx={{ px: 1.5, py: 1.25, fontSize, lineHeight }}
+          sx={
+            bare
+              ? {
+                  flex: 1,
+                  minHeight: 0,
+                  alignItems: 'stretch',
+                  px: { xs: 2.5, md: 4 },
+                  py: 2.5,
+                  fontSize,
+                  lineHeight,
+                  // The autosizing textarea would grow the page; on the stage
+                  // it IS the scroll container instead.
+                  '& textarea': { height: '100% !important', overflowY: 'auto !important' },
+                }
+              : { px: 1.5, py: 1.25, fontSize, lineHeight }
+          }
         />
       )}
       <Stack
         direction="row"
         spacing={1}
-        sx={{ px: 0.75, pb: 0.75, justifyContent: 'space-between', alignItems: 'center' }}
+        sx={
+          bare
+            ? {
+                px: 2,
+                py: 1,
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                borderTop: '1px solid',
+                borderColor: 'divider',
+                flexWrap: 'wrap',
+                gap: 0.5,
+              }
+            : { px: 0.75, pb: 0.75, justifyContent: 'space-between', alignItems: 'center' }
+        }
       >
         <Stack direction="row" spacing={1} sx={{ alignItems: 'center', pl: 0.25 }}>
           <EmojiPickerButton onSelect={insertEmoji} disabled={disabled || previewing} />

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -427,7 +427,7 @@ describe('full-screen writing stage (issue #403)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Full screen' }));
     const dialog = screen.getByTestId('fullscreen-composer');
 
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Comment' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Comment/ }));
 
     expect(addMutate).toHaveBeenCalledWith('Written on the stage', expect.anything());
     await waitFor(() =>

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -20,7 +20,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../../theme/theme';
 import { useAuthStore } from '../../../stores/authStore';
@@ -357,5 +357,81 @@ describe('CommentThread permalinks (#412)', () => {
     );
     expect(notify).toHaveBeenCalledWith('This comment no longer exists.', 'error');
     expect(onScrolledToComment).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('full-screen writing stage (issue #403)', () => {
+  const comments = [
+    {
+      id: 'c1',
+      annotationId: 'a1',
+      authorId: 'other',
+      authorDisplayName: 'Anna',
+      body: 'The opening thought',
+      createdAt: '2026-07-01T10:00:00Z',
+    },
+    {
+      id: 'c2',
+      annotationId: 'a1',
+      authorId: 'other',
+      authorDisplayName: 'Anna',
+      body: 'A follow-up',
+      createdAt: '2026-07-02T10:00:00Z',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(useComments).mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: { comments },
+    } as unknown as ReturnType<typeof useComments>);
+  });
+
+  it('opens the stage with the whole discussion as context and carries the draft both ways', async () => {
+    renderThread();
+    fireEvent.change(screen.getByLabelText('Add a comment'), {
+      target: { value: 'Half a thought' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Full screen' }));
+    const dialog = screen.getByTestId('fullscreen-composer');
+
+    // The rail shows the discussion from its opener on.
+    const rail = within(dialog).getByTestId('fullscreen-composer-context');
+    expect(rail).toHaveTextContent('The opening thought');
+    expect(rail).toHaveTextContent('A follow-up');
+
+    // The SAME draft continues on the stage…
+    const stageInput = within(dialog).getByLabelText('Add a comment');
+    expect(stageInput).toHaveValue('Half a thought');
+    fireEvent.change(stageInput, { target: { value: 'Half a thought, finished.' } });
+
+    // …and survives the way back to the inline field (the stage fades out
+    // before unmounting, so wait for it to leave the tree).
+    fireEvent.click(within(dialog).getAllByRole('button', { name: 'Exit full screen' })[0]);
+    await waitFor(() =>
+      expect(screen.queryByTestId('fullscreen-composer')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByLabelText('Add a comment')).toHaveValue('Half a thought, finished.');
+  });
+
+  it('sends from the stage and closes it', async () => {
+    addMutate.mockImplementation((_body: string, options: { onSuccess: () => void }) =>
+      options.onSuccess(),
+    );
+    renderThread();
+    fireEvent.change(screen.getByLabelText('Add a comment'), {
+      target: { value: 'Written on the stage' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Full screen' }));
+    const dialog = screen.getByTestId('fullscreen-composer');
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Comment' }));
+
+    expect(addMutate).toHaveBeenCalledWith('Written on the stage', expect.anything());
+    await waitFor(() =>
+      expect(screen.queryByTestId('fullscreen-composer')).not.toBeInTheDocument(),
+    );
   });
 });

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -355,38 +355,21 @@ export function CommentThread({
         )}
       </Stack>
       {/* The full-screen writing stage (issue #403 follow-up): the same
-          controlled draft on a reading-wide column, with the whole discussion
-          — opener included — in the context rail. Sending closes the stage. */}
+          controlled draft as a frameless editor filling the stage, with the
+          whole discussion — opener included, timeline anatomy and all — in the
+          resizable context rail. Sending closes the stage. */}
       <FullscreenComposerDialog
         open={writingFullscreen}
         onClose={() => setWritingFullscreen(false)}
         title="Write a reply"
         contextTitle={`Discussion (${comments.length})`}
         context={
-          <Stack spacing={2}>
-            {comments.map((comment) => {
-              const own = comment.authorId === userId;
-              const name = own
-                ? (displayName ?? 'You')
-                : (comment.authorDisplayName ?? 'Participant');
-              return (
-                <CommentMessage
-                  key={comment.id}
-                  name={name}
-                  own={own}
-                  avatarUrl={avatarUrl}
-                  body={comment.body}
-                  createdAt={comment.createdAt}
-                  notify={notify}
-                />
-              );
-            })}
-            {comments.length === 0 && (
-              <Typography variant="body2" color="text.secondary">
-                No comments yet.
-              </Typography>
-            )}
-          </Stack>
+          <CommentThread
+            annotationId={annotationId}
+            notify={notify}
+            readOnly
+            previousSeenAt={previousSeenAt}
+          />
         }
       >
         <MarkdownComposer
@@ -394,13 +377,20 @@ export function CommentThread({
           onChange={setDraft}
           onSubmit={() => submit(() => setWritingFullscreen(false))}
           inputAriaLabel="Add a comment"
-          minRows={12}
-          maxRows={26}
-          roomy
+          bare
           onUploadAttachment={uploadAttachment}
           fullscreen
           onToggleFullscreen={() => setWritingFullscreen(false)}
-          actions={sendAction(() => setWritingFullscreen(false))}
+          actions={
+            <Button
+              size="small"
+              variant="contained"
+              onClick={() => submit(() => setWritingFullscreen(false))}
+              disabled={!draft.trim() || addComment.isPending}
+            >
+              Comment ({submitShortcutLabel()})
+            </Button>
+          }
         />
       </FullscreenComposerDialog>
     </Box>

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -36,6 +36,7 @@ import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { isNewComment } from '../newSince';
 import type { BuildPermalink } from '../useReviewPermalink';
+import { FullscreenComposerDialog } from '../markdown/FullscreenComposerDialog';
 import { MarkdownComposer } from '../markdown/MarkdownComposer';
 import { useCommentAttachmentUpload } from '../markdown/useCommentAttachmentUpload';
 import { AVATAR_SIZE, CommentMessage } from './CommentMessage';
@@ -108,13 +109,19 @@ export function CommentThread({
   const addComment = useAddComment(annotationId);
   const uploadAttachment = useCommentAttachmentUpload(documentId, notify);
   const [draft, setDraft] = useState('');
+  // The full-screen writing stage (issue #403 follow-up). The draft state
+  // stays HERE, so it survives entering and leaving the stage.
+  const [writingFullscreen, setWritingFullscreen] = useState(false);
   const pulseColor = alpha(theme.qnop.brand.blue, 0.5);
 
-  const submit = () => {
+  const submit = (onDone?: () => void) => {
     const body = draft.trim();
     if (!body || addComment.isPending) return;
     addComment.mutate(body, {
-      onSuccess: () => setDraft(''),
+      onSuccess: () => {
+        setDraft('');
+        onDone?.();
+      },
       onError: (error) => {
         const code = apiErrorCode(error);
         notify(
@@ -128,6 +135,22 @@ export function CommentThread({
       },
     });
   };
+
+  const sendAction = (onDone?: () => void) => (
+    <Tooltip title={`Send (${submitShortcutLabel()})`}>
+      <span>
+        <IconButton
+          size="small"
+          aria-label="Comment"
+          color="primary"
+          onClick={() => submit(onDone)}
+          disabled={!draft.trim() || addComment.isPending}
+        >
+          <SendHorizontal size={16} />
+        </IconButton>
+      </span>
+    </Tooltip>
+  );
 
   const comments = useMemo(() => commentsQuery.data?.comments ?? [], [commentsQuery.data]);
   // With the opening annotation living in the head card (issue #403), the
@@ -320,30 +343,66 @@ export function CommentThread({
               <MarkdownComposer
                 value={draft}
                 onChange={setDraft}
-                onSubmit={submit}
+                onSubmit={() => submit()}
                 inputAriaLabel="Add a comment"
                 minRows={3}
                 onUploadAttachment={uploadAttachment}
-                actions={
-                  <Tooltip title={`Send (${submitShortcutLabel()})`}>
-                    <span>
-                      <IconButton
-                        size="small"
-                        aria-label="Comment"
-                        color="primary"
-                        onClick={submit}
-                        disabled={!draft.trim() || addComment.isPending}
-                      >
-                        <SendHorizontal size={16} />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                }
+                onToggleFullscreen={() => setWritingFullscreen(true)}
+                actions={sendAction()}
               />
             </Box>
           </Stack>
         )}
       </Stack>
+      {/* The full-screen writing stage (issue #403 follow-up): the same
+          controlled draft on a reading-wide column, with the whole discussion
+          — opener included — in the context rail. Sending closes the stage. */}
+      <FullscreenComposerDialog
+        open={writingFullscreen}
+        onClose={() => setWritingFullscreen(false)}
+        title="Write a reply"
+        contextTitle={`Discussion (${comments.length})`}
+        context={
+          <Stack spacing={2}>
+            {comments.map((comment) => {
+              const own = comment.authorId === userId;
+              const name = own
+                ? (displayName ?? 'You')
+                : (comment.authorDisplayName ?? 'Participant');
+              return (
+                <CommentMessage
+                  key={comment.id}
+                  name={name}
+                  own={own}
+                  avatarUrl={avatarUrl}
+                  body={comment.body}
+                  createdAt={comment.createdAt}
+                  notify={notify}
+                />
+              );
+            })}
+            {comments.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                No comments yet.
+              </Typography>
+            )}
+          </Stack>
+        }
+      >
+        <MarkdownComposer
+          value={draft}
+          onChange={setDraft}
+          onSubmit={() => submit(() => setWritingFullscreen(false))}
+          inputAriaLabel="Add a comment"
+          minRows={12}
+          maxRows={26}
+          roomy
+          onUploadAttachment={uploadAttachment}
+          fullscreen
+          onToggleFullscreen={() => setWritingFullscreen(false)}
+          actions={sendAction(() => setWritingFullscreen(false))}
+        />
+      </FullscreenComposerDialog>
     </Box>
   );
 }

--- a/qnop-ui/src/components/reviews/panel/Composer.tsx
+++ b/qnop-ui/src/components/reviews/panel/Composer.tsx
@@ -75,8 +75,9 @@ export function Composer({
   const create = () => onCreate(comment, type || undefined, priority || undefined);
 
   // Rendered twice — inline and on the full-screen stage — over the SAME
-  // state, so the two views can never drift apart.
-  const classification = (
+  // state, so the two views can never drift apart. Inline the selects stretch;
+  // on the stage's bottom action bar they stay compact.
+  const classificationRow = (compact: boolean) => (
     <Stack direction="row" spacing={1}>
       <TextField
         select
@@ -84,7 +85,7 @@ export function Composer({
         label="Type"
         value={type}
         onChange={(event) => setType(event.target.value as AnnotationType | '')}
-        sx={{ flex: 1 }}
+        sx={compact ? { width: 150 } : { flex: 1 }}
         slotProps={{ htmlInput: { 'aria-label': 'Annotation type' } }}
       >
         <MenuItem value="">
@@ -117,7 +118,7 @@ export function Composer({
         label="Priority"
         value={priority}
         onChange={(event) => setPriority(event.target.value as AnnotationPriority | '')}
-        sx={{ flex: 1 }}
+        sx={compact ? { width: 150 } : { flex: 1 }}
         slotProps={{ htmlInput: { 'aria-label': 'Annotation priority' } }}
       >
         <MenuItem value="">
@@ -193,7 +194,7 @@ export function Composer({
           onToggleFullscreen={() => setWritingFullscreen(true)}
         />
         {/* Optional classification (issue #392) in the system's task language. */}
-        {classification}
+        {classificationRow(false)}
         {actionRow}
       </Stack>
       {/* The full-screen writing stage (issue #403 follow-up): the same
@@ -231,25 +232,30 @@ export function Composer({
           )
         }
       >
-        <Stack spacing={1.5}>
-          <MarkdownComposer
-            value={comment}
-            onChange={setComment}
-            onSubmit={() => {
-              if (canCreate) create();
-            }}
-            inputAriaLabel="Annotation comment"
-            minRows={12}
-            maxRows={26}
-            roomy
-            disabled={creating}
-            onUploadAttachment={onUploadAttachment}
-            fullscreen
-            onToggleFullscreen={() => setWritingFullscreen(false)}
-          />
-          {classification}
-          {actionRow}
-        </Stack>
+        <MarkdownComposer
+          value={comment}
+          onChange={setComment}
+          onSubmit={() => {
+            if (canCreate) create();
+          }}
+          inputAriaLabel="Annotation comment"
+          bare
+          disabled={creating}
+          onUploadAttachment={onUploadAttachment}
+          fullscreen
+          onToggleFullscreen={() => setWritingFullscreen(false)}
+          actions={
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+              {classificationRow(true)}
+              <Button size="small" variant="contained" onClick={create} disabled={!canCreate}>
+                Create annotation ({submitShortcutLabel()})
+              </Button>
+              <Button size="small" onClick={onCancel} disabled={creating}>
+                Cancel
+              </Button>
+            </Stack>
+          }
+        />
       </FullscreenComposerDialog>
     </Paper>
   );

--- a/qnop-ui/src/components/reviews/panel/Composer.tsx
+++ b/qnop-ui/src/components/reviews/panel/Composer.tsx
@@ -32,6 +32,7 @@ import type { Anchor } from '../../../api/generated';
 import { AnnotationPriority, AnnotationType } from '../../../api/generated';
 import { submitShortcutLabel } from '../../../utils/platform';
 import { PRIORITY_CUES, TYPE_CUES } from '../tasks/tasksModel';
+import { FullscreenComposerDialog } from '../markdown/FullscreenComposerDialog';
 import { MarkdownComposer } from '../markdown/MarkdownComposer';
 import type { UploadedAttachment } from '../markdown/useCommentAttachmentUpload';
 
@@ -66,9 +67,95 @@ export function Composer({
   const [comment, setComment] = useState('');
   const [type, setType] = useState<AnnotationType | ''>('');
   const [priority, setPriority] = useState<AnnotationPriority | ''>('');
+  // The full-screen writing stage (issue #403 follow-up); the draft and the
+  // classification live HERE, so they survive the mode switch both ways.
+  const [writingFullscreen, setWritingFullscreen] = useState(false);
   const canCreate = !creating && comment.trim().length > 0;
   const quote = pendingAnchor?.textQuote?.quote;
   const create = () => onCreate(comment, type || undefined, priority || undefined);
+
+  // Rendered twice — inline and on the full-screen stage — over the SAME
+  // state, so the two views can never drift apart.
+  const classification = (
+    <Stack direction="row" spacing={1}>
+      <TextField
+        select
+        size="small"
+        label="Type"
+        value={type}
+        onChange={(event) => setType(event.target.value as AnnotationType | '')}
+        sx={{ flex: 1 }}
+        slotProps={{ htmlInput: { 'aria-label': 'Annotation type' } }}
+      >
+        <MenuItem value="">
+          <Typography component="span" variant="body2" color="text.secondary">
+            None
+          </Typography>
+        </MenuItem>
+        {Object.values(AnnotationType).map((value) => {
+          const cue = TYPE_CUES[value];
+          const CueIcon = cue.icon;
+          return (
+            <MenuItem key={value} value={value}>
+              <Stack
+                direction="row"
+                spacing={0.75}
+                sx={{ alignItems: 'center', color: cue.color(theme) }}
+              >
+                <CueIcon size={13} aria-hidden />
+                <Typography component="span" variant="body2">
+                  {cue.label}
+                </Typography>
+              </Stack>
+            </MenuItem>
+          );
+        })}
+      </TextField>
+      <TextField
+        select
+        size="small"
+        label="Priority"
+        value={priority}
+        onChange={(event) => setPriority(event.target.value as AnnotationPriority | '')}
+        sx={{ flex: 1 }}
+        slotProps={{ htmlInput: { 'aria-label': 'Annotation priority' } }}
+      >
+        <MenuItem value="">
+          <Typography component="span" variant="body2" color="text.secondary">
+            None
+          </Typography>
+        </MenuItem>
+        {Object.values(AnnotationPriority).map((value) => {
+          const cue = PRIORITY_CUES[value];
+          return (
+            <MenuItem key={value} value={value}>
+              <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                <Box
+                  sx={{ width: 7, height: 7, borderRadius: '50%', bgcolor: cue.color(theme) }}
+                  aria-hidden
+                />
+                <Typography component="span" variant="body2">
+                  {cue.label}
+                </Typography>
+              </Stack>
+            </MenuItem>
+          );
+        })}
+      </TextField>
+    </Stack>
+  );
+
+  const actionRow = (
+    <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end', alignItems: 'center' }}>
+      <Button size="small" variant="contained" onClick={create} disabled={!canCreate}>
+        Create annotation ({submitShortcutLabel()})
+      </Button>
+      <Button size="small" onClick={onCancel} disabled={creating}>
+        Cancel
+      </Button>
+    </Stack>
+  );
+
   return (
     <Paper
       variant={frameless ? 'elevation' : 'outlined'}
@@ -103,87 +190,67 @@ export function Composer({
           minRows={5}
           disabled={creating}
           onUploadAttachment={onUploadAttachment}
+          onToggleFullscreen={() => setWritingFullscreen(true)}
         />
         {/* Optional classification (issue #392) in the system's task language. */}
-        <Stack direction="row" spacing={1}>
-          <TextField
-            select
-            size="small"
-            label="Type"
-            value={type}
-            onChange={(event) => setType(event.target.value as AnnotationType | '')}
-            sx={{ flex: 1 }}
-            slotProps={{ htmlInput: { 'aria-label': 'Annotation type' } }}
-          >
-            <MenuItem value="">
-              <Typography component="span" variant="body2" color="text.secondary">
-                None
-              </Typography>
-            </MenuItem>
-            {Object.values(AnnotationType).map((value) => {
-              const cue = TYPE_CUES[value];
-              const CueIcon = cue.icon;
-              return (
-                <MenuItem key={value} value={value}>
-                  <Stack
-                    direction="row"
-                    spacing={0.75}
-                    sx={{ alignItems: 'center', color: cue.color(theme) }}
-                  >
-                    <CueIcon size={13} aria-hidden />
-                    <Typography component="span" variant="body2">
-                      {cue.label}
-                    </Typography>
-                  </Stack>
-                </MenuItem>
-              );
-            })}
-          </TextField>
-          <TextField
-            select
-            size="small"
-            label="Priority"
-            value={priority}
-            onChange={(event) => setPriority(event.target.value as AnnotationPriority | '')}
-            sx={{ flex: 1 }}
-            slotProps={{ htmlInput: { 'aria-label': 'Annotation priority' } }}
-          >
-            <MenuItem value="">
-              <Typography component="span" variant="body2" color="text.secondary">
-                None
-              </Typography>
-            </MenuItem>
-            {Object.values(AnnotationPriority).map((value) => {
-              const cue = PRIORITY_CUES[value];
-              return (
-                <MenuItem key={value} value={value}>
-                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                    <Box
-                      sx={{ width: 7, height: 7, borderRadius: '50%', bgcolor: cue.color(theme) }}
-                      aria-hidden
-                    />
-                    <Typography component="span" variant="body2">
-                      {cue.label}
-                    </Typography>
-                  </Stack>
-                </MenuItem>
-              );
-            })}
-          </TextField>
-        </Stack>
-        <Stack
-          direction="row"
-          spacing={1}
-          sx={{ justifyContent: 'flex-end', alignItems: 'center' }}
-        >
-          <Button size="small" variant="contained" onClick={create} disabled={!canCreate}>
-            Create annotation ({submitShortcutLabel()})
-          </Button>
-          <Button size="small" onClick={onCancel} disabled={creating}>
-            Cancel
-          </Button>
-        </Stack>
+        {classification}
+        {actionRow}
       </Stack>
+      {/* The full-screen writing stage (issue #403 follow-up): the same
+          controlled draft on a reading-wide column, with the passage under
+          annotation as the context rail. */}
+      <FullscreenComposerDialog
+        open={writingFullscreen}
+        onClose={() => setWritingFullscreen(false)}
+        title="New annotation"
+        contextTitle="You are annotating"
+        context={
+          quote ? (
+            <Box
+              sx={{
+                borderLeft: '3px solid',
+                borderColor: 'divider',
+                bgcolor: 'background.paper',
+                borderRadius: '0 6px 6px 0',
+                px: 1.25,
+                py: 0.75,
+              }}
+            >
+              <Typography variant="body2" sx={{ fontStyle: 'italic', color: 'text.secondary' }}>
+                “{quote}”
+              </Typography>
+            </Box>
+          ) : pendingAnchor?.region ? (
+            <Typography variant="body2" color="text.secondary">
+              A region on page {pendingAnchor.region.surfaceIndex + 1}.
+            </Typography>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              A general remark on the whole document — not pinned to a passage.
+            </Typography>
+          )
+        }
+      >
+        <Stack spacing={1.5}>
+          <MarkdownComposer
+            value={comment}
+            onChange={setComment}
+            onSubmit={() => {
+              if (canCreate) create();
+            }}
+            inputAriaLabel="Annotation comment"
+            minRows={12}
+            maxRows={26}
+            roomy
+            disabled={creating}
+            onUploadAttachment={onUploadAttachment}
+            fullscreen
+            onToggleFullscreen={() => setWritingFullscreen(false)}
+          />
+          {classification}
+          {actionRow}
+        </Stack>
+      </FullscreenComposerDialog>
     </Paper>
   );
 }

--- a/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
@@ -25,18 +25,14 @@ import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/material/styles';
 import { ExternalLink, X } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { useAuthStore } from '../../../stores/authStore';
 import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
-import { ToneBadge } from '../../admin/ToneBadge';
-import { isDocumentScoped } from '../annotationScope';
-import { WholeDocumentChip } from '../WholeDocumentChip';
 import type { BuildPermalink } from '../useReviewPermalink';
-import { CopyLinkButton } from '../permalink/CopyLinkButton';
+import { AnnotationHead } from '../panel/AnnotationHead';
 import { CommentThread } from '../panel/CommentThread';
 import { ResolveBar } from '../panel/ResolveBar';
 import {
@@ -45,9 +41,6 @@ import {
   useReopenWithFeedback,
   useResolveWithFeedback,
 } from '../panel/resolve';
-import { PlacementStatusChip } from '../panel/PlacementStatusChip';
-import { STATUS_CUES } from '../panel/statusCues';
-import { PRIORITY_CUES, TYPE_CUES, taskTitle } from './tasksModel';
 
 interface TaskDrawerProps {
   annotation: AnnotationView | null;
@@ -55,7 +48,6 @@ interface TaskDrawerProps {
   previousSeenAt?: string | null;
   /** Tracker-style shorthand ("T-3") of the open annotation. */
   taskKey: string;
-  authorName: string;
   notify: Notify;
   /** True once the review is FINALIZED/CANCELLED (issue #394): no reopening. */
   reviewClosed?: boolean;
@@ -71,18 +63,18 @@ interface TaskDrawerProps {
 }
 
 /**
- * The task's issue-detail drawer (issue #393, prototype `reviewhub.jsx`):
- * type/priority/anchor header, the opening comment as the title, the full
- * discussion thread and the author's Resolve bar — reusing the panel's
- * `CommentThread` and `ResolveBar`, so a thread reads and behaves identically
- * on every surface. Also the keyboard path for resolving (the board's
- * drag-to-Resolved is a pointer shortcut).
+ * The task's issue-detail drawer (issue #393, prototype `reviewhub.jsx`): a
+ * slim tracker header (task key, deep link, close), then the discussion led by
+ * the same author-fronted `AnnotationHead` the document view opens with
+ * (issue #403 follow-up) — the thread starter, badges, quoted passage and
+ * opening text read identically on every surface — followed by the full
+ * `CommentThread` and the author's Resolve bar. Also the keyboard path for
+ * resolving (the board's drag-to-Resolved is a pointer shortcut).
  */
 export function TaskDrawer({
   annotation,
   previousSeenAt = null,
   taskKey,
-  authorName,
   notify,
   reviewClosed = false,
   threadParticipation = 'OPEN',
@@ -91,7 +83,6 @@ export function TaskDrawer({
   onShowInDocument,
   buildPermalink,
 }: TaskDrawerProps) {
-  const theme = useTheme();
   const userId = useAuthStore((state) => state.userId);
   const { resolveWith, isPending } = useResolveWithFeedback(notify);
   const { reopenWith } = useReopenWithFeedback(notify);
@@ -102,12 +93,6 @@ export function TaskDrawer({
     threadParticipation !== 'OPEN' &&
     annotation.authorId !== userId &&
     !(ownerId != null && userId === ownerId);
-  const type = annotation.type ? TYPE_CUES[annotation.type] : null;
-  const priority = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
-  const TypeIcon = type?.icon;
-  const statusCue = STATUS_CUES[annotation.status];
-  const page = annotation.anchor?.region ? annotation.anchor.region.surfaceIndex + 1 : null;
-
   return (
     <Drawer
       anchor="right"
@@ -117,8 +102,9 @@ export function TaskDrawer({
       data-testid="task-drawer"
     >
       <Stack sx={{ height: '100%' }}>
-        <Box sx={{ p: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1 }}>
+        {/* Slim tracker header — the discussion below leads with the head. */}
+        <Box sx={{ px: 2, py: 1, borderBottom: '1px solid', borderColor: 'divider' }}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
             <Typography
               component="span"
               sx={{
@@ -130,75 +116,7 @@ export function TaskDrawer({
             >
               {taskKey}
             </Typography>
-            {type && TypeIcon && (
-              <Stack
-                direction="row"
-                spacing={0.5}
-                sx={{ alignItems: 'center', color: type.color(theme) }}
-              >
-                <TypeIcon size={13} aria-hidden />
-                <Typography component="span" sx={{ fontSize: 11.5, fontWeight: 600 }}>
-                  {type.label}
-                </Typography>
-              </Stack>
-            )}
-            {priority && (
-              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-                <Box
-                  sx={{
-                    width: 6,
-                    height: 6,
-                    borderRadius: '50%',
-                    bgcolor: priority.color(theme),
-                  }}
-                  aria-hidden
-                />
-                <Typography variant="caption" color="text.secondary">
-                  {priority.label}
-                </Typography>
-              </Stack>
-            )}
             <Box sx={{ flex: 1 }} />
-            <IconButton size="small" onClick={onClose} aria-label="Close task">
-              <X size={16} />
-            </IconButton>
-          </Stack>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
-            {taskTitle(annotation)}
-          </Typography>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mt: 1, flexWrap: 'wrap' }}>
-            <ToneBadge tone={statusCue.tone} label={statusCue.label} />
-            <PlacementStatusChip status={annotation.placementStatus} />
-            {isDocumentScoped(annotation) && <WholeDocumentChip />}
-            {page !== null && (
-              <Typography variant="caption" color="text.secondary">
-                p. {page}
-              </Typography>
-            )}
-            <Typography variant="caption" color="text.secondary">
-              · opened by {authorName}
-            </Typography>
-          </Stack>
-          {annotation.anchor?.textQuote?.quote && (
-            <Typography
-              variant="body2"
-              sx={{
-                mt: 1.25,
-                fontStyle: 'italic',
-                color: 'text.secondary',
-                borderLeft: '3px solid',
-                borderColor: 'divider',
-                pl: 1.25,
-                display: '-webkit-box',
-                WebkitLineClamp: 3,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-              }}
-            >
-              “{annotation.anchor.textQuote.quote}”
-            </Typography>
-          )}
-          <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', mt: 1 }}>
             <Button
               size="small"
               variant="text"
@@ -207,17 +125,22 @@ export function TaskDrawer({
             >
               Show in document
             </Button>
-            {buildPermalink && (
-              <CopyLinkButton
-                url={buildPermalink(annotation.id)}
-                notify={notify}
-                label="Copy link to annotation"
-              />
-            )}
+            <IconButton size="small" onClick={onClose} aria-label="Close task">
+              <X size={16} />
+            </IconButton>
           </Stack>
         </Box>
 
-        <Box sx={{ flex: 1, overflowY: 'auto', px: 2, py: 1 }}>
+        <Box sx={{ flex: 1, overflowY: 'auto', px: 2, py: 1.5 }}>
+          {/* The root post, exactly as the document view presents it: the
+              author leading, badges, the quoted passage and the opening text
+              (issue #403 follow-up). It carries the annotation copy-link in
+              its author row. */}
+          <AnnotationHead
+            annotation={annotation}
+            permalinkUrl={buildPermalink?.(annotation.id)}
+            notify={notify}
+          />
           <CommentThread
             annotationId={annotation.id}
             documentId={annotation.documentId}

--- a/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskDrawer.tsx
@@ -21,7 +21,6 @@
 
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -32,6 +31,7 @@ import { useAuthStore } from '../../../stores/authStore';
 import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
 import type { BuildPermalink } from '../useReviewPermalink';
+import { ResizableDrawer } from '../ResizableDrawer';
 import { AnnotationHead } from '../panel/AnnotationHead';
 import { CommentThread } from '../panel/CommentThread';
 import { ResolveBar } from '../panel/ResolveBar';
@@ -94,12 +94,14 @@ export function TaskDrawer({
     annotation.authorId !== userId &&
     !(ownerId != null && userId === ownerId);
   return (
-    <Drawer
-      anchor="right"
+    <ResizableDrawer
       open
       onClose={onClose}
-      slotProps={{ paper: { sx: { width: { xs: '100%', sm: 460 } } } }}
-      data-testid="task-drawer"
+      storageKey="qnop-task-drawer-width"
+      defaultWidth={460}
+      handleAriaLabel="Resize the task drawer"
+      handleTestId="task-drawer-resize-handle"
+      drawerTestId="task-drawer"
     >
       <Stack sx={{ height: '100%' }}>
         {/* Slim tracker header — the discussion below leads with the head. */}
@@ -164,6 +166,6 @@ export function TaskDrawer({
           </Box>
         )}
       </Stack>
-    </Drawer>
+    </ResizableDrawer>
   );
 }

--- a/qnop-ui/src/components/reviews/useResizeHandle.ts
+++ b/qnop-ui/src/components/reviews/useResizeHandle.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState, type KeyboardEvent, type PointerEvent } from 'react';
+
+const KEYBOARD_STEP = 24;
+
+interface ResizeHandleOptions {
+  /** localStorage key for the persisted width — one preference per surface. */
+  storageKey: string;
+  defaultWidth: number;
+  minWidth: number;
+  /** Upper bound, read live so window resizes are honoured. */
+  maxWidth?: () => number;
+}
+
+export interface ResizeHandleState {
+  width: number;
+  resizing: boolean;
+  handleProps: {
+    onPointerDown: (event: PointerEvent<HTMLDivElement>) => void;
+    onPointerMove: (event: PointerEvent<HTMLDivElement>) => void;
+    onPointerUp: (event: PointerEvent<HTMLDivElement>) => void;
+    onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
+  };
+}
+
+/** Keeps a slice of the underlying page visible even on generous drags. */
+function defaultMaxWidth(minWidth: number): number {
+  return Math.max(minWidth, Math.min(900, window.innerWidth - 240));
+}
+
+/**
+ * The width of a right-docked, user-resizable surface (issue #403): a leading
+ * grab handle drags it (pointer capture), arrow keys nudge it on the focused
+ * separator, bounds are clamped, and the choice persists per `storageKey`.
+ * Shared by the review drawers and the writing stage's context rail.
+ */
+export function useResizeHandle({
+  storageKey,
+  defaultWidth,
+  minWidth,
+  maxWidth,
+}: ResizeHandleOptions): ResizeHandleState {
+  const clamp = (width: number) =>
+    Math.min(Math.max(width, minWidth), maxWidth ? maxWidth() : defaultMaxWidth(minWidth));
+
+  const [width, setWidth] = useState<number>(() => {
+    try {
+      const value = Number(localStorage.getItem(storageKey));
+      return Number.isFinite(value) && value >= minWidth ? clamp(value) : defaultWidth;
+    } catch {
+      return defaultWidth;
+    }
+  });
+  const [resizing, setResizing] = useState(false);
+  // The live value for the pointer-up persist — state updates lag the drag.
+  const widthRef = useRef(width);
+
+  const persist = (value: number) => {
+    try {
+      localStorage.setItem(storageKey, String(value));
+    } catch {
+      // best-effort persistence
+    }
+  };
+
+  const applyWidth = (next: number) => {
+    const clamped = clamp(next);
+    widthRef.current = clamped;
+    setWidth(clamped);
+    return clamped;
+  };
+
+  return {
+    width,
+    resizing,
+    handleProps: {
+      onPointerDown: (event) => {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+        setResizing(true);
+      },
+      onPointerMove: (event) => {
+        if (!event.currentTarget.hasPointerCapture?.(event.pointerId)) return;
+        // Anchored right: the surface spans from the pointer to the viewport edge.
+        applyWidth(window.innerWidth - event.clientX);
+      },
+      onPointerUp: (event) => {
+        event.currentTarget.releasePointerCapture?.(event.pointerId);
+        setResizing(false);
+        persist(widthRef.current);
+      },
+      onKeyDown: (event) => {
+        // The handle sits on the LEADING edge: left grows the surface, right shrinks it.
+        if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+        event.preventDefault();
+        persist(
+          applyWidth(
+            widthRef.current + (event.key === 'ArrowLeft' ? KEYBOARD_STEP : -KEYBOARD_STEP),
+          ),
+        );
+      },
+    },
+  };
+}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -312,7 +312,6 @@ export function ReviewTasksPage() {
         annotation={openTask}
         previousSeenAt={previousSeenAt}
         taskKey={openTask ? taskKeyOf(openTask.id) : ''}
-        authorName={openTask ? authorNameOf(openTask.authorId) : ''}
         notify={notify}
         reviewClosed={!isOpenWorkflowState(document.workflowState)}
         threadParticipation={document.threadParticipation ?? 'OPEN'}


### PR DESCRIPTION
## Summary

Another polish round on the review surfaces (part of #403), in four steps:

### Task drawer leads with the annotation head
- The task detail drawer opens its discussion with the same author-fronted `AnnotationHead` the document view uses — thread starter, badge row, quoted passage and opening text — instead of a metadata-heavy header duplicating the opener as a clamped title. The header slims down to the tracker key, "Show in document" and close; the annotation copy-link moves into the head's author row, as on every other surface.

### Both drawers resize with shared logic
- The focus drawer's resize mechanism (leading-edge grab handle, pointer-capture drag, arrow keys on the focusable separator, clamped bounds, per-surface width persistence) is extracted and the **task drawer adopts it** with its own storage key (`qnop-task-drawer-width`, 460px default). Key-repeat bursts now read the live width ref instead of stale state.

### Full-screen writing stage
- Every composer (replies **and** new annotations) gains an expand affordance in its Write|Preview row that lifts writing onto a full-screen stage. The composer's new `bare` mode drops the frame and fills the stage like a real editor (16px reading type; the textarea is the scroll container).
- The composer's footer becomes the **bottom-fixed action bar**: the reply's `Comment (⌘⏎)` button, and the annotation's compact Type/Priority selects with Create/Cancel.
- The conversation stays in sight in a **resizable context rail** on the right, rendered as the document view's own thread anatomy (read-only `CommentThread`, timeline rail and all); a new annotation shows the anchored passage / region / whole-document note instead.
- The host renders the SAME controlled composer on the stage, so drafts (and classification) survive the mode switch in both directions; Escape or collapse returns to the inline field, sending closes the stage, focus lands in the editor with the caret at the draft's end.
- Resize mechanics unified into `useResizeHandle` + `ResizeHandle`, consumed by both drawers and the stage rail.

## Test plan
- [x] `pnpm test:run` — 714 tests (new: ResizableDrawer keyboard/persist/clamp/per-key isolation, full-screen toggle visibility, stage draft round-trip, rail context, send-closes-stage), `pnpm lint`, `pnpm typecheck`
- [x] Manual browser walkthrough: task drawer head anatomy (T-2 whole-doc, T-6 region with 5 replies), drawer drag + keyboard resize with independent persistence per surface, stage from panel/focus/task-drawer composers, draft carry-over incl. Escape, bottom-bar actions, rail resize (400→496px persisted)

Part of #403.

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)