### PR TITLE
feat(reviews): copy to clipboard — viewer selection, quotes & comments

### DIFF
--- a/qnop-ui/src/components/reviews/CopyTextButton.test.tsx
+++ b/qnop-ui/src/components/reviews/CopyTextButton.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { CopyTextButton } from './CopyTextButton';
+import { copyToClipboard } from '../../utils/clipboard';
+
+vi.mock('../../utils/clipboard', () => ({ copyToClipboard: vi.fn() }));
+
+const mockedCopy = vi.mocked(copyToClipboard);
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('CopyTextButton (issue #478)', () => {
+  it('copies the payload, toasts success, and never toggles the host card', async () => {
+    mockedCopy.mockResolvedValue(true);
+    const notify = vi.fn();
+    const cardClick = vi.fn();
+    render(
+      <div role="presentation" onClick={cardClick}>
+        <CopyTextButton
+          text="the liability clause"
+          notify={notify}
+          label="Copy quote"
+          copiedMessage="Quote copied."
+        />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy quote' }));
+
+    await waitFor(() => expect(notify).toHaveBeenCalledWith('Quote copied.', 'success'));
+    expect(mockedCopy).toHaveBeenCalledWith('the liability clause');
+    expect(cardClick).not.toHaveBeenCalled();
+  });
+
+  it('degrades to an error toast when the clipboard is unavailable', async () => {
+    mockedCopy.mockResolvedValue(false);
+    const notify = vi.fn();
+    render(<CopyTextButton text="x" notify={notify} label="Copy comment" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy comment' }));
+
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith('Could not copy to the clipboard.', 'error'),
+    );
+  });
+});

--- a/qnop-ui/src/components/reviews/CopyTextButton.tsx
+++ b/qnop-ui/src/components/reviews/CopyTextButton.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { MouseEvent } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { Copy } from 'lucide-react';
+import { copyToClipboard } from '../../utils/clipboard';
+import type { Notify } from '../admin/layout/useToast';
+
+interface CopyTextButtonProps {
+  /** The exact string written to the clipboard (e.g. raw quote or comment body). */
+  text: string;
+  notify: Notify;
+  /** Tooltip + accessible label, e.g. "Copy quote" / "Copy comment". */
+  label: string;
+  /** Success toast; the error message is shared. */
+  copiedMessage?: string;
+  iconSize?: number;
+}
+
+/**
+ * The "copy text" sibling of {@link CopyLinkButton} (issue #478): writes a
+ * text payload to the clipboard and confirms with a toast. Stops propagation
+ * so it can sit inside clickable annotation cards, and degrades to an error
+ * toast when the Clipboard API is unavailable (insecure context).
+ */
+export function CopyTextButton({
+  text,
+  notify,
+  label,
+  copiedMessage = 'Copied to clipboard.',
+  iconSize = 13,
+}: CopyTextButtonProps) {
+  const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    const ok = await copyToClipboard(text);
+    notify(ok ? copiedMessage : 'Could not copy to the clipboard.', ok ? 'success' : 'error');
+  };
+  return (
+    <Tooltip title={label}>
+      <IconButton
+        size="small"
+        aria-label={label}
+        onClick={handleCopy}
+        sx={{ color: 'text.secondary' }}
+      >
+        <Copy size={iconSize} aria-hidden />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -26,6 +26,7 @@ import { useTheme } from '@mui/material/styles';
 import type { AnnotationView } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
 import type { Notify } from '../../admin/layout/useToast';
+import { CopyTextButton } from '../CopyTextButton';
 import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { AddReactionButton } from '../reactions/AddReactionButton';
 import { ReactionBar } from '../reactions/ReactionBar';
@@ -89,6 +90,10 @@ export function AnnotationHead({
   // Full opener once the thread is cached; the server-side excerpt until then.
   const cachedComments = useComments(annotation.id, false).data?.comments ?? [];
   const openerText = cachedComments[0]?.body ?? annotation.firstComment ?? null;
+  // Every annotation offers a copy payload (issue #478): the quoted passage
+  // when anchored to text, otherwise the opening text (document-scoped and
+  // region annotations carry no quote).
+  const copyText = annotation.anchor?.textQuote?.quote ?? openerText;
   const own = annotation.authorId === userId;
   // The author name is resolved server-side, honouring per-review anonymity
   // (issue #413): the real name in a normal review, a stable "Participant N"
@@ -145,7 +150,7 @@ export function AnnotationHead({
             >
               Started this discussion · {shortRelativeTime(annotation.createdAt)}
             </Typography>
-            {(onToggleReaction || (permalinkUrl && notify)) && (
+            {(onToggleReaction || (copyText && notify) || (permalinkUrl && notify)) && (
               // Directly after the timestamp, exactly like a comment row's
               // link. The negative margin keeps the icon buttons from growing
               // the caption line beyond the avatar's height.
@@ -153,6 +158,14 @@ export function AnnotationHead({
                 className="annotation-hover-actions"
                 sx={{ display: 'flex', alignItems: 'center', flexShrink: 0, my: '-3px' }}
               >
+                {copyText && notify && (
+                  <CopyTextButton
+                    text={copyText}
+                    notify={notify}
+                    label={quote ? 'Copy quote' : 'Copy text'}
+                    copiedMessage={quote ? 'Quote copied.' : 'Text copied.'}
+                  />
+                )}
                 {permalinkUrl && notify && (
                   <CopyLinkButton
                     url={permalinkUrl}
@@ -190,6 +203,9 @@ export function AnnotationHead({
             borderColor: 'divider',
             bgcolor: theme.qnop.surface2,
             borderRadius: '0 6px 6px 0',
+            // The passage is copy material (issue #478) — selectable even
+            // inside the clickable card (ButtonBase disables selection).
+            userSelect: 'text',
             px: 1.25,
             py: 0.75,
           }}

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -212,7 +212,13 @@ function AnnotationListItemBase({
       // Expanded, the card hosts real buttons (the head's copy-link) — a
       // <button> may not nest, so the active card is a div with button role.
       component={active ? 'div' : 'button'}
-      onClick={() => onSelect(active ? null : annotation.id)}
+      onClick={() => {
+        // Selecting quote text inside the card ends with a click on it —
+        // don't treat a live selection as a toggle (issue #478).
+        const selection = window.getSelection();
+        if (selection && !selection.isCollapsed) return;
+        onSelect(active ? null : annotation.id);
+      }}
       onMouseEnter={() => onHover?.(annotation.id)}
       onMouseLeave={() => onHover?.(null)}
       onFocus={() => onHover?.(annotation.id)}

--- a/qnop-ui/src/components/reviews/panel/CommentMessage.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentMessage.tsx
@@ -27,6 +27,7 @@ import { shortRelativeTime } from '../../../utils/relativeTime';
 import type { Notify } from '../../admin/layout/useToast';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { Markdown } from '../markdown/Markdown';
+import { CopyTextButton } from '../CopyTextButton';
 import { CopyLinkButton } from '../permalink/CopyLinkButton';
 import { AddReactionButton } from '../reactions/AddReactionButton';
 import { ReactionBar } from '../reactions/ReactionBar';
@@ -121,8 +122,16 @@ export function CommentMessage({
           >
             {shortRelativeTime(createdAt)}
           </Typography>
-          {(onToggleReaction || (permalinkUrl && notify)) && (
+          {(onToggleReaction || notify) && (
             <Box className="comment-hover-actions" sx={{ display: 'flex', alignItems: 'center' }}>
+              {notify && (
+                <CopyTextButton
+                  text={body}
+                  notify={notify}
+                  label="Copy comment"
+                  copiedMessage="Comment copied."
+                />
+              )}
               {permalinkUrl && notify && (
                 <CopyLinkButton url={permalinkUrl} notify={notify} label="Copy link to comment" />
               )}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -31,7 +31,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Popper from '@mui/material/Popper';
 import Stack from '@mui/material/Stack';
-import { NotebookPen } from 'lucide-react';
+import { Copy, NotebookPen } from 'lucide-react';
 import type { Anchor, AnnotationView, NormalizedBox } from '../../api/generated';
 import { ExtractionStatus } from '../../api/generated';
 import type { AnnotationPriority, AnnotationType } from '../../api/generated';
@@ -47,6 +47,7 @@ import {
   useRenderedDocument,
 } from '../../api/hooks/useDocuments';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { copyToClipboard } from '../../utils/clipboard';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
 import { BoundaryFallback } from '../../components/errors/BoundaryFallback';
@@ -313,6 +314,28 @@ export function DocumentReviewPage() {
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [reattaching]);
+
+  // Copy the drawn selection with the native gesture (issue #478): while a
+  // TEXT selection is pending, Cmd/Ctrl+C copies its quote — unless the user
+  // is in an input or made a real DOM selection somewhere (those keep native
+  // copy). Region selections carry no text and stay untouched.
+  const pendingQuote = pending?.anchor?.textQuote?.quote;
+  useEffect(() => {
+    if (!pendingQuote) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'c') return;
+      const target = event.target as HTMLElement | null;
+      if (target?.closest('input, textarea, [contenteditable="true"]')) return;
+      const domSelection = window.getSelection();
+      if (domSelection && !domSelection.isCollapsed) return;
+      event.preventDefault();
+      void copyToClipboard(pendingQuote).then((ok) =>
+        notify(ok ? 'Text copied.' : 'Could not copy to the clipboard.', ok ? 'success' : 'error'),
+      );
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [pendingQuote, notify]);
 
   const closeFocusCard = () => {
     setActiveAnnotationId(null);
@@ -790,6 +813,24 @@ export function DocumentReviewPage() {
           </ListItemIcon>
           <ListItemText>Create annotation</ListItemText>
         </MenuItem>
+        {pendingQuote && (
+          <MenuItem
+            onClick={() => {
+              void copyToClipboard(pendingQuote).then((ok) =>
+                notify(
+                  ok ? 'Text copied.' : 'Could not copy to the clipboard.',
+                  ok ? 'success' : 'error',
+                ),
+              );
+              setPending(null);
+            }}
+          >
+            <ListItemIcon>
+              <Copy size={16} />
+            </ListItemIcon>
+            <ListItemText>Copy text</ListItemText>
+          </MenuItem>
+        )}
       </Menu>
       <NewTaskDialog
         open={newNoteOpen}


### PR DESCRIPTION
Closes #478.

## What

Copy support in the three places text lives in a review — including the document viewer, where a drawn selection could never be copied before (canvas pixels, synthetic selection, no DOM text).

### Document viewer (the real fix)

No client text layer, ADR-0032 stays intact: the pending selection's `textQuote.quote` **is** the selected string, reconstructed server-authoritatively from spans. On top of that:

- The post-selection popup gains a **"Copy text"** item next to "Create annotation" (toast + closes the pending mark).
- **Cmd/Ctrl+C** copies the pending TEXT selection. Guards keep native copy untouched: inputs/textareas/contenteditable and any real DOM selection win; the handler never `preventDefault`s those.
- **Region selections carry no text** and show no copy affordance — the region annotation tool is unaffected.

### Annotations & comments

A shared `CopyTextButton` (the `CopyLinkButton` pattern from #412: `stopPropagation`, success/error toast, insecure-context degradation, tooltip + `aria-label`) joins the existing hover-action rows:

- **Every annotation** offers a payload: the raw quoted passage when text-anchored (*Copy quote*), otherwise the opening text (*Copy text*) — document-scoped and region annotations have no quote (caught during review of the first cut).
- **Every comment** copies its raw markdown body (*Copy comment*) — structure preserved.
- The quoted passage is now **selectable** inside the clickable annotation card (MUI `ButtonBase` suppresses selection), and a live selection no longer toggles the card on mouse-up.

## Tests & verification

- `CopyTextButton` unit tests (payload + success toast + no card toggle; error toast when the Clipboard API is unavailable).
- Full gates green: `pnpm lint` + `tsc` + 766 vitest tests.
- Verified end-to-end in the browser with real clipboard reads: selection-menu copy, Cmd+C gesture, quote button, opening-text button on a whole-document annotation, comment button — each landed the exact payload; region tool shows only "Create annotation".

## Test plan

- [x] Drag in the document → "Copy text" menu item → exact passage in the clipboard
- [x] Drag in the document → Cmd/Ctrl+C → exact passage in the clipboard
- [x] "Copy quote" / "Copy text" on anchored, whole-document and region annotations
- [x] "Copy comment" copies the raw body
- [x] Native selection works on quotes; selecting does not toggle the card
- [x] Region tool untouched; native copy in inputs/composers untouched

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)