### PR TITLE
feat(reviews): Slack-style emoji reactions on annotations and comments (#410)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2385,6 +2385,146 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /annotations/{annotationId}/reactions/{emoji}:
+    parameters:
+      - $ref: '#/components/parameters/AnnotationIdParam'
+      - $ref: '#/components/parameters/EmojiParam'
+    put:
+      tags: [Annotations]
+      summary: Add the caller's emoji reaction to an annotation
+      description: |
+        Slack-style reaction (issue #410): adds the caller's `emoji` to the
+        annotation; repeating the call is a no-op, so the PUT/DELETE pair is
+        idempotent. A reaction is a lightweight signal, not a discussion
+        contribution — RESOLVED annotations stay reactable; only a
+        FINALIZED/CANCELLED review refuses (`REVIEW_CLOSED`, 409). One reaction
+        per user per emoji; several different emojis per user are fine.
+      operationId: reactToAnnotation
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: The reaction is present (added now or already there)
+        '400':
+          description: The path segment is not a plausible emoji
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown annotation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The review is FINALIZED/CANCELLED (`REVIEW_CLOSED`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags: [Annotations]
+      summary: Remove the caller's emoji reaction from an annotation
+      description: |
+        The inverse of `reactToAnnotation` (issue #410); removing an absent
+        reaction is a no-op.
+      operationId: unreactFromAnnotation
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: The reaction is absent (removed now or never there)
+        '400':
+          description: The path segment is not a plausible emoji
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown annotation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The review is FINALIZED/CANCELLED (`REVIEW_CLOSED`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /comments/{commentId}/reactions/{emoji}:
+    parameters:
+      - $ref: '#/components/parameters/CommentIdParam'
+      - $ref: '#/components/parameters/EmojiParam'
+    put:
+      tags: [Annotations]
+      summary: Add the caller's emoji reaction to a comment
+      description: |
+        Slack-style reaction on a thread message (issue #410); the same
+        semantics as `reactToAnnotation`, keyed by the comment id.
+      operationId: reactToComment
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: The reaction is present (added now or already there)
+        '400':
+          description: The path segment is not a plausible emoji
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown comment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The review is FINALIZED/CANCELLED (`REVIEW_CLOSED`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags: [Annotations]
+      summary: Remove the caller's emoji reaction from a comment
+      description: |
+        The inverse of `reactToComment` (issue #410); removing an absent
+        reaction is a no-op.
+      operationId: unreactFromComment
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: The reaction is absent (removed now or never there)
+        '400':
+          description: The path segment is not a plausible emoji
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown comment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The review is FINALIZED/CANCELLED (`REVIEW_CLOSED`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /annotations/{annotationId}/comments:
     parameters:
       - $ref: '#/components/parameters/AnnotationIdParam'
@@ -2571,6 +2711,24 @@ components:
       schema:
         type: string
         format: uuid
+    CommentIdParam:
+      name: commentId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    EmojiParam:
+      name: emoji
+      in: path
+      required: true
+      description: >-
+        The reaction emoji, URL-encoded — stored and grouped verbatim, so ZWJ
+        sequences and skin-tone variants are distinct reactions.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 32
     AnnotationIdParam:
       name: annotationId
       in: path
@@ -4413,17 +4571,42 @@ components:
           $ref: '#/components/schemas/AnnotationType'
         priority:
           $ref: '#/components/schemas/AnnotationPriority'
+    ReactionGroup:
+      type: object
+      description: >-
+        One grouped emoji reaction on an annotation or comment (issue #410):
+        the chip's emoji, how many participants reacted with it, whether the
+        caller is among them, and the reactors' display names (resolved
+        server-side, honouring per-review anonymity, issue #413) in reaction
+        order.
+      required:
+        - emoji
+        - count
+        - reactedByMe
+        - reactors
+      properties:
+        emoji:
+          type: string
+        count:
+          type: integer
+        reactedByMe:
+          type: boolean
+        reactors:
+          type: array
+          items:
+            type: string
     AnnotationView:
       type: object
       description: |
         An annotation with, when a version was requested, its placement on that
-        version and the size of its comment thread.
+        version, the size of its comment thread and its reaction chips.
       required:
         - id
         - documentId
         - authorId
         - status
         - commentCount
+        - reactions
         - createdAt
         - updatedAt
       properties:
@@ -4473,6 +4656,11 @@ components:
         commentCount:
           type: integer
           description: Number of comments in the thread.
+        reactions:
+          type: array
+          description: The annotation's grouped emoji reactions (issue #410).
+          items:
+            $ref: '#/components/schemas/ReactionGroup'
         createdAt:
           type: string
           format: date-time
@@ -4513,6 +4701,7 @@ components:
         - annotationId
         - authorId
         - body
+        - reactions
         - createdAt
       properties:
         id:
@@ -4536,6 +4725,11 @@ components:
             authors in an anonymous review. Null only for a since-removed user.
         body:
           type: string
+        reactions:
+          type: array
+          description: The comment's grouped emoji reactions (issue #410).
+          items:
+            $ref: '#/components/schemas/ReactionGroup'
         createdAt:
           type: string
           format: date-time

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -34,7 +34,9 @@ import io.qnop.api.v1.model.CommentCreateRequest;
 import io.qnop.api.v1.model.CommentListResponse;
 import io.qnop.api.v1.model.CommentView;
 import io.qnop.api.v1.model.PlacementStatus;
+import io.qnop.api.v1.model.ReactionGroup;
 import io.qnop.service.review.AnnotationService;
+import io.qnop.service.review.ReactionService;
 import java.time.ZoneOffset;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
@@ -53,6 +55,7 @@ import tools.jackson.databind.ObjectMapper;
 public class AnnotationController implements AnnotationsApi {
 
   private final AnnotationService annotations;
+  private final ReactionService reactions;
 
   /**
    * The framework-configured Jackson 3 mapper (issue #329): reusing Boot's MVC {@link ObjectMapper}
@@ -62,8 +65,10 @@ public class AnnotationController implements AnnotationsApi {
    */
   private final ObjectMapper mapper;
 
-  public AnnotationController(AnnotationService annotations, ObjectMapper mapper) {
+  public AnnotationController(
+      AnnotationService annotations, ReactionService reactions, ObjectMapper mapper) {
     this.annotations = annotations;
+    this.reactions = reactions;
     this.mapper = mapper;
   }
 
@@ -148,6 +153,46 @@ public class AnnotationController implements AnnotationsApi {
         new CommentListResponse().comments(views.stream().map(this::toDto).toList()));
   }
 
+  @Override
+  public ResponseEntity<Void> reactToAnnotation(UUID annotationId, String emoji) {
+    reactions.reactToAnnotation(
+        annotationId, emoji, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> unreactFromAnnotation(UUID annotationId, String emoji) {
+    reactions.unreactFromAnnotation(
+        annotationId, emoji, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> reactToComment(UUID commentId, String emoji) {
+    reactions.reactToComment(commentId, emoji, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> unreactFromComment(UUID commentId, String emoji) {
+    reactions.unreactFromComment(
+        commentId, emoji, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.noContent().build();
+  }
+
+  private static java.util.List<ReactionGroup> toReactionDtos(
+      java.util.List<ReactionService.ReactionGroup> groups) {
+    return groups.stream()
+        .map(
+            group ->
+                new ReactionGroup()
+                    .emoji(group.emoji())
+                    .count(group.count())
+                    .reactedByMe(group.reactedByMe())
+                    .reactors(group.reactors()))
+        .toList();
+  }
+
   private AnnotationView toDto(AnnotationService.AnnotationView view) {
     return new AnnotationView()
         .id(view.id())
@@ -165,6 +210,7 @@ public class AnnotationController implements AnnotationsApi {
                 : PlacementStatus.fromValue(view.placementStatus()))
         .firstComment(view.firstComment())
         .commentCount(view.commentCount())
+        .reactions(toReactionDtos(view.reactions()))
         .latestCommentFromOthersAt(
             view.latestCommentFromOthersAt() == null
                 ? null
@@ -180,6 +226,7 @@ public class AnnotationController implements AnnotationsApi {
         .authorId(view.authorId())
         .authorDisplayName(view.authorDisplayName())
         .body(view.body())
+        .reactions(toReactionDtos(view.reactions()))
         .createdAt(view.createdAt().atOffset(ZoneOffset.UTC));
   }
 }

--- a/qnop-app/src/test/java/io/qnop/review/ReactionApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReactionApiIT.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Slack-style emoji reactions on annotations and comments over the wire (issue #410): the
+ * idempotent PUT/DELETE toggle pair, the grouped chips batched onto the views, the RESOLVED-stays-
+ * reactable rule versus the closed-review refusal, participants-only visibility, emoji validation
+ * and — deliberately — a multi-code-point emoji in the URL path.
+ */
+class ReactionApiIT extends SeededIntegrationTest {
+
+  private static final String THUMBS = "👍";
+  private static final String PARTY = "🎉";
+
+  /** Skin tone + ZWJ pressure on the path-variable encoding. */
+  private static final String FAMILY = "👨‍👩‍👧‍👦";
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+
+  private UUID seedDocumentWithVersion() {
+    Document document = documents.save(new Document(MEMBER_ID, "Master services agreement"));
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
+    versions.save(
+        new DocumentVersion(
+            document.getId(),
+            1,
+            "sha256/aa/deadbeef",
+            "deadbeef",
+            "application/pdf",
+            1234L,
+            MEMBER_ID));
+    return document.getId();
+  }
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  private String createAnnotation(UUID documentId, UUID actor) throws Exception {
+    String body = "{\"versionNumber\":1,\"comment\":\"please clarify\"}";
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return JsonPath.read(json, "$.id");
+  }
+
+  private String addComment(String annotationId, UUID actor, String body) throws Exception {
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/annotations/" + annotationId + "/comments"), actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"body\":\"" + body + "\"}"))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return JsonPath.read(json, "$.id");
+  }
+
+  @Test
+  @DisplayName("react/unreact on an annotation round-trips idempotently, groups on the view")
+  void annotationReactionRoundTrip() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, MEMBER_ID);
+
+    // PUT twice — the second is a no-op, not a duplicate and not an error.
+    mockMvc
+        .perform(
+            as(put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS), MEMBER_ID))
+        .andExpect(status().isNoContent());
+    mockMvc
+        .perform(
+            as(put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS), MEMBER_ID))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.reactions", hasSize(1)))
+        .andExpect(jsonPath("$.reactions[0].emoji").value(THUMBS))
+        .andExpect(jsonPath("$.reactions[0].count").value(1))
+        .andExpect(jsonPath("$.reactions[0].reactedByMe").value(true))
+        .andExpect(jsonPath("$.reactions[0].reactors", hasSize(1)));
+
+    // DELETE twice — same idempotency on the way out.
+    mockMvc
+        .perform(
+            as(
+                delete("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS),
+                MEMBER_ID))
+        .andExpect(status().isNoContent());
+    mockMvc
+        .perform(
+            as(
+                delete("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS),
+                MEMBER_ID))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.reactions", hasSize(0)));
+  }
+
+  @Test
+  @DisplayName("same emojis group with counts and reactor names; the list endpoint batches them")
+  void groupsAcrossUsers() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, MEMBER_ID);
+
+    mockMvc
+        .perform(
+            as(put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS), MEMBER_ID))
+        .andExpect(status().isNoContent());
+    mockMvc
+        .perform(
+            as(put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS), AUDITOR_ID))
+        .andExpect(status().isNoContent());
+    mockMvc
+        .perform(
+            as(put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, PARTY), MEMBER_ID))
+        .andExpect(status().isNoContent());
+
+    // The viewer is AUDITOR: 👍 carries them, 🎉 does not.
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].reactions", hasSize(2)))
+        .andExpect(jsonPath("$.annotations[0].reactions[0].emoji").value(THUMBS))
+        .andExpect(jsonPath("$.annotations[0].reactions[0].count").value(2))
+        .andExpect(jsonPath("$.annotations[0].reactions[0].reactedByMe").value(true))
+        .andExpect(jsonPath("$.annotations[0].reactions[0].reactors", hasSize(2)))
+        .andExpect(jsonPath("$.annotations[0].reactions[1].emoji").value(PARTY))
+        .andExpect(jsonPath("$.annotations[0].reactions[1].count").value(1))
+        .andExpect(jsonPath("$.annotations[0].reactions[1].reactedByMe").value(false));
+  }
+
+  @Test
+  @DisplayName("comment reactions arrive batched on the thread, ZWJ emoji survive the path")
+  void commentReactions() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, MEMBER_ID);
+    String commentId = addComment(annotationId, AUDITOR_ID, "second opinion");
+
+    mockMvc
+        .perform(as(put("/api/v1/comments/{id}/reactions/{emoji}", commentId, FAMILY), MEMBER2_ID))
+        .andExpect(status().isNoContent());
+
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId + "/comments"), MEMBER2_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.comments[0].reactions", hasSize(0)))
+        .andExpect(jsonPath("$.comments[1].reactions", hasSize(1)))
+        .andExpect(jsonPath("$.comments[1].reactions[0].emoji").value(FAMILY))
+        .andExpect(jsonPath("$.comments[1].reactions[0].reactedByMe").value(true));
+
+    mockMvc
+        .perform(
+            as(delete("/api/v1/comments/{id}/reactions/{emoji}", commentId, FAMILY), MEMBER2_ID))
+        .andExpect(status().isNoContent());
+    mockMvc
+        .perform(as(get("/api/v1/annotations/" + annotationId + "/comments"), MEMBER2_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.comments[1].reactions", hasSize(0)));
+  }
+
+  @Test
+  @DisplayName(
+      "a RESOLVED annotation stays reactable — a reaction is not a discussion contribution")
+  void resolvedStaysReactable() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, MEMBER_ID);
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/resolve"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            as(put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS), AUDITOR_ID))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("a FINALIZED review refuses reactions with REVIEW_CLOSED")
+  void closedReviewRefuses() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, MEMBER_ID);
+    Document document = documents.findById(documentId).orElseThrow();
+    document.setWorkflowState(WorkflowState.FINALIZED);
+    documents.save(document);
+
+    mockMvc
+        .perform(
+            as(put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS), MEMBER_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("REVIEW_CLOSED"));
+    mockMvc
+        .perform(
+            as(
+                delete("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS),
+                MEMBER_ID))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("a non-participant sees the same 404 as for the document (anti-enumeration)")
+  void nonParticipantGets404() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, MEMBER_ID);
+
+    mockMvc
+        .perform(
+            as(
+                put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, THUMBS),
+                EXTERNAL_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("prose in the emoji segment is rejected as 400")
+  void rejectsNonEmoji() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String annotationId = createAnnotation(documentId, MEMBER_ID);
+
+    mockMvc
+        .perform(
+            as(put("/api/v1/annotations/{id}/reactions/{emoji}", annotationId, "abc"), MEMBER_ID))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/entity/Reaction.java
+++ b/qnop-core/src/main/java/io/qnop/entity/Reaction.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+/**
+ * One user's emoji reaction on an {@link Annotation} XOR a {@link Comment} (issue #410) — Slack's
+ * model: at most one row per user × emoji × target (partial unique indexes), several DIFFERENT
+ * emojis per user allowed. Rows are immutable; toggling off deletes them. Deleting the target
+ * cascades its reactions (enforced in Liquibase, ADR-0020).
+ */
+@Entity
+@Table(name = "reaction")
+public class Reaction {
+
+  @Id
+  @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "annotation_id", updatable = false)
+  private UUID annotationId;
+
+  @Column(name = "comment_id", updatable = false)
+  private UUID commentId;
+
+  @Column(name = "user_id", nullable = false, updatable = false)
+  private UUID userId;
+
+  @Column(name = "emoji", nullable = false, updatable = false, length = 32)
+  private String emoji;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  protected Reaction() {
+    // for JPA
+  }
+
+  private Reaction(UUID annotationId, UUID commentId, UUID userId, String emoji) {
+    this.annotationId = annotationId;
+    this.commentId = commentId;
+    this.userId = userId;
+    this.emoji = emoji;
+  }
+
+  public static Reaction onAnnotation(UUID annotationId, UUID userId, String emoji) {
+    return new Reaction(annotationId, null, userId, emoji);
+  }
+
+  public static Reaction onComment(UUID commentId, UUID userId, String emoji) {
+    return new Reaction(null, commentId, userId, emoji);
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getAnnotationId() {
+    return annotationId;
+  }
+
+  public UUID getCommentId() {
+    return commentId;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public String getEmoji() {
+    return emoji;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/ReactionRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ReactionRepository.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.Reaction;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Emoji reactions on annotations and comments (issue #410). */
+public interface ReactionRepository extends JpaRepository<Reaction, UUID> {
+
+  /** All reactions of a batch of annotations, oldest first — grouped in the service (#313). */
+  List<Reaction> findByAnnotationIdInOrderByCreatedAtAsc(Collection<UUID> annotationIds);
+
+  /** All reactions of a batch of comments, oldest first — grouped in the service (#313). */
+  List<Reaction> findByCommentIdInOrderByCreatedAtAsc(Collection<UUID> commentIds);
+
+  boolean existsByAnnotationIdAndUserIdAndEmoji(UUID annotationId, UUID userId, String emoji);
+
+  boolean existsByCommentIdAndUserIdAndEmoji(UUID commentId, UUID userId, String emoji);
+
+  long deleteByAnnotationIdAndUserIdAndEmoji(UUID annotationId, UUID userId, String emoji);
+
+  long deleteByCommentIdAndUserIdAndEmoji(UUID commentId, UUID userId, String emoji);
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -74,6 +74,7 @@ public class AnnotationService {
   private final DocumentAccessService documentAccess;
   private final ReviewWorkflowService workflow;
   private final ReviewIdentityResolver identity;
+  private final ReactionService reactions_;
 
   public AnnotationService(
       AnnotationRepository annotations,
@@ -83,7 +84,8 @@ public class AnnotationService {
       AuditEventRepository auditEvents,
       DocumentAccessService documentAccess,
       ReviewWorkflowService workflow,
-      ReviewIdentityResolver identity) {
+      ReviewIdentityResolver identity,
+      ReactionService reactions) {
     this.annotations = annotations;
     this.placements = placements;
     this.comments = comments;
@@ -92,6 +94,7 @@ public class AnnotationService {
     this.documentAccess = documentAccess;
     this.workflow = workflow;
     this.identity = identity;
+    this.reactions_ = reactions;
   }
 
   /**
@@ -112,6 +115,7 @@ public class AnnotationService {
       String firstComment,
       int commentCount,
       Instant latestCommentFromOthersAt,
+      List<ReactionService.ReactionGroup> reactions,
       Instant createdAt,
       Instant updatedAt) {}
 
@@ -122,6 +126,7 @@ public class AnnotationService {
       UUID authorId,
       String authorDisplayName,
       String body,
+      List<ReactionService.ReactionGroup> reactions,
       Instant createdAt) {}
 
   /**
@@ -195,6 +200,7 @@ public class AnnotationService {
         excerpt(firstComment),
         commentCount,
         null,
+        List.of(),
         identity.forDocument(documentId, author));
   }
 
@@ -239,6 +245,10 @@ public class AnnotationService {
     Map<UUID, String> firstCommentByAnnotation = firstComments(documentAnnotations);
     Map<UUID, Instant> foreignActivityByAnnotation = foreignActivity(documentAnnotations, actor);
     ReviewIdentityResolver.ReviewIdentities identities = identity.forDocument(documentId, actor);
+    // Reaction chips, batched like the counts (issue #410).
+    Map<UUID, List<ReactionService.ReactionGroup>> reactionsByAnnotation =
+        reactions_.forAnnotations(
+            documentAnnotations.stream().map(Annotation::getId).toList(), actor, identities);
     return documentAnnotations.stream()
         .map(
             annotation ->
@@ -248,6 +258,7 @@ public class AnnotationService {
                     firstCommentByAnnotation.get(annotation.getId()),
                     threadSizeByAnnotation.getOrDefault(annotation.getId(), 0),
                     foreignActivityByAnnotation.get(annotation.getId()),
+                    reactionsByAnnotation.getOrDefault(annotation.getId(), List.of()),
                     identities))
         .filter(view -> placementStatus == null || placementStatus.equals(view.placementStatus()))
         .filter(view -> type == null || type.equals(view.type()))
@@ -283,13 +294,16 @@ public class AnnotationService {
             actor,
             "{\"annotationId\":\"%s\",\"type\":%s,\"priority\":%s}"
                 .formatted(annotationId, jsonString(type), jsonString(priority))));
+    ReviewIdentityResolver.ReviewIdentities identities =
+        identity.forDocument(annotation.getDocumentId(), actor);
     return view(
         annotation,
         null,
         firstComment(annotationId),
         threadSize(annotationId),
         foreignActivity(annotationId, actor),
-        identity.forDocument(annotation.getDocumentId(), actor));
+        annotationReactions(annotationId, actor, identities),
+        identities);
   }
 
   private static String jsonString(String value) {
@@ -315,13 +329,16 @@ public class AnnotationService {
       // A PRIVATE foreign thread is invisible — 404, like the document itself.
       throw DocumentValidationException.notFound("no such annotation: " + annotationId);
     }
+    ReviewIdentityResolver.ReviewIdentities identities =
+        identity.forDocument(annotation.getDocumentId(), actor);
     return view(
         annotation,
         null,
         firstComment(annotationId),
         threadSize(annotationId),
         foreignActivity(annotationId, actor),
-        identity.forDocument(annotation.getDocumentId(), actor));
+        annotationReactions(annotationId, actor, identities),
+        identities);
   }
 
   /**
@@ -332,13 +349,16 @@ public class AnnotationService {
   @Transactional
   public AnnotationView resolve(UUID annotationId, String note, UUID actor) {
     Annotation updated = workflow.resolveAnnotation(annotationId, note, actor);
+    ReviewIdentityResolver.ReviewIdentities identities =
+        identity.forDocument(updated.getDocumentId(), actor);
     return view(
         updated,
         null,
         firstComment(updated.getId()),
         threadSize(updated.getId()),
         foreignActivity(updated.getId(), actor),
-        identity.forDocument(updated.getDocumentId(), actor));
+        annotationReactions(updated.getId(), actor, identities),
+        identities);
   }
 
   /**
@@ -349,13 +369,16 @@ public class AnnotationService {
   @Transactional
   public AnnotationView reopen(UUID annotationId, UUID actor) {
     Annotation updated = workflow.reopenAnnotation(annotationId, actor);
+    ReviewIdentityResolver.ReviewIdentities identities =
+        identity.forDocument(updated.getDocumentId(), actor);
     return view(
         updated,
         null,
         firstComment(updated.getId()),
         threadSize(updated.getId()),
         foreignActivity(updated.getId(), actor),
-        identity.forDocument(updated.getDocumentId(), actor));
+        annotationReactions(updated.getId(), actor, identities),
+        identities);
   }
 
   /**
@@ -389,7 +412,7 @@ public class AnnotationService {
     }
     // saveAndFlush so @CreationTimestamp is populated on the returned comment before the view.
     Comment saved = comments.saveAndFlush(new Comment(annotationId, author, body));
-    return commentView(saved, identity.forDocument(annotation.getDocumentId(), author));
+    return commentView(saved, List.of(), identity.forDocument(annotation.getDocumentId(), author));
   }
 
   /** An annotation's comment thread, oldest first; visible participants only. */
@@ -403,9 +426,26 @@ public class AnnotationService {
     }
     ReviewIdentityResolver.ReviewIdentities identities =
         identity.forDocument(annotation.getDocumentId(), actor);
-    return comments.findByAnnotationIdOrderByCreatedAtAsc(annotationId).stream()
-        .map(comment -> commentView(comment, identities))
+    List<Comment> thread = comments.findByAnnotationIdOrderByCreatedAtAsc(annotationId);
+    // Reaction chips per bubble, batched (issue #410).
+    Map<UUID, List<ReactionService.ReactionGroup>> reactionsByComment =
+        reactions_.forComments(thread.stream().map(Comment::getId).toList(), actor, identities);
+    return thread.stream()
+        .map(
+            comment ->
+                commentView(
+                    comment,
+                    reactionsByComment.getOrDefault(comment.getId(), List.of()),
+                    identities))
         .toList();
+  }
+
+  /** Reaction chips of one annotation (list uses the batched variant, issue #410). */
+  private List<ReactionService.ReactionGroup> annotationReactions(
+      UUID annotationId, UUID actor, ReviewIdentityResolver.ReviewIdentities identities) {
+    return reactions_
+        .forAnnotations(List.of(annotationId), actor, identities)
+        .getOrDefault(annotationId, List.of());
   }
 
   private Annotation requireAnnotation(UUID annotationId) {
@@ -476,7 +516,7 @@ public class AnnotationService {
    * (issue #413). Only PRIVATE hides a foreign thread (a caller who is neither its author nor the
    * owner); READ_ONLY and OPEN show every thread. Admins see everything.
    */
-  private static boolean canSeeThread(
+  static boolean canSeeThread(
       DocumentAccessService.DocumentView document, UUID authorId, UUID actor, boolean admin) {
     if (!ThreadParticipation.PRIVATE.name().equals(document.threadParticipation())) {
       return true;
@@ -504,6 +544,7 @@ public class AnnotationService {
       String firstComment,
       int commentCount,
       Instant latestCommentFromOthersAt,
+      List<ReactionService.ReactionGroup> reactions,
       ReviewIdentityResolver.ReviewIdentities identities) {
     UUID authorId = annotation.getAuthorId();
     return new AnnotationView(
@@ -519,12 +560,15 @@ public class AnnotationService {
         firstComment,
         commentCount,
         latestCommentFromOthersAt,
+        reactions,
         annotation.getCreatedAt(),
         annotation.getUpdatedAt());
   }
 
   private static CommentView commentView(
-      Comment comment, ReviewIdentityResolver.ReviewIdentities identities) {
+      Comment comment,
+      List<ReactionService.ReactionGroup> reactions,
+      ReviewIdentityResolver.ReviewIdentities identities) {
     UUID authorId = comment.getAuthorId();
     return new CommentView(
         comment.getId(),
@@ -532,6 +576,7 @@ public class AnnotationService {
         identities.exposedAuthorId(authorId),
         identities.displayName(authorId),
         comment.getBody(),
+        reactions,
         comment.getCreatedAt());
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/review/ReactionService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReactionService.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.Comment;
+import io.qnop.entity.Reaction;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.ReactionRepository;
+import io.qnop.service.document.DocumentAccessService;
+import io.qnop.service.document.DocumentValidationException;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Slack-style emoji reactions on annotations and comments (issue #410). A reaction is a lightweight
+ * signal, not a discussion contribution: reacting stays possible on RESOLVED annotations (the
+ * closed-thread guard of #403 does not apply) but is refused once the review itself is
+ * FINALIZED/CANCELLED. Reacting twice with the same emoji is a no-op, un-reacting something absent
+ * likewise — the PUT/DELETE pair is idempotent. Reaction groups are aggregated per target and
+ * batched onto the annotation and comment views (#313), with reactor names resolved through the
+ * review's identities (issue #413) so anonymity holds.
+ */
+@Service
+public class ReactionService {
+
+  /** Storage cap; generous enough for ZWJ families, tight enough to reject prose. */
+  static final int MAX_EMOJI_LENGTH = 32;
+
+  private final ReactionRepository reactions;
+  private final AnnotationRepository annotations;
+  private final CommentRepository comments;
+  private final DocumentAccessService documentAccess;
+
+  public ReactionService(
+      ReactionRepository reactions,
+      AnnotationRepository annotations,
+      CommentRepository comments,
+      DocumentAccessService documentAccess) {
+    this.reactions = reactions;
+    this.annotations = annotations;
+    this.comments = comments;
+    this.documentAccess = documentAccess;
+  }
+
+  /** One grouped emoji on a target: the chip's count, own-state and reactor names. */
+  public record ReactionGroup(
+      String emoji, int count, boolean reactedByMe, List<String> reactors) {}
+
+  /** Adds {@code actor}'s {@code emoji} to an annotation; a repeat is a no-op. */
+  @Transactional
+  public void reactToAnnotation(UUID annotationId, String emoji, UUID actor, boolean admin) {
+    String validated = requireEmoji(emoji);
+    Annotation annotation = requireAnnotation(annotationId);
+    guardTarget(annotation, actor, admin);
+    if (!reactions.existsByAnnotationIdAndUserIdAndEmoji(annotationId, actor, validated)) {
+      reactions.save(Reaction.onAnnotation(annotationId, actor, validated));
+    }
+  }
+
+  /** Removes {@code actor}'s {@code emoji} from an annotation; removing nothing is a no-op. */
+  @Transactional
+  public void unreactFromAnnotation(UUID annotationId, String emoji, UUID actor, boolean admin) {
+    String validated = requireEmoji(emoji);
+    Annotation annotation = requireAnnotation(annotationId);
+    guardTarget(annotation, actor, admin);
+    reactions.deleteByAnnotationIdAndUserIdAndEmoji(annotationId, actor, validated);
+  }
+
+  /** Adds {@code actor}'s {@code emoji} to a comment; a repeat is a no-op. */
+  @Transactional
+  public void reactToComment(UUID commentId, String emoji, UUID actor, boolean admin) {
+    String validated = requireEmoji(emoji);
+    Comment comment = requireComment(commentId);
+    guardTarget(requireAnnotation(comment.getAnnotationId()), actor, admin);
+    if (!reactions.existsByCommentIdAndUserIdAndEmoji(commentId, actor, validated)) {
+      reactions.save(Reaction.onComment(commentId, actor, validated));
+    }
+  }
+
+  /** Removes {@code actor}'s {@code emoji} from a comment; removing nothing is a no-op. */
+  @Transactional
+  public void unreactFromComment(UUID commentId, String emoji, UUID actor, boolean admin) {
+    String validated = requireEmoji(emoji);
+    Comment comment = requireComment(commentId);
+    guardTarget(requireAnnotation(comment.getAnnotationId()), actor, admin);
+    reactions.deleteByCommentIdAndUserIdAndEmoji(commentId, actor, validated);
+  }
+
+  /** Reaction groups for a batch of annotations in one query (#313); absent ids have none. */
+  public Map<UUID, List<ReactionGroup>> forAnnotations(
+      Collection<UUID> annotationIds,
+      UUID viewer,
+      ReviewIdentityResolver.ReviewIdentities identities) {
+    if (annotationIds.isEmpty()) {
+      return Map.of();
+    }
+    return groupByTarget(
+        reactions.findByAnnotationIdInOrderByCreatedAtAsc(annotationIds),
+        Reaction::getAnnotationId,
+        viewer,
+        identities);
+  }
+
+  /** Reaction groups for a batch of comments in one query (#313); absent ids have none. */
+  public Map<UUID, List<ReactionGroup>> forComments(
+      Collection<UUID> commentIds,
+      UUID viewer,
+      ReviewIdentityResolver.ReviewIdentities identities) {
+    if (commentIds.isEmpty()) {
+      return Map.of();
+    }
+    return groupByTarget(
+        reactions.findByCommentIdInOrderByCreatedAtAsc(commentIds),
+        Reaction::getCommentId,
+        viewer,
+        identities);
+  }
+
+  /**
+   * Groups a target's reactions into chips — one group per emoji, in order of each emoji's FIRST
+   * appearance (Slack's stable chip order), reactor names in reaction order. Pure and DB-free, so
+   * the grouping is unit-testable on its own.
+   */
+  static List<ReactionGroup> group(
+      List<Reaction> targetReactions, UUID viewer, Function<UUID, String> nameOf) {
+    Map<String, List<Reaction>> byEmoji = new LinkedHashMap<>();
+    for (Reaction reaction : targetReactions) {
+      byEmoji
+          .computeIfAbsent(reaction.getEmoji(), emoji -> new java.util.ArrayList<>())
+          .add(reaction);
+    }
+    return byEmoji.entrySet().stream()
+        .map(
+            entry ->
+                new ReactionGroup(
+                    entry.getKey(),
+                    entry.getValue().size(),
+                    entry.getValue().stream().anyMatch(r -> viewer.equals(r.getUserId())),
+                    entry.getValue().stream().map(r -> nameOf.apply(r.getUserId())).toList()))
+        .toList();
+  }
+
+  /**
+   * Accepts anything that plausibly IS an emoji and nothing that plausibly is prose: length-capped,
+   * no whitespace/control characters, and at least one non-ASCII code point (keycap sequences like
+   * "1️⃣" contain an ASCII digit but carry U+FE0F). Stored verbatim, so ZWJ families and skin tones
+   * group exactly.
+   */
+  static String requireEmoji(String emoji) {
+    if (emoji == null || emoji.isEmpty() || emoji.length() > MAX_EMOJI_LENGTH) {
+      throw DocumentValidationException.invalidRequest("not an emoji");
+    }
+    boolean hasNonAscii = false;
+    for (int i = 0; i < emoji.length(); ) {
+      int codePoint = emoji.codePointAt(i);
+      if (Character.isWhitespace(codePoint) || Character.isISOControl(codePoint)) {
+        throw DocumentValidationException.invalidRequest("not an emoji");
+      }
+      hasNonAscii |= codePoint > 0x7F;
+      i += Character.charCount(codePoint);
+    }
+    if (!hasNonAscii) {
+      throw DocumentValidationException.invalidRequest("not an emoji");
+    }
+    return emoji;
+  }
+
+  private Map<UUID, List<ReactionGroup>> groupByTarget(
+      List<Reaction> allReactions,
+      Function<Reaction, UUID> targetOf,
+      UUID viewer,
+      ReviewIdentityResolver.ReviewIdentities identities) {
+    Map<UUID, List<Reaction>> byTarget = new LinkedHashMap<>();
+    for (Reaction reaction : allReactions) {
+      byTarget
+          .computeIfAbsent(targetOf.apply(reaction), id -> new java.util.ArrayList<>())
+          .add(reaction);
+    }
+    Map<UUID, List<ReactionGroup>> grouped = new LinkedHashMap<>();
+    byTarget.forEach(
+        (targetId, targetReactions) ->
+            grouped.put(targetId, group(targetReactions, viewer, identities::displayName)));
+    return grouped;
+  }
+
+  /**
+   * Participants only (404 otherwise, anti-enumeration), the PRIVATE thread-visibility rule of
+   * #413, and the review-closed guard: a reaction is not a discussion contribution, so RESOLVED
+   * annotations stay reactable — only FINALIZED/CANCELLED reviews refuse.
+   */
+  private void guardTarget(Annotation annotation, UUID actor, boolean admin) {
+    DocumentAccessService.DocumentView document =
+        documentAccess.getDocument(annotation.getDocumentId(), actor, admin);
+    if (!AnnotationService.canSeeThread(document, annotation.getAuthorId(), actor, admin)) {
+      throw DocumentValidationException.notFound("no such annotation: " + annotation.getId());
+    }
+    // String comparison — the column tolerates enterprise states (ADR-0011).
+    String state = document.workflowState();
+    if (WorkflowState.FINALIZED.name().equals(state)
+        || WorkflowState.CANCELLED.name().equals(state)) {
+      throw new WorkflowTransitionException(
+          WorkflowTransitionException.REVIEW_CLOSED,
+          "the review is " + state + "; reactions are closed");
+    }
+  }
+
+  private Annotation requireAnnotation(UUID annotationId) {
+    return annotations
+        .findById(annotationId)
+        .orElseThrow(() -> new AnnotationNotFoundException(annotationId));
+  }
+
+  private Comment requireComment(UUID commentId) {
+    return comments
+        .findById(commentId)
+        .orElseThrow(() -> DocumentValidationException.notFound("no such comment: " + commentId));
+  }
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -53,3 +53,6 @@ databaseChangeLog:
   - include:
       file: migrations/0014-document-attachment-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0015-reaction-schema.yaml
+      relativeToChangelogFile: true

--- a/qnop-core/src/main/resources/db/changelog/migrations/0015-reaction-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0015-reaction-schema.yaml
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Emoji reactions on annotations and comments (issue #410). One row per
+# user × emoji × target; the target is an annotation XOR a comment. Partial
+# unique indexes enforce "one reaction per user per emoji per target" while a
+# user may still add several DIFFERENT emojis, as in Slack.
+databaseChangeLog:
+  - changeSet:
+      id: 0015-reaction-schema
+      author: qnop
+      comment: Emoji reactions on annotations and comments (issue #410).
+      changes:
+        - createTable:
+            tableName: reaction
+            columns:
+              - column:
+                  name: id
+                  type: UUID
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: annotation_id
+                  type: UUID
+                  constraints: { nullable: true }
+              - column:
+                  name: comment_id
+                  type: UUID
+                  constraints: { nullable: true }
+              - column:
+                  name: user_id
+                  type: UUID
+                  constraints: { nullable: false }
+              - column:
+                  name: emoji
+                  type: VARCHAR(32)
+                  constraints: { nullable: false }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+        - addForeignKeyConstraint:
+            constraintName: fk_reaction_annotation
+            baseTableName: reaction
+            baseColumnNames: annotation_id
+            referencedTableName: annotation
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: fk_reaction_comment
+            baseTableName: reaction
+            baseColumnNames: comment_id
+            referencedTableName: comment
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: fk_reaction_user
+            baseTableName: reaction
+            baseColumnNames: user_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - sql:
+            comment: A reaction targets an annotation XOR a comment (issue #410).
+            sql: |
+              ALTER TABLE reaction ADD CONSTRAINT ck_reaction_single_target
+                CHECK ((annotation_id IS NULL) <> (comment_id IS NULL));
+        - sql:
+            comment: >-
+              One reaction per user per emoji per target — partial unique
+              indexes, because a plain composite index would treat the NULL
+              half of the XOR as distinct and never fire.
+            sql: |
+              CREATE UNIQUE INDEX ux_reaction_annotation_user_emoji
+                ON reaction (annotation_id, user_id, emoji) WHERE annotation_id IS NOT NULL;
+              CREATE UNIQUE INDEX ux_reaction_comment_user_emoji
+                ON reaction (comment_id, user_id, emoji) WHERE comment_id IS NOT NULL;
+        - createIndex:
+            indexName: ix_reaction_annotation
+            tableName: reaction
+            columns:
+              - column: { name: annotation_id }
+        - createIndex:
+            indexName: ix_reaction_comment
+            tableName: reaction
+            columns:
+              - column: { name: comment_id }

--- a/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
@@ -67,6 +67,7 @@ class AnnotationServiceTest {
   private final DocumentAccessService documentAccess = mock(DocumentAccessService.class);
   private final ReviewWorkflowService workflow = mock(ReviewWorkflowService.class);
   private final ReviewIdentityResolver identity = mock(ReviewIdentityResolver.class);
+  private final ReactionService reactions = mock(ReactionService.class);
 
   private final AnnotationService service =
       new AnnotationService(
@@ -77,7 +78,8 @@ class AnnotationServiceTest {
           auditEvents,
           documentAccess,
           workflow,
-          identity);
+          identity,
+          reactions);
 
   private final UUID documentId = UUID.randomUUID();
   private final UUID author = UUID.randomUUID();

--- a/qnop-core/src/test/java/io/qnop/service/review/ReactionServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReactionServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.entity.Reaction;
+import io.qnop.service.document.DocumentValidationException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** The DB-free grouping and validation halves of {@link ReactionService} (issue #410). */
+class ReactionServiceTest {
+
+  private static final UUID ANNOTATION = UUID.randomUUID();
+  private static final UUID ANNA = UUID.randomUUID();
+  private static final UUID BEN = UUID.randomUUID();
+  private static final UUID CARA = UUID.randomUUID();
+
+  private static final Map<UUID, String> NAMES = Map.of(ANNA, "Anna", BEN, "Ben", CARA, "Cara");
+  private static final Function<UUID, String> NAME_OF = NAMES::get;
+
+  @Test
+  @DisplayName("groups by emoji in first-appearance order with counts and reactor names")
+  void groupsByEmojiInFirstAppearanceOrder() {
+    List<Reaction> reactions =
+        List.of(
+            Reaction.onAnnotation(ANNOTATION, ANNA, "👍"),
+            Reaction.onAnnotation(ANNOTATION, BEN, "🎉"),
+            Reaction.onAnnotation(ANNOTATION, BEN, "👍"),
+            Reaction.onAnnotation(ANNOTATION, CARA, "👍"));
+
+    List<ReactionService.ReactionGroup> groups = ReactionService.group(reactions, ANNA, NAME_OF);
+
+    assertThat(groups).hasSize(2);
+    assertThat(groups.get(0).emoji()).isEqualTo("👍");
+    assertThat(groups.get(0).count()).isEqualTo(3);
+    assertThat(groups.get(0).reactors()).containsExactly("Anna", "Ben", "Cara");
+    assertThat(groups.get(1).emoji()).isEqualTo("🎉");
+    assertThat(groups.get(1).count()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("marks only the viewer's own groups as reactedByMe")
+  void marksOwnGroups() {
+    List<Reaction> reactions =
+        List.of(
+            Reaction.onAnnotation(ANNOTATION, ANNA, "👍"),
+            Reaction.onAnnotation(ANNOTATION, BEN, "🎉"));
+
+    List<ReactionService.ReactionGroup> groups = ReactionService.group(reactions, ANNA, NAME_OF);
+
+    assertThat(groups.get(0).reactedByMe()).isTrue();
+    assertThat(groups.get(1).reactedByMe()).isFalse();
+  }
+
+  @Test
+  @DisplayName("distinct skin tones and ZWJ sequences stay distinct groups")
+  void groupsVerbatim() {
+    List<Reaction> reactions =
+        List.of(
+            Reaction.onAnnotation(ANNOTATION, ANNA, "👍"),
+            Reaction.onAnnotation(ANNOTATION, BEN, "👍🏽"));
+
+    assertThat(ReactionService.group(reactions, ANNA, NAME_OF)).hasSize(2);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"👍", "🎉", "👍🏽", "👨‍👩‍👧‍👦", "1️⃣", "❤️"})
+  @DisplayName("accepts plausible emoji, incl. keycaps, skin tones and ZWJ families")
+  void acceptsEmoji(String emoji) {
+    assertThat(ReactionService.requireEmoji(emoji)).isEqualTo(emoji);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abc", ":)", "x", "1", "👍 👍"})
+  @DisplayName("rejects prose, pure ASCII and whitespace-bearing input")
+  void rejectsNonEmoji(String input) {
+    assertThatThrownBy(() -> ReactionService.requireEmoji(input))
+        .isInstanceOf(DocumentValidationException.class);
+  }
+
+  @Test
+  @DisplayName("rejects null, empty and over-long input")
+  void rejectsDegenerateInput() {
+    assertThatThrownBy(() -> ReactionService.requireEmoji(null))
+        .isInstanceOf(DocumentValidationException.class);
+    assertThatThrownBy(() -> ReactionService.requireEmoji(""))
+        .isInstanceOf(DocumentValidationException.class);
+    assertThatThrownBy(() -> ReactionService.requireEmoji("👍".repeat(20)))
+        .isInstanceOf(DocumentValidationException.class);
+  }
+}

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -21,11 +21,16 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';
 import { FocusAnnotationCard } from './FocusAnnotationCard';
+
+// The reaction toggles (issue #410) reach for the query client; the data
+// hooks above stay mocked, so a bare client per file is all the tests need.
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 vi.mock('../panel/CommentThread', () => ({
   CommentThread: ({ annotationId }: { annotationId: string }) => (
@@ -56,6 +61,7 @@ const ANNOTATION: AnnotationView = {
     textQuote: { quote: 'the disputed clause' },
   },
   commentCount: 2,
+  reactions: [],
   createdAt: '2026-07-01T10:00:00Z',
   updatedAt: '2026-07-01T10:00:00Z',
 };
@@ -84,9 +90,11 @@ function renderCard(overrides: Partial<Parameters<typeof FocusAnnotationCard>[0]
     ...overrides,
   };
   render(
-    <ThemeProvider theme={buildTheme('light')}>
-      <FocusAnnotationCard {...props} />
-    </ThemeProvider>,
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <FocusAnnotationCard {...props} />
+      </ThemeProvider>
+    </QueryClientProvider>,
   );
   return props;
 }

--- a/qnop-ui/src/components/reviews/focus/spotlightModel.test.ts
+++ b/qnop-ui/src/components/reviews/focus/spotlightModel.test.ts
@@ -35,6 +35,7 @@ const annotation = (id: string, surfaceIndex: number | null, y = 0.2): Annotatio
       ? undefined
       : { region: { surfaceIndex, box: { x: 0.1, y, width: 0.3, height: 0.02 } } },
   commentCount: 1,
+  reactions: [],
   createdAt: '2026-07-01T10:00:00Z',
   updatedAt: '2026-07-01T10:00:00Z',
 });

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
@@ -67,6 +67,7 @@ function annotation(status: AnnotationStatus): AnnotationView {
     placementStatus: PlacementStatus.Placed,
     anchor: { region: { surfaceIndex: 0, box: { x: 0, y: 0, width: 0.1, height: 0.1 } } },
     commentCount: 0,
+    reactions: [],
     createdAt: '2026-07-01T10:00:00Z',
     updatedAt: '2026-07-01T10:00:00Z',
   };

--- a/qnop-ui/src/components/reviews/markdown/EmojiPickerButton.tsx
+++ b/qnop-ui/src/components/reviews/markdown/EmojiPickerButton.tsx
@@ -19,19 +19,11 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useEffect, useRef, useState } from 'react';
-import Box from '@mui/material/Box';
-import CircularProgress from '@mui/material/CircularProgress';
+import { useState } from 'react';
 import IconButton from '@mui/material/IconButton';
-import Popover from '@mui/material/Popover';
 import Tooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/material/styles';
 import { Smile } from 'lucide-react';
-
-/** The picker's footprint, reserved so the popover doesn't jump when it loads. */
-const PICKER_WIDTH = 352;
-const PICKER_HEIGHT = 420;
+import { EmojiPickerPopover } from './EmojiPickerPopover';
 
 interface EmojiPickerButtonProps {
   /** Receives the chosen emoji as native Unicode; the popover closes itself. */
@@ -40,66 +32,12 @@ interface EmojiPickerButtonProps {
 }
 
 /**
- * The composer's emoji affordance (issue #445): a quiet smiley that opens the
- * Slack-style emoji-mart picker in a popover. The picker is heavy (the emoji
- * index alone is ~200 kB gzipped), so `emoji-mart` and its data load lazily on
- * first open and never touch the initial bundle. Selection inserts native
- * Unicode — no image sheets, no shortcodes.
+ * The composer's emoji affordance (issue #445): a quiet smiley opening the
+ * shared {@link EmojiPickerPopover}. Selection inserts native Unicode — no
+ * image sheets, no shortcodes.
  */
 export function EmojiPickerButton({ onSelect, disabled = false }: EmojiPickerButtonProps) {
-  const theme = useTheme();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const [status, setStatus] = useState<'loading' | 'ready' | 'failed'>('loading');
-  const hostRef = useRef<HTMLDivElement | null>(null);
-  // The latest callback, readable from the picker without re-creating it.
-  const onSelectRef = useRef(onSelect);
-  useEffect(() => {
-    onSelectRef.current = onSelect;
-  }, [onSelect]);
-
-  const open = Boolean(anchorEl);
-
-  // Mount the picker (a framework-agnostic custom element) into the popover
-  // once it opens. Rebuilt per open — it must re-read the current theme, and
-  // keeping it mounted would pin ~1 MB of emoji index for a rarely-open surface.
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const [{ Picker }, { default: data }] = await Promise.all([
-          import('emoji-mart'),
-          import('@emoji-mart/data'),
-        ]);
-        if (cancelled || !hostRef.current) return;
-        const picker = new Picker({
-          data,
-          set: 'native',
-          theme: theme.qnop.mode,
-          previewPosition: 'none',
-          skinTonePosition: 'search',
-          autoFocus: true,
-          onEmojiSelect: (emoji: { native?: string }) => {
-            const { native } = emoji;
-            if (!native) return;
-            setAnchorEl(null);
-            // Insert AFTER the popover's focus restore has run, so the
-            // composer's refocus of the textarea wins.
-            requestAnimationFrame(() => onSelectRef.current(native));
-          },
-        });
-        // The host div is manual-DOM only — React renders the spinner/error as
-        // siblings, so the reconciler never trips over the injected element.
-        hostRef.current.replaceChildren(picker as unknown as HTMLElement);
-        setStatus('ready');
-      } catch {
-        if (!cancelled) setStatus('failed');
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [open, theme.qnop.mode]);
 
   return (
     <>
@@ -109,10 +47,7 @@ export function EmojiPickerButton({ onSelect, disabled = false }: EmojiPickerBut
             size="small"
             aria-label="Insert emoji"
             disabled={disabled}
-            onClick={(event) => {
-              setStatus('loading');
-              setAnchorEl(event.currentTarget);
-            }}
+            onClick={(event) => setAnchorEl(event.currentTarget)}
             sx={{
               width: 26,
               height: 26,
@@ -125,35 +60,11 @@ export function EmojiPickerButton({ onSelect, disabled = false }: EmojiPickerBut
           </IconButton>
         </span>
       </Tooltip>
-      <Popover
-        open={open}
+      <EmojiPickerPopover
         anchorEl={anchorEl}
         onClose={() => setAnchorEl(null)}
-        anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
-        transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        slotProps={{ paper: { sx: { borderRadius: '10px', overflow: 'hidden' } } }}
-      >
-        <Box
-          sx={{
-            width: PICKER_WIDTH,
-            minHeight: status === 'ready' ? 0 : PICKER_HEIGHT,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            // The custom element sizes itself; cap it to the reserved frame.
-            '& em-emoji-picker': { width: '100%', height: PICKER_HEIGHT },
-          }}
-        >
-          {status === 'failed' && (
-            <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
-              The emoji picker could not be loaded.
-            </Typography>
-          )}
-          {status === 'loading' && <CircularProgress size={22} aria-label="Loading emoji picker" />}
-          <Box ref={hostRef} sx={{ alignSelf: 'stretch' }} />
-        </Box>
-      </Popover>
+        onSelect={onSelect}
+      />
     </>
   );
 }

--- a/qnop-ui/src/components/reviews/markdown/EmojiPickerPopover.tsx
+++ b/qnop-ui/src/components/reviews/markdown/EmojiPickerPopover.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Popover from '@mui/material/Popover';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+
+/** The picker's footprint, reserved so the popover doesn't jump when it loads. */
+const PICKER_WIDTH = 352;
+const PICKER_HEIGHT = 420;
+
+interface EmojiPickerPopoverProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  /**
+   * Receives the chosen emoji as native Unicode after the popover has closed
+   * and its focus restore has run — so a composer's refocus wins.
+   */
+  onSelect: (emoji: string) => void;
+}
+
+/**
+ * The Slack-style emoji-mart picker in a popover (issue #445), shared by the
+ * composer's emoji button and the reaction affordances (issue #410). The
+ * picker is heavy (the emoji index alone is ~200 kB gzipped), so `emoji-mart`
+ * and its data load lazily on open and never touch the initial bundle; closing
+ * unmounts it, so the index never stays pinned for a rarely-open surface.
+ */
+export function EmojiPickerPopover({ anchorEl, onClose, onSelect }: EmojiPickerPopoverProps) {
+  const open = Boolean(anchorEl);
+  return (
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      slotProps={{ paper: { sx: { borderRadius: '10px', overflow: 'hidden' } } }}
+      // The popover portals out of the DOM but NOT out of the React tree: a
+      // click inside would bubble synthetically into a hosting annotation
+      // card's ButtonBase and collapse it (issue #410).
+      onClick={(event) => event.stopPropagation()}
+    >
+      {/* Mount fresh per open: the picker re-reads the theme, and the loading
+          state resets by construction (no set-state-in-effect). */}
+      {open && <PickerHost onClose={onClose} onSelect={onSelect} />}
+    </Popover>
+  );
+}
+
+function PickerHost({ onClose, onSelect }: Omit<EmojiPickerPopoverProps, 'anchorEl'>) {
+  const theme = useTheme();
+  const [status, setStatus] = useState<'loading' | 'ready' | 'failed'>('loading');
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  // The latest callbacks, readable from the picker without re-creating it.
+  const onSelectRef = useRef(onSelect);
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+    onCloseRef.current = onClose;
+  }, [onSelect, onClose]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [{ Picker }, { default: data }] = await Promise.all([
+          import('emoji-mart'),
+          import('@emoji-mart/data'),
+        ]);
+        if (cancelled || !hostRef.current) return;
+        const picker = new Picker({
+          data,
+          set: 'native',
+          theme: theme.qnop.mode,
+          previewPosition: 'none',
+          skinTonePosition: 'search',
+          autoFocus: true,
+          onEmojiSelect: (emoji: { native?: string }) => {
+            const { native } = emoji;
+            if (!native) return;
+            onCloseRef.current();
+            // Deliver AFTER the popover's focus restore has run, so a
+            // composer's refocus of its textarea wins.
+            requestAnimationFrame(() => onSelectRef.current(native));
+          },
+        });
+        // The host div is manual-DOM only — React renders the spinner/error as
+        // siblings, so the reconciler never trips over the injected element.
+        hostRef.current.replaceChildren(picker as unknown as HTMLElement);
+        setStatus('ready');
+      } catch {
+        if (!cancelled) setStatus('failed');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [theme.qnop.mode]);
+
+  return (
+    <Box
+      sx={{
+        width: PICKER_WIDTH,
+        minHeight: status === 'ready' ? 0 : PICKER_HEIGHT,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        // The custom element sizes itself; cap it to the reserved frame.
+        '& em-emoji-picker': { width: '100%', height: PICKER_HEIGHT },
+      }}
+    >
+      {status === 'failed' && (
+        <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+          The emoji picker could not be loaded.
+        </Typography>
+      )}
+      {status === 'loading' && <CircularProgress size={22} aria-label="Loading emoji picker" />}
+      <Box ref={hostRef} sx={{ alignSelf: 'stretch' }} />
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/reviews/newSince.test.ts
+++ b/qnop-ui/src/components/reviews/newSince.test.ts
@@ -33,6 +33,7 @@ const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => 
   status: AnnotationStatus.Open,
   placementStatus: PlacementStatus.Placed,
   commentCount: 1,
+  reactions: [],
   createdAt: '2026-07-04T13:00:00Z',
   updatedAt: '2026-07-04T13:00:00Z',
   ...overrides,
@@ -40,6 +41,7 @@ const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => 
 
 const comment = (overrides: Partial<CommentView> = {}): CommentView => ({
   id: 'c1',
+  reactions: [],
   annotationId: 'a1',
   authorId: 'other',
   body: 'hello',

--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -27,6 +27,9 @@ import type { AnnotationView } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
 import type { Notify } from '../../admin/layout/useToast';
 import { CopyLinkButton } from '../permalink/CopyLinkButton';
+import { AddReactionButton } from '../reactions/AddReactionButton';
+import { ReactionBar } from '../reactions/ReactionBar';
+import { useToggleAnnotationReaction } from '../reactions/useReactions';
 import { useAuthStore } from '../../../stores/authStore';
 import { shortRelativeTime } from '../../../utils/relativeTime';
 import { UserAvatar } from '../../shell/UserAvatar';
@@ -67,6 +70,12 @@ export function AnnotationHead({
   notify,
 }: AnnotationHeadProps) {
   const theme = useTheme();
+  // Reactions on the opener (issue #410) — active wherever notify travels;
+  // a closed review answers REVIEW_CLOSED and the optimistic flip rolls back.
+  const toggleReaction = useToggleAnnotationReaction(annotation.id, notify ?? (() => undefined));
+  const onToggleReaction = notify
+    ? (emoji: string, reacted: boolean) => toggleReaction.mutate({ emoji, reacted })
+    : undefined;
   const userId = useAuthStore((state) => state.userId);
   const displayName = useAuthStore((state) => state.displayName);
   const avatarUrl = useAuthStore((state) => state.avatarUrl);
@@ -125,19 +134,32 @@ export function AnnotationHead({
             >
               Started this discussion · {shortRelativeTime(annotation.createdAt)}
             </Typography>
-            {permalinkUrl && notify && (
+            {(onToggleReaction || (permalinkUrl && notify)) && (
               // Directly after the timestamp, exactly like a comment row's
-              // link. The negative margin keeps the icon button from growing
+              // link. The negative margin keeps the icon buttons from growing
               // the caption line beyond the avatar's height.
               <Box
                 className="annotation-hover-actions"
-                sx={{ display: 'flex', flexShrink: 0, my: '-3px' }}
+                sx={{ display: 'flex', alignItems: 'center', flexShrink: 0, my: '-3px' }}
               >
-                <CopyLinkButton
-                  url={permalinkUrl}
-                  notify={notify}
-                  label="Copy link to annotation"
-                />
+                {permalinkUrl && notify && (
+                  <CopyLinkButton
+                    url={permalinkUrl}
+                    notify={notify}
+                    label="Copy link to annotation"
+                  />
+                )}
+                {onToggleReaction && (
+                  <AddReactionButton
+                    onPick={(emoji) =>
+                      onToggleReaction(
+                        emoji,
+                        annotation.reactions.find((group) => group.emoji === emoji)?.reactedByMe ??
+                          false,
+                      )
+                    }
+                  />
+                )}
               </Box>
             )}
           </Stack>
@@ -184,6 +206,10 @@ export function AnnotationHead({
         <Box data-testid="opening-text">
           <Markdown>{openerText}</Markdown>
         </Box>
+      )}
+      {/* The opener's reaction chips (issue #410), Slack-style under the text. */}
+      {onToggleReaction && annotation.reactions.length > 0 && (
+        <ReactionBar reactions={annotation.reactions} onToggle={onToggleReaction} />
       )}
     </Stack>
   );

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -21,12 +21,17 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus, PlacementStatus } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';
 import { useAuthStore } from '../../../stores/authStore';
 import { AnnotationPanel } from './AnnotationPanel';
+
+// The reaction toggles (issue #410) reach for the query client; the data
+// hooks above stay mocked, so a bare client per file is all the tests need.
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 vi.mock('./CommentThread', () => ({
   CommentThread: ({
@@ -77,6 +82,7 @@ const annotation = (id: string, overrides: Partial<AnnotationView> = {}): Annota
     textQuote: { quote: 'quoted text' },
   },
   commentCount: 2,
+  reactions: [],
   createdAt: '2026-07-01T10:00:00Z',
   updatedAt: '2026-07-01T10:00:00Z',
   ...overrides,
@@ -96,9 +102,11 @@ function renderPanel(props: Partial<Parameters<typeof AnnotationPanel>[0]> = {})
   };
   const merged = { ...defaults, ...props };
   render(
-    <ThemeProvider theme={buildTheme('light')}>
-      <AnnotationPanel {...merged} />
-    </ThemeProvider>,
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <AnnotationPanel {...merged} />
+      </ThemeProvider>
+    </QueryClientProvider>,
   );
   return merged;
 }

--- a/qnop-ui/src/components/reviews/panel/CommentMessage.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentMessage.tsx
@@ -22,11 +22,14 @@
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import type { ReactionGroup } from '../../../api/generated';
 import { shortRelativeTime } from '../../../utils/relativeTime';
 import type { Notify } from '../../admin/layout/useToast';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { Markdown } from '../markdown/Markdown';
 import { CopyLinkButton } from '../permalink/CopyLinkButton';
+import { AddReactionButton } from '../reactions/AddReactionButton';
+import { ReactionBar } from '../reactions/ReactionBar';
 
 /** Shared with the thread's rail and composer, so the columns stay aligned. */
 export const AVATAR_SIZE = 28;
@@ -50,6 +53,10 @@ interface CommentMessageProps {
   /** The comment's permalink; with `notify` it renders the hover copy affordance (issue #412). */
   permalinkUrl?: string;
   notify?: Notify;
+  /** The comment's grouped emoji reactions (issue #410). */
+  reactions?: ReactionGroup[];
+  /** Toggles the viewer's reaction; its presence renders the reaction affordances. */
+  onToggleReaction?: (emoji: string, reacted: boolean) => void;
 }
 
 /**
@@ -71,6 +78,8 @@ export function CommentMessage({
   domId,
   permalinkUrl,
   notify,
+  reactions = [],
+  onToggleReaction,
 }: CommentMessageProps) {
   return (
     <Stack
@@ -111,15 +120,32 @@ export function CommentMessage({
           >
             {shortRelativeTime(createdAt)}
           </Typography>
-          {permalinkUrl && notify && (
-            <Box className="comment-hover-actions" sx={{ display: 'flex' }}>
-              <CopyLinkButton url={permalinkUrl} notify={notify} label="Copy link to comment" />
+          {(onToggleReaction || (permalinkUrl && notify)) && (
+            <Box className="comment-hover-actions" sx={{ display: 'flex', alignItems: 'center' }}>
+              {permalinkUrl && notify && (
+                <CopyLinkButton url={permalinkUrl} notify={notify} label="Copy link to comment" />
+              )}
+              {onToggleReaction && (
+                <AddReactionButton
+                  onPick={(emoji) =>
+                    onToggleReaction(
+                      emoji,
+                      reactions.find((group) => group.emoji === emoji)?.reactedByMe ?? false,
+                    )
+                  }
+                />
+              )}
             </Box>
           )}
         </Stack>
         {/* The body renders as sanitised Markdown (issue #427); the hover
             preview passes clampLines to cap its height. */}
         <Markdown clampLines={clampLines}>{body}</Markdown>
+        {onToggleReaction && reactions.length > 0 && (
+          <Box sx={{ mt: 0.75 }}>
+            <ReactionBar reactions={reactions} onToggle={onToggleReaction} />
+          </Box>
+        )}
       </Box>
     </Stack>
   );

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -21,11 +21,16 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../../theme/theme';
 import { useAuthStore } from '../../../stores/authStore';
 import { CommentThread } from './CommentThread';
 import { useAddComment, useComments } from '../../../api/hooks/useComments';
+
+// The reaction toggles (issue #410) reach for the query client; the data
+// hooks above stay mocked, so a bare client per file is all the tests need.
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 vi.mock('../../../api/hooks/useComments', () => ({
   useComments: vi.fn(),
@@ -36,15 +41,17 @@ const addMutate = vi.fn();
 
 function renderThread(readOnly = false, previousSeenAt: string | null = null, closed = false) {
   return render(
-    <ThemeProvider theme={buildTheme('light')}>
-      <CommentThread
-        annotationId="a1"
-        notify={vi.fn()}
-        readOnly={readOnly}
-        closed={closed}
-        previousSeenAt={previousSeenAt}
-      />
-    </ThemeProvider>,
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <CommentThread
+          annotationId="a1"
+          notify={vi.fn()}
+          readOnly={readOnly}
+          closed={closed}
+          previousSeenAt={previousSeenAt}
+        />
+      </ThemeProvider>
+    </QueryClientProvider>,
   );
 }
 
@@ -170,9 +177,11 @@ describe('CommentThread', () => {
     } as unknown as ReturnType<typeof useComments>);
 
     render(
-      <ThemeProvider theme={buildTheme('light')}>
-        <CommentThread annotationId="a1" notify={vi.fn()} policyReadOnly />
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={buildTheme('light')}>
+          <CommentThread annotationId="a1" notify={vi.fn()} policyReadOnly />
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByTestId('thread-policy-readonly-note')).toBeInTheDocument();
@@ -243,9 +252,11 @@ describe('CommentThread', () => {
       },
     } as unknown as ReturnType<typeof useComments>);
     render(
-      <ThemeProvider theme={buildTheme('light')}>
-        <CommentThread annotationId="a1" notify={vi.fn()} closed skipOpener />
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={buildTheme('light')}>
+          <CommentThread annotationId="a1" notify={vi.fn()} closed skipOpener />
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
     expect(screen.getByText('No replies.')).toBeInTheDocument();
     expect(screen.queryByText('No replies yet.')).not.toBeInTheDocument();
@@ -259,9 +270,11 @@ describe('CommentThread', () => {
     } as unknown as ReturnType<typeof useComments>);
     const onReopen = vi.fn();
     render(
-      <ThemeProvider theme={buildTheme('light')}>
-        <CommentThread annotationId="a1" notify={vi.fn()} closed onReopen={onReopen} />
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={buildTheme('light')}>
+          <CommentThread annotationId="a1" notify={vi.fn()} closed onReopen={onReopen} />
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
     fireEvent.click(screen.getByRole('button', { name: 'Reopen' }));
     expect(onReopen).toHaveBeenCalled();
@@ -303,9 +316,11 @@ describe('CommentThread permalinks (#412)', () => {
   it('renders a copy-link affordance on every comment when a builder is provided', () => {
     vi.mocked(useComments).mockReturnValue(TWO_COMMENTS);
     render(
-      <ThemeProvider theme={buildTheme('light')}>
-        <CommentThread annotationId="a1" notify={vi.fn()} buildPermalink={buildPermalink} />
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={buildTheme('light')}>
+          <CommentThread annotationId="a1" notify={vi.fn()} buildPermalink={buildPermalink} />
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
     expect(screen.getAllByRole('button', { name: 'Copy link to comment' })).toHaveLength(2);
   });
@@ -313,9 +328,11 @@ describe('CommentThread permalinks (#412)', () => {
   it('shows no per-comment copy affordance without a builder (e.g. the hover preview)', () => {
     vi.mocked(useComments).mockReturnValue(TWO_COMMENTS);
     render(
-      <ThemeProvider theme={buildTheme('light')}>
-        <CommentThread annotationId="a1" notify={vi.fn()} />
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={buildTheme('light')}>
+          <CommentThread annotationId="a1" notify={vi.fn()} />
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
     expect(screen.queryByRole('button', { name: 'Copy link to comment' })).not.toBeInTheDocument();
   });
@@ -327,14 +344,16 @@ describe('CommentThread permalinks (#412)', () => {
     const notify = vi.fn();
     const onScrolledToComment = vi.fn();
     render(
-      <ThemeProvider theme={buildTheme('light')}>
-        <CommentThread
-          annotationId="a1"
-          notify={notify}
-          scrollToCommentId="c2"
-          onScrolledToComment={onScrolledToComment}
-        />
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={buildTheme('light')}>
+          <CommentThread
+            annotationId="a1"
+            notify={notify}
+            scrollToCommentId="c2"
+            onScrolledToComment={onScrolledToComment}
+          />
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
     expect(onScrolledToComment).toHaveBeenCalledTimes(1);
@@ -346,14 +365,16 @@ describe('CommentThread permalinks (#412)', () => {
     const notify = vi.fn();
     const onScrolledToComment = vi.fn();
     render(
-      <ThemeProvider theme={buildTheme('light')}>
-        <CommentThread
-          annotationId="a1"
-          notify={notify}
-          scrollToCommentId="ghost"
-          onScrolledToComment={onScrolledToComment}
-        />
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={buildTheme('light')}>
+          <CommentThread
+            annotationId="a1"
+            notify={notify}
+            scrollToCommentId="ghost"
+            onScrolledToComment={onScrolledToComment}
+          />
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
     expect(notify).toHaveBeenCalledWith('This comment no longer exists.', 'error');
     expect(onScrolledToComment).toHaveBeenCalledTimes(1);

--- a/qnop-ui/src/components/reviews/panel/CommentThread.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.tsx
@@ -36,6 +36,7 @@ import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { isNewComment } from '../newSince';
 import type { BuildPermalink } from '../useReviewPermalink';
+import { useToggleCommentReaction } from '../reactions/useReactions';
 import { FullscreenComposerDialog } from '../markdown/FullscreenComposerDialog';
 import { MarkdownComposer } from '../markdown/MarkdownComposer';
 import { useCommentAttachmentUpload } from '../markdown/useCommentAttachmentUpload';
@@ -107,6 +108,7 @@ export function CommentThread({
   const avatarUrl = useAuthStore((state) => state.avatarUrl);
   const commentsQuery = useComments(annotationId);
   const addComment = useAddComment(annotationId);
+  const toggleReaction = useToggleCommentReaction(annotationId, notify);
   const uploadAttachment = useCommentAttachmentUpload(documentId, notify);
   const [draft, setDraft] = useState('');
   // The full-screen writing stage (issue #403 follow-up). The draft state
@@ -265,6 +267,13 @@ export function CommentThread({
                 domId={`comment-${comment.id}`}
                 permalinkUrl={buildPermalink?.(annotationId, comment.id)}
                 notify={notify}
+                reactions={comment.reactions}
+                onToggleReaction={
+                  readOnly
+                    ? undefined
+                    : (emoji, reacted) =>
+                        toggleReaction.mutate({ commentId: comment.id, emoji, reacted })
+                }
               />
             </Fragment>
           );

--- a/qnop-ui/src/components/reviews/panel/panelFilters.test.ts
+++ b/qnop-ui/src/components/reviews/panel/panelFilters.test.ts
@@ -31,6 +31,7 @@ const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => 
   status: AnnotationStatus.Open,
   placementStatus: 'PLACED' as AnnotationView['placementStatus'],
   commentCount: 1,
+  reactions: [],
   anchor: {
     region: { surfaceIndex: 0, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 } },
     textQuote: { quote: 'the disputed clause' },

--- a/qnop-ui/src/components/reviews/reactions/AddReactionButton.tsx
+++ b/qnop-ui/src/components/reviews/reactions/AddReactionButton.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { SmilePlus } from 'lucide-react';
+import { EmojiPickerPopover } from '../markdown/EmojiPickerPopover';
+
+interface AddReactionButtonProps {
+  /** Receives the chosen emoji as native Unicode. */
+  onPick: (emoji: string) => void;
+  /** Matches the copy-link affordance's footprint in the hover clusters. */
+  iconSize?: number;
+}
+
+/**
+ * The hover-cluster entry point for the FIRST reaction (issue #410) — Slack's
+ * smiley-plus next to a message. Sits beside the copy-link in the header rows
+ * of comments and annotation heads; once reactions exist, the bar's trailing
+ * "+" chip takes over for the follow-ups.
+ */
+export function AddReactionButton({ onPick, iconSize = 13 }: AddReactionButtonProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  return (
+    <>
+      <Tooltip title="Add reaction">
+        <IconButton
+          size="small"
+          aria-label="Add reaction"
+          onClick={(event) => {
+            // Lives inside clickable cards — opening the picker stays local.
+            event.stopPropagation();
+            setAnchorEl(event.currentTarget);
+          }}
+          sx={{ p: 0.5, color: 'text.secondary', '&:hover': { color: 'text.primary' } }}
+        >
+          <SmilePlus size={iconSize} aria-hidden />
+        </IconButton>
+      </Tooltip>
+      <EmojiPickerPopover anchorEl={anchorEl} onClose={() => setAnchorEl(null)} onSelect={onPick} />
+    </>
+  );
+}

--- a/qnop-ui/src/components/reviews/reactions/ReactionBar.test.tsx
+++ b/qnop-ui/src/components/reviews/reactions/ReactionBar.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { ReactionGroup } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { ReactionBar } from './ReactionBar';
+import { toggleReactionGroup } from './reactionGroups';
+
+const GROUPS: ReactionGroup[] = [
+  { emoji: '👍', count: 3, reactedByMe: true, reactors: ['You', 'Anna Krause', 'Ben Roth'] },
+  { emoji: '🎉', count: 1, reactedByMe: false, reactors: ['Anna Krause'] },
+];
+
+function renderBar(onToggle = vi.fn(), reactions: ReactionGroup[] = GROUPS) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <ReactionBar reactions={reactions} onToggle={onToggle} />
+    </ThemeProvider>,
+  );
+  return onToggle;
+}
+
+describe('ReactionBar (issue #410)', () => {
+  it('renders one chip per emoji with the count, own chips pressed', () => {
+    renderBar();
+
+    const thumbs = screen.getByRole('button', { name: '👍 3' });
+    expect(thumbs).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '🎉 1' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('toggles with the chip’s CURRENT own-state', () => {
+    const onToggle = renderBar();
+
+    fireEvent.click(screen.getByRole('button', { name: '👍 3' }));
+    expect(onToggle).toHaveBeenCalledWith('👍', true);
+
+    fireEvent.click(screen.getByRole('button', { name: '🎉 1' }));
+    expect(onToggle).toHaveBeenCalledWith('🎉', false);
+  });
+
+  it('renders nothing without reactions — the first one comes from the hover affordance', () => {
+    renderBar(vi.fn(), []);
+    expect(screen.queryByTestId('reaction-bar')).not.toBeInTheDocument();
+  });
+
+  it('offers a trailing add-reaction affordance', () => {
+    renderBar();
+    expect(screen.getByRole('button', { name: 'Add reaction' })).toBeInTheDocument();
+  });
+});
+
+describe('toggleReactionGroup (optimistic flip)', () => {
+  it('adds a fresh group for a first reaction', () => {
+    const next = toggleReactionGroup([], '👍', 'You');
+    expect(next).toEqual([{ emoji: '👍', count: 1, reactedByMe: true, reactors: ['You'] }]);
+  });
+
+  it('joins an existing group', () => {
+    const next = toggleReactionGroup(
+      [{ emoji: '👍', count: 1, reactedByMe: false, reactors: ['Anna'] }],
+      '👍',
+      'You',
+    );
+    expect(next).toEqual([{ emoji: '👍', count: 2, reactedByMe: true, reactors: ['Anna', 'You'] }]);
+  });
+
+  it('leaves an own group, dropping it entirely at zero', () => {
+    const shared = toggleReactionGroup(
+      [{ emoji: '👍', count: 2, reactedByMe: true, reactors: ['You', 'Anna'] }],
+      '👍',
+      'You',
+    );
+    expect(shared[0]).toMatchObject({ count: 1, reactedByMe: false, reactors: ['Anna'] });
+
+    const solo = toggleReactionGroup(
+      [{ emoji: '👍', count: 1, reactedByMe: true, reactors: ['You'] }],
+      '👍',
+      'You',
+    );
+    expect(solo).toEqual([]);
+  });
+
+  it('never mutates its input', () => {
+    const input = [{ emoji: '👍', count: 1, reactedByMe: false, reactors: ['Anna'] }];
+    toggleReactionGroup(input, '👍', 'You');
+    expect(input[0]).toEqual({ emoji: '👍', count: 1, reactedByMe: false, reactors: ['Anna'] });
+  });
+});

--- a/qnop-ui/src/components/reviews/reactions/ReactionBar.tsx
+++ b/qnop-ui/src/components/reviews/reactions/ReactionBar.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import { alpha, useTheme } from '@mui/material/styles';
+import { SmilePlus } from 'lucide-react';
+import type { ReactionGroup } from '../../../api/generated';
+import { EmojiPickerPopover } from '../markdown/EmojiPickerPopover';
+
+interface ReactionBarProps {
+  reactions: ReactionGroup[];
+  /** Toggles the viewer's reaction; `reacted` is the chip's CURRENT own-state. */
+  onToggle: (emoji: string, reacted: boolean) => void;
+}
+
+/**
+ * Slack's reaction row (issue #410): one pill chip per emoji with a tabular
+ * count, the viewer's own reactions accented in brand blue, hovering reveals
+ * who reacted, clicking toggles. A trailing "+" chip opens the shared emoji
+ * picker for another emoji. Renders nothing while there are no reactions —
+ * the FIRST reaction comes from the hover affordance next to the message
+ * ({@link AddReactionButton}), as in Slack.
+ */
+export function ReactionBar({ reactions, onToggle }: ReactionBarProps) {
+  const theme = useTheme();
+  const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null);
+  if (reactions.length === 0) return null;
+
+  const chipSx = (own: boolean) => ({
+    height: 24,
+    px: 1,
+    borderRadius: '12px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 0.5,
+    fontSize: '0.8125rem',
+    lineHeight: 1,
+    border: '1px solid',
+    transition: 'border-color 120ms ease, background-color 120ms ease',
+    '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
+    ...(own
+      ? {
+          borderColor: alpha(theme.qnop.brand.blue, 0.55),
+          bgcolor: alpha(theme.qnop.brand.blue, 0.1),
+          color: theme.qnop.brand.blue,
+        }
+      : {
+          borderColor: 'divider',
+          bgcolor: theme.qnop.surface2,
+          color: 'text.secondary',
+        }),
+    '&:hover': {
+      borderColor: alpha(theme.qnop.brand.blue, 0.55),
+      bgcolor: alpha(theme.qnop.brand.blue, own ? 0.16 : 0.06),
+    },
+  });
+
+  return (
+    <Stack
+      direction="row"
+      spacing={0.5}
+      sx={{ flexWrap: 'wrap', alignItems: 'center', rowGap: 0.5 }}
+      data-testid="reaction-bar"
+    >
+      {reactions.map((group) => (
+        <Tooltip key={group.emoji} title={group.reactors.join(', ')}>
+          <ButtonBase
+            onClick={(event) => {
+              // Chips live inside clickable cards — the toggle stays local.
+              event.stopPropagation();
+              onToggle(group.emoji, group.reactedByMe);
+            }}
+            aria-pressed={group.reactedByMe}
+            aria-label={`${group.emoji} ${group.count}`}
+            sx={chipSx(group.reactedByMe)}
+          >
+            <Box component="span" sx={{ fontSize: '0.875rem' }}>
+              {group.emoji}
+            </Box>
+            <Box
+              component="span"
+              sx={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600, fontSize: '0.75rem' }}
+            >
+              {group.count}
+            </Box>
+          </ButtonBase>
+        </Tooltip>
+      ))}
+      <Tooltip title="Add reaction">
+        <ButtonBase
+          aria-label="Add reaction"
+          onClick={(event) => {
+            event.stopPropagation();
+            setPickerAnchor(event.currentTarget);
+          }}
+          sx={{
+            height: 24,
+            width: 28,
+            borderRadius: '12px',
+            border: '1px dashed',
+            borderColor: 'divider',
+            color: 'text.secondary',
+            '&:hover': {
+              borderColor: alpha(theme.qnop.brand.blue, 0.55),
+              color: theme.qnop.brand.blue,
+            },
+          }}
+        >
+          <SmilePlus size={13} aria-hidden />
+        </ButtonBase>
+      </Tooltip>
+      <EmojiPickerPopover
+        anchorEl={pickerAnchor}
+        onClose={() => setPickerAnchor(null)}
+        onSelect={(emoji) => {
+          const existing = reactions.find((group) => group.emoji === emoji);
+          onToggle(emoji, existing?.reactedByMe ?? false);
+        }}
+      />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/reactions/reactionGroups.ts
+++ b/qnop-ui/src/components/reviews/reactions/reactionGroups.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactionGroup } from '../../../api/generated';
+
+/**
+ * The optimistic half of a reaction toggle (issue #410): what the server will
+ * answer, computed locally so the chip flips before the round-trip. Adding to
+ * an existing group bumps its count and appends the viewer; removing decrements
+ * and drops the whole group at zero. Immutably — the caches keep their
+ * snapshots for the rollback.
+ */
+export function toggleReactionGroup(
+  groups: ReactionGroup[],
+  emoji: string,
+  viewerName: string,
+): ReactionGroup[] {
+  const existing = groups.find((group) => group.emoji === emoji);
+  if (!existing) {
+    return [...groups, { emoji, count: 1, reactedByMe: true, reactors: [viewerName] }];
+  }
+  if (!existing.reactedByMe) {
+    return groups.map((group) =>
+      group.emoji === emoji
+        ? {
+            ...group,
+            count: group.count + 1,
+            reactedByMe: true,
+            reactors: [...group.reactors, viewerName],
+          }
+        : group,
+    );
+  }
+  if (existing.count <= 1) {
+    return groups.filter((group) => group.emoji !== emoji);
+  }
+  return groups.map((group) =>
+    group.emoji === emoji
+      ? {
+          ...group,
+          count: group.count - 1,
+          reactedByMe: false,
+          // Best effort: the server resolves the authoritative list on refetch.
+          reactors: group.reactors.filter((name) => name !== viewerName),
+        }
+      : group,
+  );
+}

--- a/qnop-ui/src/components/reviews/reactions/useReactions.ts
+++ b/qnop-ui/src/components/reviews/reactions/useReactions.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type {
+  AnnotationListResponse,
+  AnnotationView,
+  CommentListResponse,
+} from '../../../api/generated';
+import { annotationsApi } from '../../../api/config';
+import { annotationKeys } from '../../../api/hooks/useAnnotations';
+import { commentKeys } from '../../../api/hooks/useComments';
+import { apiErrorCode } from '../../../utils/apiError';
+import { useAuthStore } from '../../../stores/authStore';
+import type { Notify } from '../../admin/layout/useToast';
+import { toggleReactionGroup } from './reactionGroups';
+
+/** The toggle's input: the chip's emoji and whether the viewer already carries it. */
+export interface ReactionToggle {
+  emoji: string;
+  reacted: boolean;
+}
+
+function notifyToggleError(error: unknown, notify: Notify) {
+  notify(
+    apiErrorCode(error) === 'REVIEW_CLOSED'
+      ? 'The review is closed — reactions are read-only.'
+      : 'Could not update the reaction.',
+    'error',
+  );
+}
+
+/**
+ * Toggles the viewer's emoji reaction on an annotation (issue #410),
+ * optimistically: every cached annotation list flips the chip immediately and
+ * rolls back on error; the server truth is refetched on settle. The document
+ * detail (with its PDF binaries) is deliberately NOT touched (#403 lesson).
+ */
+export function useToggleAnnotationReaction(annotationId: string, notify: Notify) {
+  const queryClient = useQueryClient();
+  const viewerName = useAuthStore((state) => state.displayName) ?? 'You';
+  return useMutation({
+    mutationFn: async ({ emoji, reacted }: ReactionToggle) => {
+      if (reacted) {
+        await annotationsApi.unreactFromAnnotation({ annotationId, emoji });
+      } else {
+        await annotationsApi.reactToAnnotation({ annotationId, emoji });
+      }
+    },
+    onMutate: async ({ emoji }: ReactionToggle) => {
+      await queryClient.cancelQueries({ queryKey: annotationKeys.all });
+      const snapshots = queryClient.getQueriesData<AnnotationListResponse>({
+        queryKey: annotationKeys.all,
+      });
+      snapshots.forEach(([key, data]) => {
+        if (!data?.annotations) return;
+        queryClient.setQueryData<AnnotationListResponse>(key, {
+          ...data,
+          annotations: data.annotations.map((annotation: AnnotationView) =>
+            annotation.id === annotationId
+              ? {
+                  ...annotation,
+                  reactions: toggleReactionGroup(annotation.reactions, emoji, viewerName),
+                }
+              : annotation,
+          ),
+        });
+      });
+      return { snapshots };
+    },
+    onError: (error, _toggle, context) => {
+      context?.snapshots.forEach(([key, data]) => queryClient.setQueryData(key, data));
+      notifyToggleError(error, notify);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: annotationKeys.all });
+    },
+  });
+}
+
+/**
+ * Toggles the viewer's emoji reaction on a comment (issue #410) — the same
+ * optimistic flip against the annotation's cached thread.
+ */
+export function useToggleCommentReaction(annotationId: string, notify: Notify) {
+  const queryClient = useQueryClient();
+  const viewerName = useAuthStore((state) => state.displayName) ?? 'You';
+  return useMutation({
+    mutationFn: async ({ commentId, emoji, reacted }: ReactionToggle & { commentId: string }) => {
+      if (reacted) {
+        await annotationsApi.unreactFromComment({ commentId, emoji });
+      } else {
+        await annotationsApi.reactToComment({ commentId, emoji });
+      }
+    },
+    onMutate: async ({ commentId, emoji }) => {
+      const key = commentKeys.list(annotationId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const snapshot = queryClient.getQueryData<CommentListResponse>(key);
+      if (snapshot?.comments) {
+        queryClient.setQueryData<CommentListResponse>(key, {
+          ...snapshot,
+          comments: snapshot.comments.map((comment) =>
+            comment.id === commentId
+              ? {
+                  ...comment,
+                  reactions: toggleReactionGroup(comment.reactions, emoji, viewerName),
+                }
+              : comment,
+          ),
+        });
+      }
+      return { snapshot, key };
+    },
+    onError: (error, _toggle, context) => {
+      if (context) queryClient.setQueryData(context.key, context.snapshot);
+      notifyToggleError(error, notify);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(annotationId) });
+    },
+  });
+}

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
@@ -48,6 +48,7 @@ const annotation = (id: string, overrides: Partial<AnnotationView> = {}): Annota
   priority: AnnotationPriority.High,
   firstComment: `first comment of ${id}`,
   commentCount: 1,
+  reactions: [],
   createdAt: '2026-07-01T10:00:00Z',
   updatedAt: '2026-07-01T10:00:00Z',
   ...overrides,

--- a/qnop-ui/src/components/reviews/tasks/tasksModel.test.ts
+++ b/qnop-ui/src/components/reviews/tasks/tasksModel.test.ts
@@ -36,6 +36,7 @@ const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => 
   },
   firstComment: 'Please extend the payment target',
   commentCount: 1,
+  reactions: [],
   createdAt: '2026-07-01T10:00:00Z',
   updatedAt: '2026-07-01T10:00:00Z',
   ...overrides,

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.test.tsx
@@ -44,6 +44,7 @@ const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => 
     textQuote: { quote: 'quoted text' },
   },
   commentCount: 3,
+  reactions: [],
   createdAt: '2026-07-01T10:00:00Z',
   updatedAt: '2026-07-01T10:00:00Z',
   ...overrides,

--- a/qnop-ui/src/components/reviews/viewer/HighlightLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/HighlightLayer.test.tsx
@@ -65,6 +65,7 @@ const annotation = (
     textQuote: { quote: 'the quoted passage' },
   },
   commentCount: 1,
+  reactions: [],
   createdAt: '2026-07-01T10:00:00Z',
   updatedAt: '2026-07-01T10:00:00Z',
 });

--- a/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
+++ b/qnop-ui/src/components/reviews/viewer/anchoring.test.ts
@@ -350,6 +350,7 @@ describe('compareAnnotationsByPosition', () => {
     authorId: 'u1',
     status: AnnotationStatus.Open,
     commentCount: 0,
+    reactions: [],
     createdAt,
     updatedAt: createdAt,
     ...(region && {

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -21,6 +21,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView, RenderedSurface } from '../../api/generated';
@@ -38,6 +39,10 @@ import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotati
 import { useComments } from '../../api/hooks/useComments';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import { useAuthStore } from '../../stores/authStore';
+
+// The reaction toggles (issue #410) reach for the query client; the data
+// hooks above stay mocked, so a bare client per file is all the tests need.
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 vi.mock('../../api/hooks/useDocuments', () => ({
   useDocument: vi.fn(),
@@ -127,6 +132,7 @@ const ANNOTATIONS: AnnotationView[] = [
       textQuote: { quote: 'Hello' },
     },
     commentCount: 0,
+    reactions: [],
     createdAt: '2026-07-01T10:00:00Z',
     updatedAt: '2026-07-01T10:00:00Z',
   },
@@ -179,13 +185,15 @@ function seedHappyPath(extractionStatus: ExtractionStatus = ExtractionStatus.Rea
 
 function renderPage(initialEntry = '/reviews/doc-1') {
   render(
-    <ThemeProvider theme={buildTheme('light')}>
-      <MemoryRouter initialEntries={[initialEntry]}>
-        <Routes>
-          <Route path="/reviews/:documentId" element={<DocumentReviewPage />} />
-        </Routes>
-      </MemoryRouter>
-    </ThemeProvider>,
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path="/reviews/:documentId" element={<DocumentReviewPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
   );
 }
 

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -21,6 +21,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView } from '../../api/generated';
@@ -36,6 +37,10 @@ import { useParticipants } from '../../api/hooks/useReviews';
 import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';
 import { ReviewTasksPage } from './ReviewTasksPage';
+
+// The reaction toggles (issue #410) reach for the query client; the data
+// hooks above stay mocked, so a bare client per file is all the tests need.
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 vi.mock('../../api/hooks/useDocuments', () => ({
   useDocument: vi.fn(),
@@ -73,6 +78,7 @@ const annotation = (id: string, overrides: Partial<AnnotationView> = {}): Annota
   priority: AnnotationPriority.High,
   firstComment: `Concern ${id}`,
   commentCount: 1,
+  reactions: [],
   createdAt: '2026-07-01T10:00:00Z',
   updatedAt: '2026-07-01T10:00:00Z',
   ...overrides,
@@ -104,14 +110,16 @@ function mockData() {
 
 function renderPage(initialEntry = '/reviews/d1/tasks') {
   render(
-    <ThemeProvider theme={buildTheme('light')}>
-      <MemoryRouter initialEntries={[initialEntry]}>
-        <Routes>
-          <Route path="/reviews/:documentId/tasks" element={<ReviewTasksPage />} />
-          <Route path="/reviews/:documentId" element={<div data-testid="review-page" />} />
-        </Routes>
-      </MemoryRouter>
-    </ThemeProvider>,
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path="/reviews/:documentId/tasks" element={<ReviewTasksPage />} />
+            <Route path="/reviews/:documentId" element={<div data-testid="review-page" />} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
   );
 }
 


### PR DESCRIPTION
## Summary

Implements #410 in its widened scope: not plain likes but **Slack-style emoji reactions** — any emoji, grouped chips with counts, hover reveals who reacted — on annotations **and** comments, across all three thread surfaces (panel, focus card, task drawer).

### Model & API
- `reaction` relation (Liquibase `0015`): `annotation_id` XOR `comment_id` (CHECK), `user_id`, `emoji`, `created_at`; **partial unique indexes** enforce one reaction per user per emoji per target while allowing several distinct emojis per user.
- OpenAPI-first (ADR-0021): idempotent toggle pairs `PUT`/`DELETE /annotations/{id}/reactions/{emoji}` and `/comments/{id}/reactions/{emoji}`, the emoji URL-encoded in the path (ZWJ families covered by an IT).
- `reactions: [{ emoji, count, reactedByMe, reactors }]` batched onto `AnnotationView` and `CommentView` (#313 aggregation pattern, no N+1); reactor names resolved through the review identities, honouring per-review anonymity (#413).
- Rules: participants only (404 anti-enumeration); RESOLVED annotations stay reactable — a reaction is not a discussion contribution; FINALIZED/CANCELLED reviews refuse with `REVIEW_CLOSED`. Emoji validated server-side (≤32 chars, no whitespace/control characters, at least one non-ASCII code point — keycaps like 1️⃣ pass, prose does not).
- Grouping and validation are DB-free pure code in `ReactionService`, unit-tested on their own (guardrail from CLAUDE.md).

### UI
- `ReactionBar`: Slack-style pill chips (emoji + tabular count), the viewer's own reactions accented in brand blue, tooltip lists the reactors, click toggles. Trailing dashed "+" chip for follow-up emojis; the FIRST reaction comes from a smiley-plus in the hover cluster next to the copy-link — on comment rows and the annotation head alike.
- Optimistic toggle with snapshot rollback and a `REVIEW_CLOSED` toast; annotation flips patch the annotation list caches only, never the document detail with its PDF binaries (#403 lesson).
- The emoji picker is now a shared lazy `EmojiPickerPopover` (composer button + both reaction affordances). Fixed along the way: clicks inside the picker's portal bubbled through the React tree into the hosting annotation card's ButtonBase and collapsed it — the popover now stops propagation.

## Test plan
- [x] Backend: `./gradlew build` (Spotless, ArchUnit); `ReactionServiceTest` (grouping order/counts/own-state, emoji validation incl. keycaps & ZWJ); `ReactionApiIT` — 7 tests: PUT/DELETE idempotency, cross-user grouping with reactor names, comment reactions batched on the thread, ZWJ emoji through the URL path, RESOLVED reactable, FINALIZED → 409 `REVIEW_CLOSED`, non-participant → 404, prose → 400
- [x] Frontend: 722 tests (`ReactionBar` chips/toggle/empty-state, `toggleReactionGroup` optimistic flip incl. immutability), `pnpm lint`, `pnpm typecheck`
- [x] Browser E2E on the dev stack: add via picker (persisted), toggle off via chip (persisted), two-user grouping ("👍 2", accented), comment chip "🎉 1", reactor tooltip

Closes #410.

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)