### PR TITLE
feat(theme): black-based neutral dark mode, derived greyscale ramp (#423)

### DIFF
--- a/qnop-ui/src/components/auth/AuthModeSwitch.tsx
+++ b/qnop-ui/src/components/auth/AuthModeSwitch.tsx
@@ -56,7 +56,7 @@ export function AuthModeSwitch({ active }: { active: Mode }) {
             to={to}
             replace
             aria-current={isActive ? 'page' : undefined}
-            sx={{
+            sx={(theme) => ({
               flex: 1,
               height: 38,
               display: 'flex',
@@ -70,9 +70,12 @@ export function AuthModeSwitch({ active }: { active: Mode }) {
               transition: 'all .15s',
               color: isActive ? 'text.primary' : 'text.secondary',
               bgcolor: isActive ? 'background.paper' : 'transparent',
-              boxShadow: isActive ? '0 1px 3px rgba(1,32,66,0.10)' : 'none',
+              boxShadow:
+                isActive && theme.palette.mode === 'light'
+                  ? '0 1px 3px rgba(1,32,66,0.10)'
+                  : 'none',
               '&:hover': { color: isActive ? 'text.primary' : 'text.primary' },
-            }}
+            })}
           >
             {label}
           </Box>

--- a/qnop-ui/src/components/reviews/focus/FocusScrimLayer.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusScrimLayer.tsx
@@ -58,7 +58,10 @@ export function FocusScrimLayer({ spotlight, onDismiss, surfaceIndex }: FocusScr
         backdropFilter: 'blur(1px)',
         '@media (prefers-reduced-transparency: reduce)': {
           backdropFilter: 'none',
-          bgcolor: 'rgba(1, 32, 66, 0.14)',
+          // Neutral veil per mode (issue #423): navy tint in light, plain
+          // white-alpha lift on the black-based dark surfaces.
+          bgcolor: (theme) =>
+            theme.palette.mode === 'light' ? 'rgba(1, 32, 66, 0.14)' : 'rgba(255, 255, 255, 0.10)',
         },
         clipPath: spotlight ? holePolygon(spotlight) : undefined,
         transition: `clip-path ${tokens.motion.durSlow}ms ${tokens.motion.easeInOut}`,

--- a/qnop-ui/src/components/reviews/list/ReviewCards.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewCards.tsx
@@ -72,7 +72,10 @@ export function ReviewCards({ reviews, userId, onOpen }: ReviewCardsProps) {
               '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
               '&:hover': {
                 transform: 'translateY(-3px)',
-                boxShadow: '0 14px 36px -14px rgba(1, 32, 66, 0.22)',
+                boxShadow:
+                  theme.palette.mode === 'light'
+                    ? '0 14px 36px -14px rgba(1, 32, 66, 0.22)'
+                    : 'none',
                 borderColor: theme.palette.text.disabled,
               },
               '&:focus-visible': { boxShadow: theme.qnop.focusRing },

--- a/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
+++ b/qnop-ui/src/components/reviews/viewer/AnnotationHoverCard.tsx
@@ -104,7 +104,8 @@ export function AnnotationHoverCard({ annotation, getAnchorPosition }: Annotatio
             width: 320,
             borderRadius: 0.75,
             border: `1px solid ${theme.palette.divider}`,
-            boxShadow: '0 12px 32px -8px rgba(1, 32, 66, 0.25)',
+            boxShadow:
+              theme.palette.mode === 'light' ? '0 12px 32px -8px rgba(1, 32, 66, 0.25)' : 'none',
             overflow: 'hidden',
           },
         },

--- a/qnop-ui/src/components/shell/UserAvatar.tsx
+++ b/qnop-ui/src/components/shell/UserAvatar.tsx
@@ -69,6 +69,10 @@ export function UserAvatar({ name, size = 28, imageUrl }: UserAvatarProps) {
         flexShrink: 0,
         overflow: 'hidden',
         bgcolor: palette[idx],
+        // On the black-based dark surfaces (issue #423) the darkest palette
+        // tones sink below 3:1 against the page — a quiet ring keeps every
+        // avatar's boundary readable without touching the identity colours.
+        border: theme.qnop.mode === 'dark' ? `1px solid ${theme.palette.divider}` : 'none',
         color: '#fff',
         display: 'flex',
         alignItems: 'center',

--- a/qnop-ui/src/theme/tokens.ts
+++ b/qnop-ui/src/theme/tokens.ts
@@ -68,13 +68,19 @@ const light = {
   borderStrong: '#CBD4DF',
 } as const;
 
+// Black-based neutral ramp (issue #423): a near-black base with a hair of
+// cool temperature (not clinical #000), surfaces raised in even neutral
+// steps, and an untinted text ramp. Calibrated programmatically: fg ≥15:1,
+// fg2 ≥8:1, fg3 ≥4.9:1 on every surface; brand blue reads at ≥5.1:1 and all
+// badge fgDark tones at ≥6.4:1 on their tinted surfaces. The borders were
+// already neutral white-alpha and carry over unchanged.
 const dark = {
-  bg: '#0A1828',
-  surface: '#0F2340',
-  surface2: '#132A4A',
-  fg: '#EAF1FA',
-  fg2: '#B9C6D4',
-  fg3: '#7A8BA0',
+  bg: '#0B0C0E',
+  surface: '#141518',
+  surface2: '#1C1D21',
+  fg: '#F2F3F5',
+  fg2: '#B4B8BF',
+  fg3: '#878B93',
   border: 'rgba(255,255,255,0.08)',
   borderStrong: 'rgba(255,255,255,0.14)',
 } as const;


### PR DESCRIPTION
## Summary

The dark theme drops its navy base for a **near-black neutral ramp** — every dark colour now derives from one black base, as #423 asks. Light mode is untouched.

### The ramp

| Token | New | Was (navy) |
|---|---|---|
| `bg` | `#0B0C0E` | `#0A1828` |
| `surface` | `#141518` | `#0F2340` |
| `surface2` | `#1C1D21` | `#132A4A` |
| `fg` | `#F2F3F5` | `#EAF1FA` |
| `fg2` | `#B4B8BF` | `#B9C6D4` |
| `fg3` | `#878B93` | `#7A8BA0` |
| `border`/`borderStrong` | unchanged (already neutral white-alpha) | — |

Calibrated **programmatically against WCAG AA** (script output, worst surface): `fg` 15.2:1, `fg2` 8.5:1, `fg3` 4.9:1; brand blue 5.1:1 (better than on navy); badge `fgDark` tones 6.4–8.7:1 on their tinted surfaces; semantic tones 4.3–11:1.

### Navy assumptions outside the tokens

- The three navy-tinted shadows that did **not** branch on mode (auth mode switch, annotation hover card, review cards) now drop to `none` in dark — matching what `SurfacePage`/`ComparePane` already did.
- The focus scrim's `prefers-reduced-transparency` fallback veils with white-alpha on dark instead of navy.
- **Avatars gain a quiet divider ring in dark mode**: the two darkest palette tones (`#055396`, `#3B4958`) fell below 3:1 boundary contrast on black — the ring keeps every avatar readable without touching the deterministic identity colours.

## Test plan
- [x] 742 frontend tests, `pnpm lint`, `pnpm typecheck` — `theme.test.ts` reads the tokens and needed no change (as the issue anticipated)
- [x] Contrast calibration script over the full matrix (text ramp × surfaces, accents, badge tones, avatar palette)
- [x] Dark-mode visual pass with the seeded data: dashboard (stat tiles, card scroller fades follow `background.paper` automatically), reviews list, review workspace with annotation panel (reaction chips, badges, progress), focus mode (scrim + floating card) — no navy left anywhere

Closes #423.

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)