### PR TITLE
feat(reviews): re-attach orphaned annotations by selecting a new passage

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2633,6 +2633,71 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /annotations/{annotationId}/placements/{versionNumber}/anchor:
+    parameters:
+      - $ref: '#/components/parameters/AnnotationIdParam'
+      - name: versionNumber
+        in: path
+        required: true
+        schema:
+          type: integer
+    put:
+      tags: [Annotations]
+      summary: Re-attach an annotation by replacing its anchor (owner or author)
+      description: |
+        The manual rescue for lost placements (ADR-0009, issue #457): the
+        document owner or the annotation's author picks a new passage on the
+        LATEST version and the placement takes that anchor, flipping to
+        PLACED — the discussion thread stays untouched. Allowed from ORPHANED,
+        FAILED and MOVED (a manual correction of a bad guess); a PLACED
+        placement answers 409 (`PLACEMENT_NOT_REATTACHABLE`) so nothing is
+        overwritten by accident. Older versions are a read-only record
+        (`VERSION_READ_ONLY`), closed reviews refuse (`REVIEW_CLOSED`).
+      operationId: reattachPlacement
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlacementReattachRequest'
+      responses:
+        '200':
+          description: The updated annotation with the re-attached placement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationView'
+        '400':
+          description: The anchor is missing or malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: The caller is neither the document owner nor the annotation's author
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown annotation, version, or no placement on that version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: >-
+            The placement is PLACED (`PLACEMENT_NOT_REATTACHABLE`), the version
+            is not the latest (`VERSION_READ_ONLY`), or the review is closed
+            (`REVIEW_CLOSED`)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /annotations/{annotationId}/comments:
     parameters:
       - $ref: '#/components/parameters/AnnotationIdParam'
@@ -3462,6 +3527,14 @@ components:
       enum:
         - INTERNAL
         - EXTERNAL
+    PlacementReattachRequest:
+      type: object
+      description: The new home of a lost placement (issue #457).
+      required:
+        - anchor
+      properties:
+        anchor:
+          $ref: '#/components/schemas/Anchor'
     PublicUserProfile:
       type: object
       description: The workspace-public slice of a user (issue #454).

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationController.java
@@ -33,6 +33,7 @@ import io.qnop.api.v1.model.AnnotationView;
 import io.qnop.api.v1.model.CommentCreateRequest;
 import io.qnop.api.v1.model.CommentListResponse;
 import io.qnop.api.v1.model.CommentView;
+import io.qnop.api.v1.model.PlacementReattachRequest;
 import io.qnop.api.v1.model.PlacementStatus;
 import io.qnop.api.v1.model.ReactionGroup;
 import io.qnop.service.review.AnnotationService;
@@ -135,6 +136,19 @@ public class AnnotationController implements AnnotationsApi {
     String note = request == null ? null : request.getNote();
     return ResponseEntity.ok(
         toDto(annotations.resolve(annotationId, note, CurrentUser.requireUserId())));
+  }
+
+  @Override
+  public ResponseEntity<AnnotationView> reattachPlacement(
+      UUID annotationId, Integer versionNumber, PlacementReattachRequest request) {
+    return ResponseEntity.ok(
+        toDto(
+            annotations.reattachPlacement(
+                annotationId,
+                versionNumber,
+                request.getAnchor() == null ? null : mapper.writeValueAsString(request.getAnchor()),
+                CurrentUser.requireUserId(),
+                CurrentUser.isAdmin())));
   }
 
   @Override

--- a/qnop-app/src/test/java/io/qnop/review/PlacementReattachApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/PlacementReattachApiIT.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Manual re-attach of lost placements over the wire (ADR-0009, issue #457): the owner or the
+ * annotation's author gives an ORPHANED (or MOVED) placement a new anchor on the latest version,
+ * flipping it to PLACED with the thread untouched; PLACED refuses, old versions are read-only,
+ * strangers are forbidden.
+ */
+class PlacementReattachApiIT extends SeededIntegrationTest {
+
+  private static final String ANCHOR =
+      "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.1}},"
+          + "\"textQuote\":{\"quote\":\"the clause\"}}";
+  private static final String NEW_ANCHOR_BODY =
+      "{\"anchor\":{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.5,\"y\":0.6,\"width\":0.2,"
+          + "\"height\":0.05}},\"textQuote\":{\"quote\":\"the relocated clause\"}}}";
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+  @Autowired private AnnotationPlacementRepository placements;
+
+  private UUID documentId;
+  private UUID versionId;
+
+  private void seedDocument() {
+    Document document = documents.save(new Document(MEMBER_ID, "Master services agreement"));
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
+    versionId =
+        versions
+            .save(
+                new DocumentVersion(
+                    document.getId(),
+                    1,
+                    "sha256/aa/deadbeef",
+                    "deadbeef",
+                    "application/pdf",
+                    1234L,
+                    MEMBER_ID))
+            .getId();
+    documentId = document.getId();
+  }
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  /** Creates an anchored annotation as AUDITOR and forces its v1 placement to ORPHANED. */
+  private String orphanedAnnotation() throws Exception {
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        "{\"versionNumber\":1,\"anchor\":" + ANCHOR + ",\"comment\":\"check\"}"))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String annotationId = JsonPath.read(json, "$.id");
+    AnnotationPlacement placement =
+        placements
+            .findByAnnotationIdAndDocumentVersionId(UUID.fromString(annotationId), versionId)
+            .orElseThrow();
+    placement.markOrphaned();
+    placements.save(placement);
+    return annotationId;
+  }
+
+  private MockHttpServletRequestBuilder reattach(String annotationId, int version, UUID actor) {
+    return as(
+            put("/api/v1/annotations/" + annotationId + "/placements/" + version + "/anchor"),
+            actor)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(NEW_ANCHOR_BODY);
+  }
+
+  @Test
+  @DisplayName("the author re-attaches an orphan: new anchor, PLACED, thread untouched")
+  void authorReattaches() throws Exception {
+    seedDocument();
+    String annotationId = orphanedAnnotation();
+
+    mockMvc
+        .perform(reattach(annotationId, 1, AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.placementStatus").value("PLACED"))
+        .andExpect(jsonPath("$.anchor.textQuote.quote").value("the relocated clause"))
+        .andExpect(jsonPath("$.commentCount").value(1));
+  }
+
+  @Test
+  @DisplayName("the owner may re-attach; other participants may not")
+  void ownerYesStrangerNo() throws Exception {
+    seedDocument();
+    String annotationId = orphanedAnnotation();
+
+    mockMvc.perform(reattach(annotationId, 1, MEMBER2_ID)).andExpect(status().isForbidden());
+    mockMvc.perform(reattach(annotationId, 1, MEMBER_ID)).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("a PLACED placement refuses — nothing is overwritten by accident")
+  void placedRefuses() throws Exception {
+    seedDocument();
+    String annotationId = orphanedAnnotation();
+    mockMvc.perform(reattach(annotationId, 1, AUDITOR_ID)).andExpect(status().isOk());
+
+    mockMvc
+        .perform(reattach(annotationId, 1, AUDITOR_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("PLACEMENT_NOT_REATTACHABLE"));
+  }
+
+  @Test
+  @DisplayName("older versions are a read-only record")
+  void oldVersionRefuses() throws Exception {
+    seedDocument();
+    String annotationId = orphanedAnnotation();
+    versions.save(
+        new DocumentVersion(
+            documentId, 2, "sha256/bb/cafebabe", "cafebabe", "application/pdf", 1234L, MEMBER_ID));
+
+    mockMvc
+        .perform(reattach(annotationId, 1, AUDITOR_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("VERSION_READ_ONLY"));
+  }
+
+  @Test
+  @DisplayName("a closed review refuses with REVIEW_CLOSED")
+  void closedReviewRefuses() throws Exception {
+    seedDocument();
+    String annotationId = orphanedAnnotation();
+    Document document = documents.findById(documentId).orElseThrow();
+    document.setWorkflowState(WorkflowState.FINALIZED);
+    documents.save(document);
+
+    mockMvc
+        .perform(reattach(annotationId, 1, AUDITOR_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("REVIEW_CLOSED"));
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -64,6 +64,7 @@ public class AnnotationService {
   static final String AUDIT_ANNOTATION_CREATED = "annotation.created";
   static final String AUDIT_ANNOTATION_CLASSIFIED = "annotation.classified";
   static final String AUDIT_PLACEMENT_CONFIRMED = "placement.confirmed";
+  static final String AUDIT_PLACEMENT_REATTACHED = "placement.reattached";
 
   /** Comments can be 20k chars; the view carries only what a card title needs (issue #393). */
   static final int FIRST_COMMENT_EXCERPT_CHARS = 300;
@@ -437,6 +438,87 @@ public class AnnotationService {
         foreignActivity(annotationId, actor),
         annotationReactions(annotationId, actor, identities),
         identities);
+  }
+
+  /**
+   * Re-attaches a lost placement by hand (ADR-0009, issue #457): the owner or the annotation's
+   * author picked a new passage on the LATEST version, so the placement takes that anchor and flips
+   * to PLACED — the thread stays untouched. Allowed from ORPHANED, FAILED and MOVED (a manual
+   * correction); PLACED refuses, so nothing is overwritten by accident.
+   */
+  @Transactional
+  public AnnotationView reattachPlacement(
+      UUID annotationId, int versionNumber, String anchorJson, UUID actor, boolean admin) {
+    if (anchorJson == null || anchorJson.isBlank()) {
+      throw DocumentValidationException.invalidRequest("anchor is required");
+    }
+    Annotation annotation = requireAnnotation(annotationId);
+    DocumentAccessService.DocumentView document =
+        documentAccess.getDocument(annotation.getDocumentId(), actor, admin);
+    if (!canSeeThread(document, annotation.getAuthorId(), actor, admin)) {
+      throw DocumentValidationException.notFound("no such annotation: " + annotationId);
+    }
+    if (!admin && !document.ownerId().equals(actor) && !annotation.getAuthorId().equals(actor)) {
+      throw new AnnotationActionForbiddenException(
+          "Only the document owner or the annotation's author may re-attach a placement");
+    }
+    if (isClosed(document.workflowState())) {
+      throw new WorkflowTransitionException(
+          WorkflowTransitionException.REVIEW_CLOSED,
+          "the review is " + document.workflowState() + "; placements can no longer change");
+    }
+    DocumentVersion version =
+        versions
+            .findByDocumentIdAndVersionNumber(annotation.getDocumentId(), versionNumber)
+            .orElseThrow(
+                () -> DocumentValidationException.notFound("no such version: " + versionNumber));
+    int latest =
+        versions
+            .findTopByDocumentIdOrderByVersionNumberDesc(annotation.getDocumentId())
+            .map(DocumentVersion::getVersionNumber)
+            .orElse(versionNumber);
+    if (versionNumber != latest) {
+      throw DocumentValidationException.versionReadOnly(
+          "placements are re-attached on the latest version (v%d), not v%d"
+              .formatted(latest, versionNumber));
+    }
+    AnnotationPlacement placement =
+        placements
+            .findByAnnotationIdAndDocumentVersionId(annotationId, version.getId())
+            .orElseThrow(
+                () ->
+                    DocumentValidationException.notFound(
+                        "no placement on version " + versionNumber));
+    if (placement.getStatus() == PlacementStatus.PLACED
+        || placement.getStatus() == PlacementStatus.PENDING) {
+      throw new WorkflowTransitionException(
+          WorkflowTransitionException.PLACEMENT_NOT_REATTACHABLE,
+          "placement is " + placement.getStatus() + "; re-attach rescues lost placements");
+    }
+    placement.markPlaced(anchorJson);
+    auditEvents.save(
+        new AuditEvent(
+            annotation.getDocumentId(),
+            AUDIT_PLACEMENT_REATTACHED,
+            actor,
+            "{\"annotationId\":\"%s\",\"versionNumber\":%d}"
+                .formatted(annotationId, versionNumber)));
+    ReviewIdentityResolver.ReviewIdentities identities =
+        identity.forDocument(annotation.getDocumentId(), actor);
+    return view(
+        annotation,
+        placement,
+        firstComment(annotationId),
+        threadSize(annotationId),
+        foreignActivity(annotationId, actor),
+        annotationReactions(annotationId, actor, identities),
+        identities);
+  }
+
+  /** FINALIZED/CANCELLED as strings — the column tolerates enterprise states (ADR-0011). */
+  private static boolean isClosed(String workflowState) {
+    return io.qnop.entity.WorkflowState.FINALIZED.name().equals(workflowState)
+        || io.qnop.entity.WorkflowState.CANCELLED.name().equals(workflowState);
   }
 
   /**

--- a/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
@@ -75,6 +75,7 @@ public class DashboardService {
           "annotation.resolved",
           "annotation.reopened",
           "placement.confirmed",
+          "placement.reattached",
           "workflow.transition",
           "document.due_date.changed");
 

--- a/qnop-core/src/main/java/io/qnop/service/review/WorkflowTransitionException.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/WorkflowTransitionException.java
@@ -36,6 +36,8 @@ public class WorkflowTransitionException extends RuntimeException {
 
   public static final String PLACEMENT_NOT_MOVED = "PLACEMENT_NOT_MOVED";
 
+  public static final String PLACEMENT_NOT_REATTACHABLE = "PLACEMENT_NOT_REATTACHABLE";
+
   /** An annotation was raised on a review that is already FINALIZED or CANCELLED (issue #405). */
   public static final String REVIEW_CLOSED = "REVIEW_CLOSED";
 

--- a/qnop-ui/src/api/hooks/useAnnotations.ts
+++ b/qnop-ui/src/api/hooks/useAnnotations.ts
@@ -20,7 +20,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { AnnotationCreateRequest, AnnotationListResponse } from '../generated';
+import type { Anchor, AnnotationCreateRequest, AnnotationListResponse } from '../generated';
 import { annotationsApi } from '../config';
 import type { Notify } from '../../components/admin/layout/useToast';
 import { commentKeys } from './useComments';
@@ -142,5 +142,30 @@ export function useConfirmPlacement(notify: Notify) {
       queryClient.invalidateQueries({ queryKey: annotationKeys.all });
     },
     onError: () => notify('Could not confirm the placement.', 'error'),
+  });
+}
+
+/**
+ * Gives a lost (ORPHANED/FAILED — or second-guessed MOVED) placement a new
+ * home on the version's canvas (issue #457): the owner or the annotation's
+ * author points at the new passage and the placement flips to PLACED with the
+ * thread untouched.
+ */
+export function useReattachPlacement(notify: Notify) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { annotationId: string; versionNumber: number; anchor: Anchor }) => {
+      const response = await annotationsApi.reattachPlacement({
+        annotationId: input.annotationId,
+        versionNumber: input.versionNumber,
+        placementReattachRequest: { anchor: input.anchor },
+      });
+      return response.data;
+    },
+    onSuccess: () => {
+      notify('Annotation re-attached.', 'success');
+      queryClient.invalidateQueries({ queryKey: annotationKeys.all });
+    },
+    onError: () => notify('Could not re-attach the annotation.', 'error'),
   });
 }

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../../api/hooks/useComments', () => ({
 const { resolveMutate } = vi.hoisted(() => ({ resolveMutate: vi.fn() }));
 vi.mock('../../../api/hooks/useAnnotations', () => ({
   useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useReattachPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useResolveAnnotation: () => ({ mutate: resolveMutate, isPending: false }),
   useReopenAnnotation: () => ({ mutate: vi.fn(), isPending: false }),
 }));

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -64,6 +64,8 @@ interface FocusAnnotationCardProps {
   readOnly?: boolean;
   /** The viewed version — the scope of placement confirmation (issue #326). */
   versionNumber?: number | null;
+  /** Arms re-attaching a lost placement (issue #457) — the page closes the card and waits for the selection. */
+  onArmReattach?: (annotation: AnnotationView) => void;
   /** True once the review is FINALIZED/CANCELLED (issue #394): no reopening. */
   reviewClosed?: boolean;
   /** Thread participation policy (issue #413) — READ_ONLY suppresses foreign composers. */
@@ -106,6 +108,7 @@ export function FocusAnnotationCard({
   notify,
   readOnly = false,
   versionNumber = null,
+  onArmReattach,
   reviewClosed = false,
   threadParticipation = 'OPEN',
   ownerId,
@@ -343,6 +346,17 @@ export function FocusAnnotationCard({
                                 annotationId: annotation.id,
                                 versionNumber,
                               })
+                          : undefined
+                      }
+                      onReattachPlacement={
+                        onArmReattach != null &&
+                        versionNumber != null &&
+                        !readOnly &&
+                        !reviewClosed &&
+                        (annotation.placementStatus === 'ORPHANED' ||
+                          annotation.placementStatus === 'FAILED') &&
+                        (userId === ownerId || userId === annotation.authorId)
+                          ? () => onArmReattach(annotation)
                           : undefined
                       }
                     />

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.test.tsx
@@ -40,10 +40,9 @@ const annotation = (overrides: Partial<AnnotationView>): AnnotationView =>
     ...overrides,
   }) as AnnotationView;
 
-function renderRow(
-  view: AnnotationView,
-  handlers: Parameters<typeof AnnotationBadgeRow>[0] = {} as never,
-) {
+type Handlers = Partial<Omit<Parameters<typeof AnnotationBadgeRow>[0], 'annotation'>>;
+
+function renderRow(view: AnnotationView, handlers: Handlers = {}) {
   render(
     <ThemeProvider theme={buildTheme('light')}>
       <AnnotationBadgeRow annotation={view} {...handlers} />
@@ -75,7 +74,7 @@ describe('AnnotationBadgeRow placement affordances', () => {
   it('offers Re-attach for a FAILED placement too', () => {
     renderRow(annotation({ placementStatus: PlacementStatus.Failed }), {
       onReattachPlacement: vi.fn(),
-    } as never);
+    });
     expect(screen.getByRole('button', { name: 'Re-attach' })).toBeInTheDocument();
   });
 
@@ -83,7 +82,7 @@ describe('AnnotationBadgeRow placement affordances', () => {
     renderRow(annotation({ placementStatus: PlacementStatus.Placed }), {
       onReattachPlacement: vi.fn(),
       onConfirmPlacement: vi.fn(),
-    } as never);
+    });
     expect(screen.queryByRole('button', { name: 'Re-attach' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Looks right' })).not.toBeInTheDocument();
   });

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.test.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AnnotationView } from '../../../api/generated';
+import { PlacementStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { AnnotationBadgeRow } from './AnnotationBadgeRow';
+
+const annotation = (overrides: Partial<AnnotationView>): AnnotationView =>
+  ({
+    id: 'a1',
+    documentId: 'd1',
+    authorId: 'u1',
+    status: 'OPEN',
+    commentCount: 1,
+    reactions: [],
+    createdAt: '2026-07-01T10:00:00Z',
+    updatedAt: '2026-07-01T10:00:00Z',
+    ...overrides,
+  }) as AnnotationView;
+
+function renderRow(
+  view: AnnotationView,
+  handlers: Parameters<typeof AnnotationBadgeRow>[0] = {} as never,
+) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <AnnotationBadgeRow annotation={view} {...handlers} />
+    </ThemeProvider>,
+  );
+}
+
+describe('AnnotationBadgeRow placement affordances', () => {
+  it('offers Re-attach for an orphaned placement and stops the card click', () => {
+    const onReattachPlacement = vi.fn();
+    const cardClick = vi.fn();
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        {/* Stands in for the clickable annotation card the row sits inside. */}
+        <div role="presentation" onClick={cardClick}>
+          <AnnotationBadgeRow
+            annotation={annotation({ placementStatus: PlacementStatus.Orphaned })}
+            onReattachPlacement={onReattachPlacement}
+          />
+        </div>
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
+    expect(onReattachPlacement).toHaveBeenCalled();
+    expect(cardClick).not.toHaveBeenCalled();
+  });
+
+  it('offers Re-attach for a FAILED placement too', () => {
+    renderRow(annotation({ placementStatus: PlacementStatus.Failed }), {
+      onReattachPlacement: vi.fn(),
+    } as never);
+    expect(screen.getByRole('button', { name: 'Re-attach' })).toBeInTheDocument();
+  });
+
+  it('keeps Re-attach away from settled placements and Looks right on MOVED only', () => {
+    renderRow(annotation({ placementStatus: PlacementStatus.Placed }), {
+      onReattachPlacement: vi.fn(),
+      onConfirmPlacement: vi.fn(),
+    } as never);
+    expect(screen.queryByRole('button', { name: 'Re-attach' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Looks right' })).not.toBeInTheDocument();
+  });
+
+  it('hides Re-attach without a handler — read-only viewers see only the chip', () => {
+    renderRow(annotation({ placementStatus: PlacementStatus.Orphaned }));
+    expect(screen.queryByRole('button', { name: 'Re-attach' })).not.toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
@@ -25,7 +25,7 @@ import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { Check, MessageSquare } from 'lucide-react';
+import { Check, Crosshair, MessageSquare } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { PlacementStatus } from '../../../api/generated';
 import { ToneBadge } from '../../admin/ToneBadge';
@@ -44,6 +44,11 @@ interface AnnotationBadgeRowProps {
    * renders the "Looks right" affordance beside the Moved chip.
    */
   onConfirmPlacement?: () => void;
+  /**
+   * Arms re-attaching a lost placement (issue #457) — its presence renders the
+   * "Re-attach" affordance beside the Orphaned/Failed chip.
+   */
+  onReattachPlacement?: () => void;
 }
 
 /**
@@ -56,6 +61,7 @@ export function AnnotationBadgeRow({
   annotation,
   unseen = false,
   onConfirmPlacement,
+  onReattachPlacement,
 }: AnnotationBadgeRowProps) {
   const theme = useTheme();
   const statusCue = STATUS_CUES[annotation.status];
@@ -109,6 +115,23 @@ export function AnnotationBadgeRow({
           Looks right
         </Button>
       )}
+      {onReattachPlacement &&
+        (annotation.placementStatus === PlacementStatus.Orphaned ||
+          annotation.placementStatus === PlacementStatus.Failed) && (
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<Crosshair size={12} />}
+            onClick={(event) => {
+              // Sits inside clickable cards — arming must not toggle them.
+              event.stopPropagation();
+              onReattachPlacement();
+            }}
+            sx={{ py: 0, minHeight: 0, fontSize: 12 }}
+          >
+            Re-attach
+          </Button>
+        )}
       <Stack
         direction="row"
         spacing={1}

--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -54,6 +54,8 @@ interface AnnotationHeadProps {
   notify?: Notify;
   /** Confirms a reviewed MOVED placement (issue #326) — rendered beside the Moved chip. */
   onConfirmPlacement?: () => void;
+  /** Arms re-attaching a lost placement (issue #457) — rendered beside the Orphaned chip. */
+  onReattachPlacement?: () => void;
 }
 
 /**
@@ -71,6 +73,7 @@ export function AnnotationHead({
   permalinkUrl,
   notify,
   onConfirmPlacement,
+  onReattachPlacement,
 }: AnnotationHeadProps) {
   const theme = useTheme();
   // Reactions on the opener (issue #410) — active wherever notify travels;
@@ -172,6 +175,7 @@ export function AnnotationHead({
         annotation={annotation}
         unseen={unseen}
         onConfirmPlacement={onConfirmPlacement}
+        onReattachPlacement={onReattachPlacement}
       />
       {/* The anchored passage, styled as a real quotation. */}
       {quote ? (

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -129,6 +129,8 @@ interface AnnotationListItemProps {
   notify?: Notify;
   /** Confirms a reviewed MOVED placement (issue #326) — threaded to the head's badge row. */
   onConfirmPlacement?: () => void;
+  /** Arms re-attaching a lost placement (issue #457). */
+  onReattachPlacement?: () => void;
   onHover?: (annotationId: string | null) => void;
 }
 
@@ -155,6 +157,7 @@ function AnnotationListItemBase({
   permalinkUrl,
   notify,
   onConfirmPlacement,
+  onReattachPlacement,
 }: AnnotationListItemProps) {
   const theme = useTheme();
   const viewerId = useAuthStore((state) => state.userId);
@@ -246,6 +249,7 @@ function AnnotationListItemBase({
           permalinkUrl={permalinkUrl}
           notify={notify}
           onConfirmPlacement={onConfirmPlacement}
+          onReattachPlacement={onReattachPlacement}
         />
       ) : (
         <Stack spacing={0.5} sx={{ minWidth: 0 }}>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -63,6 +63,7 @@ vi.mock('../../../api/hooks/useReviews', () => ({
 }));
 vi.mock('../../../api/hooks/useAnnotations', () => ({
   useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useReattachPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useResolveAnnotation: () => ({ mutate: resolveMutate, isPending: false }),
   useReopenAnnotation: () => ({ mutate: vi.fn(), isPending: false }),
 }));

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -86,6 +86,11 @@ interface AnnotationPanelProps {
   readOnly?: boolean;
   /** The viewed version — the scope of placement outcomes and their confirmation (issue #326). */
   versionNumber?: number | null;
+  /**
+   * Arms re-attaching a lost placement (issue #457) — the page owns the
+   * viewer, so it turns the next selection into the new anchor.
+   */
+  onArmReattach?: (annotation: AnnotationView) => void;
   /** True once the review is FINALIZED/CANCELLED (issue #394): no reopening. */
   reviewClosed?: boolean;
   /** Drops the section's outer card frame — the focus drawer brings its own edge. */
@@ -237,6 +242,7 @@ export function AnnotationPanel({
   onUploadAttachment,
   readOnly = false,
   versionNumber = null,
+  onArmReattach,
   reviewClosed = false,
   frameless = false,
   previousSeenAt = null,
@@ -320,6 +326,17 @@ export function AnnotationPanel({
             annotation.placementStatus === 'MOVED' &&
             (userId === ownerId || userId === annotation.authorId)
               ? () => confirmPlacement.mutate({ annotationId: annotation.id, versionNumber })
+              : undefined
+          }
+          onReattachPlacement={
+            onArmReattach != null &&
+            versionNumber != null &&
+            !readOnly &&
+            !reviewClosed &&
+            (annotation.placementStatus === 'ORPHANED' ||
+              annotation.placementStatus === 'FAILED') &&
+            (userId === ownerId || userId === annotation.authorId)
+              ? () => onArmReattach(annotation)
               : undefined
           }
         />

--- a/qnop-ui/src/components/reviews/viewer/ReattachHintBar.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ReattachHintBar.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import { ReattachHintBar } from './ReattachHintBar';
+
+function renderBar(excerpt: string | null, onCancel = vi.fn()) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <ReattachHintBar excerpt={excerpt} onCancel={onCancel} />
+    </ThemeProvider>,
+  );
+  return onCancel;
+}
+
+describe('ReattachHintBar (issue #457)', () => {
+  it('names the passage being re-homed and cancels on the X', () => {
+    const onCancel = renderBar('the moved clause');
+
+    expect(screen.getByTestId('reattach-hint')).toHaveTextContent(
+      'Placing “the moved clause” — select the new passage',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel re-attaching' }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('falls back to a generic prompt for region-only annotations', () => {
+    renderBar(null);
+    expect(screen.getByTestId('reattach-hint')).toHaveTextContent(
+      'Placing the annotation — select its new location',
+    );
+  });
+
+  it('truncates a long excerpt so the pill stays a pill', () => {
+    renderBar('x'.repeat(80));
+    expect(screen.getByTestId('reattach-hint')).toHaveTextContent(`${'x'.repeat(60)}…`);
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/ReattachHintBar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ReattachHintBar.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import { Crosshair, X } from 'lucide-react';
+
+const EXCERPT_MAX = 60;
+
+interface ReattachHintBarProps {
+  /** The lost placement's old quote — null for region-only annotations. */
+  excerpt: string | null;
+  onCancel: () => void;
+}
+
+/**
+ * The "placing" mode indicator (issue #457): while a lost annotation is armed
+ * for re-attaching, this pill floats over the document stage and turns the
+ * next text/region selection into the new anchor. Escape (or the X) leaves
+ * the mode without touching anything.
+ */
+export function ReattachHintBar({ excerpt, onCancel }: ReattachHintBarProps) {
+  const theme = useTheme();
+  const trimmed =
+    excerpt && excerpt.length > EXCERPT_MAX ? `${excerpt.slice(0, EXCERPT_MAX)}…` : excerpt;
+
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      data-testid="reattach-hint"
+      sx={{
+        position: 'absolute',
+        top: 12,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 5,
+        maxWidth: 'calc(100% - 32px)',
+        alignItems: 'center',
+        pl: 1.5,
+        pr: 0.5,
+        py: 0.5,
+        borderRadius: '999px',
+        border: '1px solid',
+        borderColor: alpha(theme.palette.info.main, 0.5),
+        bgcolor: 'background.paper',
+        boxShadow:
+          theme.qnop.mode === 'dark'
+            ? `0 4px 24px ${alpha('#000', 0.5)}`
+            : '0 4px 24px rgba(1,32,66,0.18)',
+      }}
+    >
+      <Box
+        aria-hidden
+        sx={{
+          color: theme.palette.info.main,
+          display: 'flex',
+          flexShrink: 0,
+          '@keyframes reattachPulse': {
+            '0%, 100%': { opacity: 1 },
+            '50%': { opacity: 0.35 },
+          },
+          animation: 'reattachPulse 1.6s ease-in-out infinite',
+          '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+        }}
+      >
+        <Crosshair size={15} />
+      </Box>
+      <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
+        {trimmed ? (
+          <>
+            Placing{' '}
+            <Box component="span" sx={{ fontWeight: 600 }}>
+              “{trimmed}”
+            </Box>{' '}
+            — select the new passage
+          </>
+        ) : (
+          'Placing the annotation — select its new location'
+        )}
+      </Typography>
+      <Box
+        component="kbd"
+        sx={{
+          flexShrink: 0,
+          px: 0.75,
+          py: 0.1,
+          borderRadius: '5px',
+          border: '1px solid',
+          borderColor: 'divider',
+          fontFamily: 'inherit',
+          fontSize: 11,
+          color: 'text.secondary',
+        }}
+      >
+        Esc
+      </Box>
+      <IconButton size="small" aria-label="Cancel re-attaching" onClick={onCancel}>
+        <X size={13} />
+      </IconButton>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -52,6 +52,7 @@ vi.mock('../../api/hooks/useDocuments', () => ({
 }));
 vi.mock('../../api/hooks/useAnnotations', () => ({
   useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useReattachPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useAnnotations: vi.fn(),
   useCreateAnnotation: vi.fn(),
   useResolveAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -32,10 +32,14 @@ import MenuItem from '@mui/material/MenuItem';
 import Popper from '@mui/material/Popper';
 import Stack from '@mui/material/Stack';
 import { NotebookPen } from 'lucide-react';
-import type { Anchor, NormalizedBox } from '../../api/generated';
+import type { Anchor, AnnotationView, NormalizedBox } from '../../api/generated';
 import { ExtractionStatus } from '../../api/generated';
 import type { AnnotationPriority, AnnotationType } from '../../api/generated';
-import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotations';
+import {
+  useAnnotations,
+  useCreateAnnotation,
+  useReattachPlacement,
+} from '../../api/hooks/useAnnotations';
 import {
   useDocument,
   useDocumentVersions,
@@ -86,6 +90,7 @@ import { DocumentViewer } from '../../components/reviews/viewer/DocumentViewer';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import type { ViewerTool } from '../../components/reviews/viewer/ViewerToolbar';
 import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
+import { ReattachHintBar } from '../../components/reviews/viewer/ReattachHintBar';
 import { isOpenWorkflowState } from '../../components/reviews/workflowMeta';
 import { recordRecentReview } from '../../components/dashboard/recentReviews';
 import { useAuthStore } from '../../stores/authStore';
@@ -240,6 +245,13 @@ export function DocumentReviewPage() {
     anchor: Anchor;
     menuPosition: { left: number; top: number } | null;
   } | null>(null);
+  // Re-attach mode (issue #457): while armed, the next text/region selection
+  // becomes the lost annotation's new anchor instead of a fresh mark.
+  const [reattaching, setReattaching] = useState<{
+    annotationId: string;
+    excerpt: string | null;
+  } | null>(null);
+  const reattachPlacement = useReattachPlacement(notify);
 
   const surfaces = renderedQuery.data?.surfaces;
   const annotations = useMemo(
@@ -292,6 +304,16 @@ export function DocumentReviewPage() {
     focusMode && composingPending ? 'pending-highlight' : null,
   );
 
+  // Escape leaves the re-attach mode without touching anything (issue #457).
+  useEffect(() => {
+    if (!reattaching) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setReattaching(null);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [reattaching]);
+
   const closeFocusCard = () => {
     setActiveAnnotationId(null);
     activeMarkEl?.focus();
@@ -301,11 +323,35 @@ export function DocumentReviewPage() {
     setSearchParams({ version: String(version) });
     setActiveAnnotationId(null);
     setPending(null);
+    setReattaching(null);
   };
 
   const stagePending = (anchor: Anchor, at: ScreenPosition) => {
+    if (reattaching && versionNumber !== undefined) {
+      const { annotationId } = reattaching;
+      setReattaching(null);
+      reattachPlacement.mutate(
+        { annotationId, versionNumber, anchor },
+        // Land on the re-homed thread — except in focus mode, where activating
+        // would re-open the overlay the user just aimed past (issue #403).
+        { onSuccess: () => (focusMode ? undefined : setActiveAnnotationId(annotationId)) },
+      );
+      return;
+    }
     setPending({ anchor, menuPosition: at });
     setActiveAnnotationId(null);
+  };
+
+  // Arming (issue #457): mutually exclusive with drafting a new mark, and the
+  // focus overlay/drawer make way so the document is selectable.
+  const armReattach = (annotation: AnnotationView) => {
+    setPending(null);
+    setActiveAnnotationId(null);
+    setListOpen(false);
+    setReattaching({
+      annotationId: annotation.id,
+      excerpt: annotation.anchor?.textQuote?.quote ?? null,
+    });
   };
 
   const handleTextSelected = (
@@ -502,9 +548,17 @@ export function DocumentReviewPage() {
                   flex: 1,
                   minHeight: { xs: 480, md: 0 },
                   borderRadius: 1,
+                  // The re-attach hint pill anchors to this stage (issue #457).
+                  position: 'relative',
                   bgcolor: (theme) => theme.qnop.surface2,
                 }}
               >
+                {reattaching && (
+                  <ReattachHintBar
+                    excerpt={reattaching.excerpt}
+                    onCancel={() => setReattaching(null)}
+                  />
+                )}
                 {/* A crash in the pdf.js viewer must not take down the panel or the
                     page — scope it and let the reviewer retry (issue #331). */}
                 <ErrorBoundary
@@ -524,6 +578,7 @@ export function DocumentReviewPage() {
                     onSelectAnnotation={(id) => {
                       setActiveAnnotationId(id);
                       setPending(null);
+                      setReattaching(null);
                     }}
                     onHoverAnnotation={setHoverAnnotationId}
                     onVisiblePageChange={setCurrentPage}
@@ -590,6 +645,7 @@ export function DocumentReviewPage() {
                   onUploadAttachment={uploadAttachment}
                   readOnly={!isLatestVersion}
                   versionNumber={versionNumber}
+                  onArmReattach={armReattach}
                   reviewClosed={!isOpenWorkflowState(document.workflowState)}
                   previousSeenAt={previousSeenAt}
                   buildPermalink={buildPermalink}
@@ -627,6 +683,8 @@ export function DocumentReviewPage() {
               canAnnotate={canAnnotate}
               notify={notify}
               readOnly={!isLatestVersion}
+              versionNumber={versionNumber}
+              onArmReattach={armReattach}
               reviewClosed={!isOpenWorkflowState(document.workflowState)}
               previousSeenAt={previousSeenAt}
               buildPermalink={buildPermalink}
@@ -648,6 +706,7 @@ export function DocumentReviewPage() {
           notify={notify}
           readOnly={!isLatestVersion}
           versionNumber={versionNumber}
+          onArmReattach={armReattach}
           reviewClosed={!isOpenWorkflowState(document.workflowState)}
           threadParticipation={document.threadParticipation ?? 'OPEN'}
           ownerId={document.ownerId}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../../api/hooks/useDocuments', () => ({
 const { createMutate } = vi.hoisted(() => ({ createMutate: vi.fn() }));
 vi.mock('../../api/hooks/useAnnotations', () => ({
   useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useReattachPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useAnnotations: vi.fn(),
   useCreateAnnotation: vi.fn().mockReturnValue({ mutate: createMutate, isPending: false }),
   useResolveAnnotation: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),

--- a/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
@@ -48,6 +48,7 @@ vi.mock('../../api/hooks/useReviews', () => ({
 }));
 vi.mock('../../api/hooks/useAnnotations', () => ({
   useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useReattachPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useAnnotations: vi.fn().mockReturnValue({ data: undefined }),
 }));
 vi.mock('../../api/hooks/useVersionDiff', async (importOriginal) => ({


### PR DESCRIPTION
Closes #457.

> **Stacked on #458** — this PR is based on `feat/issue-326-reanchoring-visibility` so it shows only the re-attach changes. Merge #458 first; GitHub will retarget this PR to `main` automatically.

## What

Re-anchoring can lose a placement (`ORPHANED`/`FAILED`) when the annotated passage disappears from a new version. The thread survived, but could never return to the document. This adds the manual half of recovery: the owner or the annotation's author points at the new passage, and the placement flips back to `PLACED` — thread, comments and history untouched.

## Backend

- **`PUT /annotations/{annotationId}/placements/{versionNumber}/anchor`** (`reattachPlacement`, OpenAPI-first): replaces a lost placement's anchor with the request body's `anchor` and marks it `PLACED`.
- Allowed for `ORPHANED`, `FAILED` — and `MOVED`, so a mis-guessed automatic match can be overridden by pointing at the right passage instead of confirming the wrong one.
- Guards: 404 (visibility / unknown version / no placement), 403 (participants who are neither owner nor author), 409 `REVIEW_CLOSED` (finalized/cancelled), 409 `VERSION_READ_ONLY` (older versions are a read-only record), 409 `PLACEMENT_NOT_REATTACHABLE` (`PLACED`/`PENDING` refuse — nothing is overwritten by accident).
- Audited as `placement.reattached` and included in the dashboard activity feed.

## Frontend

- **"Re-attach" affordance** beside the `Orphaned`/`Failed` chip in the annotation head — panel card and focus card — gated to owner/author on the latest version of an open review.
- **Arming mode** on the review page: clicking Re-attach collapses the card and floats a hint pill over the document stage — *Placing “<old quote>” — select the new passage · Esc*. The next text or region selection becomes the new anchor; the annotation list, chip, banner counts and document mark update in place.
- Escape, switching versions, or clicking another annotation leaves the mode without touching anything; arming is mutually exclusive with drafting a new annotation.

## Tests

- `PlacementReattachApiIT` (5 cases): author re-attaches an orphan (new anchor in the response, thread intact), owner allowed / stranger 403, `PLACED` → 409, older version → 409 `VERSION_READ_ONLY`, finalized review → 409 `REVIEW_CLOSED`.
- `ReattachHintBar` unit tests (excerpt, region fallback, truncation, cancel) and `AnnotationBadgeRow` affordance tests (orphaned/failed show it, settled placements and read-only viewers don't, card click is not toggled).
- Full gates green: `./gradlew build`, `pnpm lint` + `tsc` + 756 vitest tests.
- Verified end-to-end against live re-anchored orphans (SciFi Story v4): re-attach → toast, chip flip, banner count 4 → 3, new mark; Esc cancel path.

## Test plan

- [x] Orphaned annotation re-attached via text selection lands as `PLACED` with the new quote
- [x] Escape / version switch / annotation click cancel the armed mode
- [x] Non-owner/author participants see no affordance; API answers 403
- [x] Older versions and closed reviews refuse with stable 409 codes

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)