### PR TITLE
feat(reviews): surface re-anchoring outcomes — banner, facet, cues & confirm (#326)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2584,6 +2584,55 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /annotations/{annotationId}/placements/{versionNumber}/confirm:
+    parameters:
+      - $ref: '#/components/parameters/AnnotationIdParam'
+      - name: versionNumber
+        in: path
+        required: true
+        schema:
+          type: integer
+    post:
+      tags: [Annotations]
+      summary: Confirm a MOVED placement after review (owner or author)
+      description: |
+        The human half of re-anchoring (ADR-0009, issue #326): a MOVED
+        placement means the anchor was relocated with a change worth checking.
+        Once the document owner or the annotation's author has verified the
+        highlight on that version, confirming flips the placement back to
+        PLACED, keeping the resolved anchor. Only MOVED placements confirm —
+        anything else answers 409 (`PLACEMENT_NOT_MOVED`); orphans are handled
+        by re-drawing or resolving instead.
+      operationId: confirmPlacement
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The updated annotation with the confirmed placement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationView'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: The caller is neither the document owner nor the annotation's author
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown annotation, version, or no placement on that version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: The placement is not MOVED (`PLACEMENT_NOT_MOVED`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /annotations/{annotationId}/comments:
     parameters:
       - $ref: '#/components/parameters/AnnotationIdParam'

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -138,6 +138,14 @@ public class AnnotationController implements AnnotationsApi {
   }
 
   @Override
+  public ResponseEntity<AnnotationView> confirmPlacement(UUID annotationId, Integer versionNumber) {
+    return ResponseEntity.ok(
+        toDto(
+            annotations.confirmPlacement(
+                annotationId, versionNumber, CurrentUser.requireUserId(), CurrentUser.isAdmin())));
+  }
+
+  @Override
   public ResponseEntity<CommentView> addComment(UUID annotationId, CommentCreateRequest request) {
     AnnotationService.CommentView view =
         annotations.addComment(

--- a/qnop-app/src/test/java/io/qnop/review/PlacementConfirmApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/PlacementConfirmApiIT.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * The human half of re-anchoring over the wire (ADR-0009, issue #326): the document owner or the
+ * annotation's author confirms a reviewed MOVED placement back to PLACED; other participants are
+ * refused, non-MOVED placements answer a stable 409, and the confirmation lands in the audit trail.
+ */
+class PlacementConfirmApiIT extends SeededIntegrationTest {
+
+  private static final String ANCHOR =
+      "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.1}},"
+          + "\"textQuote\":{\"quote\":\"the clause\"}}";
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+  @Autowired private AnnotationPlacementRepository placements;
+  @Autowired private AuditEventRepository auditEvents;
+
+  private UUID documentId;
+  private UUID versionId;
+
+  private void seedDocument() {
+    Document document = documents.save(new Document(MEMBER_ID, "Master services agreement"));
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
+    versionId =
+        versions
+            .save(
+                new DocumentVersion(
+                    document.getId(),
+                    1,
+                    "sha256/aa/deadbeef",
+                    "deadbeef",
+                    "application/pdf",
+                    1234L,
+                    MEMBER_ID))
+            .getId();
+    documentId = document.getId();
+  }
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  /** Creates an anchored annotation as AUDITOR and forces its v1 placement to MOVED. */
+  private String movedAnnotation() throws Exception {
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        "{\"versionNumber\":1,\"anchor\":" + ANCHOR + ",\"comment\":\"check\"}"))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String annotationId = JsonPath.read(json, "$.id");
+    AnnotationPlacement placement =
+        placements
+            .findByAnnotationIdAndDocumentVersionId(UUID.fromString(annotationId), versionId)
+            .orElseThrow();
+    placement.markMoved(ANCHOR);
+    placements.save(placement);
+    return annotationId;
+  }
+
+  @Test
+  @DisplayName("the author confirms a reviewed MOVED placement back to PLACED, audited")
+  void authorConfirms() throws Exception {
+    seedDocument();
+    String annotationId = movedAnnotation();
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/placements/1/confirm"), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.placementStatus").value("PLACED"));
+
+    assertThat(
+            auditEvents.findByDocumentIdOrderByCreatedAtDesc(documentId).stream()
+                .anyMatch(event -> event.getEventType().equals("placement.confirmed")))
+        .isTrue();
+    // The list view reflects it too.
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/annotations?version=1"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.annotations[0].placementStatus").value("PLACED"));
+  }
+
+  @Test
+  @DisplayName("the document owner may confirm as well; other participants may not")
+  void ownerYesStrangerNo() throws Exception {
+    seedDocument();
+    String annotationId = movedAnnotation();
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/placements/1/confirm"), MEMBER2_ID))
+        .andExpect(status().isForbidden());
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/placements/1/confirm"), MEMBER_ID))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("only MOVED confirms — a PLACED placement answers 409 PLACEMENT_NOT_MOVED")
+  void placedRefuses() throws Exception {
+    seedDocument();
+    String annotationId = movedAnnotation();
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/placements/1/confirm"), AUDITOR_ID))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/placements/1/confirm"), AUDITOR_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("PLACEMENT_NOT_MOVED"));
+  }
+
+  @Test
+  @DisplayName("an unknown version or a version without a placement answers 404")
+  void missingPlacement404() throws Exception {
+    seedDocument();
+    String annotationId = movedAnnotation();
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/placements/9/confirm"), AUDITOR_ID))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -30,6 +30,7 @@ import io.qnop.entity.AnnotationType;
 import io.qnop.entity.AuditEvent;
 import io.qnop.entity.Comment;
 import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.PlacementStatus;
 import io.qnop.entity.ThreadParticipation;
 import io.qnop.repository.AnnotationCommentActivity;
 import io.qnop.repository.AnnotationCommentCount;
@@ -62,6 +63,7 @@ public class AnnotationService {
 
   static final String AUDIT_ANNOTATION_CREATED = "annotation.created";
   static final String AUDIT_ANNOTATION_CLASSIFIED = "annotation.classified";
+  static final String AUDIT_PLACEMENT_CONFIRMED = "placement.confirmed";
 
   /** Comments can be 20k chars; the view carries only what a card title needs (issue #393). */
   static final int FIRST_COMMENT_EXCERPT_CHARS = 300;
@@ -378,6 +380,62 @@ public class AnnotationService {
         threadSize(updated.getId()),
         foreignActivity(updated.getId(), actor),
         annotationReactions(updated.getId(), actor, identities),
+        identities);
+  }
+
+  /**
+   * Confirms a MOVED placement after human review (ADR-0009, issue #326): the document owner or the
+   * annotation's author verified the relocated highlight on {@code versionNumber}, so the placement
+   * flips back to PLACED, keeping the resolved anchor. Only MOVED confirms — anything else answers
+   * 409, so a stale client racing the re-anchoring job gets a stable signal.
+   */
+  @Transactional
+  public AnnotationView confirmPlacement(
+      UUID annotationId, int versionNumber, UUID actor, boolean admin) {
+    Annotation annotation = requireAnnotation(annotationId);
+    DocumentAccessService.DocumentView document =
+        documentAccess.getDocument(annotation.getDocumentId(), actor, admin);
+    if (!canSeeThread(document, annotation.getAuthorId(), actor, admin)) {
+      throw DocumentValidationException.notFound("no such annotation: " + annotationId);
+    }
+    if (!admin && !document.ownerId().equals(actor) && !annotation.getAuthorId().equals(actor)) {
+      throw new AnnotationActionForbiddenException(
+          "Only the document owner or the annotation's author may confirm a placement");
+    }
+    DocumentVersion version =
+        versions
+            .findByDocumentIdAndVersionNumber(annotation.getDocumentId(), versionNumber)
+            .orElseThrow(
+                () -> DocumentValidationException.notFound("no such version: " + versionNumber));
+    AnnotationPlacement placement =
+        placements
+            .findByAnnotationIdAndDocumentVersionId(annotationId, version.getId())
+            .orElseThrow(
+                () ->
+                    DocumentValidationException.notFound(
+                        "no placement on version " + versionNumber));
+    if (placement.getStatus() != PlacementStatus.MOVED) {
+      throw new WorkflowTransitionException(
+          WorkflowTransitionException.PLACEMENT_NOT_MOVED,
+          "placement is " + placement.getStatus() + "; only MOVED placements confirm");
+    }
+    placement.markPlaced(placement.getAnchor());
+    auditEvents.save(
+        new AuditEvent(
+            annotation.getDocumentId(),
+            AUDIT_PLACEMENT_CONFIRMED,
+            actor,
+            "{\"annotationId\":\"%s\",\"versionNumber\":%d}"
+                .formatted(annotationId, versionNumber)));
+    ReviewIdentityResolver.ReviewIdentities identities =
+        identity.forDocument(annotation.getDocumentId(), actor);
+    return view(
+        annotation,
+        placement,
+        firstComment(annotationId),
+        threadSize(annotationId),
+        foreignActivity(annotationId, actor),
+        annotationReactions(annotationId, actor, identities),
         identities);
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
@@ -74,6 +74,7 @@ public class DashboardService {
           "annotation.created",
           "annotation.resolved",
           "annotation.reopened",
+          "placement.confirmed",
           "workflow.transition",
           "document.due_date.changed");
 

--- a/qnop-core/src/main/java/io/qnop/service/review/WorkflowTransitionException.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/WorkflowTransitionException.java
@@ -34,6 +34,8 @@ public class WorkflowTransitionException extends RuntimeException {
   /** A resolution was requested on an annotation that is no longer {@code OPEN}. */
   public static final String ANNOTATION_ALREADY_RESOLVED = "ANNOTATION_ALREADY_RESOLVED";
 
+  public static final String PLACEMENT_NOT_MOVED = "PLACEMENT_NOT_MOVED";
+
   /** An annotation was raised on a review that is already FINALIZED or CANCELLED (issue #405). */
   public static final String REVIEW_CLOSED = "REVIEW_CLOSED";
 

--- a/qnop-ui/src/api/hooks/useAnnotations.ts
+++ b/qnop-ui/src/api/hooks/useAnnotations.ts
@@ -22,6 +22,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { AnnotationCreateRequest, AnnotationListResponse } from '../generated';
 import { annotationsApi } from '../config';
+import type { Notify } from '../../components/admin/layout/useToast';
 import { commentKeys } from './useComments';
 import { documentKeys } from './useDocuments';
 
@@ -121,5 +122,25 @@ export function useResolveAnnotation() {
       // only, so the PDF/rendered caches stay put (issue #403).
       queryClient.invalidateQueries({ queryKey: documentKeys.detail(updated.documentId) });
     },
+  });
+}
+
+/**
+ * Confirms a reviewed MOVED placement back to PLACED (ADR-0009, issue #326) —
+ * the human half of re-anchoring, allowed for the owner or the annotation's
+ * author on the version whose highlight was verified.
+ */
+export function useConfirmPlacement(notify: Notify) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { annotationId: string; versionNumber: number }) => {
+      const response = await annotationsApi.confirmPlacement(input);
+      return response.data;
+    },
+    onSuccess: () => {
+      notify('Placement confirmed.', 'success');
+      queryClient.invalidateQueries({ queryKey: annotationKeys.all });
+    },
+    onError: () => notify('Could not confirm the placement.', 'error'),
   });
 }

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -46,6 +46,7 @@ vi.mock('../../../api/hooks/useComments', () => ({
 
 const { resolveMutate } = vi.hoisted(() => ({ resolveMutate: vi.fn() }));
 vi.mock('../../../api/hooks/useAnnotations', () => ({
+  useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useResolveAnnotation: () => ({ mutate: resolveMutate, isPending: false }),
   useReopenAnnotation: () => ({ mutate: vi.fn(), isPending: false }),
 }));

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -38,6 +38,7 @@ import { AnnotationStatus } from '../../../api/generated';
 import { tokens } from '../../../theme/tokens';
 import type { Notify } from '../../admin/layout/useToast';
 import type { BuildPermalink } from '../useReviewPermalink';
+import { useConfirmPlacement } from '../../../api/hooks/useAnnotations';
 import { AnnotationHead } from '../panel/AnnotationHead';
 import { CommentThread } from '../panel/CommentThread';
 import { ResolveBar } from '../panel/ResolveBar';
@@ -61,6 +62,8 @@ interface FocusAnnotationCardProps {
   notify: Notify;
   /** True while an OLDER version is viewed (#306): thread readable, nothing writable. */
   readOnly?: boolean;
+  /** The viewed version — the scope of placement confirmation (issue #326). */
+  versionNumber?: number | null;
   /** True once the review is FINALIZED/CANCELLED (issue #394): no reopening. */
   reviewClosed?: boolean;
   /** Thread participation policy (issue #413) — READ_ONLY suppresses foreign composers. */
@@ -102,6 +105,7 @@ export function FocusAnnotationCard({
   userId,
   notify,
   readOnly = false,
+  versionNumber = null,
   reviewClosed = false,
   threadParticipation = 'OPEN',
   ownerId,
@@ -117,6 +121,7 @@ export function FocusAnnotationCard({
     threadParticipation !== 'OPEN' &&
     annotation.authorId !== userId &&
     !(ownerId != null && userId === ownerId);
+  const confirmPlacement = useConfirmPlacement(notify);
   const { resolveWith, isPending: resolving } = useResolveWithFeedback(notify);
   const { reopenWith } = useReopenWithFeedback(notify);
 
@@ -327,6 +332,19 @@ export function FocusAnnotationCard({
                       annotation={annotation}
                       permalinkUrl={buildPermalink?.(annotation.id)}
                       notify={notify}
+                      onConfirmPlacement={
+                        versionNumber != null &&
+                        !readOnly &&
+                        !reviewClosed &&
+                        annotation.placementStatus === 'MOVED' &&
+                        (userId === ownerId || userId === annotation.authorId)
+                          ? () =>
+                              confirmPlacement.mutate({
+                                annotationId: annotation.id,
+                                versionNumber,
+                              })
+                          : undefined
+                      }
                     />
                   </Box>
 

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
@@ -20,12 +20,14 @@
  */
 
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { MessageSquare } from 'lucide-react';
+import { Check, MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
+import { PlacementStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { isDocumentScoped } from '../annotationScope';
 import { WholeDocumentChip } from '../WholeDocumentChip';
@@ -37,6 +39,11 @@ interface AnnotationBadgeRowProps {
   annotation: AnnotationView;
   /** Adds the "New" badge (issue #307). */
   unseen?: boolean;
+  /**
+   * Confirms a reviewed MOVED placement (ADR-0009, issue #326) — its presence
+   * renders the "Looks right" affordance beside the Moved chip.
+   */
+  onConfirmPlacement?: () => void;
 }
 
 /**
@@ -45,7 +52,11 @@ interface AnnotationBadgeRowProps {
  * panel's head card and the mark's hover preview stay pixel-identical
  * (issue #403).
  */
-export function AnnotationBadgeRow({ annotation, unseen = false }: AnnotationBadgeRowProps) {
+export function AnnotationBadgeRow({
+  annotation,
+  unseen = false,
+  onConfirmPlacement,
+}: AnnotationBadgeRowProps) {
   const theme = useTheme();
   const statusCue = STATUS_CUES[annotation.status];
   const typeCue = annotation.type ? TYPE_CUES[annotation.type] : null;
@@ -83,6 +94,21 @@ export function AnnotationBadgeRow({ annotation, unseen = false }: AnnotationBad
         </Tooltip>
       )}
       <PlacementStatusChip status={annotation.placementStatus} />
+      {onConfirmPlacement && annotation.placementStatus === PlacementStatus.Moved && (
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<Check size={12} />}
+          onClick={(event) => {
+            // Sits inside clickable cards — confirming must not toggle them.
+            event.stopPropagation();
+            onConfirmPlacement();
+          }}
+          sx={{ py: 0, minHeight: 0, fontSize: 12 }}
+        >
+          Looks right
+        </Button>
+      )}
       <Stack
         direction="row"
         spacing={1}

--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -52,6 +52,8 @@ interface AnnotationHeadProps {
   /** With `notify`, the author row carries the hover-revealed copy-link (issue #412). */
   permalinkUrl?: string;
   notify?: Notify;
+  /** Confirms a reviewed MOVED placement (issue #326) — rendered beside the Moved chip. */
+  onConfirmPlacement?: () => void;
 }
 
 /**
@@ -68,6 +70,7 @@ export function AnnotationHead({
   unseen = false,
   permalinkUrl,
   notify,
+  onConfirmPlacement,
 }: AnnotationHeadProps) {
   const theme = useTheme();
   // Reactions on the opener (issue #410) — active wherever notify travels;
@@ -165,7 +168,11 @@ export function AnnotationHead({
           </Stack>
         </Box>
       </Stack>
-      <AnnotationBadgeRow annotation={annotation} unseen={unseen} />
+      <AnnotationBadgeRow
+        annotation={annotation}
+        unseen={unseen}
+        onConfirmPlacement={onConfirmPlacement}
+      />
       {/* The anchored passage, styled as a real quotation. */}
       {quote ? (
         <Box

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -25,9 +25,10 @@ import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { alpha, useTheme } from '@mui/material/styles';
-import { MessageSquare } from 'lucide-react';
+import { alpha, useTheme, type Theme } from '@mui/material/styles';
+import { MessageSquare, MoveRight, Unlink } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
+import { PlacementStatus } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
@@ -126,6 +127,8 @@ interface AnnotationListItemProps {
   /** The annotation permalink (issue #412) — shown in the expanded head's author row. */
   permalinkUrl?: string;
   notify?: Notify;
+  /** Confirms a reviewed MOVED placement (issue #326) — threaded to the head's badge row. */
+  onConfirmPlacement?: () => void;
   onHover?: (annotationId: string | null) => void;
 }
 
@@ -151,6 +154,7 @@ function AnnotationListItemBase({
   onHover,
   permalinkUrl,
   notify,
+  onConfirmPlacement,
 }: AnnotationListItemProps) {
   const theme = useTheme();
   const viewerId = useAuthStore((state) => state.userId);
@@ -161,6 +165,15 @@ function AnnotationListItemBase({
   const statusCue = STATUS_CUES[annotation.status];
   const StatusIcon = statusCue.icon;
   const typeCue = annotation.type ? TYPE_CUES[annotation.type] : null;
+  // Re-anchoring outcome worth a glance (ADR-0009, issue #326): amber for a
+  // relocated highlight, red for one the resolver lost.
+  const placementCue =
+    annotation.placementStatus === PlacementStatus.Moved
+      ? { icon: MoveRight, label: 'Moved', color: (t: Theme) => t.palette.warning.main }
+      : annotation.placementStatus === PlacementStatus.Orphaned ||
+          annotation.placementStatus === PlacementStatus.Failed
+        ? { icon: Unlink, label: 'Orphaned', color: (t: Theme) => t.palette.error.main }
+        : null;
   const priorityCue = annotation.priority ? PRIORITY_CUES[annotation.priority] : null;
   const viewerAvatarUrl = useAuthStore((state) => state.avatarUrl);
   const viewerName = useAuthStore((state) => state.displayName);
@@ -232,6 +245,7 @@ function AnnotationListItemBase({
           unseen={unseen}
           permalinkUrl={permalinkUrl}
           notify={notify}
+          onConfirmPlacement={onConfirmPlacement}
         />
       ) : (
         <Stack spacing={0.5} sx={{ minWidth: 0 }}>
@@ -307,6 +321,18 @@ function AnnotationListItemBase({
             >
               {shortRelativeTime(annotation.createdAt)}
             </Typography>
+            {placementCue && (
+              <Stack
+                direction="row"
+                spacing={0.4}
+                sx={{ alignItems: 'center', color: placementCue.color(theme), flexShrink: 0 }}
+              >
+                <placementCue.icon size={11} aria-hidden />
+                <Typography component="span" sx={{ fontSize: 11, fontWeight: 700 }}>
+                  {placementCue.label}
+                </Typography>
+              </Stack>
+            )}
             {typeCue && (
               <Stack
                 direction="row"

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -62,6 +62,7 @@ vi.mock('../../../api/hooks/useReviews', () => ({
   }),
 }));
 vi.mock('../../../api/hooks/useAnnotations', () => ({
+  useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useResolveAnnotation: () => ({ mutate: resolveMutate, isPending: false }),
   useReopenAnnotation: () => ({ mutate: vi.fn(), isPending: false }),
 }));

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -43,12 +43,14 @@ import { compareAnnotationsByPosition } from '../viewer/anchoring';
 import { isUnseen } from '../newSince';
 import { isDocumentScoped } from '../annotationScope';
 import type { BuildPermalink } from '../useReviewPermalink';
+import { useConfirmPlacement } from '../../../api/hooks/useAnnotations';
 import { AnnotationListItem } from './AnnotationListItem';
 import type { UploadedAttachment } from '../markdown/useCommentAttachmentUpload';
 import { CommentThread } from './CommentThread';
 import { Composer } from './Composer';
 import type { FilterAuthor } from './PanelFilterBar';
 import { PanelFilterBar } from './PanelFilterBar';
+import { ReanchorBanner } from './ReanchorBanner';
 import type { AnnotationFilters } from './panelFilters';
 import { EMPTY_FILTERS, matchesFilters } from './panelFilters';
 import { ResolveBar } from './ResolveBar';
@@ -82,6 +84,8 @@ interface AnnotationPanelProps {
   onUploadAttachment?: (file: File) => Promise<UploadedAttachment>;
   /** True while an OLDER version is viewed (#306): threads readable, nothing writable. */
   readOnly?: boolean;
+  /** The viewed version — the scope of placement outcomes and their confirmation (issue #326). */
+  versionNumber?: number | null;
   /** True once the review is FINALIZED/CANCELLED (issue #394): no reopening. */
   reviewClosed?: boolean;
   /** Drops the section's outer card frame — the focus drawer brings its own edge. */
@@ -232,6 +236,7 @@ export function AnnotationPanel({
   notify,
   onUploadAttachment,
   readOnly = false,
+  versionNumber = null,
   reviewClosed = false,
   frameless = false,
   previousSeenAt = null,
@@ -243,6 +248,7 @@ export function AnnotationPanel({
   const [filters, setFilters] = useState<AnnotationFilters>(EMPTY_FILTERS);
   const userId = useAuthStore((state) => state.userId);
   const { resolveWith, isPending: resolving } = useResolveWithFeedback(notify);
+  const confirmPlacement = useConfirmPlacement(notify);
   const { reopenWith } = useReopenWithFeedback(notify);
 
   // Author names are resolved server-side and travel on the annotation itself
@@ -307,6 +313,15 @@ export function AnnotationPanel({
           onHover={onHover}
           permalinkUrl={buildPermalink?.(annotation.id)}
           notify={notify}
+          onConfirmPlacement={
+            versionNumber != null &&
+            !readOnly &&
+            !reviewClosed &&
+            annotation.placementStatus === 'MOVED' &&
+            (userId === ownerId || userId === annotation.authorId)
+              ? () => confirmPlacement.mutate({ annotationId: annotation.id, versionNumber })
+              : undefined
+          }
         />
         <Collapse in={active} unmountOnExit>
           {!readOnly && mayResolveAnnotation(annotation, userId) && (
@@ -358,6 +373,13 @@ export function AnnotationPanel({
       }
     >
       <Stack spacing={1.5}>
+        {versionNumber != null && (
+          <ReanchorBanner
+            annotations={annotations}
+            versionNumber={versionNumber}
+            onReview={() => setFilters((current) => ({ ...current, placement: 'attention' }))}
+          />
+        )}
         {annotations.length > 0 && (
           <PanelFilterBar
             filters={filters}

--- a/qnop-ui/src/components/reviews/panel/PanelFilterBar.tsx
+++ b/qnop-ui/src/components/reviews/panel/PanelFilterBar.tsx
@@ -53,6 +53,14 @@ const PILL_SX = {
   '& .MuiChip-icon': { ml: 0.5, mr: -0.25 },
 } as const;
 
+/** The re-anchoring facet (ADR-0009, issue #326). */
+const PLACEMENT_OPTIONS: { value: AnnotationFilters['placement']; label: string }[] = [
+  { value: 'all', label: 'Any placement' },
+  { value: 'attention', label: 'Needs attention' },
+  { value: 'moved', label: 'Moved' },
+  { value: 'orphaned', label: 'Orphaned' },
+];
+
 const STATUS_OPTIONS: { value: AnnotationFilters['status']; label: string }[] = [
   { value: 'all', label: 'All' },
   { value: 'open', label: 'Open' },
@@ -130,6 +138,13 @@ export function PanelFilterBar({
               data-testid="active-filter-chips"
               sx={{ alignItems: 'center', flexShrink: 0, maxWidth: '60%', overflow: 'hidden' }}
             >
+              {filters.placement !== 'all' && (
+                <Chip
+                  size="small"
+                  label={PLACEMENT_OPTIONS.find((o) => o.value === filters.placement)?.label}
+                  onDelete={() => set({ placement: 'all' })}
+                />
+              )}
               {statusFacet && filters.status !== 'all' && (
                 <Chip
                   size="small"
@@ -240,6 +255,21 @@ export function PanelFilterBar({
               ))}
             </TextField>
           )}
+          <TextField
+            select
+            size="small"
+            label="Placement"
+            value={filters.placement}
+            onChange={(event) =>
+              set({ placement: event.target.value as AnnotationFilters['placement'] })
+            }
+          >
+            {PLACEMENT_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </TextField>
           <TextField
             select
             size="small"

--- a/qnop-ui/src/components/reviews/panel/ReanchorBanner.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/ReanchorBanner.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { PlacementStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { ReanchorBanner } from './ReanchorBanner';
+
+const annotation = (overrides: Partial<AnnotationView>): AnnotationView =>
+  ({
+    id: 'a1',
+    documentId: 'd1',
+    authorId: 'u1',
+    status: 'OPEN',
+    commentCount: 1,
+    reactions: [],
+    createdAt: '2026-07-01T10:00:00Z',
+    updatedAt: '2026-07-01T10:00:00Z',
+    ...overrides,
+  }) as AnnotationView;
+
+function renderBanner(annotations: AnnotationView[], onReview = vi.fn()) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <ReanchorBanner annotations={annotations} versionNumber={3} onReview={onReview} />
+    </ThemeProvider>,
+  );
+  return onReview;
+}
+
+beforeEach(() => localStorage.clear());
+
+describe('ReanchorBanner (issue #326)', () => {
+  it('summarises the version’s re-anchoring outcomes and filters on Review', () => {
+    const onReview = renderBanner([
+      annotation({ id: 'm1', placementStatus: PlacementStatus.Moved }),
+      annotation({ id: 'o1', placementStatus: PlacementStatus.Orphaned }),
+      annotation({ id: 'p1', placementStatus: PlacementStatus.Placed }),
+    ]);
+
+    expect(screen.getByTestId('reanchor-banner')).toHaveTextContent(
+      'Re-anchoring on v3: 1 moved, 1 orphaned.',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Review' }));
+    expect(onReview).toHaveBeenCalled();
+  });
+
+  it('stays silent when every placement is settled', () => {
+    renderBanner([annotation({ id: 'p1', placementStatus: PlacementStatus.Placed })]);
+    expect(screen.queryByTestId('reanchor-banner')).not.toBeInTheDocument();
+  });
+
+  it('dismisses per document version and stays dismissed', () => {
+    renderBanner([annotation({ id: 'm1', placementStatus: PlacementStatus.Moved })]);
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss re-anchoring notice' }));
+    expect(screen.queryByTestId('reanchor-banner')).not.toBeInTheDocument();
+
+    renderBanner([annotation({ id: 'm1', placementStatus: PlacementStatus.Moved })]);
+    expect(screen.queryByTestId('reanchor-banner')).not.toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/reviews/panel/ReanchorBanner.tsx
+++ b/qnop-ui/src/components/reviews/panel/ReanchorBanner.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { Anchor, X } from 'lucide-react';
+import type { AnnotationView } from '../../../api/generated';
+import { reanchorSummary } from './panelFilters';
+
+function dismissKey(documentId: string, versionNumber: number) {
+  return `qnop-reanchor-dismissed-${documentId}-v${versionNumber}`;
+}
+
+interface ReanchorBannerProps {
+  annotations: AnnotationView[];
+  versionNumber: number;
+  /** Sets the panel's placement facet to "needs attention". */
+  onReview: () => void;
+}
+
+/**
+ * The "review re-anchoring changes" cue (ADR-0009, issue #326): when the
+ * viewed version carries MOVED/ORPHANED placements, an amber strip above the
+ * panel says so in one sentence and filters the list on click. Dismissable per
+ * document version (device-local) — and it retires by itself once every
+ * outcome is handled.
+ */
+export function ReanchorBanner({ annotations, versionNumber, onReview }: ReanchorBannerProps) {
+  const theme = useTheme();
+  const documentId = annotations[0]?.documentId;
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return Boolean(
+        documentId && localStorage.getItem(dismissKey(documentId, versionNumber)) === '1',
+      );
+    } catch {
+      return false;
+    }
+  });
+
+  const summary = reanchorSummary(annotations);
+  if (summary.total === 0 || dismissed || !documentId) return null;
+
+  const parts = [
+    summary.moved > 0 ? `${summary.moved} moved` : null,
+    summary.orphaned > 0 ? `${summary.orphaned} orphaned` : null,
+  ].filter(Boolean);
+
+  const dismiss = () => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(dismissKey(documentId, versionNumber), '1');
+    } catch {
+      // best-effort persistence
+    }
+  };
+
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      data-testid="reanchor-banner"
+      sx={{
+        alignItems: 'center',
+        px: 1.25,
+        py: 0.75,
+        borderRadius: '8px',
+        border: '1px solid',
+        borderColor: alpha(theme.palette.warning.main, 0.4),
+        bgcolor: alpha(theme.palette.warning.main, 0.08),
+      }}
+    >
+      <Box aria-hidden sx={{ color: theme.palette.warning.main, display: 'flex', flexShrink: 0 }}>
+        <Anchor size={14} />
+      </Box>
+      <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }}>
+        Re-anchoring on v{versionNumber}: {parts.join(', ')}.
+      </Typography>
+      <Button size="small" variant="text" onClick={onReview} sx={{ flexShrink: 0 }}>
+        Review
+      </Button>
+      <IconButton size="small" aria-label="Dismiss re-anchoring notice" onClick={dismiss}>
+        <X size={13} />
+      </IconButton>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/panelFilters.test.ts
+++ b/qnop-ui/src/components/reviews/panel/panelFilters.test.ts
@@ -21,8 +21,13 @@
 
 import { describe, expect, it } from 'vitest';
 import type { AnnotationView } from '../../../api/generated';
-import { AnnotationPriority, AnnotationStatus, AnnotationType } from '../../../api/generated';
-import { EMPTY_FILTERS, activeFacetCount, matchesFilters } from './panelFilters';
+import {
+  AnnotationPriority,
+  AnnotationStatus,
+  AnnotationType,
+  PlacementStatus,
+} from '../../../api/generated';
+import { EMPTY_FILTERS, activeFacetCount, matchesFilters, reanchorSummary } from './panelFilters';
 
 const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => ({
   id: 'a1',
@@ -113,5 +118,39 @@ describe('activeFacetCount', () => {
         query: 'ignored',
       }),
     ).toBe(3);
+  });
+});
+
+describe('placement facet & re-anchoring summary (issue #326)', () => {
+  const placed = annotation({ id: 'p1', placementStatus: PlacementStatus.Placed });
+  const moved = annotation({ id: 'm1', placementStatus: PlacementStatus.Moved });
+  const orphaned = annotation({ id: 'o1', placementStatus: PlacementStatus.Orphaned });
+  const failed = annotation({ id: 'f1', placementStatus: PlacementStatus.Failed });
+
+  it("'attention' keeps every outcome a human still owes a look", () => {
+    const filters = { ...EMPTY_FILTERS, placement: 'attention' as const };
+    expect(matchesFilters(placed, filters, '')).toBe(false);
+    expect(matchesFilters(moved, filters, '')).toBe(true);
+    expect(matchesFilters(orphaned, filters, '')).toBe(true);
+    expect(matchesFilters(failed, filters, '')).toBe(true);
+  });
+
+  it('moved and orphaned narrow to their exact outcome', () => {
+    expect(matchesFilters(moved, { ...EMPTY_FILTERS, placement: 'moved' }, '')).toBe(true);
+    expect(matchesFilters(orphaned, { ...EMPTY_FILTERS, placement: 'moved' }, '')).toBe(false);
+    expect(matchesFilters(orphaned, { ...EMPTY_FILTERS, placement: 'orphaned' }, '')).toBe(true);
+  });
+
+  it('counts as an active facet', () => {
+    expect(activeFacetCount({ ...EMPTY_FILTERS, placement: 'attention' })).toBe(1);
+  });
+
+  it('summarises what re-anchoring left for humans', () => {
+    expect(reanchorSummary([placed, moved, orphaned, failed])).toEqual({
+      moved: 1,
+      orphaned: 2,
+      total: 3,
+    });
+    expect(reanchorSummary([placed]).total).toBe(0);
   });
 });

--- a/qnop-ui/src/components/reviews/panel/panelFilters.ts
+++ b/qnop-ui/src/components/reviews/panel/panelFilters.ts
@@ -20,12 +20,19 @@
  */
 
 import type { AnnotationView } from '../../../api/generated';
-import { AnnotationPriority, AnnotationStatus, AnnotationType } from '../../../api/generated';
+import {
+  AnnotationPriority,
+  AnnotationStatus,
+  AnnotationType,
+  PlacementStatus,
+} from '../../../api/generated';
 import { stripMarkdown } from '../../../utils/markdown';
 
 /** The panel's filter facets (issue #403); `null`/`'all'`/`''` mean "any". */
 export interface AnnotationFilters {
   status: 'all' | 'open' | 'resolved';
+  /** Re-anchoring outcome (ADR-0009, issue #326); 'attention' = MOVED/ORPHANED/FAILED. */
+  placement: 'all' | 'attention' | 'moved' | 'orphaned';
   type: AnnotationType | null;
   priority: AnnotationPriority | null;
   /** The author's principal id. */
@@ -36,6 +43,7 @@ export interface AnnotationFilters {
 
 export const EMPTY_FILTERS: AnnotationFilters = {
   status: 'all',
+  placement: 'all',
   type: null,
   priority: null,
   author: null,
@@ -46,9 +54,26 @@ export const EMPTY_FILTERS: AnnotationFilters = {
 export function activeFacetCount(filters: AnnotationFilters): number {
   return (
     (filters.status !== 'all' ? 1 : 0) +
+    (filters.placement !== 'all' ? 1 : 0) +
     (filters.type !== null ? 1 : 0) +
     (filters.priority !== null ? 1 : 0) +
     (filters.author !== null ? 1 : 0)
+  );
+}
+
+/** The re-anchoring facet (issue #326): which placement outcomes pass. */
+function matchesPlacement(
+  annotation: AnnotationView,
+  placement: AnnotationFilters['placement'],
+): boolean {
+  if (placement === 'all') return true;
+  const status = annotation.placementStatus;
+  if (placement === 'moved') return status === PlacementStatus.Moved;
+  if (placement === 'orphaned') return status === PlacementStatus.Orphaned;
+  return (
+    status === PlacementStatus.Moved ||
+    status === PlacementStatus.Orphaned ||
+    status === PlacementStatus.Failed
   );
 }
 
@@ -60,6 +85,7 @@ export function matchesFilters(
 ): boolean {
   if (filters.status === 'open' && annotation.status !== AnnotationStatus.Open) return false;
   if (filters.status === 'resolved' && annotation.status === AnnotationStatus.Open) return false;
+  if (!matchesPlacement(annotation, filters.placement)) return false;
   if (filters.type !== null && annotation.type !== filters.type) return false;
   if (filters.priority !== null && annotation.priority !== filters.priority) return false;
   if (filters.author !== null && annotation.authorId !== filters.author) return false;
@@ -72,4 +98,17 @@ export function matchesFilters(
     stripMarkdown(annotation.firstComment).toLowerCase().includes(needle) ||
     authorName.toLowerCase().includes(needle)
   );
+}
+
+/** What the current version's re-anchoring left for humans (issue #326). */
+export function reanchorSummary(annotations: AnnotationView[]) {
+  const moved = annotations.filter(
+    (annotation) => annotation.placementStatus === PlacementStatus.Moved,
+  ).length;
+  const orphaned = annotations.filter(
+    (annotation) =>
+      annotation.placementStatus === PlacementStatus.Orphaned ||
+      annotation.placementStatus === PlacementStatus.Failed,
+  ).length;
+  return { moved, orphaned, total: moved + orphaned };
 }

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -51,6 +51,7 @@ vi.mock('../../api/hooks/useDocuments', () => ({
   useOriginalPdf: vi.fn(),
 }));
 vi.mock('../../api/hooks/useAnnotations', () => ({
+  useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useAnnotations: vi.fn(),
   useCreateAnnotation: vi.fn(),
   useResolveAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -589,6 +589,7 @@ export function DocumentReviewPage() {
                   notify={notify}
                   onUploadAttachment={uploadAttachment}
                   readOnly={!isLatestVersion}
+                  versionNumber={versionNumber}
                   reviewClosed={!isOpenWorkflowState(document.workflowState)}
                   previousSeenAt={previousSeenAt}
                   buildPermalink={buildPermalink}
@@ -646,6 +647,7 @@ export function DocumentReviewPage() {
           userId={userId}
           notify={notify}
           readOnly={!isLatestVersion}
+          versionNumber={versionNumber}
           reviewClosed={!isOpenWorkflowState(document.workflowState)}
           threadParticipation={document.threadParticipation ?? 'OPEN'}
           ownerId={document.ownerId}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -48,6 +48,7 @@ vi.mock('../../api/hooks/useDocuments', () => ({
 }));
 const { createMutate } = vi.hoisted(() => ({ createMutate: vi.fn() }));
 vi.mock('../../api/hooks/useAnnotations', () => ({
+  useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useAnnotations: vi.fn(),
   useCreateAnnotation: vi.fn().mockReturnValue({ mutate: createMutate, isPending: false }),
   useResolveAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -112,6 +112,7 @@ export function ReviewTasksPage() {
   const priorityParam = searchParams.get('priority');
   const facets: AnnotationFilters = {
     status: 'all',
+    placement: 'all',
     type: Object.values(AnnotationType).includes(typeParam as AnnotationType)
       ? (typeParam as AnnotationType)
       : null,

--- a/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../api/hooks/useReviews', () => ({
   useParticipants: vi.fn(),
 }));
 vi.mock('../../api/hooks/useAnnotations', () => ({
+  useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useAnnotations: vi.fn().mockReturnValue({ data: undefined }),
 }));
 vi.mock('../../api/hooks/useVersionDiff', async (importOriginal) => ({


### PR DESCRIPTION
## Summary

Re-anchoring outcomes (ADR-0009) stop being invisible — and the human half of the loop gets its missing verb.

### What was already there
`PlacementStatusChip` in the expanded annotation head, the MOVED marker cue in the viewer, and the no-placement grouping landed with the #403 rounds. What was missing: a filter, a proactive cue, glanceable outcomes on collapsed rows — and any way to act on a MOVED placement.

### New
- **Re-anchoring banner** (`ReanchorBanner`): when the viewed version carries MOVED/ORPHANED/FAILED placements, an amber strip above the annotation panel summarises them in one sentence ("Re-anchoring on v4: 1 moved, 4 orphaned.") and filters the list on click. Dismissable per document version (device-local); retires by itself once every outcome is handled. Zero extra requests — derived from the already-loaded annotations.
- **Placement facet** in the panel filters (any / needs attention / moved / orphaned) with its own pill and facet count; the tasks page keeps its neutral default.
- **Collapsed-row cues**: panel rows show "→ Moved" (amber) or "Orphaned" (red) without expanding.
- **Confirm verb**: idempotent `POST /annotations/{annotationId}/placements/{versionNumber}/confirm` — the document owner or the annotation's author flips a reviewed MOVED placement back to PLACED (keeping the resolved anchor). Anything else answers a stable `409 PLACEMENT_NOT_MOVED`; unknown version/placement 404; participants-only visibility (anti-enumeration). Audited as `placement.confirmed`, which the dashboard activity feed now carries.
- **"Looks right"** beside the Moved chip in the panel's expanded head and the focus card — owner/author only, latest version only, never on read-only or closed reviews. The tasks drawer keeps chips without the action: confirming belongs where the highlight is visible.

Deliberately out of scope: manually re-attaching ORPHANED annotations — filed as #457 with the full flow sketch.

## Test plan
- [x] Backend: `./gradlew build`; `PlacementConfirmApiIT` — author confirms (audited, list view reflects it), owner may / other participants may not (403), non-MOVED → 409 `PLACEMENT_NOT_MOVED`, unknown version → 404
- [x] Frontend: 749 tests (placement facet matrix, `reanchorSummary`, banner render/filter/dismiss-persistence), `pnpm lint`, `pnpm typecheck`
- [x] Live E2E against a REAL re-anchoring run: uploaded a new version onto a review with anchored annotations → the job produced 1 MOVED + 4 ORPHANED; banner, facet pill, row cues verified; "Looks right" confirmed the MOVED placement — toast, row leaving the attention filter, banner counting down to "4 orphaned" live

Closes #326.

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)