### PR TITLE
feat(dashboard): the review command centre (#454)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1503,6 +1503,40 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '429':
           $ref: '#/components/responses/TooManyRequests'
+  /users/{userId}:
+    get:
+      tags:
+        - Users
+      summary: A user's workspace-public profile
+      description: |
+        The lean slice any signed-in user may see about a colleague (issue
+        #454): display name, avatar and tenure — no email, role or source.
+        Backs the profile links on dashboards and review surfaces.
+      operationId: getUserProfile
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The user's public profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicUserProfile'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /users/me:
     get:
       tags:
@@ -3379,6 +3413,25 @@ components:
       enum:
         - INTERNAL
         - EXTERNAL
+    PublicUserProfile:
+      type: object
+      description: The workspace-public slice of a user (issue #454).
+      required:
+        - id
+        - displayName
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        displayName:
+          type: string
+        avatarUrl:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
     CurrentUserResponse:
       type: object
       description: The authenticated user's own profile.
@@ -4049,6 +4102,18 @@ components:
         documentSlug:
           type: string
           nullable: true
+        authorId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            The author's REAL user id — null when the review anonymises this
+            author towards the caller (issue #413); the client links and loads
+            avatars only when present.
+        authorAvatarUrl:
+          type: string
+          nullable: true
+          description: The author's avatar URL, when identifiable and uploaded.
         authorDisplayName:
           type: string
           nullable: true
@@ -4086,6 +4151,15 @@ components:
         documentSlug:
           type: string
           nullable: true
+        actorId:
+          type: string
+          format: uuid
+          nullable: true
+          description: The actor's REAL user id — null when anonymised (issue #413).
+        actorAvatarUrl:
+          type: string
+          nullable: true
+          description: The actor's avatar URL, when identifiable and uploaded.
         actorDisplayName:
           type: string
           nullable: true

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1689,6 +1689,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /dashboard:
+    get:
+      tags: [Dashboard]
+      summary: The caller's dashboard aggregates
+      description: |
+        The cross-review aggregates of the command-centre dashboard (issue
+        #454): the latest replies by others in threads the caller started or
+        joined, the recent activity of their reviews (from the audit trail),
+        and the weekly resolved count. Everything per-review (state, progress,
+        participants, due date) already travels on `GET /documents` — a client
+        renders the whole dashboard from those two calls. Names honour
+        per-review anonymity (issue #413); annotation activity of a
+        PRIVATE-participation review is shown only to its owner.
+      operationId: getDashboard
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The dashboard aggregates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /documents:
     get:
       tags:
@@ -3995,6 +4020,103 @@ components:
       required:
         - field
         - message
+    DashboardReply:
+      type: object
+      description: >-
+        One reply by someone else in a thread the caller started or joined
+        (issue #454), newest first. `annotationExcerpt` is the thread's opening
+        line for context; `authorDisplayName` is resolved server-side,
+        honouring per-review anonymity (issue #413).
+      required:
+        - commentId
+        - annotationId
+        - documentId
+        - documentTitle
+        - body
+        - createdAt
+      properties:
+        commentId:
+          type: string
+          format: uuid
+        annotationId:
+          type: string
+          format: uuid
+        documentId:
+          type: string
+          format: uuid
+        documentTitle:
+          type: string
+        documentSlug:
+          type: string
+          nullable: true
+        authorDisplayName:
+          type: string
+          nullable: true
+        body:
+          type: string
+          description: The reply, excerpted for the card.
+        annotationExcerpt:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+    DashboardActivity:
+      type: object
+      description: >-
+        One feed entry from the audit trail of the caller's reviews (issue
+        #454) — the caller's own actions are excluded.
+      required:
+        - type
+        - documentId
+        - documentTitle
+        - createdAt
+      properties:
+        type:
+          type: string
+          description: >-
+            The audit event type — annotation.created, annotation.resolved,
+            annotation.reopened, workflow.transition or
+            document.due_date.changed.
+        documentId:
+          type: string
+          format: uuid
+        documentTitle:
+          type: string
+        documentSlug:
+          type: string
+          nullable: true
+        actorDisplayName:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+    DashboardStats:
+      type: object
+      required:
+        - resolvedThisWeek
+      properties:
+        resolvedThisWeek:
+          type: integer
+          description: Annotations resolved across the caller's reviews in the last 7 days.
+    DashboardResponse:
+      type: object
+      required:
+        - replies
+        - activity
+        - stats
+      properties:
+        replies:
+          type: array
+          items:
+            $ref: '#/components/schemas/DashboardReply'
+        activity:
+          type: array
+          items:
+            $ref: '#/components/schemas/DashboardActivity'
+        stats:
+          $ref: '#/components/schemas/DashboardStats'
     DocumentSummary:
       type: object
       description: One document in the caller's reviews overview (issue #292).

--- a/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
@@ -22,13 +22,19 @@ package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.UsersApi;
 import io.qnop.api.v1.model.CurrentUserResponse;
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.api.v1.model.PublicUserProfile;
 import io.qnop.api.v1.model.UserRole;
 import io.qnop.api.v1.model.UserSource;
+import io.qnop.service.UserNotFoundException;
 import io.qnop.service.UserService;
+import io.qnop.service.UserService.PublicUserProfileView;
 import io.qnop.service.UserService.UserProfileView;
 import io.qnop.service.avatar.AvatarService;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -60,5 +66,23 @@ public class CurrentUserController implements UsersApi {
             .role(UserRole.fromValue(profile.role()))
             .source(UserSource.fromValue(profile.source()))
             .avatarUrl(AvatarUrls.forUser(userId, avatars.updatedAt(userId).orElse(null))));
+  }
+
+  @Override
+  public ResponseEntity<PublicUserProfile> getUserProfile(UUID userId) {
+    CurrentUser.requireUserId(); // signed-in colleagues only, any role
+    PublicUserProfileView profile = users.getPublicProfile(userId);
+    return ResponseEntity.ok(
+        new PublicUserProfile()
+            .id(profile.id())
+            .displayName(profile.displayName())
+            .avatarUrl(AvatarUrls.forUser(userId, avatars.updatedAt(userId).orElse(null)))
+            .createdAt(profile.createdAt().atOffset(java.time.ZoneOffset.UTC)));
+  }
+
+  @ExceptionHandler(UserNotFoundException.class)
+  public ResponseEntity<ErrorResponse> onUserNotFound(UserNotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(new ErrorResponse().code("USER_NOT_FOUND").message("No such user."));
   }
 }

--- a/qnop-app/src/main/java/io/qnop/web/DashboardController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DashboardController.java
@@ -25,8 +25,10 @@ import io.qnop.api.v1.model.DashboardActivity;
 import io.qnop.api.v1.model.DashboardReply;
 import io.qnop.api.v1.model.DashboardResponse;
 import io.qnop.api.v1.model.DashboardStats;
+import io.qnop.service.avatar.AvatarService;
 import io.qnop.service.review.DashboardService;
 import java.time.ZoneOffset;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,9 +40,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class DashboardController implements DashboardApi {
 
   private final DashboardService dashboard;
+  private final AvatarService avatars;
 
-  public DashboardController(DashboardService dashboard) {
+  public DashboardController(DashboardService dashboard, AvatarService avatars) {
     this.dashboard = dashboard;
+    this.avatars = avatars;
   }
 
   @Override
@@ -48,31 +52,43 @@ public class DashboardController implements DashboardApi {
     DashboardService.DashboardView view = dashboard.overview(CurrentUser.requireUserId());
     return ResponseEntity.ok(
         new DashboardResponse()
-            .replies(view.replies().stream().map(DashboardController::toDto).toList())
-            .activity(view.activity().stream().map(DashboardController::toDto).toList())
+            .replies(view.replies().stream().map(this::toDto).toList())
+            .activity(view.activity().stream().map(this::toDto).toList())
             .stats(new DashboardStats().resolvedThisWeek(view.resolvedThisWeek())));
   }
 
-  private static DashboardReply toDto(DashboardService.ReplyView view) {
+  private DashboardReply toDto(DashboardService.ReplyView view) {
     return new DashboardReply()
         .commentId(view.commentId())
         .annotationId(view.annotationId())
         .documentId(view.documentId())
         .documentTitle(view.documentTitle())
         .documentSlug(view.documentSlug())
+        .authorId(view.authorId())
+        .authorAvatarUrl(avatarUrlOf(view.authorId()))
         .authorDisplayName(view.authorDisplayName())
         .body(view.body())
         .annotationExcerpt(view.annotationExcerpt())
         .createdAt(view.createdAt().atOffset(ZoneOffset.UTC));
   }
 
-  private static DashboardActivity toDto(DashboardService.ActivityView view) {
+  private DashboardActivity toDto(DashboardService.ActivityView view) {
     return new DashboardActivity()
         .type(view.type())
         .documentId(view.documentId())
         .documentTitle(view.documentTitle())
         .documentSlug(view.documentSlug())
+        .actorId(view.actorId())
+        .actorAvatarUrl(avatarUrlOf(view.actorId()))
         .actorDisplayName(view.actorDisplayName())
         .createdAt(view.createdAt().atOffset(ZoneOffset.UTC));
+  }
+
+  /** Null for anonymised identities (no id) and for users without an uploaded avatar. */
+  private String avatarUrlOf(UUID userId) {
+    if (userId == null) {
+      return null;
+    }
+    return AvatarUrls.forUser(userId, avatars.updatedAt(userId).orElse(null));
   }
 }

--- a/qnop-app/src/main/java/io/qnop/web/DashboardController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DashboardController.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.DashboardApi;
+import io.qnop.api.v1.model.DashboardActivity;
+import io.qnop.api.v1.model.DashboardReply;
+import io.qnop.api.v1.model.DashboardResponse;
+import io.qnop.api.v1.model.DashboardStats;
+import io.qnop.service.review.DashboardService;
+import java.time.ZoneOffset;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The dashboard's cross-review aggregates (issue #454), implementing the generated {@link
+ * DashboardApi} contract — a thin mapping over {@link DashboardService}.
+ */
+@RestController
+public class DashboardController implements DashboardApi {
+
+  private final DashboardService dashboard;
+
+  public DashboardController(DashboardService dashboard) {
+    this.dashboard = dashboard;
+  }
+
+  @Override
+  public ResponseEntity<DashboardResponse> getDashboard() {
+    DashboardService.DashboardView view = dashboard.overview(CurrentUser.requireUserId());
+    return ResponseEntity.ok(
+        new DashboardResponse()
+            .replies(view.replies().stream().map(DashboardController::toDto).toList())
+            .activity(view.activity().stream().map(DashboardController::toDto).toList())
+            .stats(new DashboardStats().resolvedThisWeek(view.resolvedThisWeek())));
+  }
+
+  private static DashboardReply toDto(DashboardService.ReplyView view) {
+    return new DashboardReply()
+        .commentId(view.commentId())
+        .annotationId(view.annotationId())
+        .documentId(view.documentId())
+        .documentTitle(view.documentTitle())
+        .documentSlug(view.documentSlug())
+        .authorDisplayName(view.authorDisplayName())
+        .body(view.body())
+        .annotationExcerpt(view.annotationExcerpt())
+        .createdAt(view.createdAt().atOffset(ZoneOffset.UTC));
+  }
+
+  private static DashboardActivity toDto(DashboardService.ActivityView view) {
+    return new DashboardActivity()
+        .type(view.type())
+        .documentId(view.documentId())
+        .documentTitle(view.documentTitle())
+        .documentSlug(view.documentSlug())
+        .actorDisplayName(view.actorDisplayName())
+        .createdAt(view.createdAt().atOffset(ZoneOffset.UTC));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/DashboardApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DashboardApiIT.java
@@ -117,9 +117,12 @@ class DashboardApiIT extends SeededIntegrationTest {
         .andExpect(jsonPath("$.replies[0].body").value("after I joined"))
         .andExpect(jsonPath("$.replies[0].annotationExcerpt").value("their concern"))
         .andExpect(jsonPath("$.replies[0].documentTitle").value("Master services agreement"))
-        // …then the reply on my own annotation.
+        // …then the reply on my own annotation — with the author's REAL id and
+        // name (this review is not anonymous, issue #413/#454).
         .andExpect(jsonPath("$.replies[1].body").value("will do"))
-        .andExpect(jsonPath("$.replies[1].annotationId").value(mine));
+        .andExpect(jsonPath("$.replies[1].annotationId").value(mine))
+        .andExpect(jsonPath("$.replies[1].authorId").value(AUDITOR_ID.toString()))
+        .andExpect(jsonPath("$.replies[1].authorDisplayName").value("Avery Auditor"));
   }
 
   @Test
@@ -145,6 +148,7 @@ class DashboardApiIT extends SeededIntegrationTest {
         // Newest first: MEMBER's resolve, then MEMBER's creation — AUDITOR's own
         // annotation.created is filtered out.
         .andExpect(jsonPath("$.activity[0].type").value("annotation.resolved"))
+        .andExpect(jsonPath("$.activity[0].actorId").value(MEMBER_ID.toString()))
         .andExpect(jsonPath("$.activity[0].actorDisplayName").value("Mia Member"));
 
     mockMvc

--- a/qnop-app/src/test/java/io/qnop/review/DashboardApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DashboardApiIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * The dashboard aggregates over the wire (issue #454): replies directed at the caller (their own
+ * comments never among them), the activity feed excluding the caller's own actions, the weekly
+ * resolved stat, and clean empty states for a user without reviews.
+ */
+class DashboardApiIT extends SeededIntegrationTest {
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+
+  private UUID seedDocumentWithVersion() {
+    Document document = documents.save(new Document(MEMBER_ID, "Master services agreement"));
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
+    versions.save(
+        new DocumentVersion(
+            document.getId(),
+            1,
+            "sha256/aa/deadbeef",
+            "deadbeef",
+            "application/pdf",
+            1234L,
+            MEMBER_ID));
+    return document.getId();
+  }
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  private String createAnnotation(UUID documentId, UUID actor, String comment) throws Exception {
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), actor)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"versionNumber\":1,\"comment\":\"" + comment + "\"}"))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return JsonPath.read(json, "$.id");
+  }
+
+  private void addComment(String annotationId, UUID actor, String body) throws Exception {
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/comments"), actor)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"" + body + "\"}"))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  @DisplayName("surfaces replies by others on my threads, with document context and author name")
+  void repliesToMe() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String mine = createAnnotation(documentId, MEMBER_ID, "please clarify");
+    addComment(mine, AUDITOR_ID, "will do");
+    addComment(mine, MEMBER_ID, "thanks"); // own comment — never a reply to me
+    // A foreign thread I joined: replies AFTER my comment count, earlier ones do not.
+    String theirs = createAnnotation(documentId, AUDITOR_ID, "their concern");
+    addComment(theirs, MEMBER2_ID, "before I joined");
+    addComment(theirs, MEMBER_ID, "joining in");
+    addComment(theirs, MEMBER2_ID, "after I joined");
+
+    mockMvc
+        .perform(as(get("/api/v1/dashboard"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.replies", hasSize(2)))
+        // Newest first: the reply after my comment in the foreign thread…
+        .andExpect(jsonPath("$.replies[0].body").value("after I joined"))
+        .andExpect(jsonPath("$.replies[0].annotationExcerpt").value("their concern"))
+        .andExpect(jsonPath("$.replies[0].documentTitle").value("Master services agreement"))
+        // …then the reply on my own annotation.
+        .andExpect(jsonPath("$.replies[1].body").value("will do"))
+        .andExpect(jsonPath("$.replies[1].annotationId").value(mine));
+  }
+
+  @Test
+  @DisplayName("feeds recent activity excluding my own actions, and counts this week's resolves")
+  void activityAndStats() throws Exception {
+    UUID documentId = seedDocumentWithVersion();
+    String mine = createAnnotation(documentId, MEMBER_ID, "please clarify");
+    createAnnotation(documentId, AUDITOR_ID, "a second concern");
+    // The author resolves their annotation — MEMBER's feed carries it, MEMBER's
+    // own creation is absent; the weekly stat counts the resolve for everyone.
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + mine + "/resolve"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(as(get("/api/v1/dashboard"), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.stats.resolvedThisWeek").value(1))
+        .andExpect(jsonPath("$.activity", hasSize(greaterThanOrEqualTo(2))))
+        // Newest first: MEMBER's resolve, then MEMBER's creation — AUDITOR's own
+        // annotation.created is filtered out.
+        .andExpect(jsonPath("$.activity[0].type").value("annotation.resolved"))
+        .andExpect(jsonPath("$.activity[0].actorDisplayName").value("Mia Member"));
+
+    mockMvc
+        .perform(as(get("/api/v1/dashboard"), MEMBER_ID))
+        .andExpect(status().isOk())
+        // MEMBER sees AUDITOR's creation but none of their own actions.
+        .andExpect(jsonPath("$.activity", hasSize(1)))
+        .andExpect(jsonPath("$.activity[0].type").value("annotation.created"));
+  }
+
+  @Test
+  @DisplayName("a user without reviews gets clean empty aggregates")
+  void emptyDashboard() throws Exception {
+    mockMvc
+        .perform(as(get("/api/v1/dashboard"), EXTERNAL_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.replies", hasSize(0)))
+        .andExpect(jsonPath("$.activity", hasSize(0)))
+        .andExpect(jsonPath("$.stats.resolvedThisWeek").value(0));
+  }
+
+  @Test
+  @DisplayName("requires authentication")
+  void requiresAuth() throws Exception {
+    mockMvc.perform(get("/api/v1/dashboard")).andExpect(status().isUnauthorized());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/UserProfileApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/UserProfileApiIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The workspace-public user profile (issue #454): any signed-in user sees a colleague's display
+ * name and tenure — never email, role or source — and unknown ids answer 404.
+ */
+class UserProfileApiIT extends SeededIntegrationTest {
+
+  @Test
+  @DisplayName("serves a colleague's lean profile to any signed-in user")
+  void servesLeanProfile() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/users/" + MEMBER_ID)
+                .header("Authorization", "Bearer " + token(AUDITOR_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(MEMBER_ID.toString()))
+        .andExpect(jsonPath("$.displayName").value("Mia Member"))
+        .andExpect(jsonPath("$.createdAt").exists())
+        // The lean slice: nothing beyond name, avatar and tenure.
+        .andExpect(jsonPath("$.email").doesNotExist())
+        .andExpect(jsonPath("$.role").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("answers 404 for an unknown user and 401 unauthenticated")
+  void guards() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/users/" + UUID.randomUUID())
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isNotFound());
+    mockMvc.perform(get("/api/v1/users/" + MEMBER_ID)).andExpect(status().isUnauthorized());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/AuditEventRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/AuditEventRepository.java
@@ -21,8 +21,11 @@
 package io.qnop.repository;
 
 import io.qnop.entity.AuditEvent;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** Data access for the append-only per-document audit trail (issue #244, ADR-0011). */
@@ -30,4 +33,12 @@ public interface AuditEventRepository extends JpaRepository<AuditEvent, UUID> {
 
   /** A document's audit trail, most recent first. */
   List<AuditEvent> findByDocumentIdOrderByCreatedAtDesc(UUID documentId);
+
+  /** The newest events of the given types across a set of documents (issue #454). */
+  List<AuditEvent> findByDocumentIdInAndEventTypeInOrderByCreatedAtDesc(
+      Collection<UUID> documentIds, Collection<String> eventTypes, Pageable pageable);
+
+  /** How many events of one type landed after {@code since} (issue #454's weekly stat). */
+  long countByDocumentIdInAndEventTypeAndCreatedAtAfter(
+      Collection<UUID> documentIds, String eventType, Instant since);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -89,4 +90,21 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
           + " FROM Comment c WHERE c.annotationId IN :annotationIds GROUP BY c.annotationId")
   List<AnnotationCommentCount> countByAnnotationIdIn(
       @Param("annotationIds") Collection<UUID> annotationIds);
+
+  /**
+   * Replies directed at {@code viewer} for the dashboard (issue #454): comments by OTHERS on
+   * annotations the viewer authored, or later than the viewer's own comment in threads they joined.
+   * Newest first; the caller caps via {@code pageable}.
+   */
+  @Query(
+      "SELECT c FROM Comment c, Annotation a WHERE a.id = c.annotationId"
+          + " AND a.documentId IN :documentIds AND c.authorId <> :viewer"
+          + " AND (a.authorId = :viewer OR EXISTS (SELECT 1 FROM Comment mine"
+          + "   WHERE mine.annotationId = c.annotationId AND mine.authorId = :viewer"
+          + "   AND mine.createdAt < c.createdAt))"
+          + " ORDER BY c.createdAt DESC")
+  List<Comment> repliesToViewer(
+      @Param("documentIds") Collection<UUID> documentIds,
+      @Param("viewer") UUID viewer,
+      Pageable pageable);
 }

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -104,6 +104,21 @@ public class UserService {
   public record UserProfileView(
       UUID id, String displayName, String email, String role, String source) {}
 
+  /**
+   * The lean, workspace-public slice of a user (issue #454): what any signed-in user may see about
+   * a colleague — display name and tenure, nothing more (no email, role or source).
+   */
+  @Transactional(readOnly = true)
+  public PublicUserProfileView getPublicProfile(UUID id) {
+    return users
+        .findById(id)
+        .map(u -> new PublicUserProfileView(u.getId(), u.getDisplayName(), u.getCreatedAt()))
+        .orElseThrow(() -> new UserNotFoundException(id));
+  }
+
+  /** The public slice served by {@code GET /users/{userId}} (issue #454). */
+  public record PublicUserProfileView(UUID id, String displayName, Instant createdAt) {}
+
   /** Activates a user after successful email verification. */
   @Transactional
   public User enable(UUID id) {

--- a/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
@@ -96,24 +96,30 @@ public class DashboardService {
     this.identity = identity;
   }
 
-  /** One reply by someone else in a thread the caller started or joined. */
+  /**
+   * One reply by someone else in a thread the caller started or joined. {@code authorId} is the
+   * REAL user id when the review does not anonymise the author towards the caller, and null for a
+   * pseudonymised identity (issue #413) — the client links and loads avatars only when present.
+   */
   public record ReplyView(
       UUID commentId,
       UUID annotationId,
       UUID documentId,
       String documentTitle,
       String documentSlug,
+      UUID authorId,
       String authorDisplayName,
       String body,
       String annotationExcerpt,
       Instant createdAt) {}
 
-  /** One feed entry from the audit trail of the caller's reviews. */
+  /** One feed entry from the audit trail; {@code actorId} follows the same anonymity rule. */
   public record ActivityView(
       String type,
       UUID documentId,
       String documentTitle,
       String documentSlug,
+      UUID actorId,
       String actorDisplayName,
       Instant createdAt) {}
 
@@ -173,13 +179,16 @@ public class DashboardService {
             comment -> {
               Annotation annotation = annotationById.get(comment.getAnnotationId());
               Document document = documentById.get(annotation.getDocumentId());
+              ReviewIdentityResolver.ReviewIdentities documentIdentities =
+                  identitiesOf.apply(document.getId());
               return new ReplyView(
                   comment.getId(),
                   comment.getAnnotationId(),
                   document.getId(),
                   document.getTitle(),
                   document.getSlug(),
-                  identitiesOf.apply(document.getId()).displayName(comment.getAuthorId()),
+                  realIdOrNull(documentIdentities, comment.getAuthorId()),
+                  documentIdentities.displayName(comment.getAuthorId()),
                   excerpt(comment.getBody(), REPLY_EXCERPT_CHARS),
                   contextByAnnotation.get(comment.getAnnotationId()),
                   comment.getCreatedAt());
@@ -203,6 +212,8 @@ public class DashboardService {
         .map(
             event -> {
               Document document = documentById.get(event.getDocumentId());
+              ReviewIdentityResolver.ReviewIdentities documentIdentities =
+                  identitiesOf.apply(document.getId());
               return new ActivityView(
                   event.getEventType(),
                   document.getId(),
@@ -210,7 +221,10 @@ public class DashboardService {
                   document.getSlug(),
                   event.getActorId() == null
                       ? null
-                      : identitiesOf.apply(document.getId()).displayName(event.getActorId()),
+                      : realIdOrNull(documentIdentities, event.getActorId()),
+                  event.getActorId() == null
+                      ? null
+                      : documentIdentities.displayName(event.getActorId()),
                   event.getCreatedAt());
             })
         .toList();
@@ -229,6 +243,16 @@ public class DashboardService {
       return true;
     }
     return document.getOwnerId().equals(actor);
+  }
+
+  /**
+   * The id the caller may see: the real user id when the identities expose it unchanged, null when
+   * the review pseudonymises this author towards the caller (issue #413) — a pseudonym token must
+   * neither link to a profile nor load an avatar.
+   */
+  private static UUID realIdOrNull(
+      ReviewIdentityResolver.ReviewIdentities identities, UUID userId) {
+    return userId.equals(identities.exposedAuthorId(userId)) ? userId : null;
   }
 
   private static String excerpt(String body, int max) {

--- a/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static java.util.stream.Collectors.toMap;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.Comment;
+import io.qnop.entity.Document;
+import io.qnop.entity.ThreadParticipation;
+import io.qnop.repository.AnnotationFirstComment;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.DocumentRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The dashboard's cross-review aggregates (issue #454): replies directed at the caller, the recent
+ * activity of their reviews, and the weekly resolved count. Everything the per-review cards need
+ * already travels on the documents overview (issue #292) — this service only adds what no existing
+ * endpoint answers, in a bounded number of queries (#313 spirit: batch, never per-review).
+ *
+ * <p>Names honour per-review anonymity (issue #413) by resolving through each document's {@link
+ * ReviewIdentityResolver.ReviewIdentities}. Activity on PRIVATE-participation reviews follows the
+ * thread-visibility rule conservatively: annotation events of such a review are shown only to its
+ * owner (payloads stay unparsed, so per-thread filtering is out of reach — hiding is the safe
+ * default; the caller's own events are excluded anyway).
+ */
+@Service
+public class DashboardService {
+
+  /** The dashboard is a glance, not an archive. */
+  static final int MAX_REPLIES = 15;
+
+  static final int MAX_ACTIVITY = 20;
+  static final int REPLY_EXCERPT_CHARS = 240;
+  static final int CONTEXT_EXCERPT_CHARS = 120;
+
+  /** Documents considered for the aggregates — far above any real workspace. */
+  static final int MAX_DOCUMENTS = 200;
+
+  static final List<String> FEED_EVENT_TYPES =
+      List.of(
+          "annotation.created",
+          "annotation.resolved",
+          "annotation.reopened",
+          "workflow.transition",
+          "document.due_date.changed");
+
+  private final DocumentRepository documents;
+  private final AnnotationRepository annotations;
+  private final CommentRepository comments;
+  private final AuditEventRepository auditEvents;
+  private final ReviewIdentityResolver identity;
+
+  public DashboardService(
+      DocumentRepository documents,
+      AnnotationRepository annotations,
+      CommentRepository comments,
+      AuditEventRepository auditEvents,
+      ReviewIdentityResolver identity) {
+    this.documents = documents;
+    this.annotations = annotations;
+    this.comments = comments;
+    this.auditEvents = auditEvents;
+    this.identity = identity;
+  }
+
+  /** One reply by someone else in a thread the caller started or joined. */
+  public record ReplyView(
+      UUID commentId,
+      UUID annotationId,
+      UUID documentId,
+      String documentTitle,
+      String documentSlug,
+      String authorDisplayName,
+      String body,
+      String annotationExcerpt,
+      Instant createdAt) {}
+
+  /** One feed entry from the audit trail of the caller's reviews. */
+  public record ActivityView(
+      String type,
+      UUID documentId,
+      String documentTitle,
+      String documentSlug,
+      String actorDisplayName,
+      Instant createdAt) {}
+
+  public record DashboardView(
+      List<ReplyView> replies, List<ActivityView> activity, int resolvedThisWeek) {}
+
+  @Transactional(readOnly = true)
+  public DashboardView overview(UUID actor) {
+    List<Document> visible =
+        documents
+            .findVisibleTo(actor, null, PageRequest.of(0, MAX_DOCUMENTS, Sort.by("updatedAt")))
+            .getContent();
+    if (visible.isEmpty()) {
+      return new DashboardView(List.of(), List.of(), 0);
+    }
+    Map<UUID, Document> documentById =
+        visible.stream().collect(toMap(Document::getId, document -> document));
+    List<UUID> documentIds = List.copyOf(documentById.keySet());
+    // Identities are resolved lazily per document and cached for this pass —
+    // replies and activity together touch a handful of reviews, not N.
+    Map<UUID, ReviewIdentityResolver.ReviewIdentities> identities = new HashMap<>();
+    Function<UUID, ReviewIdentityResolver.ReviewIdentities> identitiesOf =
+        documentId -> identities.computeIfAbsent(documentId, id -> identity.forDocument(id, actor));
+
+    List<ReplyView> replies = replies(documentIds, documentById, actor, identitiesOf);
+    List<ActivityView> activity = activity(documentIds, documentById, actor, identitiesOf);
+    int resolvedThisWeek =
+        (int)
+            auditEvents.countByDocumentIdInAndEventTypeAndCreatedAtAfter(
+                documentIds, "annotation.resolved", Instant.now().minus(Duration.ofDays(7)));
+    return new DashboardView(replies, activity, resolvedThisWeek);
+  }
+
+  private List<ReplyView> replies(
+      List<UUID> documentIds,
+      Map<UUID, Document> documentById,
+      UUID actor,
+      Function<UUID, ReviewIdentityResolver.ReviewIdentities> identitiesOf) {
+    List<Comment> latest =
+        comments.repliesToViewer(documentIds, actor, PageRequest.of(0, MAX_REPLIES));
+    if (latest.isEmpty()) {
+      return List.of();
+    }
+    List<UUID> annotationIds = latest.stream().map(Comment::getAnnotationId).distinct().toList();
+    Map<UUID, Annotation> annotationById =
+        annotations.findAllById(annotationIds).stream()
+            .collect(toMap(Annotation::getId, annotation -> annotation));
+    // The thread's opening line as context — batched like the views do (#393).
+    Map<UUID, String> contextByAnnotation =
+        comments.findFirstByAnnotationIdIn(annotationIds).stream()
+            .collect(
+                toMap(
+                    AnnotationFirstComment::getAnnotationId,
+                    first -> excerpt(first.getBody(), CONTEXT_EXCERPT_CHARS)));
+    return latest.stream()
+        .map(
+            comment -> {
+              Annotation annotation = annotationById.get(comment.getAnnotationId());
+              Document document = documentById.get(annotation.getDocumentId());
+              return new ReplyView(
+                  comment.getId(),
+                  comment.getAnnotationId(),
+                  document.getId(),
+                  document.getTitle(),
+                  document.getSlug(),
+                  identitiesOf.apply(document.getId()).displayName(comment.getAuthorId()),
+                  excerpt(comment.getBody(), REPLY_EXCERPT_CHARS),
+                  contextByAnnotation.get(comment.getAnnotationId()),
+                  comment.getCreatedAt());
+            })
+        .toList();
+  }
+
+  private List<ActivityView> activity(
+      List<UUID> documentIds,
+      Map<UUID, Document> documentById,
+      UUID actor,
+      Function<UUID, ReviewIdentityResolver.ReviewIdentities> identitiesOf) {
+    // Fetch beyond the cap: own events and PRIVATE-hidden ones are dropped below.
+    List<AuditEvent> events =
+        auditEvents.findByDocumentIdInAndEventTypeInOrderByCreatedAtDesc(
+            documentIds, FEED_EVENT_TYPES, PageRequest.of(0, MAX_ACTIVITY * 3));
+    return events.stream()
+        .filter(event -> !actor.equals(event.getActorId()))
+        .filter(event -> visibleActivity(event, documentById.get(event.getDocumentId()), actor))
+        .limit(MAX_ACTIVITY)
+        .map(
+            event -> {
+              Document document = documentById.get(event.getDocumentId());
+              return new ActivityView(
+                  event.getEventType(),
+                  document.getId(),
+                  document.getTitle(),
+                  document.getSlug(),
+                  event.getActorId() == null
+                      ? null
+                      : identitiesOf.apply(document.getId()).displayName(event.getActorId()),
+                  event.getCreatedAt());
+            })
+        .toList();
+  }
+
+  /**
+   * The PRIVATE-participation rule (#413), applied conservatively: annotation events of a PRIVATE
+   * review are shown only to its owner — the audit payload is not parsed, so per-thread visibility
+   * cannot be decided here and hiding is the safe default.
+   */
+  private static boolean visibleActivity(AuditEvent event, Document document, UUID actor) {
+    if (!event.getEventType().startsWith("annotation.")) {
+      return true;
+    }
+    if (document.getThreadParticipation() != ThreadParticipation.PRIVATE) {
+      return true;
+    }
+    return document.getOwnerId().equals(actor);
+  }
+
+  private static String excerpt(String body, int max) {
+    return body.length() <= max ? body : body.substring(0, max);
+  }
+}

--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -35,6 +35,7 @@ import {
   ReviewWorkflowApi,
   ServerConfigApi,
   UsersApi,
+  DashboardApi,
 } from './generated';
 import { performRefresh } from './refresh';
 import { useAuthStore } from '../stores/authStore';
@@ -97,6 +98,7 @@ export const adminSettingsApi = new AdminSettingsApi(undefined, undefined, axios
 export const adminOidcProvidersApi = new AdminOidcProvidersApi(undefined, undefined, axiosInstance);
 export const adminEmailApi = new AdminEmailApi(undefined, undefined, axiosInstance);
 export const documentsApi = new DocumentsApi(undefined, undefined, axiosInstance);
+export const dashboardApi = new DashboardApi(undefined, undefined, axiosInstance);
 export const annotationsApi = new AnnotationsApi(undefined, undefined, axiosInstance);
 export const principalsApi = new PrincipalsApi(undefined, undefined, axiosInstance);
 export const reviewWorkflowApi = new ReviewWorkflowApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useDashboard.ts
+++ b/qnop-ui/src/api/hooks/useDashboard.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import type { DashboardResponse } from '../generated';
+import { dashboardApi } from '../config';
+
+export const dashboardKeys = {
+  all: ['dashboard'] as const,
+};
+
+/**
+ * The dashboard's cross-review aggregates (issue #454): replies directed at
+ * the caller, recent activity, the weekly resolved count. Everything
+ * per-review comes from {@link useReviews} — together the dashboard is two
+ * requests, never a per-review fan-out.
+ */
+export function useDashboard() {
+  return useQuery<DashboardResponse>({
+    queryKey: dashboardKeys.all,
+    queryFn: async () => {
+      const response = await dashboardApi.getDashboard();
+      return response.data;
+    },
+  });
+}

--- a/qnop-ui/src/components/dashboard/ActivityCard.tsx
+++ b/qnop-ui/src/components/dashboard/ActivityCard.tsx
@@ -37,6 +37,7 @@ import Link from '@mui/material/Link';
 import type { DashboardActivity } from '../../api/generated';
 import { shortRelativeTime } from '../../utils/relativeTime';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { PersonLink } from './PersonLink';
 import { activityPhrase, reviewPath } from './dashboardModel';
 
 const TYPE_ICONS: Record<string, LucideIcon> = {
@@ -84,6 +85,15 @@ export function ActivityCard({ activity }: ActivityCardProps) {
                   sx={{ color: theme.palette.text.secondary, pt: 0.25, flexShrink: 0 }}
                 >
                   <Icon size={14} />
+                </Box>
+                <Box sx={{ pt: '1px', flexShrink: 0 }}>
+                  <PersonLink
+                    userId={item.actorId}
+                    name={item.actorDisplayName ?? 'Someone'}
+                    avatarUrl={item.actorAvatarUrl}
+                    size={20}
+                    avatarOnly
+                  />
                 </Box>
                 <Typography variant="body2" sx={{ minWidth: 0, color: 'text.secondary' }}>
                   <Typography

--- a/qnop-ui/src/components/dashboard/ActivityCard.tsx
+++ b/qnop-ui/src/components/dashboard/ActivityCard.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import {
+  Activity,
+  CalendarClock,
+  CircleCheck,
+  MessageSquarePlus,
+  RotateCcw,
+  Workflow,
+  type LucideIcon,
+} from 'lucide-react';
+import { Link as RouterLink } from 'react-router-dom';
+import Link from '@mui/material/Link';
+import type { DashboardActivity } from '../../api/generated';
+import { shortRelativeTime } from '../../utils/relativeTime';
+import { SectionCard } from '../admin/layout/SectionCard';
+import { activityPhrase, reviewPath } from './dashboardModel';
+
+const TYPE_ICONS: Record<string, LucideIcon> = {
+  'annotation.created': MessageSquarePlus,
+  'annotation.resolved': CircleCheck,
+  'annotation.reopened': RotateCcw,
+  'workflow.transition': Workflow,
+  'document.due_date.changed': CalendarClock,
+};
+
+interface ActivityCardProps {
+  activity: DashboardActivity[];
+}
+
+/**
+ * What moved while the caller was away (issue #454): a slim feed from the
+ * audit trail of their reviews, their own actions excluded.
+ */
+export function ActivityCard({ activity }: ActivityCardProps) {
+  const theme = useTheme();
+
+  return (
+    <SectionCard
+      icon={Activity}
+      title="Recent activity"
+      description="What happened across your reviews."
+    >
+      {activity.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Nothing new — you are all caught up.
+        </Typography>
+      ) : (
+        <Stack spacing={1.25}>
+          {activity.map((item, index) => {
+            const Icon = TYPE_ICONS[item.type] ?? Activity;
+            return (
+              <Stack
+                key={`${item.type}-${item.createdAt}-${index}`}
+                direction="row"
+                spacing={1.25}
+                sx={{ alignItems: 'flex-start', minWidth: 0 }}
+              >
+                <Box
+                  aria-hidden
+                  sx={{ color: theme.palette.text.secondary, pt: 0.25, flexShrink: 0 }}
+                >
+                  <Icon size={14} />
+                </Box>
+                <Typography variant="body2" sx={{ minWidth: 0, color: 'text.secondary' }}>
+                  <Typography
+                    component="span"
+                    variant="body2"
+                    sx={{ fontWeight: 600, color: 'text.primary' }}
+                  >
+                    {item.actorDisplayName ?? 'Someone'}
+                  </Typography>{' '}
+                  {activityPhrase(item.type)}{' '}
+                  <Link
+                    component={RouterLink}
+                    to={reviewPath({ id: item.documentId, slug: item.documentSlug })}
+                    underline="hover"
+                    sx={{ fontWeight: 600 }}
+                  >
+                    {item.documentTitle}
+                  </Link>{' '}
+                  · {shortRelativeTime(item.createdAt)}
+                </Typography>
+              </Stack>
+            );
+          })}
+        </Stack>
+      )}
+    </SectionCard>
+  );
+}

--- a/qnop-ui/src/components/dashboard/ActivityCard.tsx
+++ b/qnop-ui/src/components/dashboard/ActivityCard.tsx
@@ -37,6 +37,8 @@ import Link from '@mui/material/Link';
 import type { DashboardActivity } from '../../api/generated';
 import { shortRelativeTime } from '../../utils/relativeTime';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { CardScroller } from './CardScroller';
+import { CountPill } from './CountPill';
 import { PersonLink } from './PersonLink';
 import { activityPhrase, reviewPath } from './dashboardModel';
 
@@ -64,60 +66,63 @@ export function ActivityCard({ activity }: ActivityCardProps) {
       icon={Activity}
       title="Recent activity"
       description="What happened across your reviews."
+      action={<CountPill value={activity.length} />}
     >
       {activity.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           Nothing new — you are all caught up.
         </Typography>
       ) : (
-        <Stack spacing={1.25}>
-          {activity.map((item, index) => {
-            const Icon = TYPE_ICONS[item.type] ?? Activity;
-            return (
-              <Stack
-                key={`${item.type}-${item.createdAt}-${index}`}
-                direction="row"
-                spacing={1.25}
-                sx={{ alignItems: 'flex-start', minWidth: 0 }}
-              >
-                <Box
-                  aria-hidden
-                  sx={{ color: theme.palette.text.secondary, pt: 0.25, flexShrink: 0 }}
+        <CardScroller>
+          <Stack spacing={1.25}>
+            {activity.map((item, index) => {
+              const Icon = TYPE_ICONS[item.type] ?? Activity;
+              return (
+                <Stack
+                  key={`${item.type}-${item.createdAt}-${index}`}
+                  direction="row"
+                  spacing={1.25}
+                  sx={{ alignItems: 'flex-start', minWidth: 0 }}
                 >
-                  <Icon size={14} />
-                </Box>
-                <Box sx={{ pt: '1px', flexShrink: 0 }}>
-                  <PersonLink
-                    userId={item.actorId}
-                    name={item.actorDisplayName ?? 'Someone'}
-                    avatarUrl={item.actorAvatarUrl}
-                    size={20}
-                    avatarOnly
-                  />
-                </Box>
-                <Typography variant="body2" sx={{ minWidth: 0, color: 'text.secondary' }}>
-                  <Typography
-                    component="span"
-                    variant="body2"
-                    sx={{ fontWeight: 600, color: 'text.primary' }}
+                  <Box
+                    aria-hidden
+                    sx={{ color: theme.palette.text.secondary, pt: 0.25, flexShrink: 0 }}
                   >
-                    {item.actorDisplayName ?? 'Someone'}
-                  </Typography>{' '}
-                  {activityPhrase(item.type)}{' '}
-                  <Link
-                    component={RouterLink}
-                    to={reviewPath({ id: item.documentId, slug: item.documentSlug })}
-                    underline="hover"
-                    sx={{ fontWeight: 600 }}
-                  >
-                    {item.documentTitle}
-                  </Link>{' '}
-                  · {shortRelativeTime(item.createdAt)}
-                </Typography>
-              </Stack>
-            );
-          })}
-        </Stack>
+                    <Icon size={14} />
+                  </Box>
+                  <Box sx={{ pt: '1px', flexShrink: 0 }}>
+                    <PersonLink
+                      userId={item.actorId}
+                      name={item.actorDisplayName ?? 'Someone'}
+                      avatarUrl={item.actorAvatarUrl}
+                      size={20}
+                      avatarOnly
+                    />
+                  </Box>
+                  <Typography variant="body2" sx={{ minWidth: 0, color: 'text.secondary' }}>
+                    <Typography
+                      component="span"
+                      variant="body2"
+                      sx={{ fontWeight: 600, color: 'text.primary' }}
+                    >
+                      {item.actorDisplayName ?? 'Someone'}
+                    </Typography>{' '}
+                    {activityPhrase(item.type)}{' '}
+                    <Link
+                      component={RouterLink}
+                      to={reviewPath({ id: item.documentId, slug: item.documentSlug })}
+                      underline="hover"
+                      sx={{ fontWeight: 600 }}
+                    >
+                      {item.documentTitle}
+                    </Link>{' '}
+                    · {shortRelativeTime(item.createdAt)}
+                  </Typography>
+                </Stack>
+              );
+            })}
+          </Stack>
+        </CardScroller>
       )}
     </SectionCard>
   );

--- a/qnop-ui/src/components/dashboard/CardScroller.tsx
+++ b/qnop-ui/src/components/dashboard/CardScroller.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState, type ReactNode, type UIEvent } from 'react';
+import Box from '@mui/material/Box';
+import { alpha, useTheme } from '@mui/material/styles';
+
+/** One viewport for every dashboard card — the cockpit stays one screen. */
+const DEFAULT_MAX_HEIGHT = 336;
+const EDGE_TOLERANCE = 4;
+
+interface CardScrollerProps {
+  maxHeight?: number;
+  children: ReactNode;
+}
+
+/**
+ * The dashboard cards' content viewport (issue #454 follow-up): lists grew
+ * with real data, so every card caps at one height and scrolls internally.
+ * Soft fade masks at the edges say "there is more" without a visible border —
+ * the bottom fade lifts once the list is fully read, a top fade appears once
+ * scrolled. The scrollbar stays a quiet hairline.
+ */
+export function CardScroller({ maxHeight = DEFAULT_MAX_HEIGHT, children }: CardScrollerProps) {
+  const theme = useTheme();
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const [edges, setEdges] = useState({ above: false, below: false });
+
+  const measure = (el: HTMLDivElement | null) => {
+    if (!el) return;
+    const below = el.scrollTop + el.clientHeight < el.scrollHeight - EDGE_TOLERANCE;
+    const above = el.scrollTop > EDGE_TOLERANCE;
+    setEdges((current) =>
+      current.above === above && current.below === below ? current : { above, below },
+    );
+  };
+
+  const handleScroll = (event: UIEvent<HTMLDivElement>) => measure(event.currentTarget);
+
+  const fade = (direction: 'top' | 'bottom', visible: boolean) => ({
+    content: '""',
+    position: 'absolute' as const,
+    left: 0,
+    right: 0,
+    [direction]: 0,
+    height: 36,
+    pointerEvents: 'none' as const,
+    opacity: visible ? 1 : 0,
+    transition: 'opacity 160ms ease',
+    background: `linear-gradient(${direction === 'top' ? 'to bottom' : 'to top'}, ${
+      theme.palette.background.paper
+    }, ${alpha(theme.palette.background.paper, 0)})`,
+    zIndex: 1,
+  });
+
+  return (
+    <Box sx={{ position: 'relative' }}>
+      <Box sx={fade('top', edges.above)} aria-hidden />
+      <Box
+        ref={(el: HTMLDivElement | null) => {
+          viewportRef.current = el;
+          measure(el);
+        }}
+        onScroll={handleScroll}
+        sx={{
+          maxHeight,
+          overflowY: 'auto',
+          // A quiet hairline scrollbar, matching the product's calm chrome.
+          scrollbarWidth: 'thin',
+          scrollbarColor: `${alpha(theme.palette.text.primary, 0.18)} transparent`,
+          '&::-webkit-scrollbar': { width: 6 },
+          '&::-webkit-scrollbar-thumb': {
+            borderRadius: 3,
+            backgroundColor: alpha(theme.palette.text.primary, 0.18),
+          },
+          '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
+        }}
+      >
+        {children}
+      </Box>
+      <Box sx={fade('bottom', edges.below)} aria-hidden />
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/dashboard/CountPill.tsx
+++ b/qnop-ui/src/components/dashboard/CountPill.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import { alpha, useTheme } from '@mui/material/styles';
+
+/**
+ * The card header's total (issue #454 follow-up): with the lists capped to a
+ * scrolling viewport, the pill keeps the real volume honest at a glance.
+ * Renders nothing for zero — an empty card already says so.
+ */
+export function CountPill({ value }: { value: number }) {
+  const theme = useTheme();
+  if (value === 0) return null;
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: 24,
+        height: 22,
+        px: 0.75,
+        borderRadius: '11px',
+        fontSize: '0.75rem',
+        fontWeight: 700,
+        fontVariantNumeric: 'tabular-nums',
+        color: theme.qnop.brand.blue,
+        bgcolor: alpha(theme.qnop.brand.blue, 0.1),
+      }}
+    >
+      {value}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/dashboard/DeadlinesCard.tsx
+++ b/qnop-ui/src/components/dashboard/DeadlinesCard.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { CalendarClock } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { DocumentSummary } from '../../api/generated';
+import { SectionCard } from '../admin/layout/SectionCard';
+import { dueUrgency, reviewPath } from './dashboardModel';
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' });
+
+interface DeadlinesCardProps {
+  reviews: DocumentSummary[];
+}
+
+/**
+ * Every open review with a completion deadline (issue #295), soonest first,
+ * in the dashboard's urgency colours (issue #454): overdue in danger, due
+ * today in warning, the rest quiet.
+ */
+export function DeadlinesCard({ reviews }: DeadlinesCardProps) {
+  const theme = useTheme();
+  const navigate = useNavigate();
+
+  const urgencyColor = (level: string) =>
+    level === 'overdue'
+      ? theme.palette.error.main
+      : level === 'today' || level === 'soon'
+        ? theme.palette.warning.main
+        : theme.qnop.brand.blue;
+
+  return (
+    <SectionCard
+      icon={CalendarClock}
+      title="Deadlines"
+      description="When your running reviews are due."
+    >
+      {reviews.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No deadlines — nothing is due.
+        </Typography>
+      ) : (
+        <Stack spacing={0.5} sx={{ mx: -1 }}>
+          {reviews.map((review) => {
+            const urgency = dueUrgency(review.dueAt as string);
+            const color = urgencyColor(urgency.level);
+            return (
+              <ButtonBase
+                key={review.id}
+                onClick={() => navigate(reviewPath(review))}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.25,
+                  textAlign: 'left',
+                  borderRadius: '8px',
+                  px: 1,
+                  py: 0.75,
+                  '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
+                }}
+              >
+                {/* The urgency, readable before the words. */}
+                <Box
+                  aria-hidden
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    bgcolor: color,
+                    flexShrink: 0,
+                    boxShadow: `0 0 0 3px ${alpha(color, 0.18)}`,
+                  }}
+                />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography noWrap sx={{ fontWeight: 600, fontSize: '0.85rem' }}>
+                    {review.title}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" noWrap component="p">
+                    {DATE_FORMAT.format(new Date(review.dueAt as string))}
+                  </Typography>
+                </Box>
+                <Typography
+                  variant="caption"
+                  sx={{ color, fontWeight: 700, flexShrink: 0 }}
+                  data-urgency={urgency.level}
+                >
+                  {urgency.label}
+                </Typography>
+              </ButtonBase>
+            );
+          })}
+        </Stack>
+      )}
+    </SectionCard>
+  );
+}

--- a/qnop-ui/src/components/dashboard/DeadlinesCard.tsx
+++ b/qnop-ui/src/components/dashboard/DeadlinesCard.tsx
@@ -28,6 +28,8 @@ import { CalendarClock } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { DocumentSummary } from '../../api/generated';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { CardScroller } from './CardScroller';
+import { CountPill } from './CountPill';
 import { dueUrgency, reviewPath } from './dashboardModel';
 
 const DATE_FORMAT = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' });
@@ -57,62 +59,65 @@ export function DeadlinesCard({ reviews }: DeadlinesCardProps) {
       icon={CalendarClock}
       title="Deadlines"
       description="When your running reviews are due."
+      action={<CountPill value={reviews.length} />}
     >
       {reviews.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No deadlines — nothing is due.
         </Typography>
       ) : (
-        <Stack spacing={0.5} sx={{ mx: -1 }}>
-          {reviews.map((review) => {
-            const urgency = dueUrgency(review.dueAt as string);
-            const color = urgencyColor(urgency.level);
-            return (
-              <ButtonBase
-                key={review.id}
-                onClick={() => navigate(reviewPath(review))}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1.25,
-                  textAlign: 'left',
-                  borderRadius: '8px',
-                  px: 1,
-                  py: 0.75,
-                  '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
-                }}
-              >
-                {/* The urgency, readable before the words. */}
-                <Box
-                  aria-hidden
+        <CardScroller>
+          <Stack spacing={0.5} sx={{ mx: -1 }}>
+            {reviews.map((review) => {
+              const urgency = dueUrgency(review.dueAt as string);
+              const color = urgencyColor(urgency.level);
+              return (
+                <ButtonBase
+                  key={review.id}
+                  onClick={() => navigate(reviewPath(review))}
                   sx={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: '50%',
-                    bgcolor: color,
-                    flexShrink: 0,
-                    boxShadow: `0 0 0 3px ${alpha(color, 0.18)}`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.25,
+                    textAlign: 'left',
+                    borderRadius: '8px',
+                    px: 1,
+                    py: 0.75,
+                    '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
                   }}
-                />
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography noWrap sx={{ fontWeight: 600, fontSize: '0.85rem' }}>
-                    {review.title}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary" noWrap component="p">
-                    {DATE_FORMAT.format(new Date(review.dueAt as string))}
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="caption"
-                  sx={{ color, fontWeight: 700, flexShrink: 0 }}
-                  data-urgency={urgency.level}
                 >
-                  {urgency.label}
-                </Typography>
-              </ButtonBase>
-            );
-          })}
-        </Stack>
+                  {/* The urgency, readable before the words. */}
+                  <Box
+                    aria-hidden
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      bgcolor: color,
+                      flexShrink: 0,
+                      boxShadow: `0 0 0 3px ${alpha(color, 0.18)}`,
+                    }}
+                  />
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography noWrap sx={{ fontWeight: 600, fontSize: '0.85rem' }}>
+                      {review.title}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" noWrap component="p">
+                      {DATE_FORMAT.format(new Date(review.dueAt as string))}
+                    </Typography>
+                  </Box>
+                  <Typography
+                    variant="caption"
+                    sx={{ color, fontWeight: 700, flexShrink: 0 }}
+                    data-urgency={urgency.level}
+                  >
+                    {urgency.label}
+                  </Typography>
+                </ButtonBase>
+              );
+            })}
+          </Stack>
+        </CardScroller>
       )}
     </SectionCard>
   );

--- a/qnop-ui/src/components/dashboard/PersonLink.tsx
+++ b/qnop-ui/src/components/dashboard/PersonLink.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { Link as RouterLink } from 'react-router-dom';
+import { useAuthStore } from '../../stores/authStore';
+import { UserAvatar } from '../shell/UserAvatar';
+
+interface PersonLinkProps {
+  /**
+   * The person's REAL user id — absent for pseudonymised identities
+   * (issue #413), which then render as a plain avatar+name without a link.
+   */
+  userId?: string | null;
+  name: string;
+  /** Server-built avatar URL (null when none is uploaded). */
+  avatarUrl?: string | null;
+  size?: number;
+  /** Drops the name — an avatar-only variant for tight rows. */
+  avatarOnly?: boolean;
+}
+
+/**
+ * A person as the product shows people (issue #454): avatar and bold name in
+ * one unit, linking to the profile — `/profile` for yourself, the colleague's
+ * `/users/{id}` page otherwise. Pseudonymised identities stay unlinked and
+ * initials-only, so anonymity never leaks through a click.
+ */
+export function PersonLink({
+  userId,
+  name,
+  avatarUrl,
+  size = 26,
+  avatarOnly = false,
+}: PersonLinkProps) {
+  const theme = useTheme();
+  const selfId = useAuthStore((s) => s.userId);
+  const to = userId ? (userId === selfId ? '/profile' : `/users/${userId}`) : null;
+
+  const body = (
+    <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0 }}>
+      <UserAvatar name={name} size={size} imageUrl={avatarUrl ?? null} />
+      {!avatarOnly && (
+        <Typography
+          component="span"
+          noWrap
+          sx={{ fontWeight: 700, fontSize: '0.85rem', color: 'text.primary' }}
+        >
+          {name}
+        </Typography>
+      )}
+    </Stack>
+  );
+
+  if (!to) return body;
+  return (
+    <Stack
+      component={RouterLink}
+      to={to}
+      onClick={(event) => event.stopPropagation()}
+      direction="row"
+      sx={{
+        alignItems: 'center',
+        minWidth: 0,
+        textDecoration: 'none',
+        borderRadius: '6px',
+        '&:hover': {
+          bgcolor: alpha(theme.qnop.brand.blue, 0.08),
+          '& .MuiTypography-root': { color: theme.qnop.brand.blue },
+        },
+      }}
+      aria-label={`View ${name}'s profile`}
+    >
+      {body}
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/dashboard/RepliesCard.tsx
+++ b/qnop-ui/src/components/dashboard/RepliesCard.tsx
@@ -29,7 +29,7 @@ import { useNavigate } from 'react-router-dom';
 import type { DashboardReply } from '../../api/generated';
 import { shortRelativeTime } from '../../utils/relativeTime';
 import { SectionCard } from '../admin/layout/SectionCard';
-import { UserAvatar } from '../shell/UserAvatar';
+import { PersonLink } from './PersonLink';
 import { reviewPath } from './dashboardModel';
 
 interface RepliesCardProps {
@@ -76,18 +76,13 @@ export function RepliesCard({ replies }: RepliesCardProps) {
               }}
             >
               <Stack direction="row" spacing={1.25} sx={{ alignItems: 'flex-start', minWidth: 0 }}>
-                <Box sx={{ pt: 0.25 }}>
-                  <UserAvatar name={reply.authorDisplayName ?? 'Participant'} size={26} />
-                </Box>
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0 }}>
-                    <Typography
-                      component="span"
-                      noWrap
-                      sx={{ fontWeight: 700, fontSize: '0.85rem' }}
-                    >
-                      {reply.authorDisplayName ?? 'Participant'}
-                    </Typography>
+                    <PersonLink
+                      userId={reply.authorId}
+                      name={reply.authorDisplayName ?? 'Participant'}
+                      avatarUrl={reply.authorAvatarUrl}
+                    />
                     <Typography component="span" variant="caption" color="text.secondary" noWrap>
                       in {reply.documentTitle} · {shortRelativeTime(reply.createdAt)}
                     </Typography>

--- a/qnop-ui/src/components/dashboard/RepliesCard.tsx
+++ b/qnop-ui/src/components/dashboard/RepliesCard.tsx
@@ -29,6 +29,8 @@ import { useNavigate } from 'react-router-dom';
 import type { DashboardReply } from '../../api/generated';
 import { shortRelativeTime } from '../../utils/relativeTime';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { CardScroller } from './CardScroller';
+import { CountPill } from './CountPill';
 import { PersonLink } from './PersonLink';
 import { reviewPath } from './dashboardModel';
 
@@ -50,77 +52,88 @@ export function RepliesCard({ replies }: RepliesCardProps) {
       icon={MessagesSquare}
       title="Replies to you"
       description="The latest answers in discussions you started or joined."
+      action={<CountPill value={replies.length} />}
     >
       {replies.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           No new replies — your threads are quiet.
         </Typography>
       ) : (
-        <Stack spacing={0.5} sx={{ mx: -1 }}>
-          {replies.map((reply) => (
-            <ButtonBase
-              key={reply.commentId}
-              onClick={() =>
-                navigate(
-                  `${reviewPath({ id: reply.documentId, slug: reply.documentSlug })}` +
-                    `?annotation=${reply.annotationId}&comment=${reply.commentId}`,
-                )
-              }
-              sx={{
-                display: 'block',
-                textAlign: 'left',
-                borderRadius: '8px',
-                px: 1,
-                py: 0.75,
-                '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
-              }}
-            >
-              <Stack direction="row" spacing={1.25} sx={{ alignItems: 'flex-start', minWidth: 0 }}>
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0 }}>
-                    <PersonLink
-                      userId={reply.authorId}
-                      name={reply.authorDisplayName ?? 'Participant'}
-                      avatarUrl={reply.authorAvatarUrl}
-                    />
-                    <Typography component="span" variant="caption" color="text.secondary" noWrap>
-                      in {reply.documentTitle} · {shortRelativeTime(reply.createdAt)}
-                    </Typography>
-                  </Stack>
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      mt: 0.25,
-                      display: '-webkit-box',
-                      WebkitLineClamp: 2,
-                      WebkitBoxOrient: 'vertical',
-                      overflow: 'hidden',
-                    }}
-                  >
-                    {reply.body}
-                  </Typography>
-                  {reply.annotationExcerpt && (
+        <CardScroller>
+          <Stack spacing={0.5} sx={{ mx: -1 }}>
+            {replies.map((reply) => (
+              <ButtonBase
+                key={reply.commentId}
+                onClick={() =>
+                  navigate(
+                    `${reviewPath({ id: reply.documentId, slug: reply.documentSlug })}` +
+                      `?annotation=${reply.annotationId}&comment=${reply.commentId}`,
+                  )
+                }
+                sx={{
+                  display: 'block',
+                  textAlign: 'left',
+                  borderRadius: '8px',
+                  px: 1,
+                  py: 0.75,
+                  '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
+                }}
+              >
+                <Stack
+                  direction="row"
+                  spacing={1.25}
+                  sx={{ alignItems: 'flex-start', minWidth: 0 }}
+                >
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Stack
+                      direction="row"
+                      spacing={0.75}
+                      sx={{ alignItems: 'center', minWidth: 0 }}
+                    >
+                      <PersonLink
+                        userId={reply.authorId}
+                        name={reply.authorDisplayName ?? 'Participant'}
+                        avatarUrl={reply.authorAvatarUrl}
+                      />
+                      <Typography component="span" variant="caption" color="text.secondary" noWrap>
+                        in {reply.documentTitle} · {shortRelativeTime(reply.createdAt)}
+                      </Typography>
+                    </Stack>
                     <Typography
-                      variant="caption"
-                      noWrap
-                      component="p"
+                      variant="body2"
                       sx={{
                         mt: 0.25,
-                        color: 'text.secondary',
-                        fontStyle: 'italic',
-                        borderLeft: '2px solid',
-                        borderColor: 'divider',
-                        pl: 0.75,
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
                       }}
                     >
-                      {reply.annotationExcerpt}
+                      {reply.body}
                     </Typography>
-                  )}
-                </Box>
-              </Stack>
-            </ButtonBase>
-          ))}
-        </Stack>
+                    {reply.annotationExcerpt && (
+                      <Typography
+                        variant="caption"
+                        noWrap
+                        component="p"
+                        sx={{
+                          mt: 0.25,
+                          color: 'text.secondary',
+                          fontStyle: 'italic',
+                          borderLeft: '2px solid',
+                          borderColor: 'divider',
+                          pl: 0.75,
+                        }}
+                      >
+                        {reply.annotationExcerpt}
+                      </Typography>
+                    )}
+                  </Box>
+                </Stack>
+              </ButtonBase>
+            ))}
+          </Stack>
+        </CardScroller>
       )}
     </SectionCard>
   );

--- a/qnop-ui/src/components/dashboard/RepliesCard.tsx
+++ b/qnop-ui/src/components/dashboard/RepliesCard.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { MessagesSquare } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { DashboardReply } from '../../api/generated';
+import { shortRelativeTime } from '../../utils/relativeTime';
+import { SectionCard } from '../admin/layout/SectionCard';
+import { UserAvatar } from '../shell/UserAvatar';
+import { reviewPath } from './dashboardModel';
+
+interface RepliesCardProps {
+  replies: DashboardReply[];
+}
+
+/**
+ * Replies directed at the caller (issue #454): the latest comments by others
+ * in threads they started or joined, each row deep-linking straight into the
+ * thread via the permalink params (issue #412).
+ */
+export function RepliesCard({ replies }: RepliesCardProps) {
+  const theme = useTheme();
+  const navigate = useNavigate();
+
+  return (
+    <SectionCard
+      icon={MessagesSquare}
+      title="Replies to you"
+      description="The latest answers in discussions you started or joined."
+    >
+      {replies.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No new replies — your threads are quiet.
+        </Typography>
+      ) : (
+        <Stack spacing={0.5} sx={{ mx: -1 }}>
+          {replies.map((reply) => (
+            <ButtonBase
+              key={reply.commentId}
+              onClick={() =>
+                navigate(
+                  `${reviewPath({ id: reply.documentId, slug: reply.documentSlug })}` +
+                    `?annotation=${reply.annotationId}&comment=${reply.commentId}`,
+                )
+              }
+              sx={{
+                display: 'block',
+                textAlign: 'left',
+                borderRadius: '8px',
+                px: 1,
+                py: 0.75,
+                '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
+              }}
+            >
+              <Stack direction="row" spacing={1.25} sx={{ alignItems: 'flex-start', minWidth: 0 }}>
+                <Box sx={{ pt: 0.25 }}>
+                  <UserAvatar name={reply.authorDisplayName ?? 'Participant'} size={26} />
+                </Box>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0 }}>
+                    <Typography
+                      component="span"
+                      noWrap
+                      sx={{ fontWeight: 700, fontSize: '0.85rem' }}
+                    >
+                      {reply.authorDisplayName ?? 'Participant'}
+                    </Typography>
+                    <Typography component="span" variant="caption" color="text.secondary" noWrap>
+                      in {reply.documentTitle} · {shortRelativeTime(reply.createdAt)}
+                    </Typography>
+                  </Stack>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      mt: 0.25,
+                      display: '-webkit-box',
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: 'vertical',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {reply.body}
+                  </Typography>
+                  {reply.annotationExcerpt && (
+                    <Typography
+                      variant="caption"
+                      noWrap
+                      component="p"
+                      sx={{
+                        mt: 0.25,
+                        color: 'text.secondary',
+                        fontStyle: 'italic',
+                        borderLeft: '2px solid',
+                        borderColor: 'divider',
+                        pl: 0.75,
+                      }}
+                    >
+                      {reply.annotationExcerpt}
+                    </Typography>
+                  )}
+                </Box>
+              </Stack>
+            </ButtonBase>
+          ))}
+        </Stack>
+      )}
+    </SectionCard>
+  );
+}

--- a/qnop-ui/src/components/dashboard/ReviewListCard.tsx
+++ b/qnop-ui/src/components/dashboard/ReviewListCard.tsx
@@ -24,13 +24,13 @@ import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
-import { CircleCheck, type LucideIcon } from 'lucide-react';
+import { CircleCheck, PartyPopper, type LucideIcon } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { DocumentSummary } from '../../api/generated';
 import { ToneBadge } from '../admin/ToneBadge';
 import { SectionCard } from '../admin/layout/SectionCard';
 import { DueDateLabel } from '../reviews/DueDateLabel';
-import { ProgressBar } from '../reviews/list/ReviewListParts';
+import { ProgressBar, ReviewerStack } from '../reviews/list/ReviewListParts';
 import { progressOf } from '../reviews/list/reviewListModel';
 import { WORKFLOW_TONES, workflowLabel } from '../reviews/workflowMeta';
 import { readyToFinalize, reviewPath } from './dashboardModel';
@@ -45,6 +45,8 @@ interface ReviewListCardProps {
   ownerCues?: boolean;
   /** Caps the visible rows; the card stays a glance, not a second list page. */
   maxRows?: number;
+  /** Turns the empty state into a small celebration — earned quiet, not absence. */
+  celebrateEmpty?: boolean;
 }
 
 /**
@@ -60,6 +62,7 @@ export function ReviewListCard({
   emptyText,
   ownerCues = false,
   maxRows = 5,
+  celebrateEmpty = false,
 }: ReviewListCardProps) {
   const theme = useTheme();
   const navigate = useNavigate();
@@ -68,9 +71,33 @@ export function ReviewListCard({
   return (
     <SectionCard icon={icon} title={title} description={description}>
       {visible.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          {emptyText}
-        </Typography>
+        celebrateEmpty ? (
+          <Stack spacing={1} sx={{ alignItems: 'center', py: 2 }}>
+            <Box
+              aria-hidden
+              sx={{
+                width: 44,
+                height: 44,
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: theme.palette.success.main,
+                bgcolor: alpha(theme.palette.success.main, 0.12),
+              }}
+            >
+              <PartyPopper size={20} />
+            </Box>
+            <Typography sx={{ fontWeight: 700 }}>All caught up!</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {emptyText}
+            </Typography>
+          </Stack>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            {emptyText}
+          </Typography>
+        )
       ) : (
         <Stack spacing={0.5} sx={{ mx: -1 }}>
           {visible.map((review) => {
@@ -127,6 +154,7 @@ export function ReviewListCard({
                     </Typography>
                   )}
                   <Box sx={{ flex: 1 }} />
+                  <ReviewerStack participants={review.participants ?? []} />
                   <DueDateLabel dueAt={review.dueAt} workflowState={review.workflowState} />
                 </Stack>
               </ButtonBase>

--- a/qnop-ui/src/components/dashboard/ReviewListCard.tsx
+++ b/qnop-ui/src/components/dashboard/ReviewListCard.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { CircleCheck, type LucideIcon } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { DocumentSummary } from '../../api/generated';
+import { ToneBadge } from '../admin/ToneBadge';
+import { SectionCard } from '../admin/layout/SectionCard';
+import { DueDateLabel } from '../reviews/DueDateLabel';
+import { ProgressBar } from '../reviews/list/ReviewListParts';
+import { progressOf } from '../reviews/list/reviewListModel';
+import { WORKFLOW_TONES, workflowLabel } from '../reviews/workflowMeta';
+import { readyToFinalize, reviewPath } from './dashboardModel';
+
+interface ReviewListCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  reviews: DocumentSummary[];
+  emptyText: string;
+  /** Shows the owner's "Ready to finalize" cue on settled reviews. */
+  ownerCues?: boolean;
+  /** Caps the visible rows; the card stays a glance, not a second list page. */
+  maxRows?: number;
+}
+
+/**
+ * One dashboard review list (issue #454) — the "waiting on you" and "my
+ * reviews" cards share this anatomy: linked rows with the workflow badge,
+ * resolution progress and the due-date label, sorted by the caller.
+ */
+export function ReviewListCard({
+  icon,
+  title,
+  description,
+  reviews,
+  emptyText,
+  ownerCues = false,
+  maxRows = 5,
+}: ReviewListCardProps) {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const visible = reviews.slice(0, maxRows);
+
+  return (
+    <SectionCard icon={icon} title={title} description={description}>
+      {visible.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          {emptyText}
+        </Typography>
+      ) : (
+        <Stack spacing={0.5} sx={{ mx: -1 }}>
+          {visible.map((review) => {
+            const progress = progressOf(review);
+            return (
+              <ButtonBase
+                key={review.id}
+                onClick={() => navigate(reviewPath(review))}
+                sx={{
+                  display: 'block',
+                  textAlign: 'left',
+                  borderRadius: '8px',
+                  px: 1,
+                  py: 0.75,
+                  '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
+                }}
+              >
+                <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+                  <Typography noWrap sx={{ fontWeight: 600, fontSize: '0.875rem', flex: 1 }}>
+                    {review.title}
+                  </Typography>
+                  {ownerCues && readyToFinalize(review) ? (
+                    <ToneBadge
+                      tone="green"
+                      label="Ready to finalize"
+                      icon={<CircleCheck size={11} aria-hidden />}
+                    />
+                  ) : (
+                    <ToneBadge
+                      tone={WORKFLOW_TONES[review.workflowState] ?? 'neutral'}
+                      label={workflowLabel(review.workflowState)}
+                    />
+                  )}
+                </Stack>
+                <Stack
+                  direction="row"
+                  spacing={1.25}
+                  sx={{ alignItems: 'center', mt: 0.5, minWidth: 0 }}
+                >
+                  {progress ? (
+                    <>
+                      <ProgressBar
+                        resolved={progress.resolved}
+                        total={progress.total}
+                        color={theme.qnop.brand.blue}
+                      />
+                      <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                        {progress.resolved}/{progress.total} resolved
+                      </Typography>
+                    </>
+                  ) : (
+                    <Typography variant="caption" color="text.secondary">
+                      No annotations yet
+                    </Typography>
+                  )}
+                  <Box sx={{ flex: 1 }} />
+                  <DueDateLabel dueAt={review.dueAt} workflowState={review.workflowState} />
+                </Stack>
+              </ButtonBase>
+            );
+          })}
+        </Stack>
+      )}
+    </SectionCard>
+  );
+}

--- a/qnop-ui/src/components/dashboard/ReviewListCard.tsx
+++ b/qnop-ui/src/components/dashboard/ReviewListCard.tsx
@@ -29,6 +29,8 @@ import { useNavigate } from 'react-router-dom';
 import type { DocumentSummary } from '../../api/generated';
 import { ToneBadge } from '../admin/ToneBadge';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { CardScroller } from './CardScroller';
+import { CountPill } from './CountPill';
 import { DueDateLabel } from '../reviews/DueDateLabel';
 import { ProgressBar, ReviewerStack } from '../reviews/list/ReviewListParts';
 import { progressOf } from '../reviews/list/reviewListModel';
@@ -43,8 +45,6 @@ interface ReviewListCardProps {
   emptyText: string;
   /** Shows the owner's "Ready to finalize" cue on settled reviews. */
   ownerCues?: boolean;
-  /** Caps the visible rows; the card stays a glance, not a second list page. */
-  maxRows?: number;
   /** Turns the empty state into a small celebration — earned quiet, not absence. */
   celebrateEmpty?: boolean;
 }
@@ -61,15 +61,19 @@ export function ReviewListCard({
   reviews,
   emptyText,
   ownerCues = false,
-  maxRows = 5,
   celebrateEmpty = false,
 }: ReviewListCardProps) {
   const theme = useTheme();
   const navigate = useNavigate();
-  const visible = reviews.slice(0, maxRows);
+  const visible = reviews;
 
   return (
-    <SectionCard icon={icon} title={title} description={description}>
+    <SectionCard
+      icon={icon}
+      title={title}
+      description={description}
+      action={<CountPill value={reviews.length} />}
+    >
       {visible.length === 0 ? (
         celebrateEmpty ? (
           <Stack spacing={1} sx={{ alignItems: 'center', py: 2 }}>
@@ -99,68 +103,70 @@ export function ReviewListCard({
           </Typography>
         )
       ) : (
-        <Stack spacing={0.5} sx={{ mx: -1 }}>
-          {visible.map((review) => {
-            const progress = progressOf(review);
-            return (
-              <ButtonBase
-                key={review.id}
-                onClick={() => navigate(reviewPath(review))}
-                sx={{
-                  display: 'block',
-                  textAlign: 'left',
-                  borderRadius: '8px',
-                  px: 1,
-                  py: 0.75,
-                  '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
-                }}
-              >
-                <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
-                  <Typography noWrap sx={{ fontWeight: 600, fontSize: '0.875rem', flex: 1 }}>
-                    {review.title}
-                  </Typography>
-                  {ownerCues && readyToFinalize(review) ? (
-                    <ToneBadge
-                      tone="green"
-                      label="Ready to finalize"
-                      icon={<CircleCheck size={11} aria-hidden />}
-                    />
-                  ) : (
-                    <ToneBadge
-                      tone={WORKFLOW_TONES[review.workflowState] ?? 'neutral'}
-                      label={workflowLabel(review.workflowState)}
-                    />
-                  )}
-                </Stack>
-                <Stack
-                  direction="row"
-                  spacing={1.25}
-                  sx={{ alignItems: 'center', mt: 0.5, minWidth: 0 }}
+        <CardScroller>
+          <Stack spacing={0.5} sx={{ mx: -1 }}>
+            {visible.map((review) => {
+              const progress = progressOf(review);
+              return (
+                <ButtonBase
+                  key={review.id}
+                  onClick={() => navigate(reviewPath(review))}
+                  sx={{
+                    display: 'block',
+                    textAlign: 'left',
+                    borderRadius: '8px',
+                    px: 1,
+                    py: 0.75,
+                    '&:hover': { bgcolor: alpha(theme.qnop.brand.blue, 0.05) },
+                  }}
                 >
-                  {progress ? (
-                    <>
-                      <ProgressBar
-                        resolved={progress.resolved}
-                        total={progress.total}
-                        color={theme.qnop.brand.blue}
-                      />
-                      <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
-                        {progress.resolved}/{progress.total} resolved
-                      </Typography>
-                    </>
-                  ) : (
-                    <Typography variant="caption" color="text.secondary">
-                      No annotations yet
+                  <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+                    <Typography noWrap sx={{ fontWeight: 600, fontSize: '0.875rem', flex: 1 }}>
+                      {review.title}
                     </Typography>
-                  )}
-                  <Box sx={{ flex: 1 }} />
-                  <ReviewerStack participants={review.participants ?? []} />
-                  <DueDateLabel dueAt={review.dueAt} workflowState={review.workflowState} />
-                </Stack>
-              </ButtonBase>
-            );
-          })}
-        </Stack>
+                    {ownerCues && readyToFinalize(review) ? (
+                      <ToneBadge
+                        tone="green"
+                        label="Ready to finalize"
+                        icon={<CircleCheck size={11} aria-hidden />}
+                      />
+                    ) : (
+                      <ToneBadge
+                        tone={WORKFLOW_TONES[review.workflowState] ?? 'neutral'}
+                        label={workflowLabel(review.workflowState)}
+                      />
+                    )}
+                  </Stack>
+                  <Stack
+                    direction="row"
+                    spacing={1.25}
+                    sx={{ alignItems: 'center', mt: 0.5, minWidth: 0 }}
+                  >
+                    {progress ? (
+                      <>
+                        <ProgressBar
+                          resolved={progress.resolved}
+                          total={progress.total}
+                          color={theme.qnop.brand.blue}
+                        />
+                        <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                          {progress.resolved}/{progress.total} resolved
+                        </Typography>
+                      </>
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">
+                        No annotations yet
+                      </Typography>
+                    )}
+                    <Box sx={{ flex: 1 }} />
+                    <ReviewerStack participants={review.participants ?? []} />
+                    <DueDateLabel dueAt={review.dueAt} workflowState={review.workflowState} />
+                  </Stack>
+                </ButtonBase>
+              );
+            })}
+          </Stack>
+        </CardScroller>
       )}
     </SectionCard>
   );

--- a/qnop-ui/src/components/dashboard/StatStrip.tsx
+++ b/qnop-ui/src/components/dashboard/StatStrip.tsx
@@ -21,14 +21,17 @@
 
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
+import type { LucideIcon } from 'lucide-react';
 
 export interface StatTile {
   label: string;
   value: number;
-  /** Colours the value once it deserves attention (e.g. anything overdue). */
-  tone?: 'accent' | 'warning' | 'danger';
+  icon: LucideIcon;
+  /** Colours the tile once it deserves attention (e.g. anything overdue). */
+  tone?: 'accent' | 'warning' | 'danger' | 'success';
 }
 
 /**
@@ -43,9 +46,11 @@ export function StatStrip({ tiles }: { tiles: StatTile[] }) {
       ? theme.palette.error.main
       : tone === 'warning'
         ? theme.palette.warning.main
-        : tone === 'accent'
-          ? theme.qnop.brand.blue
-          : theme.palette.text.primary;
+        : tone === 'success'
+          ? theme.palette.success.main
+          : tone === 'accent'
+            ? theme.qnop.brand.blue
+            : theme.palette.text.primary;
 
   return (
     <Box
@@ -55,34 +60,60 @@ export function StatStrip({ tiles }: { tiles: StatTile[] }) {
         gap: 1.5,
       }}
     >
-      {tiles.map((tile) => (
-        <Paper
-          key={tile.label}
-          variant="outlined"
-          sx={{
-            px: 2,
-            py: 1.5,
-            borderRadius: '10px',
-            bgcolor:
-              tile.tone && tile.value > 0 ? alpha(toneColor(tile.tone), 0.05) : 'background.paper',
-          }}
-        >
-          <Typography
+      {tiles.map((tile) => {
+        const active = tile.tone && tile.value > 0;
+        const color = toneColor(tile.tone);
+        const Icon = tile.icon;
+        return (
+          <Paper
+            key={tile.label}
+            variant="outlined"
             sx={{
-              fontSize: '1.5rem',
-              fontWeight: 800,
-              lineHeight: 1.2,
-              fontVariantNumeric: 'tabular-nums',
-              color: tile.value > 0 ? toneColor(tile.tone) : 'text.primary',
+              px: 2,
+              py: 1.5,
+              borderRadius: '12px',
+              bgcolor: active ? alpha(color, 0.05) : 'background.paper',
+              borderColor: active ? alpha(color, 0.35) : 'divider',
             }}
           >
-            {tile.value}
-          </Typography>
-          <Typography variant="caption" color="text.secondary" noWrap component="p">
-            {tile.label}
-          </Typography>
-        </Paper>
-      ))}
+            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+              {/* A playful tinted round — the tile's mood at a glance. */}
+              <Box
+                aria-hidden
+                sx={{
+                  width: 34,
+                  height: 34,
+                  borderRadius: '10px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                  color: active ? color : 'text.secondary',
+                  bgcolor: alpha(active ? color : theme.palette.text.secondary, 0.1),
+                }}
+              >
+                <Icon size={16} />
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  sx={{
+                    fontSize: '1.4rem',
+                    fontWeight: 800,
+                    lineHeight: 1.2,
+                    fontVariantNumeric: 'tabular-nums',
+                    color: tile.value > 0 ? color : 'text.primary',
+                  }}
+                >
+                  {tile.value}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" noWrap component="p">
+                  {tile.label}
+                </Typography>
+              </Box>
+            </Stack>
+          </Paper>
+        );
+      })}
     </Box>
   );
 }

--- a/qnop-ui/src/components/dashboard/StatStrip.tsx
+++ b/qnop-ui/src/components/dashboard/StatStrip.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+
+export interface StatTile {
+  label: string;
+  value: number;
+  /** Colours the value once it deserves attention (e.g. anything overdue). */
+  tone?: 'accent' | 'warning' | 'danger';
+}
+
+/**
+ * The masthead's glance numbers (issue #454, prototype anatomy): four quiet
+ * tiles whose values only take colour when they mean work — tabular numerals,
+ * no decoration.
+ */
+export function StatStrip({ tiles }: { tiles: StatTile[] }) {
+  const theme = useTheme();
+  const toneColor = (tone?: StatTile['tone']) =>
+    tone === 'danger'
+      ? theme.palette.error.main
+      : tone === 'warning'
+        ? theme.palette.warning.main
+        : tone === 'accent'
+          ? theme.qnop.brand.blue
+          : theme.palette.text.primary;
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(4, 1fr)' },
+        gap: 1.5,
+      }}
+    >
+      {tiles.map((tile) => (
+        <Paper
+          key={tile.label}
+          variant="outlined"
+          sx={{
+            px: 2,
+            py: 1.5,
+            borderRadius: '10px',
+            bgcolor:
+              tile.tone && tile.value > 0 ? alpha(toneColor(tile.tone), 0.05) : 'background.paper',
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: '1.5rem',
+              fontWeight: 800,
+              lineHeight: 1.2,
+              fontVariantNumeric: 'tabular-nums',
+              color: tile.value > 0 ? toneColor(tile.tone) : 'text.primary',
+            }}
+          >
+            {tile.value}
+          </Typography>
+          <Typography variant="caption" color="text.secondary" noWrap component="p">
+            {tile.label}
+          </Typography>
+        </Paper>
+      ))}
+    </Box>
+  );
+}

--- a/qnop-ui/src/components/dashboard/dashboardModel.test.ts
+++ b/qnop-ui/src/components/dashboard/dashboardModel.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { DocumentSummary } from '../../api/generated';
+import {
+  activityPhrase,
+  deadlines,
+  dueUrgency,
+  greeting,
+  myReviews,
+  readyToFinalize,
+  reviewPath,
+  waitingOnYou,
+} from './dashboardModel';
+import { readRecentReviews, recordRecentReview } from './recentReviews';
+
+const ME = 'me';
+
+function review(overrides: Partial<DocumentSummary> = {}): DocumentSummary {
+  return {
+    id: 'd1',
+    title: 'Master agreement',
+    ownerId: 'someone-else',
+    workflowState: 'IN_REVIEW',
+    latestVersionNumber: 1,
+    annotationCount: 4,
+    openAnnotationCount: 2,
+    participants: [],
+    createdAt: '2026-07-01T10:00:00Z',
+    updatedAt: '2026-07-01T10:00:00Z',
+    ...overrides,
+  } as DocumentSummary;
+}
+
+describe('dueUrgency (issue #454)', () => {
+  const now = new Date('2026-07-11T12:00:00Z');
+
+  it('flags overdue with the day count', () => {
+    expect(dueUrgency('2026-07-08T12:00:00Z', now)).toEqual({
+      level: 'overdue',
+      label: 'Overdue by 3 days',
+    });
+  });
+
+  it('reads a same-day deadline as due today', () => {
+    expect(dueUrgency('2026-07-11T13:00:00Z', now).level).toBe('today');
+  });
+
+  it('counts down nearby deadlines as soon, distant ones as later', () => {
+    expect(dueUrgency('2026-07-12T12:00:00Z', now)).toEqual({
+      level: 'soon',
+      label: 'Due tomorrow',
+    });
+    expect(dueUrgency('2026-07-14T12:00:00Z', now).level).toBe('soon');
+    expect(dueUrgency('2026-07-25T12:00:00Z', now)).toEqual({
+      level: 'later',
+      label: '14 days left',
+    });
+  });
+});
+
+describe('role split (issue #454)', () => {
+  it('waitingOnYou keeps only open foreign reviews with open annotations', () => {
+    const reviews = [
+      review({ id: 'w1' }), // reviewer, open work → waiting
+      review({ id: 'o1', ownerId: ME }), // owned → not waiting
+      review({ id: 'f1', workflowState: 'FINALIZED' }), // closed → not waiting
+      review({ id: 'z1', openAnnotationCount: 0 }), // nothing open → not waiting
+    ];
+    expect(waitingOnYou(reviews, ME).map((r) => r.id)).toEqual(['w1']);
+  });
+
+  it('sorts the waiting list by due date first, then latest activity', () => {
+    const reviews = [
+      review({ id: 'later', dueAt: '2026-08-01T00:00:00Z' }),
+      review({ id: 'none', updatedAt: '2026-07-10T00:00:00Z' }),
+      review({ id: 'soon', dueAt: '2026-07-12T00:00:00Z' }),
+    ];
+    expect(waitingOnYou(reviews, ME).map((r) => r.id)).toEqual(['soon', 'later', 'none']);
+  });
+
+  it('myReviews lists owned reviews, running ones first', () => {
+    const reviews = [
+      review({
+        id: 'closed',
+        ownerId: ME,
+        workflowState: 'FINALIZED',
+        updatedAt: '2026-07-09T00:00:00Z',
+      }),
+      review({ id: 'open', ownerId: ME, updatedAt: '2026-07-01T00:00:00Z' }),
+      review({ id: 'foreign' }),
+    ];
+    expect(myReviews(reviews, ME).map((r) => r.id)).toEqual(['open', 'closed']);
+  });
+
+  it('deadlines keeps open reviews with a due date, soonest first', () => {
+    const reviews = [
+      review({ id: 'b', dueAt: '2026-08-01T00:00:00Z' }),
+      review({ id: 'a', dueAt: '2026-07-12T00:00:00Z' }),
+      review({ id: 'done', dueAt: '2026-07-01T00:00:00Z', workflowState: 'FINALIZED' }),
+      review({ id: 'undated' }),
+    ];
+    expect(deadlines(reviews).map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('readyToFinalize needs annotations, all settled, on a running review', () => {
+    expect(readyToFinalize(review({ annotationCount: 3, openAnnotationCount: 0 }))).toBe(true);
+    expect(readyToFinalize(review({ annotationCount: 0, openAnnotationCount: 0 }))).toBe(false);
+    expect(readyToFinalize(review({ openAnnotationCount: 1 }))).toBe(false);
+    expect(
+      readyToFinalize(
+        review({ annotationCount: 3, openAnnotationCount: 0, workflowState: 'FINALIZED' }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('labels & paths', () => {
+  it('greets by the hour, as the prototype does', () => {
+    expect(greeting(8)).toBe('Good morning');
+    expect(greeting(14)).toBe('Good afternoon');
+    expect(greeting(21)).toBe('Good evening');
+  });
+
+  it('prefers the slug in review paths', () => {
+    expect(reviewPath({ id: 'uuid', slug: 'master-agreement' })).toBe('/reviews/master-agreement');
+    expect(reviewPath({ id: 'uuid', slug: null })).toBe('/reviews/uuid');
+  });
+
+  it('maps every audit type to a verb phrase', () => {
+    expect(activityPhrase('annotation.resolved')).toBe('resolved an annotation in');
+    expect(activityPhrase('something.else')).toBe('updated');
+  });
+});
+
+describe('recent reviews (device-local continue strip)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips, deduplicates by id and caps at four', () => {
+    for (const n of [1, 2, 3, 4, 5]) {
+      recordRecentReview({ id: `d${n}`, slug: null, title: `Doc ${n}` });
+    }
+    recordRecentReview({ id: 'd3', slug: null, title: 'Doc 3 again' });
+
+    const recents = readRecentReviews();
+    expect(recents.map((r) => r.id)).toEqual(['d3', 'd5', 'd4', 'd2']);
+    expect(recents[0].title).toBe('Doc 3 again');
+  });
+
+  it('survives corrupted storage', () => {
+    localStorage.setItem('qnop-recent-reviews', '{not json');
+    expect(readRecentReviews()).toEqual([]);
+  });
+});

--- a/qnop-ui/src/components/dashboard/dashboardModel.ts
+++ b/qnop-ui/src/components/dashboard/dashboardModel.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { DocumentSummary } from '../../api/generated';
+import { isOpenWorkflowState } from '../reviews/workflowMeta';
+import { roleOf } from '../reviews/list/reviewListModel';
+
+const DAY_MS = 86_400_000;
+
+/** The dashboard's shared urgency language (prototype: overdue / today / soon). */
+export interface DueUrgency {
+  level: 'overdue' | 'today' | 'soon' | 'later';
+  label: string;
+}
+
+/**
+ * How a due date reads on the dashboard: overdue in days, "Due today", or the
+ * remaining time — `soon` within three days, `later` beyond.
+ */
+export function dueUrgency(dueAt: string, now: Date = new Date()): DueUrgency {
+  // Calendar days, not 24h windows — "tomorrow" means the next date.
+  const startOfDay = (date: Date) =>
+    new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  const diffDays = Math.round((startOfDay(new Date(dueAt)) - startOfDay(now)) / DAY_MS);
+  if (diffDays < 0) {
+    const days = -diffDays;
+    return { level: 'overdue', label: `Overdue by ${days} ${days === 1 ? 'day' : 'days'}` };
+  }
+  if (diffDays === 0) return { level: 'today', label: 'Due today' };
+  if (diffDays === 1) return { level: 'soon', label: 'Due tomorrow' };
+  return { level: diffDays <= 3 ? 'soon' : 'later', label: `${diffDays} days left` };
+}
+
+/** By due-date urgency first (missing dates last), then most recently updated. */
+function byUrgencyThenActivity(a: DocumentSummary, b: DocumentSummary): number {
+  if (a.dueAt && b.dueAt && a.dueAt !== b.dueAt) return a.dueAt.localeCompare(b.dueAt);
+  if (Boolean(a.dueAt) !== Boolean(b.dueAt)) return a.dueAt ? -1 : 1;
+  return b.updatedAt.localeCompare(a.updatedAt);
+}
+
+/**
+ * The reviewer hat's worklist: reviews I do NOT own, still running, with open
+ * annotations — what the round is waiting on.
+ */
+export function waitingOnYou(reviews: DocumentSummary[], userId: string | null) {
+  return reviews
+    .filter(
+      (review) =>
+        roleOf(review, userId) === 'reviewer' &&
+        isOpenWorkflowState(review.workflowState) &&
+        review.openAnnotationCount > 0,
+    )
+    .sort(byUrgencyThenActivity);
+}
+
+/** The owner hat: my reviews, running ones first, each most recent first. */
+export function myReviews(reviews: DocumentSummary[], userId: string | null) {
+  return reviews
+    .filter((review) => roleOf(review, userId) === 'owner')
+    .sort((a, b) => {
+      const openA = isOpenWorkflowState(a.workflowState);
+      const openB = isOpenWorkflowState(b.workflowState);
+      if (openA !== openB) return openA ? -1 : 1;
+      return b.updatedAt.localeCompare(a.updatedAt);
+    });
+}
+
+/** Every open review with a deadline, soonest first — the deadlines rail. */
+export function deadlines(reviews: DocumentSummary[]) {
+  return reviews
+    .filter((review) => Boolean(review.dueAt) && isOpenWorkflowState(review.workflowState))
+    .sort((a, b) => (a.dueAt as string).localeCompare(b.dueAt as string));
+}
+
+/** An owner cue: every concern settled, the review only awaits finalizing. */
+export function readyToFinalize(review: DocumentSummary): boolean {
+  return (
+    isOpenWorkflowState(review.workflowState) &&
+    review.annotationCount > 0 &&
+    review.openAnnotationCount === 0
+  );
+}
+
+/** The activity feed's verb phrase per audit event type (issue #454). */
+export function activityPhrase(type: string): string {
+  switch (type) {
+    case 'annotation.created':
+      return 'opened an annotation in';
+    case 'annotation.resolved':
+      return 'resolved an annotation in';
+    case 'annotation.reopened':
+      return 'reopened an annotation in';
+    case 'workflow.transition':
+      return 'changed the state of';
+    case 'document.due_date.changed':
+      return 'changed the due date of';
+    default:
+      return 'updated';
+  }
+}
+
+/** The prototype's time-of-day greeting. */
+export function greeting(hour: number): string {
+  if (hour < 11) return 'Good morning';
+  if (hour < 18) return 'Good afternoon';
+  return 'Good evening';
+}
+
+/** The review page path — the slug when one exists, the id otherwise. */
+export function reviewPath(review: { id: string; slug?: string | null }): string {
+  return `/reviews/${review.slug ?? review.id}`;
+}

--- a/qnop-ui/src/components/dashboard/dashboardModel.ts
+++ b/qnop-ui/src/components/dashboard/dashboardModel.ts
@@ -124,6 +124,13 @@ export function greeting(hour: number): string {
   return 'Good evening';
 }
 
+/** The greeting's small companion — one emoji, matched to the hour. */
+export function greetingEmoji(hour: number): string {
+  if (hour < 11) return '☀️';
+  if (hour < 18) return '👋';
+  return '🌙';
+}
+
 /** The review page path — the slug when one exists, the id otherwise. */
 export function reviewPath(review: { id: string; slug?: string | null }): string {
   return `/reviews/${review.slug ?? review.id}`;

--- a/qnop-ui/src/components/dashboard/recentReviews.ts
+++ b/qnop-ui/src/components/dashboard/recentReviews.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+const KEY = 'qnop-recent-reviews';
+const MAX_RECENTS = 4;
+
+/** One "continue where you left off" entry (issue #454) — device-local by design. */
+export interface RecentReview {
+  id: string;
+  slug?: string | null;
+  title: string;
+}
+
+/** The last opened reviews, newest first — [] when none or storage is unavailable. */
+export function readRecentReviews(): RecentReview[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is RecentReview =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as RecentReview).id === 'string' &&
+        typeof (entry as RecentReview).title === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Records a visit, deduplicated by id, newest first, capped. Best effort. */
+export function recordRecentReview(entry: RecentReview) {
+  try {
+    const rest = readRecentReviews().filter((existing) => existing.id !== entry.id);
+    localStorage.setItem(KEY, JSON.stringify([entry, ...rest].slice(0, MAX_RECENTS)));
+  } catch {
+    // best-effort persistence
+  }
+}

--- a/qnop-ui/src/components/reviews/list/ReviewListParts.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewListParts.tsx
@@ -147,7 +147,16 @@ export function ReviewerStack({ participants }: { participants: ParticipantView[
               zIndex: shown.length - index,
             }}
           >
-            <UserAvatar name={participant.displayName} size={24} />
+            <UserAvatar
+              name={participant.displayName}
+              size={24}
+              // Public read path (ADR-0031); a 404 quietly falls back to initials.
+              imageUrl={
+                participant.kind === 'USER'
+                  ? `/api/v1/users/${participant.principalId}/avatar`
+                  : null
+              }
+            />
           </Box>
         </Tooltip>
       ))}

--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -43,15 +43,21 @@ export function AppShell() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   // The document review workspace (#250), the version comparison (#252) and
-  // the tasks board (#393) span the full width; every other surface keeps the
-  // centred reading container. /reviews/new also matches the dynamic segment
-  // but is a regular centred page (the wizard, #251).
+  // the tasks board (#393) manage their own scrolling and tight padding.
+  // /reviews/new also matches the dynamic segment but is a regular page (the
+  // wizard, #251).
   const reviewMatch = useMatch('/reviews/:documentId');
   const compareMatch = useMatch('/reviews/:documentId/compare');
   const tasksMatch = useMatch('/reviews/:documentId/tasks');
   const fullBleed = Boolean(
     (reviewMatch && reviewMatch.params.documentId !== 'new') || compareMatch || tasksMatch,
   );
+  // The work surfaces share one width language (issue #454 follow-up): the
+  // dashboard and the reviews overview span the full width like the review
+  // workspace; admin and profile keep the centred reading container.
+  const dashboardMatch = useMatch('/');
+  const reviewsListMatch = useMatch('/reviews');
+  const wide = fullBleed || Boolean(dashboardMatch) || Boolean(reviewsListMatch);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
       return localStorage.getItem(COLLAPSE_KEY) === '1';
@@ -129,7 +135,7 @@ export function AppShell() {
           }}
         >
           <Container
-            maxWidth={fullBleed ? false : 'lg'}
+            maxWidth={wide ? false : 'lg'}
             sx={{
               py: fullBleed ? 2 : { xs: 3, md: 4 },
               height: fullBleed ? { md: '100%' } : undefined,

--- a/qnop-ui/src/components/shell/navConfig.tsx
+++ b/qnop-ui/src/components/shell/navConfig.tsx
@@ -148,6 +148,10 @@ export function crumbsFor(pathname: string): Crumb[] {
   if (pathname === '/') {
     return [{ label: 'Dashboard' }];
   }
+  // A colleague's public profile (issue #454) — never show the raw id.
+  if (pathname.startsWith('/users/')) {
+    return [{ label: 'Profile' }];
+  }
   for (const group of NAV_GROUPS) {
     // Exact match, or a detail page nested under an item (e.g. /admin/teams/:id):
     // both resolve to the item's section context (the id segment is not shown).

--- a/qnop-ui/src/pages/HomePage.test.tsx
+++ b/qnop-ui/src/pages/HomePage.test.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import type { DashboardResponse, DocumentSummary } from '../api/generated';
+import { useDashboard } from '../api/hooks/useDashboard';
+import { useReviews } from '../api/hooks/useReviews';
+import { buildTheme } from '../theme/theme';
+import { useAuthStore } from '../stores/authStore';
+import { HomePage } from './HomePage';
+
+vi.mock('../api/hooks/useReviews', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/hooks/useReviews')>()),
+  useReviews: vi.fn(),
+}));
+vi.mock('../api/hooks/useDashboard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/hooks/useDashboard')>()),
+  useDashboard: vi.fn(),
+}));
+
+const ME = 'me';
+
+function review(overrides: Partial<DocumentSummary> = {}): DocumentSummary {
+  return {
+    id: 'd1',
+    title: 'Master agreement',
+    ownerId: 'someone-else',
+    workflowState: 'IN_REVIEW',
+    latestVersionNumber: 1,
+    annotationCount: 4,
+    openAnnotationCount: 2,
+    participants: [],
+    createdAt: '2026-07-01T10:00:00Z',
+    updatedAt: '2026-07-01T10:00:00Z',
+    ...overrides,
+  } as DocumentSummary;
+}
+
+function mockData(reviews: DocumentSummary[], dashboard?: Partial<DashboardResponse>) {
+  vi.mocked(useReviews).mockReturnValue({
+    isPending: false,
+    isError: false,
+    data: { items: reviews, total: reviews.length, page: 0, size: 100 },
+  } as unknown as ReturnType<typeof useReviews>);
+  vi.mocked(useDashboard).mockReturnValue({
+    isPending: false,
+    isError: false,
+    data: {
+      replies: [],
+      activity: [],
+      stats: { resolvedThisWeek: 0 },
+      ...dashboard,
+    },
+  } as unknown as ReturnType<typeof useDashboard>);
+}
+
+function renderPage() {
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/reviews/:documentId" element={<div data-testid="review-page" />} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  useAuthStore.setState({ userId: ME, displayName: 'Mia Member' });
+});
+
+describe('HomePage dashboard (issue #454)', () => {
+  it('splits the two hats: waiting on you vs. my reviews', () => {
+    mockData([
+      review({ id: 'w1', title: 'Their contract' }),
+      review({ id: 'o1', title: 'My own paper', ownerId: ME }),
+    ]);
+    renderPage();
+
+    expect(screen.getAllByText('Waiting on you').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Their contract')).toBeInTheDocument();
+    expect(screen.getByText('My own paper')).toBeInTheDocument();
+  });
+
+  it('greets by first name and shows the glance numbers', () => {
+    mockData([review({ id: 'w1' }), review({ id: 'o1', ownerId: ME })], {
+      stats: { resolvedThisWeek: 8 },
+    });
+    renderPage();
+
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toMatch(/Good .*, Mia\./);
+    expect(screen.getByText('Resolved this week').previousSibling).toHaveTextContent('8');
+    expect(screen.getByText('Waiting on you', { selector: 'p' })).toBeInTheDocument();
+  });
+
+  it('cues the owner when every annotation is settled', () => {
+    mockData([review({ id: 'o1', ownerId: ME, annotationCount: 3, openAnnotationCount: 0 })]);
+    renderPage();
+
+    expect(screen.getByText('Ready to finalize')).toBeInTheDocument();
+  });
+
+  it('lists deadlines with the urgency label and links replies into the thread', () => {
+    mockData([review({ id: 'd-due', title: 'Due thing', dueAt: '2020-01-01T00:00:00Z' })], {
+      replies: [
+        {
+          commentId: 'c9',
+          annotationId: 'a9',
+          documentId: 'd-due',
+          documentTitle: 'Due thing',
+          authorDisplayName: 'Anna Krause',
+          body: 'I disagree with the wording.',
+          annotationExcerpt: 'please clarify',
+          createdAt: '2026-07-11T09:00:00Z',
+        },
+      ],
+    });
+    renderPage();
+
+    expect(screen.getByText(/Overdue by/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText('I disagree with the wording.'));
+    expect(screen.getByTestId('review-page')).toBeInTheDocument();
+  });
+
+  it('tells the activity story in sentences', () => {
+    mockData([review()], {
+      activity: [
+        {
+          type: 'annotation.resolved',
+          documentId: 'd1',
+          documentTitle: 'Master agreement',
+          actorDisplayName: 'Ben Roth',
+          createdAt: '2026-07-11T08:00:00Z',
+        },
+      ],
+    });
+    renderPage();
+
+    expect(screen.getByText('Ben Roth')).toBeInTheDocument();
+    expect(screen.getByText(/resolved an annotation in/)).toBeInTheDocument();
+  });
+
+  it('offers the continue strip once a review was visited', () => {
+    localStorage.setItem(
+      'qnop-recent-reviews',
+      JSON.stringify([{ id: 'd1', slug: 'master-agreement', title: 'Master agreement' }]),
+    );
+    mockData([review()]);
+    renderPage();
+
+    fireEvent.click(
+      screen
+        .getByText('Continue where you left off:')
+        .parentElement!.querySelector('.MuiChip-root')!,
+    );
+    expect(screen.getByTestId('review-page')).toBeInTheDocument();
+  });
+
+  it('welcomes a brand-new user with the empty state', () => {
+    mockData([]);
+    renderPage();
+
+    expect(screen.getByText('No reviews yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /New review/ })).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/pages/HomePage.tsx
+++ b/qnop-ui/src/pages/HomePage.tsx
@@ -20,32 +20,100 @@
  */
 
 import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { Inbox } from 'lucide-react';
+import { FileText, History, Inbox, Plus, UserCheck } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useDashboard } from '../api/hooks/useDashboard';
+import { useReviews } from '../api/hooks/useReviews';
+import { ActivityCard } from '../components/dashboard/ActivityCard';
+import {
+  deadlines,
+  dueUrgency,
+  greeting,
+  myReviews,
+  reviewPath,
+  waitingOnYou,
+} from '../components/dashboard/dashboardModel';
+import { DeadlinesCard } from '../components/dashboard/DeadlinesCard';
+import { readRecentReviews } from '../components/dashboard/recentReviews';
+import { RepliesCard } from '../components/dashboard/RepliesCard';
+import { ReviewListCard } from '../components/dashboard/ReviewListCard';
+import { StatStrip } from '../components/dashboard/StatStrip';
+import { isOpenWorkflowState } from '../components/reviews/workflowMeta';
 import { useAuthStore } from '../stores/authStore';
 
+const DATE_FORMAT = new Intl.DateTimeFormat('en-US', {
+  weekday: 'long',
+  day: 'numeric',
+  month: 'long',
+});
+
 /**
- * Dashboard placeholder (#102). Shows the signed-in user (from GET /users/me)
- * and frames the review workspace to come. The real command-centre dashboard
- * from the prototype lands in the PDF vertical slice (Phase B).
+ * The command-centre dashboard (issue #454, prototype `dashboard.jsx`): a
+ * greeting masthead with the glance numbers, then the two hats side by side —
+ * what the caller owes as a reviewer, what their own reviews are up to —
+ * flanked by replies directed at them, the deadline rail and the recent
+ * activity of their reviews. Renders from exactly two requests: the reviews
+ * overview and the dashboard aggregates.
  */
 export function HomePage() {
+  const navigate = useNavigate();
   const displayName = useAuthStore((s) => s.displayName);
+  const userId = useAuthStore((s) => s.userId);
+  const reviewsQuery = useReviews({ page: 0, size: 100, sort: 'updatedAt,desc' });
+  const dashboardQuery = useDashboard();
+
+  const reviews = reviewsQuery.data?.items ?? [];
+  const waiting = waitingOnYou(reviews, userId);
+  const owned = myReviews(reviews, userId);
+  const due = deadlines(reviews);
+  const recents = readRecentReviews();
+  const firstName = displayName?.split(' ')[0];
+
+  const overdueCount = due.filter(
+    (review) => dueUrgency(review.dueAt as string).level === 'overdue',
+  ).length;
+  const dueSoonCount = due.filter((review) =>
+    ['overdue', 'today', 'soon'].includes(dueUrgency(review.dueAt as string).level),
+  ).length;
+
+  const loading = reviewsQuery.isPending || dashboardQuery.isPending;
+  const empty = !reviewsQuery.isPending && reviews.length === 0;
 
   return (
     <Stack spacing={3}>
+      {/* Masthead: who, when, and the day's numbers. */}
       <Box>
-        <Typography variant="h1">Welcome{displayName ? `, ${displayName}` : ''}.</Typography>
-        <Typography color="text.secondary" sx={{ mt: 1 }}>
-          Your review workspace will take shape here over the next steps.
+        <Typography variant="h1">
+          {greeting(new Date().getHours())}
+          {firstName ? `, ${firstName}` : ''}.
+        </Typography>
+        <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+          {DATE_FORMAT.format(new Date())}
         </Typography>
       </Box>
 
-      <Card>
-        <CardContent>
+      {loading ? (
+        <Stack spacing={2}>
+          <Skeleton variant="rounded" height={76} />
+          <Skeleton variant="rounded" height={220} />
+        </Stack>
+      ) : empty ? (
+        // A brand-new workspace: keep the calm single-card welcome.
+        <Stack
+          spacing={2}
+          sx={{
+            alignItems: 'flex-start',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: '12px',
+            p: 3,
+          }}
+        >
           <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
             <Box
               sx={{
@@ -65,12 +133,91 @@ export function HomePage() {
             <Box>
               <Typography variant="h6">No reviews yet</Typography>
               <Typography color="text.secondary">
-                Once document upload is ready, your reviews will appear here.
+                Start your first review — upload a document and invite reviewers.
               </Typography>
             </Box>
           </Stack>
-        </CardContent>
-      </Card>
+          <Button
+            variant="contained"
+            startIcon={<Plus size={16} />}
+            onClick={() => navigate('/reviews')}
+          >
+            New review
+          </Button>
+        </Stack>
+      ) : (
+        <>
+          <StatStrip
+            tiles={[
+              {
+                label: 'Open reviews',
+                value: reviews.filter((r) => isOpenWorkflowState(r.workflowState)).length,
+              },
+              { label: 'Waiting on you', value: waiting.length, tone: 'accent' },
+              {
+                label: 'Due soon',
+                value: dueSoonCount,
+                tone: overdueCount > 0 ? 'danger' : 'warning',
+              },
+              {
+                label: 'Resolved this week',
+                value: dashboardQuery.data?.stats.resolvedThisWeek ?? 0,
+              },
+            ]}
+          />
+
+          {/* Continue where you left off — device-local, one click back in. */}
+          {recents.length > 0 && (
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+              <History size={14} aria-hidden style={{ opacity: 0.6 }} />
+              <Typography variant="caption" color="text.secondary">
+                Continue where you left off:
+              </Typography>
+              {recents.map((recent) => (
+                <Chip
+                  key={recent.id}
+                  label={recent.title}
+                  size="small"
+                  onClick={() => navigate(reviewPath(recent))}
+                />
+              ))}
+            </Stack>
+          )}
+
+          {/* The two hats plus context — main column and rail. */}
+          <Box
+            sx={{
+              display: 'grid',
+              gap: 2.5,
+              gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 7fr) minmax(0, 5fr)' },
+              alignItems: 'start',
+            }}
+          >
+            <Stack spacing={2.5} sx={{ minWidth: 0 }}>
+              <ReviewListCard
+                icon={UserCheck}
+                title="Waiting on you"
+                description="Reviews you are asked to work through."
+                reviews={waiting}
+                emptyText="Nothing waits on you — enjoy the quiet."
+              />
+              <ReviewListCard
+                icon={FileText}
+                title="My reviews"
+                description="Reviews you own, running ones first."
+                reviews={owned}
+                emptyText="You own no reviews yet."
+                ownerCues
+              />
+              <RepliesCard replies={dashboardQuery.data?.replies ?? []} />
+            </Stack>
+            <Stack spacing={2.5} sx={{ minWidth: 0 }}>
+              <DeadlinesCard reviews={due} />
+              <ActivityCard activity={dashboardQuery.data?.activity ?? []} />
+            </Stack>
+          </Box>
+        </>
+      )}
     </Stack>
   );
 }

--- a/qnop-ui/src/pages/HomePage.tsx
+++ b/qnop-ui/src/pages/HomePage.tsx
@@ -25,7 +25,7 @@ import Chip from '@mui/material/Chip';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { FileText, History, Inbox, Plus, UserCheck } from 'lucide-react';
+import { CalendarClock, FileText, History, Inbox, Plus, Trophy, UserCheck } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useDashboard } from '../api/hooks/useDashboard';
 import { useReviews } from '../api/hooks/useReviews';
@@ -34,6 +34,7 @@ import {
   deadlines,
   dueUrgency,
   greeting,
+  greetingEmoji,
   myReviews,
   reviewPath,
   waitingOnYou,
@@ -90,7 +91,10 @@ export function HomePage() {
       <Box>
         <Typography variant="h1">
           {greeting(new Date().getHours())}
-          {firstName ? `, ${firstName}` : ''}.
+          {firstName ? `, ${firstName}` : ''}.{' '}
+          <Box component="span" aria-hidden sx={{ fontSize: '0.8em' }}>
+            {greetingEmoji(new Date().getHours())}
+          </Box>
         </Typography>
         <Typography color="text.secondary" sx={{ mt: 0.5 }}>
           {DATE_FORMAT.format(new Date())}
@@ -152,16 +156,20 @@ export function HomePage() {
               {
                 label: 'Open reviews',
                 value: reviews.filter((r) => isOpenWorkflowState(r.workflowState)).length,
+                icon: Inbox,
               },
-              { label: 'Waiting on you', value: waiting.length, tone: 'accent' },
+              { label: 'Waiting on you', value: waiting.length, tone: 'accent', icon: UserCheck },
               {
                 label: 'Due soon',
                 value: dueSoonCount,
                 tone: overdueCount > 0 ? 'danger' : 'warning',
+                icon: CalendarClock,
               },
               {
                 label: 'Resolved this week',
                 value: dashboardQuery.data?.stats.resolvedThisWeek ?? 0,
+                tone: 'success',
+                icon: Trophy,
               },
             ]}
           />
@@ -200,6 +208,7 @@ export function HomePage() {
                 description="Reviews you are asked to work through."
                 reviews={waiting}
                 emptyText="Nothing waits on you — enjoy the quiet."
+                celebrateEmpty
               />
               <ReviewListCard
                 icon={FileText}

--- a/qnop-ui/src/pages/HomePage.tsx
+++ b/qnop-ui/src/pages/HomePage.tsx
@@ -189,7 +189,7 @@ export function HomePage() {
             sx={{
               display: 'grid',
               gap: 2.5,
-              gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 7fr) minmax(0, 5fr)' },
+              gridTemplateColumns: { xs: '1fr', lg: 'repeat(2, minmax(0, 1fr))' },
               alignItems: 'start',
             }}
           >

--- a/qnop-ui/src/pages/UserProfilePage.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { CalendarDays } from 'lucide-react';
+import { Navigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import type { PublicUserProfile } from '../api/generated';
+import { usersApi } from '../api/config';
+import { useAuthStore } from '../stores/authStore';
+import { UserAvatar } from '../components/shell/UserAvatar';
+
+const SINCE_FORMAT = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
+
+/**
+ * A colleague's workspace-public profile (issue #454): the person behind the
+ * avatars and names linked across the dashboards — display name, picture and
+ * tenure, deliberately nothing more. Your own id redirects to the full
+ * {@code /profile}.
+ */
+export function UserProfilePage() {
+  const theme = useTheme();
+  const { userId } = useParams<{ userId: string }>();
+  const selfId = useAuthStore((s) => s.userId);
+  const profileQuery = useQuery<PublicUserProfile>({
+    queryKey: ['users', 'public-profile', userId],
+    queryFn: async () => {
+      const response = await usersApi.getUserProfile({ userId: userId as string });
+      return response.data;
+    },
+    enabled: Boolean(userId) && userId !== selfId,
+  });
+
+  if (userId && userId === selfId) {
+    return <Navigate to="/profile" replace />;
+  }
+  if (profileQuery.isPending) {
+    return <Skeleton variant="rounded" height={220} sx={{ maxWidth: 560 }} />;
+  }
+  if (profileQuery.isError || !profileQuery.data) {
+    return <Alert severity="error">This user does not exist.</Alert>;
+  }
+
+  const profile = profileQuery.data;
+  return (
+    <Stack spacing={0} sx={{ maxWidth: 560 }}>
+      {/* A soft identity band — the avatar palette's tint as atmosphere. */}
+      <Box
+        sx={{
+          height: 84,
+          borderRadius: '14px 14px 0 0',
+          background: `linear-gradient(120deg, ${alpha(theme.qnop.brand.blue, 0.16)}, ${alpha(
+            theme.qnop.brand.blue,
+            0.04,
+          )})`,
+          border: '1px solid',
+          borderBottom: 'none',
+          borderColor: 'divider',
+        }}
+      />
+      <Stack
+        spacing={1.5}
+        sx={{
+          px: 3,
+          pb: 3,
+          border: '1px solid',
+          borderTop: 'none',
+          borderColor: 'divider',
+          borderRadius: '0 0 14px 14px',
+        }}
+      >
+        <Box sx={{ mt: -4.5 }}>
+          <Box
+            sx={{
+              display: 'inline-flex',
+              borderRadius: '50%',
+              border: '4px solid',
+              borderColor: 'background.paper',
+            }}
+          >
+            <UserAvatar name={profile.displayName} size={76} imageUrl={profile.avatarUrl ?? null} />
+          </Box>
+        </Box>
+        <Box>
+          <Typography variant="h2" sx={{ fontSize: '1.4rem' }}>
+            {profile.displayName}
+          </Typography>
+          <Stack
+            direction="row"
+            spacing={0.75}
+            sx={{ alignItems: 'center', color: 'text.secondary', mt: 0.5 }}
+          >
+            <CalendarDays size={14} aria-hidden />
+            <Typography variant="body2">
+              Member since {SINCE_FORMAT.format(new Date(profile.createdAt))}
+            </Typography>
+          </Stack>
+        </Box>
+      </Stack>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -87,6 +87,7 @@ import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
 import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
 import { isOpenWorkflowState } from '../../components/reviews/workflowMeta';
+import { recordRecentReview } from '../../components/dashboard/recentReviews';
 import { useAuthStore } from '../../stores/authStore';
 import { apiErrorCode } from '../../utils/apiError';
 import { pdfFetchVersion, resolveEffectiveVersion } from './resolveEffectiveVersion';
@@ -148,6 +149,18 @@ export function DocumentReviewPage() {
   const [viewMode, setViewMode] = useViewMode();
   // The unseen-marker baseline (issue #307): the PREVIOUS visit, stamped once.
   const previousSeenAt = useRecordVisit(documentId);
+  // Feed the dashboard's "continue where you left off" (issue #454) —
+  // device-local by design, so a plain localStorage stamp per resolved doc.
+  const resolvedDocument = documentQuery.data;
+  useEffect(() => {
+    if (resolvedDocument) {
+      recordRecentReview({
+        id: resolvedDocument.id,
+        slug: resolvedDocument.slug ?? null,
+        title: resolvedDocument.title,
+      });
+    }
+  }, [resolvedDocument]);
   // The view tabs (issue #398) address the mode through the URL — ?view= wins
   // over (and updates) the stored preference; the param stays shareable.
   const urlView = searchParams.get('view');

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -31,6 +31,7 @@ import { ComingSoonPage } from '../pages/ComingSoonPage';
 import { HomePage } from '../pages/HomePage';
 import { BrandingPage } from '../pages/admin/BrandingPage';
 import { ProfilePage } from '../pages/ProfilePage';
+import { UserProfilePage } from '../pages/UserProfilePage';
 import { EmailServerPage } from '../pages/admin/EmailServerPage';
 import { MailTemplatesListPage } from '../pages/admin/MailTemplatesListPage';
 import { OidcProvidersPage } from '../pages/admin/OidcProvidersPage';
@@ -92,6 +93,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> },
       { path: 'profile', element: <ProfilePage /> },
+      { path: 'users/:userId', element: <UserProfilePage /> },
       { path: 'reviews', element: <ReviewsPage /> },
       { path: 'reviews/new', element: <NewReviewPage /> },
       {


### PR DESCRIPTION
## Summary

The home page stops being the #102 placeholder and becomes the command-centre dashboard from the design prototype (`dashboard.jsx`) — built in five steps on this branch.

### The dashboard
- **Masthead** with a time-of-day greeting (+ emoji) and four glance tiles with tinted icon rounds: open reviews, waiting on you (accent), due soon (warning/danger once something is overdue), resolved this week (green trophy).
- **Two hats, split**: "Waiting on you" (foreign open reviews with open annotations, urgency-sorted, celebrating "All caught up! 🎉" when empty) and "My reviews" (running first, with a "Ready to finalize" cue once every annotation is settled). Rows carry workflow badge, resolution progress, reviewer avatar stacks and the due-date label.
- **Replies to you**: the latest comments by others in threads the caller started or joined, with thread deep links (#412 permalinks).
- **Deadlines rail**: every open review with a due date (#295), soonest first, calendar-day urgency labels ("Due today", "Due tomorrow", "Overdue by N days") in the urgency colours.
- **Recent activity**: a slim audit-trail feed in sentences (own actions excluded).
- **Continue where you left off**: device-local recents (localStorage), stamped by the review page.

### Backend
- One aggregated **`GET /dashboard`** (OpenAPI-first): replies to the caller (one batched query — annotations they authored or threads they joined), the activity feed (annotation events of PRIVATE-participation reviews only for the owner), and the weekly resolved count. Together with the existing reviews overview the whole page renders from **exactly two requests**.
- **`GET /users/{userId}`**: the lean, workspace-public profile slice (display name, avatar, member-since — no email/role/source; 404 mapped) backing the new `/users/:userId` page.
- **Anonymity holds (#413)**: the views carry the author's/actor's REAL id and a server-built avatar URL only when the review does not pseudonymise that identity towards the caller — pseudonyms stay unlinked, initials-only.

### People & playfulness
- Shared **PersonLink** (avatar + name → `/profile` for self, `/users/{id}` for colleagues) in replies and the activity feed; reviewer stacks load the public avatar read path (ADR-0031) with an initials fallback.
- **Cockpit-height cards**: with real data volumes, every card caps at one shared 336px viewport and scrolls internally (new `CardScroller`) — soft edge fades as the scroll affordance, a hairline scrollbar, and a `CountPill` per header keeping the true volume honest.

### Shell
- One width language: the dashboard and the reviews overview span the full width like the review workspace (`wide`), while `fullBleed` keeps meaning the workspace's own scrolling. Admin/profile keep the centred reading container. The dashboard grid splits 50/50.

## Test plan
- [x] Backend: `./gradlew build`; `DashboardApiIT` (replies incl. join-semantics and real-id exposure, activity excl. own actions, weekly stat, empty aggregates, auth), `UserProfileApiIT` (lean slice, 404, 401)
- [x] Frontend: 742 tests (dashboard model: urgency calendar semantics, role split, ready-to-finalize, recents round-trip; HomePage: both hats, glance numbers, deadline labels, reply deep links, activity sentences, continue strip, empty state), `pnpm lint`, `pnpm typecheck`
- [x] Browser: seeded ~30 randomised reviews across 9 users (mixed owners/reviewers, annotations, replies, reactions, resolves, all due-date urgency bands incl. backdated overdues) and walked the dashboard as owner and reviewer; profile links, card scrolling and fades verified live

Closes #454.

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)