### PR TITLE
feat(reviews): email notifications on review events

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -669,6 +669,58 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /admin/email/templates/{key}/test:
+    post:
+      tags:
+        - AdminEmail
+      summary: Send a template test email
+      description: |
+        Renders the template exactly like the preview (stored version, or the
+        supplied unsaved draft, with sample/override variables) and sends the
+        result to the given recipient. Superadmin only. Never returns a 5xx for
+        a delivery problem — the outcome is reported in the body `status`.
+      operationId: sendTemplateTestEmail
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/MailTemplateKeyParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateTestEmailRequest'
+      responses:
+        '200':
+          description: Send attempt completed (see `status` for the outcome)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendTestEmailResponse'
+        '400':
+          description: Invalid recipient or render error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown template key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Caller is not a superadmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /admin/users:
     get:
       tags:
@@ -3299,6 +3351,33 @@ components:
         - accessToken
         - tokenType
         - expiresInSeconds
+    TemplateTestEmailRequest:
+      type: object
+      description: Send a rendered template to a recipient as a test (issue #316).
+      properties:
+        recipient:
+          type: string
+          format: email
+          description: Address the rendered template is sent to.
+        locale:
+          type: string
+          description: Locale to render; falls back to the default language when omitted.
+        subject:
+          type: string
+          description: Draft subject to render instead of the stored version.
+        bodyPlain:
+          type: string
+          description: Draft plain-text body; honoured only together with a draft subject.
+        bodyHtml:
+          type: string
+          description: Optional draft HTML alternative.
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+          description: Template variables; representative sample data is used when omitted.
+      required:
+        - recipient
     SendTestEmailRequest:
       type: object
       description: Request to send a test email.

--- a/qnop-app/src/main/java/io/qnop/bootstrap/AsyncConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/AsyncConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Async plumbing for the app (issue #316). The only async consumer today is the review notification
+ * listener; it gets a small, bounded executor of its own so a slow SMTP server can back up
+ * notification mails without touching request threads or the scheduler.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfiguration {
+
+  /** Bounded executor for review notification mails; overflow runs in the caller thread. */
+  @Bean(name = "reviewNotificationExecutor")
+  @ConditionalOnProperty(
+      name = "qnop.notifications.sync-dispatch",
+      havingValue = "false",
+      matchIfMissing = true)
+  public ThreadPoolTaskExecutor reviewNotificationExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setThreadNamePrefix("review-notify-");
+    executor.setCorePoolSize(1);
+    executor.setMaxPoolSize(2);
+    executor.setQueueCapacity(200);
+    // CallerRunsPolicy: if the queue is full the committing thread sends the mail itself —
+    // slower, but nothing is silently dropped.
+    executor.setRejectedExecutionHandler(
+        new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
+    return executor;
+  }
+
+  /**
+   * Integration tests flip {@code qnop.notifications.sync-dispatch} to run the listener in the
+   * committing thread: deterministic assertions, and no async reader racing the per-test TRUNCATE.
+   */
+  @Bean(name = "reviewNotificationExecutor")
+  @ConditionalOnProperty(name = "qnop.notifications.sync-dispatch", havingValue = "true")
+  public TaskExecutor syncReviewNotificationExecutor() {
+    return new SyncTaskExecutor();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/AdminEmailController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminEmailController.java
@@ -29,6 +29,7 @@ import io.qnop.api.v1.model.PreviewMailTemplateRequest;
 import io.qnop.api.v1.model.SendStatus;
 import io.qnop.api.v1.model.SendTestEmailRequest;
 import io.qnop.api.v1.model.SendTestEmailResponse;
+import io.qnop.api.v1.model.TemplateTestEmailRequest;
 import io.qnop.api.v1.model.UpdateMailTemplateRequest;
 import io.qnop.service.mail.MailService;
 import io.qnop.service.mail.MailService.SendResult;
@@ -82,6 +83,43 @@ public class AdminEmailController implements AdminEmailApi {
           case SendResult.Failed failed -> response(SendStatus.FAILED, failed.reason());
         };
     return ResponseEntity.ok(body);
+  }
+
+  @Override
+  public ResponseEntity<SendTestEmailResponse> sendTemplateTestEmail(
+      String key, TemplateTestEmailRequest request) {
+    MailTemplateKey templateKey = resolveKey(key);
+    MailPreview preview;
+    try {
+      preview =
+          templates.preview(
+              templateKey, request.getLocale(), toVars(request.getVariables()), toDraft(request));
+    } catch (MailTemplateValidationException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+    } catch (RuntimeException e) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Template render failed: " + e.getMessage());
+    }
+    RenderedMail rendered = preview.rendered();
+    SendResult result =
+        mailService.sendMail(
+            request.getRecipient(), rendered.subject(), rendered.bodyPlain(), rendered.bodyHtml());
+    SendTestEmailResponse body =
+        switch (result) {
+          case SendResult.Sent sent -> response(SendStatus.SENT, "Sent to " + sent.recipient());
+          case SendResult.Skipped skipped -> response(SendStatus.SKIPPED, skipped.reason());
+          case SendResult.Failed failed -> response(SendStatus.FAILED, failed.reason());
+        };
+    return ResponseEntity.ok(body);
+  }
+
+  /** The template-test variant of {@link #toDraft(PreviewMailTemplateRequest)}. */
+  private MailTemplateService.MailTemplateDraft toDraft(TemplateTestEmailRequest request) {
+    if (request.getSubject() == null || request.getBodyPlain() == null) {
+      return null;
+    }
+    return new MailTemplateService.MailTemplateDraft(
+        request.getSubject(), request.getBodyPlain(), request.getBodyHtml());
   }
 
   @Override

--- a/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
@@ -66,6 +66,9 @@ public abstract class AbstractIntegrationTest {
     registry.add("qnop.auth.jwt-secret", () -> "integration-test-jwt-secret-0123456789");
     registry.add("qnop.auth.encryption-key", () -> "integration-test-encryption-key-0123456789");
     registry.add("qnop.auth.encryption-salt", () -> "0123456789abcdef0123456789abcdef");
+    // Review notifications dispatch synchronously in tests (issue #316): deterministic
+    // verification, and no async DB reader racing the per-test TRUNCATE cleanup.
+    registry.add("qnop.notifications.sync-dispatch", () -> "true");
     registry.add("qnop.cors.allowed-origins", () -> "http://localhost:5173");
     // Effectively disable the background job poller/reaper in tests (interval == initial delay ==
     // 1h): tests drive the queue via direct poll()/reap() calls, so a stray scheduled tick must not

--- a/qnop-app/src/test/java/io/qnop/mail/MailTemplateSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/mail/MailTemplateSchemaIT.java
@@ -63,7 +63,8 @@ class MailTemplateSchemaIT extends AbstractIntegrationTest {
           "review.annotation_created",
           "review.annotation_decided",
           "review.comment_added",
-          "review.workflow_changed"
+          "review.workflow_changed",
+          "review.version_uploaded"
         }) {
       assertThat(templates.findByTemplateKeyAndLocale(key, "en"))
           .hasValueSatisfying(

--- a/qnop-app/src/test/java/io/qnop/mail/MailTemplateSchemaIT.java
+++ b/qnop-app/src/test/java/io/qnop/mail/MailTemplateSchemaIT.java
@@ -56,6 +56,23 @@ class MailTemplateSchemaIT extends AbstractIntegrationTest {
     assertThat(templates.findByTemplateKeyAndLocale("auth.password_reset", "en"))
         .hasValueSatisfying(t -> assertThat(t.getBodyPlain()).contains("{{actionUrl}}"));
     assertThat(templates.findByTemplateKeyAndLocale("auth.admin_password_reset", "en")).isPresent();
+    // Review notification templates (issue #316) — seeded plain, HTML from the branded chrome.
+    for (String key :
+        new String[] {
+          "review.participant_added",
+          "review.annotation_created",
+          "review.annotation_decided",
+          "review.comment_added",
+          "review.workflow_changed"
+        }) {
+      assertThat(templates.findByTemplateKeyAndLocale(key, "en"))
+          .hasValueSatisfying(
+              t -> {
+                assertThat(t.getBodyPlain()).contains("{{recipientName}}", "{{actionUrl}}");
+                assertThat(t.getSubject()).contains("{{documentTitle}}");
+                assertThat(t.getBodyHtml()).isNull();
+              });
+    }
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/mail/SeededMailTemplateRenderIT.java
+++ b/qnop-app/src/test/java/io/qnop/mail/SeededMailTemplateRenderIT.java
@@ -55,6 +55,7 @@ class SeededMailTemplateRenderIT extends AbstractIntegrationTest {
           Map.entry("annotationExcerpt", "The liability clause needs a cap."),
           Map.entry("commentExcerpt", "Agreed — let's cap it at 12 months."),
           Map.entry("decision", "resolved"),
+          Map.entry("versionNumber", "3"),
           Map.entry("oldState", "In review"),
           Map.entry("newState", "Changes requested"));
 

--- a/qnop-app/src/test/java/io/qnop/mail/SeededMailTemplateRenderIT.java
+++ b/qnop-app/src/test/java/io/qnop/mail/SeededMailTemplateRenderIT.java
@@ -43,13 +43,20 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class SeededMailTemplateRenderIT extends AbstractIntegrationTest {
 
-  /** Exactly the variables the registration / password-reset / admin-reset flows supply (#140). */
+  /** Exactly the variables the auth flows (#140) and review notifications (#316) supply. */
   private static final Map<String, Object> FLOW_VARS =
-      Map.of(
-          "siteName", "qnop",
-          "recipientName", "Jane Doe",
-          "actionUrl", "https://qnop.example/action?token=abc123",
-          "expiresAtHuman", "in 30 minutes");
+      Map.ofEntries(
+          Map.entry("siteName", "qnop"),
+          Map.entry("recipientName", "Jane Doe"),
+          Map.entry("actionUrl", "https://qnop.example/action?token=abc123"),
+          Map.entry("expiresAtHuman", "in 30 minutes"),
+          Map.entry("actorName", "Alex Reviewer"),
+          Map.entry("documentTitle", "Q3 contract draft"),
+          Map.entry("annotationExcerpt", "The liability clause needs a cap."),
+          Map.entry("commentExcerpt", "Agreed — let's cap it at 12 months."),
+          Map.entry("decision", "resolved"),
+          Map.entry("oldState", "In review"),
+          Map.entry("newState", "Changes requested"));
 
   @Autowired MailTemplateRepository templates;
   @Autowired MailTemplateService templateService;
@@ -71,7 +78,10 @@ class SeededMailTemplateRenderIT extends AbstractIntegrationTest {
 
       RenderedMail mail = templateService.render(key, FLOW_VARS, row.getLocale());
       assertThat(mail.subject()).isNotBlank();
-      assertThat(mail.bodyPlain()).contains("Jane Doe").contains("in 30 minutes");
+      assertThat(mail.bodyPlain()).contains("Jane Doe");
+      if (row.getTemplateKey().startsWith("auth.")) {
+        assertThat(mail.bodyPlain()).contains("in 30 minutes");
+      }
       // The branded HTML chrome is built by EmailLayoutBuilder for every template.
       assertThat(mail.bodyHtml()).isNotNull().contains("<!DOCTYPE html>").contains("qnop");
     }

--- a/qnop-app/src/test/java/io/qnop/review/ReviewNotificationIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewNotificationIT.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.User;
+import io.qnop.entity.UserSetting;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.repository.UserSettingRepository;
+import io.qnop.service.UserSettingKey;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Review events end to end (issue #316): REST actions land as template mails to the right people —
+ * asynchronously after commit (hence Mockito's {@code timeout}), never to the actor, never to
+ * opted-out users, and derived workflow flips stay silent. {@link MailService} is mocked, so no
+ * SMTP is involved and the assertions read the exact template key, recipient and variables.
+ */
+class ReviewNotificationIT extends SeededIntegrationTest {
+
+  private static final String ANCHOR =
+      "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.1}},"
+          + "\"textQuote\":{\"quote\":\"the clause\"}}";
+
+  @MockitoBean private MailService mail;
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+  @Autowired private UserRepository users;
+  @Autowired private UserSettingRepository userSettings;
+
+  private UUID documentId;
+
+  private void seedDocument(boolean anonymous) {
+    Document document = new Document(MEMBER_ID, "Master services agreement");
+    document.setAnonymous(anonymous);
+    document.setWorkflowState(WorkflowState.IN_REVIEW);
+    documentId = documents.save(document).getId();
+    versions.save(
+        new DocumentVersion(
+            documentId, 1, "sha256/aa/deadbeef", "deadbeef", "application/pdf", 1234L, MEMBER_ID));
+    participants.save(ReviewParticipant.forUser(documentId, AUDITOR_ID));
+  }
+
+  private String emailOf(UUID userId) {
+    return users.findById(userId).map(User::getEmail).orElseThrow();
+  }
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  private String createAnnotation(UUID author) throws Exception {
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), author)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        "{\"versionNumber\":1,\"anchor\":"
+                            + ANCHOR
+                            + ",\"comment\":\"**Check** the cap\"}"))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return JsonPath.read(json, "$.id");
+  }
+
+  @Test
+  @DisplayName("adding a reviewer mails the new reviewer, and only them")
+  void participantAddedMailsTheReviewer() throws Exception {
+    seedDocument(false);
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER2_ID + "\"}"))
+        .andExpect(status().isCreated());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> vars = ArgumentCaptor.forClass(Map.class);
+    verify(mail, timeout(5000))
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_PARTICIPANT_ADDED),
+            eq(emailOf(MEMBER2_ID)),
+            vars.capture(),
+            isNull());
+    assertThat(vars.getValue())
+        .containsEntry("documentTitle", "Master services agreement")
+        .containsKey("actionUrl");
+    verify(mail, after(300).never())
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_PARTICIPANT_ADDED), eq(emailOf(AUDITOR_ID)), anyMap(), any());
+  }
+
+  @Test
+  @DisplayName("a new annotation mails the owner; the derived workflow flip stays silent")
+  void annotationCreatedMailsTheOwner() throws Exception {
+    seedDocument(false);
+
+    createAnnotation(AUDITOR_ID);
+
+    verify(mail, timeout(5000))
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_ANNOTATION_CREATED),
+            eq(emailOf(MEMBER_ID)),
+            anyMap(),
+            isNull());
+    // The raise derived IN_REVIEW -> CHANGES_REQUESTED — announced by the annotation
+    // mail itself, not a second workflow mail.
+    verify(mail, after(300).never())
+        .sendMailFromTemplate(eq(MailTemplateKey.REVIEW_WORKFLOW_CHANGED), any(), anyMap(), any());
+  }
+
+  @Test
+  @DisplayName("a reply mails the thread (author), never the actor")
+  void commentAddedMailsTheThread() throws Exception {
+    seedDocument(false);
+    String annotationId = createAnnotation(AUDITOR_ID);
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/comments"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"Capping at 12 months works.\"}"))
+        .andExpect(status().isCreated());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> vars = ArgumentCaptor.forClass(Map.class);
+    verify(mail, timeout(5000))
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_COMMENT_ADDED),
+            eq(emailOf(AUDITOR_ID)),
+            vars.capture(),
+            isNull());
+    assertThat(vars.getValue()).containsEntry("commentExcerpt", "Capping at 12 months works.");
+    assertThat((String) vars.getValue().get("actionUrl")).contains("annotation=", "comment=");
+  }
+
+  @Test
+  @DisplayName("resolving mails the owner with the decision")
+  void resolveMailsTheOwner() throws Exception {
+    seedDocument(false);
+    String annotationId = createAnnotation(AUDITOR_ID);
+
+    mockMvc
+        .perform(as(post("/api/v1/annotations/" + annotationId + "/resolve"), AUDITOR_ID))
+        .andExpect(status().isOk());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> vars = ArgumentCaptor.forClass(Map.class);
+    verify(mail, timeout(5000))
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_ANNOTATION_DECIDED),
+            eq(emailOf(MEMBER_ID)),
+            vars.capture(),
+            isNull());
+    assertThat(vars.getValue()).containsEntry("decision", "resolved");
+  }
+
+  @Test
+  @DisplayName("a manual transition mails the participants — unless they opted out")
+  void manualTransitionMailsParticipantsRespectingOptOut() throws Exception {
+    seedDocument(false);
+    participants.save(ReviewParticipant.forUser(documentId, MEMBER2_ID));
+    userSettings.save(
+        new UserSetting(MEMBER2_ID, UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getKey(), "false"));
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/workflow"), MEMBER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetState\":\"CANCELLED\"}"))
+        .andExpect(status().isOk());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> vars = ArgumentCaptor.forClass(Map.class);
+    verify(mail, timeout(5000))
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_WORKFLOW_CHANGED),
+            eq(emailOf(AUDITOR_ID)),
+            vars.capture(),
+            isNull());
+    assertThat(vars.getValue())
+        .containsEntry("oldState", "In review")
+        .containsEntry("newState", "Cancelled");
+    verify(mail, after(300).never())
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_WORKFLOW_CHANGED), eq(emailOf(MEMBER2_ID)), anyMap(), any());
+  }
+
+  @Test
+  @DisplayName("an anonymous review never mails a foreign author's real name")
+  void anonymousReviewKeepsAuthorsPseudonymous() throws Exception {
+    seedDocument(true);
+
+    createAnnotation(AUDITOR_ID);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> vars = ArgumentCaptor.forClass(Map.class);
+    verify(mail, timeout(5000))
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_ANNOTATION_CREATED),
+            eq(emailOf(MEMBER_ID)),
+            vars.capture(),
+            isNull());
+    String actorName = (String) vars.getValue().get("actorName");
+    String realName = users.findById(AUDITOR_ID).map(User::getDisplayName).orElseThrow();
+    assertThat(actorName).isNotEqualTo(realName).startsWith("Participant");
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/ReviewNotificationIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewNotificationIT.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,13 +48,21 @@ import io.qnop.service.UserSettingKey;
 import io.qnop.service.mail.MailService;
 import io.qnop.service.mail.MailTemplateKey;
 import io.qnop.testsupport.SeededIntegrationTest;
+import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -237,6 +246,45 @@ class ReviewNotificationIT extends SeededIntegrationTest {
     verify(mail, after(300).never())
         .sendMailFromTemplate(
             eq(MailTemplateKey.REVIEW_WORKFLOW_CHANGED), eq(emailOf(MEMBER2_ID)), anyMap(), any());
+  }
+
+  @Test
+  @DisplayName("a new version mails every participant with the version deep link")
+  void versionUploadedMailsParticipants() throws Exception {
+    seedDocument(false);
+
+    try (PDDocument pdf = new PDDocument()) {
+      PDPage page = new PDPage(PDRectangle.LETTER);
+      pdf.addPage(page);
+      try (PDPageContentStream content = new PDPageContentStream(pdf, page)) {
+        content.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+        content.beginText();
+        content.newLineAtOffset(72, 700);
+        content.showText("the clause, revised");
+        content.endText();
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      pdf.save(out);
+      mockMvc
+          .perform(
+              multipart("/api/v1/documents/" + documentId + "/versions")
+                  .file(
+                      new MockMultipartFile(
+                          "file", "doc.pdf", "application/pdf", out.toByteArray()))
+                  .header("Authorization", "Bearer " + token(MEMBER_ID)))
+          .andExpect(status().isCreated());
+    }
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> vars = ArgumentCaptor.forClass(Map.class);
+    verify(mail, timeout(5000))
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_VERSION_UPLOADED),
+            eq(emailOf(AUDITOR_ID)),
+            vars.capture(),
+            isNull());
+    assertThat(vars.getValue()).containsEntry("versionNumber", "2");
+    assertThat((String) vars.getValue().get("actionUrl")).endsWith("?version=2");
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
@@ -75,7 +75,7 @@ class AdminSettingsControllerIT extends AbstractIntegrationTest {
         .perform(get("/api/v1/admin/settings"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.settings").isArray())
-        .andExpect(jsonPath("$.settings.length()").value(19));
+        .andExpect(jsonPath("$.settings.length()").value(20));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/settings/UserSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/UserSettingsControllerIT.java
@@ -72,7 +72,7 @@ class UserSettingsControllerIT extends AbstractIntegrationTest {
             get("/api/v1/users/me/settings").with(jwt().jwt(j -> j.subject(userId.toString()))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.settings").isArray())
-        .andExpect(jsonPath("$.settings.length()").value(3));
+        .andExpect(jsonPath("$.settings.length()").value(4));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/AdminEmailControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/AdminEmailControllerTest.java
@@ -96,6 +96,39 @@ class AdminEmailControllerTest {
   }
 
   @Test
+  void templateTestSendRendersAndSends() throws Exception {
+    MailPreview preview =
+        new MailPreview(
+            new RenderedMail("Reset qnop", "Hi Jane Doe", "<p>Hi</p>"), Map.of("siteName", "qnop"));
+    when(templates.preview(eq(MailTemplateKey.PASSWORD_RESET), any(), any(), any()))
+        .thenReturn(preview);
+    when(mailService.sendMail(any(), any(), any(), any()))
+        .thenReturn(new MailService.SendResult.Sent("admin@qnop.test"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/admin/email/templates/auth.password_reset/test")
+                .contentType("application/json")
+                .content("{\"recipient\":\"admin@qnop.test\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SENT"))
+        .andExpect(jsonPath("$.detail").value("Sent to admin@qnop.test"));
+
+    // The RENDERED template travels, HTML alternative included.
+    verify(mailService).sendMail("admin@qnop.test", "Reset qnop", "Hi Jane Doe", "<p>Hi</p>");
+  }
+
+  @Test
+  void templateTestSendAnswers404ForUnknownKey() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/admin/email/templates/no.such_template/test")
+                .contentType("application/json")
+                .content("{\"recipient\":\"admin@qnop.test\"}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
   void previewReturnsEffectiveSampleVars() throws Exception {
     MailPreview preview =
         new MailPreview(

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
@@ -119,7 +119,12 @@ public enum ApplicationSettingKey {
       "auth.password_reset_token_ttl_minutes",
       SettingValueType.INTEGER,
       "30",
-      "Validity window of a password-reset token, in minutes.");
+      "Validity window of a password-reset token, in minutes."),
+  NOTIFICATIONS_REVIEW_EMAILS_ENABLED(
+      "notifications.review_emails_enabled",
+      SettingValueType.BOOLEAN,
+      "true",
+      "Send email notifications for review activity (reviewer added, annotations, replies, status changes).");
 
   private static final Map<String, ApplicationSettingKey> BY_KEY =
       Arrays.stream(values())

--- a/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
@@ -45,7 +45,12 @@ public enum UserSettingKey {
       List.of("system", "light", "dark")),
   PREFERRED_LANGUAGE(
       "preferred_language", SettingValueType.STRING, "en", "Preferred UI language (ISO 639-1)."),
-  TIMEZONE("timezone", SettingValueType.STRING, "UTC", "Preferred display timezone (IANA id).");
+  TIMEZONE("timezone", SettingValueType.STRING, "UTC", "Preferred display timezone (IANA id)."),
+  EMAIL_REVIEW_NOTIFICATIONS(
+      "email_review_notifications",
+      SettingValueType.BOOLEAN,
+      "true",
+      "Receive email notifications for review activity (issue #316).");
 
   private static final Map<String, UserSettingKey> BY_KEY =
       Arrays.stream(values())

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -34,6 +34,7 @@ import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.job.JobPayload;
 import io.qnop.service.job.JobPayloadCodec;
 import io.qnop.service.job.JobService;
+import io.qnop.service.review.ReviewEvent;
 import io.qnop.service.storage.StagedObject;
 import io.qnop.service.storage.StorageQuotaExceededException;
 import io.qnop.service.storage.StorageService;
@@ -48,6 +49,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -93,6 +95,7 @@ public class DocumentIngestService {
   private final AnnotationRepository annotations;
   private final AnnotationPlacementRepository placements;
   private final TransactionTemplate transactionTemplate;
+  private final ApplicationEventPublisher events;
 
   public DocumentIngestService(
       DocumentRepository documents,
@@ -103,7 +106,8 @@ public class DocumentIngestService {
       DocumentAccessService access,
       AnnotationRepository annotations,
       AnnotationPlacementRepository placements,
-      PlatformTransactionManager transactionManager) {
+      PlatformTransactionManager transactionManager,
+      ApplicationEventPublisher events) {
     this.documents = documents;
     this.versions = versions;
     this.storage = storage;
@@ -113,6 +117,7 @@ public class DocumentIngestService {
     this.annotations = annotations;
     this.placements = placements;
     this.transactionTemplate = new TransactionTemplate(transactionManager);
+    this.events = events;
   }
 
   /**
@@ -204,6 +209,8 @@ public class DocumentIngestService {
                       + 1;
               DocumentVersion version = saveVersionAndEnqueue(documentId, next, staged, actor);
               seedPendingPlacements(documentId, version);
+              // Participants learn about the new version after commit (issue #316).
+              events.publishEvent(new ReviewEvent.VersionUploaded(documentId, actor, next));
               return new UploadResult(
                   documentId, version.getVersionNumber(), version.getExtractionStatus().name());
             });

--- a/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
@@ -29,6 +29,7 @@ import io.qnop.repository.ParticipantProjection;
 import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.repository.TeamRepository;
 import io.qnop.repository.UserRepository;
+import io.qnop.service.review.ReviewEvent;
 import io.qnop.service.review.ReviewIdentityResolver;
 import io.qnop.service.review.ReviewIdentityResolver.ReviewIdentities;
 import java.nio.charset.StandardCharsets;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +57,7 @@ public class ReviewParticipantService {
   private final TeamRepository teams;
   private final DocumentAccessService access;
   private final ReviewIdentityResolver identity;
+  private final ApplicationEventPublisher events;
 
   public ReviewParticipantService(
       DocumentRepository documents,
@@ -62,13 +65,15 @@ public class ReviewParticipantService {
       UserRepository users,
       TeamRepository teams,
       DocumentAccessService access,
-      ReviewIdentityResolver identity) {
+      ReviewIdentityResolver identity,
+      ApplicationEventPublisher events) {
     this.documents = documents;
     this.participants = participants;
     this.users = users;
     this.teams = teams;
     this.access = access;
     this.identity = identity;
+    this.events = events;
   }
 
   /**
@@ -155,6 +160,7 @@ public class ReviewParticipantService {
         throw DocumentValidationException.duplicateParticipant("user is already a participant");
       }
       ReviewParticipant saved = participants.save(ReviewParticipant.forUser(documentId, userId));
+      events.publishEvent(new ReviewEvent.ParticipantAdded(documentId, actor, userId, null));
       return new ParticipantView(
           saved.getId(), userId, false, user.getDisplayName(), saved.getCreatedAt());
     }
@@ -168,6 +174,7 @@ public class ReviewParticipantService {
       throw DocumentValidationException.duplicateParticipant("team is already a participant");
     }
     ReviewParticipant saved = participants.save(ReviewParticipant.forTeam(documentId, teamId));
+    events.publishEvent(new ReviewEvent.ParticipantAdded(documentId, actor, null, teamId));
     return new ParticipantView(saved.getId(), teamId, true, team.getName(), saved.getCreatedAt());
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -261,6 +261,33 @@ public enum MailTemplateKey {
       "documentTitle",
       "oldState",
       "newState",
+      "actionUrl"),
+  REVIEW_VERSION_UPLOADED(
+      "review.version_uploaded",
+      "New document version",
+      "New version of “{{documentTitle}}” — v{{versionNumber}}",
+      """
+      Hi {{recipientName}},
+
+      {{actorName}} uploaded version {{versionNumber}} of "{{documentTitle}}" ({{siteName}}).
+
+      Existing annotations are being re-anchored onto the new text. Open the review to continue:
+
+      {{actionUrl}}
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">New document version</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;"><strong style="color:#18191f;">{{actorName}}</strong> uploaded version <strong style="color:#18191f;">v{{versionNumber}}</strong> of <strong style="color:#18191f;">&#8220;{{documentTitle}}&#8221;</strong>.</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">Existing annotations are being re-anchored onto the new text. Open the review to continue.</p>
+      """,
+      "Open new version",
+      "{{actorName}} uploaded v{{versionNumber}} of “{{documentTitle}}”.",
+      "siteName",
+      "recipientName",
+      "actorName",
+      "documentTitle",
+      "versionNumber",
       "actionUrl");
 
   /**
@@ -278,6 +305,7 @@ public enum MailTemplateKey {
           Map.entry("annotationExcerpt", "The liability clause needs a cap."),
           Map.entry("commentExcerpt", "Agreed — let's cap it at 12 months."),
           Map.entry("decision", "resolved"),
+          Map.entry("versionNumber", "3"),
           Map.entry("oldState", "In review"),
           Map.entry("newState", "Changes requested"));
 

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -117,18 +117,169 @@ public enum MailTemplateKey {
       "siteName",
       "recipientName",
       "actionUrl",
-      "expiresAtHuman");
+      "expiresAtHuman"),
+  REVIEW_PARTICIPANT_ADDED(
+      "review.participant_added",
+      "Review invitation",
+      "You were added as a reviewer on “{{documentTitle}}”",
+      """
+      Hi {{recipientName}},
+
+      {{actorName}} added you as a reviewer on "{{documentTitle}}" ({{siteName}}).
+
+      Open the review to see the document and its discussion:
+
+      {{actionUrl}}
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">You're on a review</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;"><strong style="color:#18191f;">{{actorName}}</strong> added you as a reviewer on <strong style="color:#18191f;">&#8220;{{documentTitle}}&#8221;</strong>.</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">Open the review to see the document and its discussion.</p>
+      """,
+      "Open review",
+      "{{actorName}} added you as a reviewer on “{{documentTitle}}”.",
+      "siteName",
+      "recipientName",
+      "actorName",
+      "documentTitle",
+      "actionUrl"),
+  REVIEW_ANNOTATION_CREATED(
+      "review.annotation_created",
+      "New annotation",
+      "New annotation on “{{documentTitle}}”",
+      """
+      Hi {{recipientName}},
+
+      {{actorName}} raised a new annotation on "{{documentTitle}}" ({{siteName}}):
+
+      "{{annotationExcerpt}}"
+
+      Open the annotation:
+
+      {{actionUrl}}
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">New annotation</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;"><strong style="color:#18191f;">{{actorName}}</strong> raised a new annotation on <strong style="color:#18191f;">&#8220;{{documentTitle}}&#8221;</strong>:</p>
+      <p style="margin:0 0 14px;padding:10px 14px;border-left:3px solid #d5d9e0;color:#5a5f6a;">{{annotationExcerpt}}</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">Open the annotation to reply or resolve it.</p>
+      """,
+      "Open annotation",
+      "{{actorName}} raised a new annotation on “{{documentTitle}}”.",
+      "siteName",
+      "recipientName",
+      "actorName",
+      "documentTitle",
+      "annotationExcerpt",
+      "actionUrl"),
+  REVIEW_ANNOTATION_DECIDED(
+      "review.annotation_decided",
+      "Annotation decision",
+      "An annotation on “{{documentTitle}}” was {{decision}}",
+      """
+      Hi {{recipientName}},
+
+      {{actorName}} {{decision}} an annotation on "{{documentTitle}}" ({{siteName}}):
+
+      "{{annotationExcerpt}}"
+
+      Open the annotation:
+
+      {{actionUrl}}
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Annotation {{decision}}</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;"><strong style="color:#18191f;">{{actorName}}</strong> {{decision}} an annotation on <strong style="color:#18191f;">&#8220;{{documentTitle}}&#8221;</strong>:</p>
+      <p style="margin:0 0 14px;padding:10px 14px;border-left:3px solid #d5d9e0;color:#5a5f6a;">{{annotationExcerpt}}</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">Open the annotation to see the discussion.</p>
+      """,
+      "Open annotation",
+      "An annotation on “{{documentTitle}}” was {{decision}}.",
+      "siteName",
+      "recipientName",
+      "actorName",
+      "documentTitle",
+      "annotationExcerpt",
+      "decision",
+      "actionUrl"),
+  REVIEW_COMMENT_ADDED(
+      "review.comment_added",
+      "New reply",
+      "New reply on “{{documentTitle}}”",
+      """
+      Hi {{recipientName}},
+
+      {{actorName}} replied in a discussion you follow on "{{documentTitle}}" ({{siteName}}):
+
+      "{{commentExcerpt}}"
+
+      Open the reply:
+
+      {{actionUrl}}
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">New reply</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;"><strong style="color:#18191f;">{{actorName}}</strong> replied in a discussion you follow on <strong style="color:#18191f;">&#8220;{{documentTitle}}&#8221;</strong>:</p>
+      <p style="margin:0 0 14px;padding:10px 14px;border-left:3px solid #d5d9e0;color:#5a5f6a;">{{commentExcerpt}}</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">Open the thread to answer.</p>
+      """,
+      "Open reply",
+      "{{actorName}} replied on “{{documentTitle}}”.",
+      "siteName",
+      "recipientName",
+      "actorName",
+      "documentTitle",
+      "commentExcerpt",
+      "actionUrl"),
+  REVIEW_WORKFLOW_CHANGED(
+      "review.workflow_changed",
+      "Review status change",
+      "“{{documentTitle}}” moved to {{newState}}",
+      """
+      Hi {{recipientName}},
+
+      The review "{{documentTitle}}" ({{siteName}}) changed its status: {{oldState}} -> {{newState}}.
+
+      Open the review:
+
+      {{actionUrl}}
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Review status change</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;"><strong style="color:#18191f;">&#8220;{{documentTitle}}&#8221;</strong> changed its status: {{oldState}} &#8594; <strong style="color:#18191f;">{{newState}}</strong>.</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">Open the review for the details.</p>
+      """,
+      "Open review",
+      "“{{documentTitle}}” moved to {{newState}}.",
+      "siteName",
+      "recipientName",
+      "documentTitle",
+      "oldState",
+      "newState",
+      "actionUrl");
 
   /**
    * Representative demo value per known placeholder, used to prefill the preview's sample-variable
    * editor (issue #141). Every placeholder a template declares must have an entry here.
    */
   private static final Map<String, String> DEMO_VALUES =
-      Map.of(
-          "siteName", "qnop",
-          "recipientName", "Jane Doe",
-          "actionUrl", "https://qnop.example/action?token=SAMPLE",
-          "expiresAtHuman", "in 30 minutes");
+      Map.ofEntries(
+          Map.entry("siteName", "qnop"),
+          Map.entry("recipientName", "Jane Doe"),
+          Map.entry("actionUrl", "https://qnop.example/action?token=SAMPLE"),
+          Map.entry("expiresAtHuman", "in 30 minutes"),
+          Map.entry("actorName", "Alex Reviewer"),
+          Map.entry("documentTitle", "Q3 contract draft"),
+          Map.entry("annotationExcerpt", "The liability clause needs a cap."),
+          Map.entry("commentExcerpt", "Agreed — let's cap it at 12 months."),
+          Map.entry("decision", "resolved"),
+          Map.entry("oldState", "In review"),
+          Map.entry("newState", "Changes requested"));
 
   private final String key;
   private final String friendlyName;

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -46,6 +46,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,6 +78,7 @@ public class AnnotationService {
   private final DocumentAccessService documentAccess;
   private final ReviewWorkflowService workflow;
   private final ReviewIdentityResolver identity;
+  private final ApplicationEventPublisher events;
   private final ReactionService reactions_;
 
   public AnnotationService(
@@ -88,7 +90,8 @@ public class AnnotationService {
       DocumentAccessService documentAccess,
       ReviewWorkflowService workflow,
       ReviewIdentityResolver identity,
-      ReactionService reactions) {
+      ReactionService reactions,
+      ApplicationEventPublisher events) {
     this.annotations = annotations;
     this.placements = placements;
     this.comments = comments;
@@ -98,6 +101,7 @@ public class AnnotationService {
     this.workflow = workflow;
     this.identity = identity;
     this.reactions_ = reactions;
+    this.events = events;
   }
 
   /**
@@ -197,6 +201,7 @@ public class AnnotationService {
     // The workflow reacts to the raise (issue #405): a closed review rolls this insert back
     // (REVIEW_CLOSED), an IN_REVIEW one derives CHANGES_REQUESTED — both under the document lock.
     workflow.annotationRaised(documentId, author);
+    events.publishEvent(new ReviewEvent.AnnotationCreated(documentId, author, annotation.getId()));
     return view(
         annotation,
         placement,
@@ -552,6 +557,9 @@ public class AnnotationService {
     }
     // saveAndFlush so @CreationTimestamp is populated on the returned comment before the view.
     Comment saved = comments.saveAndFlush(new Comment(annotationId, author, body));
+    events.publishEvent(
+        new ReviewEvent.CommentAdded(
+            annotation.getDocumentId(), author, annotationId, saved.getId()));
     return commentView(saved, List.of(), identity.forDocument(annotation.getDocumentId(), author));
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewEvent.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import java.util.UUID;
+
+/**
+ * Review activity worth telling people about (issue #316), published on Spring's application event
+ * bus by the review services inside their transactions and consumed by {@link
+ * ReviewNotificationListener} after commit. Events carry ids only — the listener re-reads current
+ * state, so a rolled-back transaction never leaks a mail and stale event payloads cannot lie.
+ */
+public sealed interface ReviewEvent {
+
+  UUID documentId();
+
+  /** The user whose action raised the event — never notified about their own action. */
+  UUID actorId();
+
+  /** A reviewer was added (issue #316): exactly one of {@code userId} / {@code teamId} is set. */
+  record ParticipantAdded(UUID documentId, UUID actorId, UUID userId, UUID teamId)
+      implements ReviewEvent {}
+
+  /** A new annotation was raised. */
+  record AnnotationCreated(UUID documentId, UUID actorId, UUID annotationId)
+      implements ReviewEvent {}
+
+  /** An annotation was decided: resolved, or reopened when {@code reopened}. */
+  record AnnotationDecided(UUID documentId, UUID actorId, UUID annotationId, boolean reopened)
+      implements ReviewEvent {}
+
+  /** A reply landed in an annotation's thread. */
+  record CommentAdded(UUID documentId, UUID actorId, UUID annotationId, UUID commentId)
+      implements ReviewEvent {}
+
+  /**
+   * The review changed workflow state. {@code manual} distinguishes owner-initiated transitions
+   * from the derived {@code IN_REVIEW ⇄ CHANGES_REQUESTED} pair (issue #405) — derived flips ride
+   * along in the annotation mails that caused them, so only manual ones are mailed.
+   */
+  record WorkflowChanged(
+      UUID documentId, UUID actorId, String fromState, String toState, boolean manual)
+      implements ReviewEvent {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewEvent.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewEvent.java
@@ -51,6 +51,9 @@ public sealed interface ReviewEvent {
   record CommentAdded(UUID documentId, UUID actorId, UUID annotationId, UUID commentId)
       implements ReviewEvent {}
 
+  /** A new document version was committed; re-anchoring of existing annotations begins. */
+  record VersionUploaded(UUID documentId, UUID actorId, int versionNumber) implements ReviewEvent {}
+
   /**
    * The review changed workflow state. {@code manual} distinguishes owner-initiated transitions
    * from the derived {@code IN_REVIEW ⇄ CHANGES_REQUESTED} pair (issue #405) — derived flips ride

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationListener.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationListener.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Bridges committed {@link ReviewEvent}s to {@link ReviewNotificationService} (issue #316): {@code
+ * AFTER_COMMIT} so a rolled-back action never mails anyone, {@code @Async} so SMTP latency never
+ * sits in a request thread. Notification failures are logged and swallowed — mail is best-effort,
+ * the review itself already happened.
+ */
+@Component
+public class ReviewNotificationListener {
+
+  private static final Logger log = LoggerFactory.getLogger(ReviewNotificationListener.class);
+
+  private final ReviewNotificationService notifications;
+
+  public ReviewNotificationListener(ReviewNotificationService notifications) {
+    this.notifications = notifications;
+  }
+
+  @Async("reviewNotificationExecutor")
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void on(ReviewEvent event) {
+    try {
+      notifications.dispatch(event);
+    } catch (RuntimeException ex) {
+      log.warn(
+          "review notification failed for {} on document {}",
+          event.getClass().getSimpleName(),
+          event.documentId(),
+          ex);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationService.java
@@ -45,6 +45,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,6 +61,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 public class ReviewNotificationService {
+
+  private static final Logger log = LoggerFactory.getLogger(ReviewNotificationService.class);
 
   /** Mail bodies quote at most this many characters of an annotation/comment. */
   private static final int EXCERPT_MAX = 140;
@@ -299,6 +303,13 @@ public class ReviewNotificationService {
 
   private String reviewUrl(Document document) {
     String base = settings.getString(ApplicationSettingKey.GENERAL_BASE_URL);
+    if (base == null || base.isBlank()) {
+      // The mail still goes out, but its links are relative and thus dead in a
+      // mail client — configure Settings -> General -> Base URL.
+      log.warn(
+          "general.base_url is not configured — notification mail links will be relative/broken");
+      base = "";
+    }
     while (base.endsWith("/")) {
       base = base.substring(0, base.length() - 1);
     }

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationService.java
@@ -113,6 +113,7 @@ public class ReviewNotificationService {
       case ReviewEvent.AnnotationCreated created -> annotationCreated(document, created);
       case ReviewEvent.AnnotationDecided decided -> annotationDecided(document, decided);
       case ReviewEvent.CommentAdded comment -> commentAdded(document, comment);
+      case ReviewEvent.VersionUploaded uploaded -> versionUploaded(document, uploaded);
       case ReviewEvent.WorkflowChanged changed -> workflowChanged(document, changed);
     }
   }
@@ -203,24 +204,32 @@ public class ReviewNotificationService {
     }
   }
 
+  private void versionUploaded(Document document, ReviewEvent.VersionUploaded event) {
+    if (event.versionNumber() <= 1) {
+      // The first version IS the review's creation — participants joining later get
+      // the invitation mail instead; there is no "new" version to announce.
+      return;
+    }
+    // Uploads are owner-only and the owner acts under their public name (issue #413).
+    String actorName =
+        users.findById(event.actorId()).map(User::getDisplayName).orElse("The owner");
+    for (User recipient : deliverable(reviewCircle(document), event.actorId())) {
+      Map<String, Object> vars = baseVars(document, recipient);
+      vars.put("actorName", actorName);
+      vars.put("versionNumber", String.valueOf(event.versionNumber()));
+      vars.put("actionUrl", reviewUrl(document) + "?version=" + event.versionNumber());
+      mail.sendMailFromTemplate(
+          MailTemplateKey.REVIEW_VERSION_UPLOADED, recipient.getEmail(), vars, null);
+    }
+  }
+
   private void workflowChanged(Document document, ReviewEvent.WorkflowChanged event) {
     if (!event.manual()) {
       // Derived IN_REVIEW ⇄ CHANGES_REQUESTED flips are announced by the annotation
       // mails that caused them — a second mail would say the same thing twice.
       return;
     }
-    Set<UUID> recipients = new LinkedHashSet<>();
-    recipients.add(document.getOwnerId());
-    for (ReviewParticipant participant : participants.findByDocumentId(document.getId())) {
-      if (participant.getUserId() != null) {
-        recipients.add(participant.getUserId());
-      } else if (participant.getTeamId() != null) {
-        teamMembers.findMembersByTeamId(participant.getTeamId()).stream()
-            .map(TeamMemberProjection::userId)
-            .forEach(recipients::add);
-      }
-    }
-    for (User recipient : deliverable(recipients, event.actorId())) {
+    for (User recipient : deliverable(reviewCircle(document), event.actorId())) {
       Map<String, Object> vars = baseVars(document, recipient);
       vars.put("oldState", humanState(event.fromState()));
       vars.put("newState", humanState(event.toState()));
@@ -235,6 +244,22 @@ public class ReviewNotificationService {
    * users with an address who have not opted out ({@link
    * UserSettingKey#EMAIL_REVIEW_NOTIFICATIONS}).
    */
+  /** Everyone attached to the review: the owner, direct participants, and team members. */
+  private Set<UUID> reviewCircle(Document document) {
+    Set<UUID> recipients = new LinkedHashSet<>();
+    recipients.add(document.getOwnerId());
+    for (ReviewParticipant participant : participants.findByDocumentId(document.getId())) {
+      if (participant.getUserId() != null) {
+        recipients.add(participant.getUserId());
+      } else if (participant.getTeamId() != null) {
+        teamMembers.findMembersByTeamId(participant.getTeamId()).stream()
+            .map(TeamMemberProjection::userId)
+            .forEach(recipients::add);
+      }
+    }
+    return recipients;
+  }
+
   private List<User> deliverable(Set<UUID> candidates, UUID actorId) {
     Set<UUID> ids = new LinkedHashSet<>(candidates);
     ids.remove(actorId);

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationService.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.Comment;
+import io.qnop.entity.Document;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.User;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.repository.TeamMemberProjection;
+import io.qnop.repository.TeamMembershipRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.repository.UserSettingRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.UserSettingKey;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Turns a committed {@link ReviewEvent} into best-effort emails (issue #316): resolves who cares
+ * (owner, participants, thread members — never the actor, never disabled users, never anyone who
+ * opted out), keeps anonymous reviews anonymous by resolving the actor's name per recipient through
+ * {@link ReviewIdentityResolver}, and hands the rendered template to {@link MailService}.
+ *
+ * <p>Runs on the notification executor after the triggering transaction committed — a failure here
+ * is logged by the listener and never disturbs the review itself.
+ */
+@Service
+public class ReviewNotificationService {
+
+  /** Mail bodies quote at most this many characters of an annotation/comment. */
+  private static final int EXCERPT_MAX = 140;
+
+  private final DocumentRepository documents;
+  private final AnnotationRepository annotations;
+  private final CommentRepository comments;
+  private final ReviewParticipantRepository participants;
+  private final TeamMembershipRepository teamMembers;
+  private final UserRepository users;
+  private final UserSettingRepository userSettings;
+  private final ApplicationSettingsService settings;
+  private final ReviewIdentityResolver identity;
+  private final MailService mail;
+
+  public ReviewNotificationService(
+      DocumentRepository documents,
+      AnnotationRepository annotations,
+      CommentRepository comments,
+      ReviewParticipantRepository participants,
+      TeamMembershipRepository teamMembers,
+      UserRepository users,
+      UserSettingRepository userSettings,
+      ApplicationSettingsService settings,
+      ReviewIdentityResolver identity,
+      MailService mail) {
+    this.documents = documents;
+    this.annotations = annotations;
+    this.comments = comments;
+    this.participants = participants;
+    this.teamMembers = teamMembers;
+    this.users = users;
+    this.userSettings = userSettings;
+    this.settings = settings;
+    this.identity = identity;
+    this.mail = mail;
+  }
+
+  /** Sends the mails a committed review event calls for; quietly done when nothing applies. */
+  @Transactional(readOnly = true)
+  public void dispatch(ReviewEvent event) {
+    if (!settings.getBoolean(ApplicationSettingKey.NOTIFICATIONS_REVIEW_EMAILS_ENABLED)) {
+      return;
+    }
+    Optional<Document> loaded = documents.findById(event.documentId());
+    if (loaded.isEmpty()) {
+      return; // deleted between commit and dispatch — nothing to say
+    }
+    Document document = loaded.get();
+    switch (event) {
+      case ReviewEvent.ParticipantAdded added -> participantAdded(document, added);
+      case ReviewEvent.AnnotationCreated created -> annotationCreated(document, created);
+      case ReviewEvent.AnnotationDecided decided -> annotationDecided(document, decided);
+      case ReviewEvent.CommentAdded comment -> commentAdded(document, comment);
+      case ReviewEvent.WorkflowChanged changed -> workflowChanged(document, changed);
+    }
+  }
+
+  private void participantAdded(Document document, ReviewEvent.ParticipantAdded event) {
+    Set<UUID> recipients = new LinkedHashSet<>();
+    if (event.userId() != null) {
+      recipients.add(event.userId());
+    } else if (event.teamId() != null) {
+      teamMembers.findMembersByTeamId(event.teamId()).stream()
+          .map(TeamMemberProjection::userId)
+          .forEach(recipients::add);
+    }
+    // The owner is not "added as a reviewer" of their own review, even via a team.
+    recipients.remove(document.getOwnerId());
+    // Adding is owner/admin-only and both act under their public name — no anonymity concern.
+    String actorName =
+        users.findById(event.actorId()).map(User::getDisplayName).orElse("An administrator");
+    for (User recipient : deliverable(recipients, event.actorId())) {
+      Map<String, Object> vars = baseVars(document, recipient);
+      vars.put("actorName", actorName);
+      vars.put("actionUrl", reviewUrl(document));
+      mail.sendMailFromTemplate(
+          MailTemplateKey.REVIEW_PARTICIPANT_ADDED, recipient.getEmail(), vars, null);
+    }
+  }
+
+  private void annotationCreated(Document document, ReviewEvent.AnnotationCreated event) {
+    if (annotations.findById(event.annotationId()).isEmpty()) {
+      return;
+    }
+    String excerpt = firstCommentExcerpt(event.annotationId());
+    for (User recipient : deliverable(Set.of(document.getOwnerId()), event.actorId())) {
+      Map<String, Object> vars = baseVars(document, recipient);
+      vars.put("actorName", actorNameFor(document, recipient, event.actorId()));
+      vars.put("annotationExcerpt", excerpt);
+      vars.put("actionUrl", annotationUrl(document, event.annotationId()));
+      mail.sendMailFromTemplate(
+          MailTemplateKey.REVIEW_ANNOTATION_CREATED, recipient.getEmail(), vars, null);
+    }
+  }
+
+  private void annotationDecided(Document document, ReviewEvent.AnnotationDecided event) {
+    Optional<Annotation> annotation = annotations.findById(event.annotationId());
+    if (annotation.isEmpty()) {
+      return;
+    }
+    Set<UUID> recipients =
+        new LinkedHashSet<>(List.of(document.getOwnerId(), annotation.get().getAuthorId()));
+    String excerpt = firstCommentExcerpt(event.annotationId());
+    String decision = event.reopened() ? "reopened" : "resolved";
+    for (User recipient : deliverable(recipients, event.actorId())) {
+      Map<String, Object> vars = baseVars(document, recipient);
+      vars.put("actorName", actorNameFor(document, recipient, event.actorId()));
+      vars.put("annotationExcerpt", excerpt);
+      vars.put("decision", decision);
+      vars.put("actionUrl", annotationUrl(document, event.annotationId()));
+      mail.sendMailFromTemplate(
+          MailTemplateKey.REVIEW_ANNOTATION_DECIDED, recipient.getEmail(), vars, null);
+    }
+  }
+
+  private void commentAdded(Document document, ReviewEvent.CommentAdded event) {
+    Optional<Annotation> annotation = annotations.findById(event.annotationId());
+    if (annotation.isEmpty()) {
+      return;
+    }
+    // Slack-thread semantics: whoever started or joined the discussion follows it.
+    Set<UUID> recipients = new LinkedHashSet<>();
+    recipients.add(annotation.get().getAuthorId());
+    List<Comment> thread = comments.findByAnnotationIdOrderByCreatedAtAsc(event.annotationId());
+    thread.forEach(comment -> recipients.add(comment.getAuthorId()));
+    String excerpt =
+        thread.stream()
+            .filter(comment -> comment.getId().equals(event.commentId()))
+            .findFirst()
+            .map(comment -> excerpt(comment.getBody()))
+            .orElse("");
+    for (User recipient : deliverable(recipients, event.actorId())) {
+      Map<String, Object> vars = baseVars(document, recipient);
+      vars.put("actorName", actorNameFor(document, recipient, event.actorId()));
+      vars.put("commentExcerpt", excerpt);
+      vars.put(
+          "actionUrl",
+          annotationUrl(document, event.annotationId()) + "&comment=" + event.commentId());
+      mail.sendMailFromTemplate(
+          MailTemplateKey.REVIEW_COMMENT_ADDED, recipient.getEmail(), vars, null);
+    }
+  }
+
+  private void workflowChanged(Document document, ReviewEvent.WorkflowChanged event) {
+    if (!event.manual()) {
+      // Derived IN_REVIEW ⇄ CHANGES_REQUESTED flips are announced by the annotation
+      // mails that caused them — a second mail would say the same thing twice.
+      return;
+    }
+    Set<UUID> recipients = new LinkedHashSet<>();
+    recipients.add(document.getOwnerId());
+    for (ReviewParticipant participant : participants.findByDocumentId(document.getId())) {
+      if (participant.getUserId() != null) {
+        recipients.add(participant.getUserId());
+      } else if (participant.getTeamId() != null) {
+        teamMembers.findMembersByTeamId(participant.getTeamId()).stream()
+            .map(TeamMemberProjection::userId)
+            .forEach(recipients::add);
+      }
+    }
+    for (User recipient : deliverable(recipients, event.actorId())) {
+      Map<String, Object> vars = baseVars(document, recipient);
+      vars.put("oldState", humanState(event.fromState()));
+      vars.put("newState", humanState(event.toState()));
+      vars.put("actionUrl", reviewUrl(document));
+      mail.sendMailFromTemplate(
+          MailTemplateKey.REVIEW_WORKFLOW_CHANGED, recipient.getEmail(), vars, null);
+    }
+  }
+
+  /**
+   * The users a mail may actually go to: the candidate set minus the actor, restricted to enabled
+   * users with an address who have not opted out ({@link
+   * UserSettingKey#EMAIL_REVIEW_NOTIFICATIONS}).
+   */
+  private List<User> deliverable(Set<UUID> candidates, UUID actorId) {
+    Set<UUID> ids = new LinkedHashSet<>(candidates);
+    ids.remove(actorId);
+    if (ids.isEmpty()) {
+      return List.of();
+    }
+    return users.findAllById(ids).stream()
+        .filter(User::isEnabled)
+        .filter(user -> user.getEmail() != null && !user.getEmail().isBlank())
+        .filter(user -> !optedOut(user.getId()))
+        .toList();
+  }
+
+  private boolean optedOut(UUID userId) {
+    return userSettings
+        .findByUserIdAndSettingKey(userId, UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getKey())
+        .map(setting -> "false".equalsIgnoreCase(setting.getSettingValue()))
+        .orElse(false);
+  }
+
+  /**
+   * The actor's name as THIS recipient is allowed to see it (issue #413): real in normal reviews,
+   * pseudonymous in anonymous ones unless the actor is the owner or the recipient themselves.
+   */
+  private String actorNameFor(Document document, User recipient, UUID actorId) {
+    String name = identity.forDocument(document.getId(), recipient.getId()).displayName(actorId);
+    return name == null || name.isBlank() ? "A participant" : name;
+  }
+
+  private Map<String, Object> baseVars(Document document, User recipient) {
+    Map<String, Object> vars = new LinkedHashMap<>();
+    vars.put("siteName", settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME));
+    vars.put("recipientName", recipient.getDisplayName());
+    vars.put("documentTitle", document.getTitle());
+    return vars;
+  }
+
+  private String reviewUrl(Document document) {
+    String base = settings.getString(ApplicationSettingKey.GENERAL_BASE_URL);
+    while (base.endsWith("/")) {
+      base = base.substring(0, base.length() - 1);
+    }
+    String segment = document.getSlug() != null ? document.getSlug() : document.getId().toString();
+    return base + "/reviews/" + segment;
+  }
+
+  private String annotationUrl(Document document, UUID annotationId) {
+    return reviewUrl(document) + "?annotation=" + annotationId;
+  }
+
+  private String firstCommentExcerpt(UUID annotationId) {
+    return comments.findByAnnotationIdOrderByCreatedAtAsc(annotationId).stream()
+        .findFirst()
+        .map(comment -> excerpt(comment.getBody()))
+        .orElse("");
+  }
+
+  /** One quotable line: markdown noise stripped, whitespace collapsed, capped with an ellipsis. */
+  static String excerpt(String body) {
+    if (body == null) {
+      return "";
+    }
+    String flat =
+        body.replaceAll("!\\[[^\\]]*\\]\\([^)]*\\)", " ") // images
+            .replaceAll("\\[([^\\]]*)\\]\\([^)]*\\)", "$1") // links → their label
+            .replaceAll("[`*_>#~]", "")
+            .replaceAll("\\s+", " ")
+            .trim();
+    return flat.length() <= EXCERPT_MAX ? flat : flat.substring(0, EXCERPT_MAX - 1).trim() + "…";
+  }
+
+  /** {@code CHANGES_REQUESTED} → {@code Changes requested} — states as humans read them. */
+  static String humanState(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return "";
+    }
+    String lower = raw.replace('_', ' ').toLowerCase();
+    return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -39,6 +39,7 @@ import io.qnop.service.review.ReviewWorkflowMachine.TransitionContext;
 import io.qnop.service.review.ReviewWorkflowMachine.TransitionResult;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,6 +74,7 @@ public class ReviewWorkflowService {
   private final CommentRepository comments;
   private final AuditEventRepository auditEvents;
   private final DocumentAccessService documentAccess;
+  private final ApplicationEventPublisher events;
 
   public ReviewWorkflowService(
       DocumentRepository documents,
@@ -81,7 +83,8 @@ public class ReviewWorkflowService {
       AnnotationPlacementRepository placements,
       CommentRepository comments,
       AuditEventRepository auditEvents,
-      DocumentAccessService documentAccess) {
+      DocumentAccessService documentAccess,
+      ApplicationEventPublisher events) {
     this.documents = documents;
     this.versions = versions;
     this.annotations = annotations;
@@ -89,6 +92,7 @@ public class ReviewWorkflowService {
     this.comments = comments;
     this.auditEvents = auditEvents;
     this.documentAccess = documentAccess;
+    this.events = events;
   }
 
   /**
@@ -166,6 +170,8 @@ public class ReviewWorkflowService {
             AUDIT_ANNOTATION_RESOLVED,
             actorId,
             "{\"annotationId\":\"" + annotationId + "\"}"));
+    events.publishEvent(
+        new ReviewEvent.AnnotationDecided(document.getId(), actorId, annotationId, false));
     rederiveWorkflow(document, actorId);
     return annotation;
   }
@@ -200,6 +206,8 @@ public class ReviewWorkflowService {
             AUDIT_ANNOTATION_REOPENED,
             actorId,
             "{\"annotationId\":\"" + annotationId + "\"}"));
+    events.publishEvent(
+        new ReviewEvent.AnnotationDecided(document.getId(), actorId, annotationId, true));
     rederiveWorkflow(document, actorId);
     return annotation;
   }
@@ -267,6 +275,8 @@ public class ReviewWorkflowService {
             AUDIT_WORKFLOW_TRANSITION,
             actorId,
             "{\"from\":\"" + from + "\",\"to\":\"" + target.name() + "\"}"));
+    events.publishEvent(
+        new ReviewEvent.WorkflowChanged(document.getId(), actorId, from, target.name(), manual));
   }
 
   private WorkflowStatus statusOf(Document document) {

--- a/qnop-core/src/main/resources/db/changelog/migrations/0002-settings-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0002-settings-schema.yaml
@@ -233,3 +233,10 @@ databaseChangeLog:
               - column: { name: setting_value, value: "30" }
               - column: { name: setting_desc, value: "Validity window of a password-reset token, in minutes." }
               - column: { name: value_type, value: "INTEGER" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "notifications.review_emails_enabled" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: setting_desc, value: "Send email notifications for review activity (reviewer added, annotations, replies, status changes)." }
+              - column: { name: value_type, value: "BOOLEAN" }

--- a/qnop-core/src/main/resources/db/changelog/migrations/0003-mail-template-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0003-mail-template-schema.yaml
@@ -141,3 +141,144 @@ databaseChangeLog:
         - delete:
             tableName: mail_template
             where: "template_key = 'auth.admin_password_reset' AND locale = 'en'"
+
+  - changeSet:
+      id: 0003-seed-review-participant-added-en
+      author: qnop
+      comment: English default for the reviewer-added notification (issue #316).
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: review.participant_added }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "You were added as a reviewer on “{{documentTitle}}”" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{recipientName}},
+
+                    {{actorName}} added you as a reviewer on "{{documentTitle}}" ({{siteName}}).
+
+                    Open the review to see the document and its discussion:
+
+                    {{actionUrl}}
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'review.participant_added' AND locale = 'en'"
+
+  - changeSet:
+      id: 0003-seed-review-annotation-created-en
+      author: qnop
+      comment: English default for the new-annotation notification (issue #316).
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: review.annotation_created }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "New annotation on “{{documentTitle}}”" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{recipientName}},
+
+                    {{actorName}} raised a new annotation on "{{documentTitle}}" ({{siteName}}):
+
+                    "{{annotationExcerpt}}"
+
+                    Open the annotation:
+
+                    {{actionUrl}}
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'review.annotation_created' AND locale = 'en'"
+
+  - changeSet:
+      id: 0003-seed-review-annotation-decided-en
+      author: qnop
+      comment: English default for the annotation-decision notification (issue #316).
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: review.annotation_decided }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "An annotation on “{{documentTitle}}” was {{decision}}" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{recipientName}},
+
+                    {{actorName}} {{decision}} an annotation on "{{documentTitle}}" ({{siteName}}):
+
+                    "{{annotationExcerpt}}"
+
+                    Open the annotation:
+
+                    {{actionUrl}}
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'review.annotation_decided' AND locale = 'en'"
+
+  - changeSet:
+      id: 0003-seed-review-comment-added-en
+      author: qnop
+      comment: English default for the thread-reply notification (issue #316).
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: review.comment_added }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "New reply on “{{documentTitle}}”" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{recipientName}},
+
+                    {{actorName}} replied in a discussion you follow on "{{documentTitle}}" ({{siteName}}):
+
+                    "{{commentExcerpt}}"
+
+                    Open the reply:
+
+                    {{actionUrl}}
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'review.comment_added' AND locale = 'en'"
+
+  - changeSet:
+      id: 0003-seed-review-workflow-changed-en
+      author: qnop
+      comment: English default for the workflow-transition notification (issue #316).
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: review.workflow_changed }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "“{{documentTitle}}” moved to {{newState}}" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{recipientName}},
+
+                    The review "{{documentTitle}}" ({{siteName}}) changed its status: {{oldState}} -> {{newState}}.
+
+                    Open the review:
+
+                    {{actionUrl}}
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'review.workflow_changed' AND locale = 'en'"

--- a/qnop-core/src/main/resources/db/changelog/migrations/0003-mail-template-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0003-mail-template-schema.yaml
@@ -282,3 +282,30 @@ databaseChangeLog:
         - delete:
             tableName: mail_template
             where: "template_key = 'review.workflow_changed' AND locale = 'en'"
+
+  - changeSet:
+      id: 0003-seed-review-version-uploaded-en
+      author: qnop
+      comment: English default for the new-document-version notification (issue #316).
+      changes:
+        - insert:
+            tableName: mail_template
+            columns:
+              - column: { name: id, valueComputed: gen_random_uuid() }
+              - column: { name: template_key, value: review.version_uploaded }
+              - column: { name: locale, value: en }
+              - column: { name: subject, value: "New version of “{{documentTitle}}” — v{{versionNumber}}" }
+              - column:
+                  name: body_plain
+                  value: |
+                    Hi {{recipientName}},
+
+                    {{actorName}} uploaded version {{versionNumber}} of "{{documentTitle}}" ({{siteName}}).
+
+                    Existing annotations are being re-anchored onto the new text. Open the review to continue:
+
+                    {{actionUrl}}
+      rollback:
+        - delete:
+            tableName: mail_template
+            where: "template_key = 'review.version_uploaded' AND locale = 'en'"

--- a/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
@@ -59,7 +59,8 @@ class ApplicationSettingKeyTest {
           "auth.self_registration_enabled",
           "auth.self_registration_default_role",
           "auth.password_reset_enabled",
-          "auth.password_reset_token_ttl_minutes");
+          "auth.password_reset_token_ttl_minutes",
+          "notifications.review_emails_enabled");
 
   @Test
   void registryMatchesSeededKeys() {

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentIngestServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentIngestServiceTest.java
@@ -100,7 +100,8 @@ class DocumentIngestServiceTest {
         access,
         annotations,
         placements,
-        transactionManager);
+        transactionManager,
+        org.mockito.Mockito.mock(org.springframework.context.ApplicationEventPublisher.class));
   }
 
   // --- request validation (rejected before any storage or settings work) -----

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
@@ -61,6 +61,7 @@ class MailTemplateServiceTest {
           Map.entry("annotationExcerpt", "The liability clause needs a cap."),
           Map.entry("commentExcerpt", "Agreed — let's cap it at 12 months."),
           Map.entry("decision", "resolved"),
+          Map.entry("versionNumber", "3"),
           Map.entry("oldState", "In review"),
           Map.entry("newState", "Changes requested"));
 

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
@@ -49,13 +49,20 @@ class MailTemplateServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private ApplicationSettingsService settings;
 
-  /** Exactly the variable set the live send flows supply (issue #140). */
+  /** Exactly the variable set the live send flows supply (issues #140, #316). */
   private static final Map<String, Object> FLOW_VARS =
-      Map.of(
-          "siteName", "qnop",
-          "recipientName", "Jane",
-          "actionUrl", "https://qnop.example/reset?token=abc",
-          "expiresAtHuman", "in 30 minutes");
+      Map.ofEntries(
+          Map.entry("siteName", "qnop"),
+          Map.entry("recipientName", "Jane"),
+          Map.entry("actionUrl", "https://qnop.example/reset?token=abc"),
+          Map.entry("expiresAtHuman", "in 30 minutes"),
+          Map.entry("actorName", "Alex Reviewer"),
+          Map.entry("documentTitle", "Q3 contract draft"),
+          Map.entry("annotationExcerpt", "The liability clause needs a cap."),
+          Map.entry("commentExcerpt", "Agreed — let's cap it at 12 months."),
+          Map.entry("decision", "resolved"),
+          Map.entry("oldState", "In review"),
+          Map.entry("newState", "Changes requested"));
 
   private MailTemplateService service;
 

--- a/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
@@ -79,7 +79,8 @@ class AnnotationServiceTest {
           documentAccess,
           workflow,
           identity,
-          reactions);
+          reactions,
+          mock(org.springframework.context.ApplicationEventPublisher.class));
 
   private final UUID documentId = UUID.randomUUID();
   private final UUID author = UUID.randomUUID();

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewNotificationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewNotificationServiceTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.repository.TeamMembershipRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.repository.UserSettingRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.mail.MailService;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * DB-free behavior of {@link ReviewNotificationService} (issue #316): the global kill switch and
+ * the text utilities. The recipient/anonymity wiring runs against the real stack in {@code
+ * ReviewNotificationIT}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReviewNotificationServiceTest {
+
+  @Mock private DocumentRepository documents;
+  @Mock private AnnotationRepository annotations;
+  @Mock private CommentRepository comments;
+  @Mock private ReviewParticipantRepository participants;
+  @Mock private TeamMembershipRepository teamMembers;
+  @Mock private UserRepository users;
+  @Mock private UserSettingRepository userSettings;
+  @Mock private ApplicationSettingsService settings;
+  @Mock private ReviewIdentityResolver identity;
+  @Mock private MailService mail;
+
+  private ReviewNotificationService service() {
+    return new ReviewNotificationService(
+        documents,
+        annotations,
+        comments,
+        participants,
+        teamMembers,
+        users,
+        userSettings,
+        settings,
+        identity,
+        mail);
+  }
+
+  @Test
+  @DisplayName("the global switch silences every event before any lookup")
+  void globalSwitchOff() {
+    when(settings.getBoolean(ApplicationSettingKey.NOTIFICATIONS_REVIEW_EMAILS_ENABLED))
+        .thenReturn(false);
+
+    service()
+        .dispatch(
+            new ReviewEvent.AnnotationCreated(
+                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()));
+
+    verifyNoInteractions(mail, documents, users);
+  }
+
+  @Test
+  @DisplayName("a vanished document is quietly nothing to say")
+  void vanishedDocument() {
+    when(settings.getBoolean(ApplicationSettingKey.NOTIFICATIONS_REVIEW_EMAILS_ENABLED))
+        .thenReturn(true);
+    when(documents.findById(any())).thenReturn(java.util.Optional.empty());
+
+    service()
+        .dispatch(
+            new ReviewEvent.AnnotationCreated(
+                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()));
+
+    verifyNoInteractions(mail);
+  }
+
+  @Test
+  @DisplayName("excerpt flattens markdown and caps the length")
+  void excerptFlattens() {
+    assertThat(ReviewNotificationService.excerpt("**Bold** and [a link](https://x) `code`"))
+        .isEqualTo("Bold and a link code");
+    assertThat(ReviewNotificationService.excerpt("![img](https://x/pic.png) after"))
+        .isEqualTo("after");
+    assertThat(ReviewNotificationService.excerpt("line\none\n\n> quoted"))
+        .isEqualTo("line one quoted");
+    assertThat(ReviewNotificationService.excerpt(null)).isEmpty();
+    String long200 = "x".repeat(200);
+    assertThat(ReviewNotificationService.excerpt(long200)).hasSize(140).endsWith("…");
+  }
+
+  @Test
+  @DisplayName("workflow states read like sentences")
+  void humanStates() {
+    assertThat(ReviewNotificationService.humanState("CHANGES_REQUESTED"))
+        .isEqualTo("Changes requested");
+    assertThat(ReviewNotificationService.humanState("IN_REVIEW")).isEqualTo("In review");
+    assertThat(ReviewNotificationService.humanState("FINALIZED")).isEqualTo("Finalized");
+    assertThat(ReviewNotificationService.humanState(null)).isEmpty();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceLockTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceLockTest.java
@@ -63,7 +63,14 @@ class ReviewWorkflowServiceLockTest {
 
   private final ReviewWorkflowService service =
       new ReviewWorkflowService(
-          documents, versions, annotations, placements, comments, auditEvents, documentAccess);
+          documents,
+          versions,
+          annotations,
+          placements,
+          comments,
+          auditEvents,
+          documentAccess,
+          mock(org.springframework.context.ApplicationEventPublisher.class));
 
   private final UUID documentId = UUID.randomUUID();
   private final UUID owner = UUID.randomUUID();

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
@@ -68,7 +68,14 @@ class ReviewWorkflowServiceTest {
 
   private final ReviewWorkflowService service =
       new ReviewWorkflowService(
-          documents, versions, annotations, placements, comments, auditEvents, documentAccess);
+          documents,
+          versions,
+          annotations,
+          placements,
+          comments,
+          auditEvents,
+          documentAccess,
+          mock(org.springframework.context.ApplicationEventPublisher.class));
 
   private final UUID documentId = UUID.randomUUID();
   private final UUID owner = UUID.randomUUID();

--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -305,9 +305,6 @@ packages:
   '@codemirror/search@6.7.1':
     resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
 
-  '@codemirror/state@6.7.0':
-    resolution: {integrity: sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==}
-
   '@codemirror/state@6.7.1':
     resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
 
@@ -3527,10 +3524,6 @@ snapshots:
       '@codemirror/view': 6.43.6
       crelt: 1.0.6
 
-  '@codemirror/state@6.7.0':
-    dependencies:
-      '@marijn/find-cluster-break': 1.0.2
-
   '@codemirror/state@6.7.1':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
@@ -3544,7 +3537,7 @@ snapshots:
 
   '@codemirror/view@6.43.6':
     dependencies:
-      '@codemirror/state': 6.7.0
+      '@codemirror/state': 6.7.1
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8

--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -34,6 +34,7 @@ import {
   PrincipalsApi,
   ReviewWorkflowApi,
   ServerConfigApi,
+  UserSettingsApi,
   UsersApi,
   DashboardApi,
 } from './generated';
@@ -102,3 +103,4 @@ export const dashboardApi = new DashboardApi(undefined, undefined, axiosInstance
 export const annotationsApi = new AnnotationsApi(undefined, undefined, axiosInstance);
 export const principalsApi = new PrincipalsApi(undefined, undefined, axiosInstance);
 export const reviewWorkflowApi = new ReviewWorkflowApi(undefined, undefined, axiosInstance);
+export const userSettingsApi = new UserSettingsApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useUserSettings.test.tsx
+++ b/qnop-ui/src/api/hooks/useUserSettings.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SettingValueType } from '../generated';
+import { userSettingsApi } from '../config';
+import {
+  EMAIL_REVIEW_NOTIFICATIONS_KEY,
+  useUpdateUserSettings,
+  useUserSettings,
+  userSettingKeys,
+} from './useUserSettings';
+
+vi.mock('../config', () => ({
+  userSettingsApi: {
+    getCurrentUserSettings: vi.fn(),
+    updateCurrentUserSettings: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(userSettingsApi);
+
+const response = (value: string) => ({
+  data: {
+    settings: [
+      {
+        key: EMAIL_REVIEW_NOTIFICATIONS_KEY,
+        value,
+        type: SettingValueType.Boolean,
+        description: 'Receive email notifications for review activity.',
+      },
+    ],
+  },
+});
+
+function harness() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useUserSettings (issue #316)', () => {
+  it('loads the settings overlay', async () => {
+    mockedApi.getCurrentUserSettings.mockResolvedValue(response('true') as never);
+    const { wrapper } = harness();
+
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.settings[0]?.value).toBe('true');
+  });
+
+  it('flips the cached value optimistically and rolls back on failure', async () => {
+    mockedApi.getCurrentUserSettings.mockResolvedValue(response('true') as never);
+    let reject: (reason: Error) => void = () => undefined;
+    mockedApi.updateCurrentUserSettings.mockReturnValue(
+      new Promise((_resolve, rej) => {
+        reject = rej;
+      }) as never,
+    );
+    const { queryClient, wrapper } = harness();
+    const settings = renderHook(() => useUserSettings(), { wrapper });
+    await waitFor(() => expect(settings.result.current.isSuccess).toBe(true));
+
+    const { result } = renderHook(() => useUpdateUserSettings(), { wrapper });
+    result.current.mutate({ [EMAIL_REVIEW_NOTIFICATIONS_KEY]: 'false' });
+
+    type Cached = { settings: { value?: string }[] };
+    await waitFor(() =>
+      expect(queryClient.getQueryData<Cached>(userSettingKeys.all)?.settings[0]?.value).toBe(
+        'false',
+      ),
+    );
+
+    reject(new Error('server refused'));
+    await waitFor(() =>
+      expect(queryClient.getQueryData<Cached>(userSettingKeys.all)?.settings[0]?.value).toBe(
+        'true',
+      ),
+    );
+  });
+});

--- a/qnop-ui/src/api/hooks/useUserSettings.ts
+++ b/qnop-ui/src/api/hooks/useUserSettings.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { UserSettingsResponse } from '../generated';
+import { userSettingsApi } from '../config';
+
+/** The per-user opt-out for review activity mails (issue #316). */
+export const EMAIL_REVIEW_NOTIFICATIONS_KEY = 'email_review_notifications';
+
+export const userSettingKeys = {
+  all: ['user-settings'] as const,
+};
+
+/** The caller's settings, stored values overlaid on registry defaults (issue #22). */
+export function useUserSettings() {
+  return useQuery<UserSettingsResponse>({
+    queryKey: userSettingKeys.all,
+    queryFn: async () => {
+      const response = await userSettingsApi.getCurrentUserSettings();
+      return response.data;
+    },
+  });
+}
+
+/**
+ * Applies a partial settings change optimistically — a toggle must not lag —
+ * and rolls back to the snapshot when the server refuses.
+ */
+export function useUpdateUserSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (values: Record<string, string>) => {
+      const response = await userSettingsApi.updateCurrentUserSettings({
+        userSettingsUpdateRequest: { values },
+      });
+      return response.data;
+    },
+    onMutate: async (values) => {
+      await queryClient.cancelQueries({ queryKey: userSettingKeys.all });
+      const snapshot = queryClient.getQueryData<UserSettingsResponse>(userSettingKeys.all);
+      if (snapshot) {
+        queryClient.setQueryData<UserSettingsResponse>(userSettingKeys.all, {
+          ...snapshot,
+          settings: snapshot.settings.map((setting) =>
+            values[setting.key] !== undefined
+              ? { ...setting, value: values[setting.key] }
+              : setting,
+          ),
+        });
+      }
+      return { snapshot };
+    },
+    onError: (_error, _values, context) => {
+      if (context?.snapshot) {
+        queryClient.setQueryData(userSettingKeys.all, context.snapshot);
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: userSettingKeys.all }),
+  });
+}

--- a/qnop-ui/src/components/admin/mail/SendTestEmailDialog.tsx
+++ b/qnop-ui/src/components/admin/mail/SendTestEmailDialog.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useEffect, useState, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -61,20 +61,32 @@ export function SendTestEmailDialog({
   send,
   helperText = 'Uses the configured SMTP settings.',
 }: SendTestEmailDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      {/* The form lives in its own component: the Dialog unmounts its children
+          when closed, so every opening starts fresh (prefilled recipient, no
+          stale result) without effect-driven state resets. */}
+      <SendTestEmailForm
+        onClose={onClose}
+        initialRecipient={initialRecipient}
+        send={send}
+        helperText={helperText}
+      />
+    </Dialog>
+  );
+}
+
+function SendTestEmailForm({
+  onClose,
+  initialRecipient,
+  send,
+  helperText,
+}: Omit<SendTestEmailDialogProps, 'open'> & { initialRecipient: string; helperText: string }) {
   const sendTest = useSendTestEmail();
   const [recipient, setRecipient] = useState(initialRecipient);
   const [sending, setSending] = useState(false);
   const [result, setResult] = useState<SendTestEmailResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
-
-  // Every opening starts fresh, prefilled with the caller's suggestion.
-  useEffect(() => {
-    if (open) {
-      setRecipient(initialRecipient);
-      setResult(null);
-      setError(null);
-    }
-  }, [open, initialRecipient]);
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -96,38 +108,36 @@ export function SendTestEmailDialog({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
-      <Box component="form" onSubmit={onSubmit} noValidate>
-        <DialogTitle>Send test email</DialogTitle>
-        <DialogContent>
-          <Stack spacing={2} sx={{ mt: 1 }}>
-            <TextField
-              label="Recipient"
-              type="email"
-              value={recipient}
-              onChange={(e) => setRecipient(e.target.value)}
-              fullWidth
-              required
-              autoComplete="off"
-              helperText={helperText}
-            />
-            {result && <Alert severity={SEVERITY[result.status]}>{result.detail}</Alert>}
-            {error && <Alert severity="error">{error}</Alert>}
-          </Stack>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2.5 }}>
-          <Button onClick={onClose} color="inherit">
-            Close
-          </Button>
-          <Button
-            type="submit"
-            variant="contained"
-            disabled={sending || recipient.trim().length === 0}
-          >
-            {sending ? 'Sending…' : 'Send'}
-          </Button>
-        </DialogActions>
-      </Box>
-    </Dialog>
+    <Box component="form" onSubmit={onSubmit} noValidate>
+      <DialogTitle>Send test email</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            label="Recipient"
+            type="email"
+            value={recipient}
+            onChange={(e) => setRecipient(e.target.value)}
+            fullWidth
+            required
+            autoComplete="off"
+            helperText={helperText}
+          />
+          {result && <Alert severity={SEVERITY[result.status]}>{result.detail}</Alert>}
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onClose} color="inherit">
+          Close
+        </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={sending || recipient.trim().length === 0}
+        >
+          {sending ? 'Sending…' : 'Send'}
+        </Button>
+      </DialogActions>
+    </Box>
   );
 }

--- a/qnop-ui/src/components/admin/mail/SendTestEmailDialog.tsx
+++ b/qnop-ui/src/components/admin/mail/SendTestEmailDialog.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -36,6 +36,15 @@ import { apiErrorMessage } from '../../../utils/apiError';
 interface SendTestEmailDialogProps {
   open: boolean;
   onClose: () => void;
+  /** Prefills the recipient (e.g. the signed-in admin's own address). */
+  initialRecipient?: string;
+  /**
+   * Custom sender — the template editor posts the rendered draft (issue #316).
+   * Defaults to the generic SMTP test message.
+   */
+  send?: (recipient: string) => Promise<SendTestEmailResponse>;
+  /** Replaces the default helper line under the recipient field. */
+  helperText?: string;
 }
 
 const SEVERITY: Record<SendTestEmailResponse['status'], 'success' | 'warning' | 'error'> = {
@@ -45,20 +54,44 @@ const SEVERITY: Record<SendTestEmailResponse['status'], 'success' | 'warning' | 
 };
 
 /** Sends a test email with the current SMTP settings and reports the outcome. */
-export function SendTestEmailDialog({ open, onClose }: SendTestEmailDialogProps) {
+export function SendTestEmailDialog({
+  open,
+  onClose,
+  initialRecipient = '',
+  send,
+  helperText = 'Uses the configured SMTP settings.',
+}: SendTestEmailDialogProps) {
   const sendTest = useSendTestEmail();
-  const [recipient, setRecipient] = useState('');
+  const [recipient, setRecipient] = useState(initialRecipient);
+  const [sending, setSending] = useState(false);
   const [result, setResult] = useState<SendTestEmailResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Every opening starts fresh, prefilled with the caller's suggestion.
+  useEffect(() => {
+    if (open) {
+      setRecipient(initialRecipient);
+      setResult(null);
+      setError(null);
+    }
+  }, [open, initialRecipient]);
+
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
+    // The dialog renders in a portal, but React bubbles the submit through the
+    // REACT tree — without this, a host page's surrounding form submits too
+    // (the template editor would silently save the draft).
+    event.stopPropagation();
     setError(null);
     setResult(null);
+    setSending(true);
     try {
-      setResult(await sendTest.mutateAsync(recipient.trim()));
+      const to = recipient.trim();
+      setResult(await (send ? send(to) : sendTest.mutateAsync(to)));
     } catch (err) {
       setError(apiErrorMessage(err, 'The test email could not be sent.'));
+    } finally {
+      setSending(false);
     }
   };
 
@@ -76,7 +109,7 @@ export function SendTestEmailDialog({ open, onClose }: SendTestEmailDialogProps)
               fullWidth
               required
               autoComplete="off"
-              helperText="Uses the configured SMTP settings."
+              helperText={helperText}
             />
             {result && <Alert severity={SEVERITY[result.status]}>{result.detail}</Alert>}
             {error && <Alert severity="error">{error}</Alert>}
@@ -89,9 +122,9 @@ export function SendTestEmailDialog({ open, onClose }: SendTestEmailDialogProps)
           <Button
             type="submit"
             variant="contained"
-            disabled={sendTest.isPending || recipient.trim().length === 0}
+            disabled={sending || recipient.trim().length === 0}
           >
-            {sendTest.isPending ? 'Sending…' : 'Send'}
+            {sending ? 'Sending…' : 'Send'}
           </Button>
         </DialogActions>
       </Box>

--- a/qnop-ui/src/components/admin/mail/mustache/MustacheCodeEditor.tsx
+++ b/qnop-ui/src/components/admin/mail/mustache/MustacheCodeEditor.tsx
@@ -23,7 +23,7 @@ import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
 import Box from '@mui/material/Box';
 import { useTheme } from '@mui/material/styles';
 import { html } from '@codemirror/lang-html';
-import { EditorView } from '@codemirror/view';
+import { EditorView, dropCursor } from '@codemirror/view';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { mustacheExtension } from './mustacheExtension';
 
@@ -79,6 +79,9 @@ export const MustacheCodeEditor = forwardRef<MustacheEditorHandle, MustacheCodeE
     const extensions = useMemo(
       () => [
         EditorView.lineWrapping,
+        // Chips can be dragged in (issue #316 polish); the drop cursor shows
+        // where the placeholder will land while hovering.
+        dropCursor(),
         mustacheExtension(placeholders, language),
         ...(language === 'html' ? [html({ autoCloseTags: true, matchClosingTags: true })] : []),
       ],

--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -53,11 +53,14 @@ export function AppShell() {
     (reviewMatch && reviewMatch.params.documentId !== 'new') || compareMatch || tasksMatch,
   );
   // The work surfaces share one width language (issue #454 follow-up): the
-  // dashboard and the reviews overview span the full width like the review
-  // workspace; admin and profile keep the centred reading container.
+  // dashboard, the reviews overview and the admin surfaces span the full
+  // width like the review workspace; the profile keeps the centred reading
+  // container (issue #316 polish).
   const dashboardMatch = useMatch('/');
   const reviewsListMatch = useMatch('/reviews');
-  const wide = fullBleed || Boolean(dashboardMatch) || Boolean(reviewsListMatch);
+  const adminMatch = useMatch('/admin/*');
+  const wide =
+    fullBleed || Boolean(dashboardMatch) || Boolean(reviewsListMatch) || Boolean(adminMatch);
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
       return localStorage.getItem(COLLAPSE_KEY) === '1';

--- a/qnop-ui/src/pages/ProfilePage.tsx
+++ b/qnop-ui/src/pages/ProfilePage.tsx
@@ -23,15 +23,22 @@ import { useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
 import Snackbar from '@mui/material/Snackbar';
 import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import { useAuthStore } from '../stores/authStore';
 import { useUploadMyAvatar, useRemoveMyAvatar } from '../api/hooks/useAvatar';
 import { UserAvatar } from '../components/shell/UserAvatar';
 import { UserRoleBadge, UserSourceBadge } from '../components/admin/users/UserBadges';
 import { AvatarUploader } from '../components/profile/AvatarUploader';
+import {
+  EMAIL_REVIEW_NOTIFICATIONS_KEY,
+  useUpdateUserSettings,
+  useUserSettings,
+} from '../api/hooks/useUserSettings';
 
 type Toast = { message: string; severity: 'success' | 'error' } | null;
 
@@ -51,6 +58,23 @@ export function ProfilePage() {
   const remove = useRemoveMyAvatar();
   const [toast, setToast] = useState<Toast>(null);
   const busy = upload.isPending || remove.isPending;
+
+  const settingsQuery = useUserSettings();
+  const updateSettings = useUpdateUserSettings();
+  const reviewMailsSetting = settingsQuery.data?.settings.find(
+    (setting) => setting.key === EMAIL_REVIEW_NOTIFICATIONS_KEY,
+  );
+  // Absent value = registry default (true) — the toggle reflects what the server does.
+  const reviewMailsOn = reviewMailsSetting ? reviewMailsSetting.value !== 'false' : true;
+
+  const onToggleReviewMails = (checked: boolean) => {
+    updateSettings.mutate(
+      { [EMAIL_REVIEW_NOTIFICATIONS_KEY]: String(checked) },
+      {
+        onError: () => setToast({ message: 'The setting could not be saved.', severity: 'error' }),
+      },
+    );
+  };
 
   const onSelect = async (blob: Blob) => {
     try {
@@ -118,6 +142,26 @@ export function ProfilePage() {
           busy={busy}
           onSelect={onSelect}
           onRemove={onRemove}
+        />
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 2.5, sm: 3 } }}>
+        <Typography sx={{ fontSize: 16, fontWeight: 600 }}>Notifications</Typography>
+        <Typography color="text.secondary" sx={{ fontSize: 14, mt: 0.5, mb: 2.5 }}>
+          Emails about reviews you are part of — being added as a reviewer, new annotations, replies
+          in your discussions, decisions, and status changes.
+        </Typography>
+        <Divider sx={{ mb: 1.5 }} />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={reviewMailsOn}
+              onChange={(event) => onToggleReviewMails(event.target.checked)}
+              disabled={settingsQuery.isPending}
+              slotProps={{ input: { 'aria-label': 'Email me about review activity' } }}
+            />
+          }
+          label="Email me about review activity"
         />
       </Paper>
 

--- a/qnop-ui/src/pages/admin/MailTemplateEditPage.test.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplateEditPage.test.tsx
@@ -53,6 +53,7 @@ vi.mock('../../api/hooks/useMailTemplates', () => ({
   useMailTemplate: () => ({ data: TEMPLATE, isLoading: false, isError: false, isFetching: false }),
   useUpdateMailTemplate: () => ({ mutateAsync: updateMutate, isPending: false }),
   useResetMailTemplate: () => ({ mutateAsync: resetMutate, isPending: false }),
+  useSendTestEmail: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 vi.mock('../../api/hooks/useMailTemplatePreview', () => ({

--- a/qnop-ui/src/pages/admin/MailTemplateEditPage.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplateEditPage.tsx
@@ -236,7 +236,7 @@ function EditForm({
             <SectionCard
               icon={Variable}
               title="Available variables"
-              description="Click a chip to insert it at the caret of the last field you edited."
+              description="Click a chip to insert it at the caret of the last field you edited — or drag it straight into a field."
             >
               {template.placeholders.length === 0 ? (
                 <Typography color="text.secondary" sx={{ fontSize: 14, fontStyle: 'italic' }}>
@@ -251,7 +251,20 @@ function EditForm({
                       size="small"
                       variant="outlined"
                       onClick={() => insertPlaceholder(name)}
-                      sx={{ fontFamily: 'monospace', fontSize: 12.5 }}
+                      // Draggable into the subject and body fields: the payload is the
+                      // literal token, so the browser's native text drop (input) and
+                      // CodeMirror's drop handling insert it at the pointer.
+                      draggable
+                      onDragStart={(event) => {
+                        event.dataTransfer.setData('text/plain', `{{${name}}}`);
+                        event.dataTransfer.effectAllowed = 'copy';
+                      }}
+                      sx={{
+                        fontFamily: 'monospace',
+                        fontSize: 12.5,
+                        cursor: 'grab',
+                        '&:active': { cursor: 'grabbing' },
+                      }}
                     />
                   ))}
                 </Stack>

--- a/qnop-ui/src/pages/admin/MailTemplateEditPage.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplateEditPage.tsx
@@ -33,7 +33,7 @@ import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { Eye, RotateCcw, Variable } from 'lucide-react';
+import { Send, Eye, RotateCcw, Variable } from 'lucide-react';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import type { MailTemplateResponse } from '../../api/generated';
 import {
@@ -44,6 +44,9 @@ import {
 import { useMailTemplatePreview } from '../../api/hooks/useMailTemplatePreview';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { SectionCard } from '../../components/admin/layout/SectionCard';
+import { adminEmailApi } from '../../api/config';
+import { useAuthStore } from '../../stores/authStore';
+import { SendTestEmailDialog } from '../../components/admin/mail/SendTestEmailDialog';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { useToast } from '../../components/admin/layout/useToast';
 import { ToneBadge } from '../../components/admin/ToneBadge';
@@ -152,6 +155,25 @@ function EditForm({
     variables: sampleOverrides,
   });
   const sampleValues = { ...(preview.data?.sampleVars ?? {}), ...sampleOverrides };
+
+  // Sends exactly what the live preview shows — current draft + sample values —
+  // to a recipient of the admin's choosing, prefilled with their own address
+  // (issue #316).
+  const ownEmail = useAuthStore((s) => s.email);
+  const [testOpen, setTestOpen] = useState(false);
+  const sendTemplateTest = async (recipient: string) => {
+    const response = await adminEmailApi.sendTemplateTestEmail({
+      key: template.key,
+      templateTestEmailRequest: {
+        recipient,
+        subject,
+        bodyPlain,
+        bodyHtml: htmlEnabled ? bodyHtml : undefined,
+        variables: sampleValues,
+      },
+    });
+    return response.data;
+  };
 
   const insertPlaceholder = (name: string) => {
     if (lastFocused.current === 'bodyHtml' && showHtml) {
@@ -353,15 +375,24 @@ function EditForm({
                 spacing={1.5}
                 sx={{ alignItems: { sm: 'center' }, justifyContent: 'space-between' }}
               >
-                <Button
-                  type="button"
-                  color="error"
-                  startIcon={<RotateCcw size={18} />}
-                  disabled={!isCustomised || resetTemplate.isPending}
-                  onClick={() => setConfirmReset(true)}
-                >
-                  Reset to default
-                </Button>
+                <Stack direction="row" spacing={1.5}>
+                  <Button
+                    type="button"
+                    color="error"
+                    startIcon={<RotateCcw size={18} />}
+                    disabled={!isCustomised || resetTemplate.isPending}
+                    onClick={() => setConfirmReset(true)}
+                  >
+                    Reset to default
+                  </Button>
+                  <Button
+                    type="button"
+                    startIcon={<Send size={16} />}
+                    onClick={() => setTestOpen(true)}
+                  >
+                    Send test email
+                  </Button>
+                </Stack>
                 <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
                   {updateTemplate.isPending && <LinearProgress sx={{ width: 100 }} />}
                   <Button
@@ -403,6 +434,13 @@ function EditForm({
         onClose={() => setConfirmReset(false)}
       />
 
+      <SendTestEmailDialog
+        open={testOpen}
+        onClose={() => setTestOpen(false)}
+        initialRecipient={ownEmail ?? ''}
+        send={sendTemplateTest}
+        helperText="Sends this template rendered with the current draft and sample data."
+      />
       <AdminToast toast={toast} onClose={clear} />
     </Box>
   );


### PR DESCRIPTION
Closes #316.

## What

Reviewers were assigned to documents but never informed; annotations, decisions, replies, new versions and workflow transitions happened silently. This adds **best-effort email notifications for six review events**, plus the admin tooling to manage and test the templates.

## Notifications

| Event | Template | Recipients |
|---|---|---|
| Reviewer added | `review.participant_added` | the added user / every member of the added team |
| New annotation | `review.annotation_created` | document owner |
| Annotation decided (resolve/reopen) | `review.annotation_decided` | owner + annotation author |
| Reply in a thread | `review.comment_added` | thread (author + everyone who commented), deep-linked to the comment (#412) |
| New document version (v2+) | `review.version_uploaded` | owner + all participants, deep-linked to the version |
| Workflow transition (manual) | `review.workflow_changed` | owner + all participants |

Rules baked in: the **actor is never notified** about their own action; disabled users and opt-outs are skipped; derived `IN_REVIEW ⇄ CHANGES_REQUESTED` flips stay silent (the causing annotation mail already announces them); the first version is the review's creation and sends nothing.

## Mechanics

- Sealed `ReviewEvent` published via `ApplicationEventPublisher` from the five service seams; consumed by `ReviewNotificationListener` — `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` on a bounded executor, so a rollback never mails and SMTP latency never sits in a request thread. ITs flip the executor synchronous via `qnop.notifications.sync-dispatch`.
- `ReviewNotificationService` resolves recipients (owner, participants, team expansion, thread members) and **keeps anonymous reviews anonymous** (#413): the actor's name is resolved per recipient through `ReviewIdentityResolver` — foreign authors appear as "Participant N", never by real name (IT-proven).
- Six `MailTemplateKey` entries with seeded `en` defaults; they surface in the admin template editor automatically. Links are built from `general.base_url` — an unset base URL now logs a clear warning instead of silently producing dead relative links.
- Switches: global `notifications.review_emails_enabled` application setting (default on) and per-user `email_review_notifications` opt-out with a toggle on the profile page (optimistic, with rollback).

## Admin/UI extras (same PR by request)

- **Per-template test email**: `POST /admin/email/templates/{key}/test` renders exactly what the live preview shows (unsaved draft + current sample variables) and sends it; the editor's "Send test email" dialog prefils the admin's own address, any recipient enterable. Fixes a real portal bug found on the way: the dialog's submit bubbled through the React tree into the editor's form and silently saved the draft.
- **Placeholder chips are draggable** into subject/body (native text drop + CodeMirror drop handling, with a drop cursor), alongside click-to-insert.
- **Admin pages span the full available width**, matching the dashboard/reviews layout language (#454).
- `chore(deps)`: deduped `@codemirror/state` (two coexisting resolutions crashed every template editor with "Unrecognized extension value").

## Migrations

- Six seed changesets in `0003-mail-template-schema.yaml` (new changesets, safe).
- `0002-settings-seed` **amended** with the new setting (pre-prod convention) — reset local dev DBs or null the changeset checksum.

## Tests

- `ReviewNotificationIT` (7 end-to-end cases): participant mail targeting, owner mail on annotation, derived-transition silence, thread reply targeting + comment deep link, decision mail, opt-out respected on manual transitions, **anonymity guarantee**, version-upload fan-out with `?version=N` link.
- `ReviewNotificationServiceTest`, `AdminEmailControllerTest` (+2), extended contract tests (template rendering against flow vars, seeded rows, settings registry sync), UI hook test for the optimistic opt-out toggle.
- Full gates green: `./gradlew build`, `pnpm lint` + `tsc` + 758 vitest tests. Verified live against Mailpit: all six mails, absolute deep links, per-template test sends.

## Test plan

- [x] Each of the six events lands as a mail to exactly the expected recipients (never the actor)
- [x] Anonymous review mails never leak a foreign author's real name
- [x] Global switch and per-user opt-out suppress mails
- [x] Template editor: live preview, chip click/drag insertion, per-template test send to any address
- [x] Unset `general.base_url` logs a warning; configured base yields absolute deep links

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)