### PR TITLE
feat(reviews): audit extraction outcomes and persist the failure reason (#325)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/document/DocumentExtractionFailureIT.java
+++ b/qnop-app/src/test/java/io/qnop/document/DocumentExtractionFailureIT.java
@@ -20,6 +20,7 @@
  */
 package io.qnop.document;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -29,8 +30,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.jayway.jsonpath.JsonPath;
 import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.User;
+import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.repository.UserRepository;
 import io.qnop.service.job.JobQueuePoller;
 import java.io.ByteArrayOutputStream;
@@ -84,6 +89,8 @@ class DocumentExtractionFailureIT extends AbstractIntegrationTest {
   @Autowired MockMvc mockMvc;
   @Autowired UserRepository users;
   @Autowired DocumentRepository documents;
+  @Autowired DocumentVersionRepository versions;
+  @Autowired AuditEventRepository auditEvents;
   @Autowired PasswordEncoder passwordEncoder;
   @Autowired JobQueuePoller poller;
 
@@ -176,7 +183,44 @@ class DocumentExtractionFailureIT extends AbstractIntegrationTest {
         .andExpect(jsonPath("$.annotations[0].placementStatus").value("FAILED"));
   }
 
+  @Test
+  @DisplayName(
+      "extraction audits success and failure, and persists the failure reason (issue #325)")
+  void auditsOutcomesAndPersistsFailureReason() throws Exception {
+    UUID owner = createUser();
+    UUID documentId = upload(owner, "the original clause stands");
+    poller.poll(); // extract v1 → READY
+
+    addVersion(owner, documentId, CORRUPT_PDF);
+    poller.poll(); // extract v2 → FAILED
+
+    List<DocumentVersion> chain = versions.findByDocumentIdOrderByVersionNumberAsc(documentId);
+    UUID v1 = chain.get(0).getId();
+    DocumentVersion v2 = chain.get(1);
+
+    // The failure reason is persisted for operators — the corrupt PDF surfaces PDFBox's message.
+    assertThat(v2.getExtractionFailureReason()).contains("Unreadable PDF");
+
+    List<AuditEvent> trail = auditEvents.findByDocumentIdOrderByCreatedAtDesc(documentId);
+    // v1's extraction succeeded — system-generated (no actor), detail names the version.
+    AuditEvent succeeded = onlyEvent(trail, "extraction.succeeded");
+    assertThat(succeeded.getActorId()).isNull();
+    assertThat(succeeded.getDetail()).contains(v1.toString());
+    // v2's extraction failed — detail names the version and carries the reason.
+    AuditEvent failed = onlyEvent(trail, "extraction.failed");
+    assertThat(failed.getActorId()).isNull();
+    assertThat(failed.getDetail()).contains(v2.getId().toString()).contains("Unreadable PDF");
+  }
+
   // --- helpers ---------------------------------------------------------------
+
+  /** The single audit event of the given type in the trail (fails if absent or duplicated). */
+  private static AuditEvent onlyEvent(List<AuditEvent> trail, String eventType) {
+    List<AuditEvent> matches =
+        trail.stream().filter(e -> e.getEventType().equals(eventType)).toList();
+    assertThat(matches).as("exactly one %s event", eventType).hasSize(1);
+    return matches.get(0);
+  }
 
   /** The annotation drawn on v1: region + the quote with its real prefix/suffix context. */
   private static String annotationBody() {

--- a/qnop-core/src/main/java/io/qnop/entity/DocumentVersion.java
+++ b/qnop-core/src/main/java/io/qnop/entity/DocumentVersion.java
@@ -50,6 +50,9 @@ import org.hibernate.type.SqlTypes;
 @Table(name = "document_version")
 public class DocumentVersion {
 
+  /** Column cap for the persisted failure reason (issue #325); longer messages are truncated. */
+  static final int MAX_FAILURE_REASON_LENGTH = 2000;
+
   @Id
   @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
   @Column(name = "id", nullable = false, updatable = false)
@@ -83,6 +86,14 @@ public class DocumentVersion {
   @Enumerated(EnumType.STRING)
   @Column(name = "extraction_status", nullable = false, length = 16)
   private ExtractionStatus extractionStatus = ExtractionStatus.PENDING;
+
+  /**
+   * Why extraction failed (issue #325): the extractor's message or "no extractor …", persisted for
+   * operators. Null unless {@code extractionStatus == FAILED}. Server-side only — never surfaced to
+   * reviewers, who see the opaque {@code EXTRACTION_FAILED} on serving.
+   */
+  @Column(name = "extraction_failure_reason", length = MAX_FAILURE_REASON_LENGTH)
+  private String extractionFailureReason;
 
   @Column(name = "created_by", nullable = false, updatable = false)
   private UUID createdBy;
@@ -127,12 +138,29 @@ public class DocumentVersion {
 
   /** Marks the extraction permanently failed (unprocessable content, issue #245). */
   public void markExtractionFailed() {
+    markExtractionFailed(null);
+  }
+
+  /**
+   * Marks the extraction permanently failed and records why (issue #325). The reason is truncated
+   * to the column cap; null leaves it unset.
+   */
+  public void markExtractionFailed(String reason) {
     this.renderedDocument = null;
     this.extractionStatus = ExtractionStatus.FAILED;
+    this.extractionFailureReason =
+        reason == null || reason.length() <= MAX_FAILURE_REASON_LENGTH
+            ? reason
+            : reason.substring(0, MAX_FAILURE_REASON_LENGTH);
   }
 
   public ExtractionStatus getExtractionStatus() {
     return extractionStatus;
+  }
+
+  /** Why extraction failed (issue #325), or null when not FAILED. Operator-facing only. */
+  public String getExtractionFailureReason() {
+    return extractionFailureReason;
   }
 
   public UUID getId() {

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
@@ -113,7 +113,8 @@ public class DocumentExtractionJobHandler implements JobHandler {
           "No DocumentExtractor supports {} — marking version {} FAILED.",
           version.getContentType(),
           versionId);
-      writer.failPermanently(versionId);
+      writer.failPermanently(
+          versionId, "no extractor supports content type " + version.getContentType());
       return;
     }
 
@@ -131,7 +132,7 @@ public class DocumentExtractionJobHandler implements JobHandler {
       renderedJson = MAPPER.writeValueAsString(rendered);
     } catch (ExtractionException e) {
       log.warn("Extraction of version {} failed permanently: {}", versionId, e.getMessage());
-      writer.failPermanently(versionId);
+      writer.failPermanently(versionId, e.getMessage());
       return;
     } catch (JacksonException e) {
       // Serializing our own SPI records can only fail on a code bug; add context and let the

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionWriter.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionWriter.java
@@ -21,19 +21,25 @@
 package io.qnop.service.document;
 
 import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.AuditEvent;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
 import io.qnop.entity.PlacementStatus;
 import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobEnqueuer;
 import io.qnop.service.job.JobPayload;
 import io.qnop.service.job.JobPayloadCodec;
 import io.qnop.service.review.ReanchorJobHandler;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * The short, transactional write phase of document extraction (issue #314). Split out of {@link
@@ -50,6 +56,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 class DocumentExtractionWriter {
 
+  /** Audit type for a successful extraction; detail carries {@code {"versionId"}} (issue #325). */
+  static final String AUDIT_EXTRACTION_SUCCEEDED = "extraction.succeeded";
+
+  /**
+   * Audit type for a permanently failed extraction; detail carries {@code {"versionId","reason"}}
+   * (issue #325).
+   */
+  static final String AUDIT_EXTRACTION_FAILED = "extraction.failed";
+
+  // Jackson 3 (tools.jackson) so the reason — arbitrary extractor text — is JSON-escaped rather
+  // than concatenated into the detail string.
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
   private final DocumentVersionRepository versions;
   private final AnnotationPlacementRepository placements;
   // The narrow write-side queue bean, injected directly (no ObjectProvider): depending on
@@ -57,14 +76,17 @@ class DocumentExtractionWriter {
   // dispatch↔handler cycle, so the follow-up re-anchoring job (issue #248) enqueues without any
   // lazy indirection (issue #318).
   private final JobEnqueuer jobs;
+  private final AuditEventRepository auditEvents;
 
   DocumentExtractionWriter(
       DocumentVersionRepository versions,
       AnnotationPlacementRepository placements,
-      JobEnqueuer jobs) {
+      JobEnqueuer jobs,
+      AuditEventRepository auditEvents) {
     this.versions = versions;
     this.placements = placements;
     this.jobs = jobs;
+    this.auditEvents = auditEvents;
   }
 
   /**
@@ -80,6 +102,11 @@ class DocumentExtractionWriter {
     }
     version.attachRenderedDocument(renderedJson);
     versions.save(version);
+    // System-generated (no actor): the async job, not a user, produced this. Commits with the
+    // READY flip so the trail can never diverge from the version's state (issue #325).
+    auditEvents.save(
+        new AuditEvent(
+            version.getDocumentId(), AUDIT_EXTRACTION_SUCCEEDED, null, detail(versionId, null)));
     if (!placements
         .findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING)
         .isEmpty()) {
@@ -90,23 +117,37 @@ class DocumentExtractionWriter {
   }
 
   /**
-   * Marks the version FAILED permanently (unprocessable content or no extractor) and fails its
-   * pending placements — they can never be re-anchored against a version with no text layer. A
-   * version already FAILED (a replay) is a no-op.
+   * Marks the version FAILED permanently (unprocessable content or no extractor), records {@code
+   * reason} for operators (issue #325), and fails its pending placements — they can never be
+   * re-anchored against a version with no text layer. A version already FAILED (a replay) is a
+   * no-op, so the failure is audited exactly once.
    */
   @Transactional
-  public void failPermanently(UUID versionId) {
+  public void failPermanently(UUID versionId, String reason) {
     DocumentVersion version = versions.findById(versionId).orElse(null);
     if (version == null || version.getExtractionStatus() == ExtractionStatus.FAILED) {
       return; // idempotent: deleted or already failed
     }
-    version.markExtractionFailed();
+    version.markExtractionFailed(reason);
     versions.save(version);
+    auditEvents.save(
+        new AuditEvent(
+            version.getDocumentId(), AUDIT_EXTRACTION_FAILED, null, detail(versionId, reason)));
     List<AnnotationPlacement> pending =
         placements.findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING);
     for (AnnotationPlacement placement : pending) {
       placement.markFailed();
       placements.save(placement);
     }
+  }
+
+  /** Builds the audit {@code detail} jsonb; {@code reason} is included only when present. */
+  private static String detail(UUID versionId, String reason) {
+    Map<String, Object> node = new LinkedHashMap<>();
+    node.put("versionId", versionId.toString());
+    if (reason != null) {
+      node.put("reason", reason);
+    }
+    return MAPPER.writeValueAsString(node);
   }
 }

--- a/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0011-document-review-schema.yaml
@@ -157,6 +157,10 @@ databaseChangeLog:
                   type: VARCHAR(16)
                   defaultValue: PENDING
                   constraints: { nullable: false }
+              # Why extraction failed (issue #325): the extractor's message or "no
+              # extractor ...", persisted for operators. Null unless extraction_status
+              # is FAILED; server-side only (never surfaced to reviewers).
+              - column: { name: extraction_failure_reason, type: VARCHAR(2000) }
               - column:
                   name: created_by
                   type: UUID

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionJobHandlerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
 import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobEnqueuer;
 import io.qnop.service.job.JobPayload;
@@ -59,6 +60,7 @@ class DocumentExtractionJobHandlerTest {
   private final AnnotationPlacementRepository placements =
       mock(AnnotationPlacementRepository.class);
   private final JobEnqueuer jobs = mock(JobEnqueuer.class);
+  private final AuditEventRepository auditEvents = mock(AuditEventRepository.class);
 
   private final UUID versionId = UUID.randomUUID();
   private DocumentVersion version;
@@ -73,7 +75,8 @@ class DocumentExtractionJobHandlerTest {
   private DocumentExtractionJobHandler handler(DocumentExtractor... extractors) {
     // The write phase lives in DocumentExtractionWriter (issue #314); in this unit test it runs
     // directly (no Spring proxy), over the same mocked repositories.
-    DocumentExtractionWriter writer = new DocumentExtractionWriter(versions, placements, jobs);
+    DocumentExtractionWriter writer =
+        new DocumentExtractionWriter(versions, placements, jobs, auditEvents);
     return new DocumentExtractionJobHandler(versions, storage, List.of(extractors), writer);
   }
 
@@ -120,6 +123,8 @@ class DocumentExtractionJobHandlerTest {
     verify(versions).save(version);
     assertThat(version.getExtractionStatus()).isEqualTo(ExtractionStatus.FAILED);
     assertThat(version.getRenderedDocument()).isNull();
+    // The extractor's message is threaded through and persisted for operators (issue #325).
+    assertThat(version.getExtractionFailureReason()).isEqualTo("corrupt");
   }
 
   @Test
@@ -130,6 +135,8 @@ class DocumentExtractionJobHandlerTest {
     handler(/* no extractors */ ).handle(payload(versionId));
 
     assertThat(version.getExtractionStatus()).isEqualTo(ExtractionStatus.FAILED);
+    assertThat(version.getExtractionFailureReason())
+        .isEqualTo("no extractor supports content type application/pdf");
   }
 
   @Test

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionWriterTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentExtractionWriterTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.AnnotationPlacement;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ExtractionStatus;
+import io.qnop.entity.PlacementStatus;
+import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.job.JobEnqueuer;
+import io.qnop.service.review.ReanchorJobHandler;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Unit tests for {@link DocumentExtractionWriter} (issue #325): the transactional write phase must
+ * emit exactly one audit event per terminal outcome (with the version id, and the reason on
+ * failure), persist the failure reason on the version, and stay idempotent on replay so a
+ * crash-and-retry never double-audits.
+ */
+@ExtendWith(MockitoExtension.class)
+class DocumentExtractionWriterTest {
+
+  @Mock private DocumentVersionRepository versions;
+  @Mock private AnnotationPlacementRepository placements;
+  @Mock private JobEnqueuer jobs;
+  @Mock private AuditEventRepository auditEvents;
+  @Captor private ArgumentCaptor<AuditEvent> auditCaptor;
+
+  private DocumentExtractionWriter writer;
+
+  private static final UUID VERSION_ID = UUID.randomUUID();
+  private static final UUID DOCUMENT_ID = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    writer = new DocumentExtractionWriter(versions, placements, jobs, auditEvents);
+  }
+
+  private DocumentVersion pendingVersion() {
+    return new DocumentVersion(
+        DOCUMENT_ID, 1, "sha256/abc", "abc", "application/pdf", 10L, UUID.randomUUID());
+  }
+
+  // --- success ---------------------------------------------------------------
+
+  @Test
+  @DisplayName("success flips to READY and audits extraction.succeeded with the version id")
+  void auditsSuccess() {
+    DocumentVersion version = pendingVersion();
+    when(versions.findById(VERSION_ID)).thenReturn(Optional.of(version));
+    when(placements.findByDocumentVersionIdAndStatus(VERSION_ID, PlacementStatus.PENDING))
+        .thenReturn(List.of());
+
+    writer.attachRenderedAndChain(VERSION_ID, "{\"surfaces\":[]}");
+
+    assertThat(version.getExtractionStatus()).isEqualTo(ExtractionStatus.READY);
+    verify(auditEvents).save(auditCaptor.capture());
+    AuditEvent event = auditCaptor.getValue();
+    assertThat(event.getDocumentId()).isEqualTo(DOCUMENT_ID);
+    assertThat(event.getEventType()).isEqualTo(DocumentExtractionWriter.AUDIT_EXTRACTION_SUCCEEDED);
+    assertThat(event.getActorId()).isNull(); // system-generated
+    assertThat(readField(event.getDetail(), "versionId")).isEqualTo(VERSION_ID.toString());
+    assertThat(event.getDetail()).doesNotContain("reason");
+    // No pending placements → no re-anchor job.
+    verify(jobs, never()).enqueue(any(), any());
+  }
+
+  @Test
+  @DisplayName("success with pending placements also chains the re-anchor job")
+  void chainsReanchorWhenPendingPlacementsExist() {
+    DocumentVersion version = pendingVersion();
+    when(versions.findById(VERSION_ID)).thenReturn(Optional.of(version));
+    when(placements.findByDocumentVersionIdAndStatus(VERSION_ID, PlacementStatus.PENDING))
+        .thenReturn(List.of(new AnnotationPlacement(UUID.randomUUID(), VERSION_ID, "{}")));
+
+    writer.attachRenderedAndChain(VERSION_ID, "{\"surfaces\":[]}");
+
+    verify(jobs).enqueue(eq(ReanchorJobHandler.TYPE), any());
+    verify(auditEvents).save(any());
+  }
+
+  @Test
+  @DisplayName("success replay on an already-READY version is a no-op — no second audit")
+  void successIdempotentOnReplay() {
+    DocumentVersion version = pendingVersion();
+    version.attachRenderedDocument("{}");
+    when(versions.findById(VERSION_ID)).thenReturn(Optional.of(version));
+
+    writer.attachRenderedAndChain(VERSION_ID, "{\"surfaces\":[]}");
+
+    verify(versions, never()).save(any());
+    verify(auditEvents, never()).save(any());
+  }
+
+  // --- failure ---------------------------------------------------------------
+
+  @Test
+  @DisplayName("failure persists the reason and audits extraction.failed with versionId + reason")
+  void auditsFailureWithReason() {
+    DocumentVersion version = pendingVersion();
+    when(versions.findById(VERSION_ID)).thenReturn(Optional.of(version));
+    when(placements.findByDocumentVersionIdAndStatus(VERSION_ID, PlacementStatus.PENDING))
+        .thenReturn(List.of());
+
+    writer.failPermanently(VERSION_ID, "encrypted PDF");
+
+    assertThat(version.getExtractionStatus()).isEqualTo(ExtractionStatus.FAILED);
+    assertThat(version.getExtractionFailureReason()).isEqualTo("encrypted PDF");
+    verify(auditEvents).save(auditCaptor.capture());
+    AuditEvent event = auditCaptor.getValue();
+    assertThat(event.getEventType()).isEqualTo(DocumentExtractionWriter.AUDIT_EXTRACTION_FAILED);
+    assertThat(event.getActorId()).isNull();
+    assertThat(readField(event.getDetail(), "versionId")).isEqualTo(VERSION_ID.toString());
+    assertThat(readField(event.getDetail(), "reason")).isEqualTo("encrypted PDF");
+  }
+
+  @Test
+  @DisplayName("failure fails every pending placement on the version")
+  void failsPendingPlacements() {
+    DocumentVersion version = pendingVersion();
+    AnnotationPlacement pending = new AnnotationPlacement(UUID.randomUUID(), VERSION_ID, "{}");
+    when(versions.findById(VERSION_ID)).thenReturn(Optional.of(version));
+    when(placements.findByDocumentVersionIdAndStatus(VERSION_ID, PlacementStatus.PENDING))
+        .thenReturn(List.of(pending));
+
+    writer.failPermanently(VERSION_ID, "corrupt");
+
+    assertThat(pending.getStatus()).isEqualTo(PlacementStatus.FAILED);
+    verify(placements).save(pending);
+  }
+
+  @Test
+  @DisplayName("a reason with quotes/newlines is JSON-escaped, not concatenated raw")
+  void escapesReasonInDetail() {
+    DocumentVersion version = pendingVersion();
+    when(versions.findById(VERSION_ID)).thenReturn(Optional.of(version));
+    when(placements.findByDocumentVersionIdAndStatus(VERSION_ID, PlacementStatus.PENDING))
+        .thenReturn(List.of());
+    String nasty = "bad \"quote\" and\nnewline";
+
+    writer.failPermanently(VERSION_ID, nasty);
+
+    verify(auditEvents).save(auditCaptor.capture());
+    // The detail round-trips as valid JSON with the reason preserved verbatim.
+    assertThat(readField(auditCaptor.getValue().getDetail(), "reason")).isEqualTo(nasty);
+  }
+
+  @Test
+  @DisplayName("failure replay on an already-FAILED version is a no-op — no second audit")
+  void failureIdempotentOnReplay() {
+    DocumentVersion version = pendingVersion();
+    version.markExtractionFailed("first reason");
+    when(versions.findById(VERSION_ID)).thenReturn(Optional.of(version));
+
+    writer.failPermanently(VERSION_ID, "second reason");
+
+    verify(versions, never()).save(any());
+    verify(auditEvents, never()).save(any());
+    assertThat(version.getExtractionFailureReason()).isEqualTo("first reason"); // unchanged
+  }
+
+  @Test
+  @DisplayName("a deleted version is a no-op for both outcomes")
+  void deletedVersionIsNoOp() {
+    when(versions.findById(VERSION_ID)).thenReturn(Optional.empty());
+
+    writer.attachRenderedAndChain(VERSION_ID, "{}");
+    writer.failPermanently(VERSION_ID, "gone");
+
+    verify(auditEvents, never()).save(any());
+    verify(versions, never()).save(any());
+  }
+
+  private static String readField(String json, String field) {
+    JsonNode node = JsonMapper.builder().build().readTree(json).path(field);
+    return node.isMissingNode() || node.isNull() ? null : node.asText();
+  }
+}


### PR DESCRIPTION
Closes #325.

## Problem
Extraction success/failure emitted no `AuditEvent` and persisted no failure reason (`DocumentExtractionJobHandler`), so operators had no way to see **why** a version failed.

## Change
- **`DocumentVersion`**: new `extraction_failure_reason` column (folded into the `0011` changeset — schema not yet in production, per the project's Liquibase convention), set via `markExtractionFailed(reason)` (truncated to 2000 chars; a no-arg overload is kept so existing test fixtures are untouched).
- **`DocumentExtractionWriter`** (the short transactional write phase): emit a system-generated `AuditEvent` (`actorId=null`) on **both** outcomes — `extraction.succeeded {versionId}` and `extraction.failed {versionId,reason}`. The audit commits atomically with the READY/FAILED flip, and the existing idempotent early-returns keep a crash-replay from double-auditing. The reason is JSON-escaped via Jackson, never string-concatenated into the `detail`.
- **`DocumentExtractionJobHandler`**: thread the reason into `failPermanently` — the `ExtractionException` message, or `"no extractor supports content type X"`.

## Deliberate scope
- The failure reason stays **operator-only** (audit trail + DB column). The serving `409 EXTRACTION_FAILED` still carries no parser internals to reviewers.
- No audit-trail REST endpoint (separate feature); no OpenAPI/ADR change (follows ADR-0011 audit trail + ADR-0033 outbox).

## Test plan
- [x] New `DocumentExtractionWriterTest` — success/failure audit, reason persistence, JSON escaping of a nasty reason, idempotent replay (no 2nd audit), deleted-version no-op.
- [x] `DocumentExtractionJobHandlerTest` — asserts the threaded reason (`ExtractionException` message and the no-extractor string).
- [x] `DocumentExtractionFailureIT` — extended to assert both audit rows + the persisted reason end-to-end.
- [x] Local gates green: `spotlessCheck`, `ArchitectureRulesTest` (ArchUnit), `:qnop-core:test`.
- [ ] CI: full `./gradlew build` + Testcontainers ITs (Postgres + MinIO) — Docker-only, verified in CI.

🤖 Co-Author: Claude (Opus 4.8) via Claude Code