### PR TITLE
feat(reviews): one flat annotation list with per-card scope markers

### DIFF
--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -34,6 +34,8 @@ import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { UserAvatar } from '../../shell/UserAvatar';
 import { avatarSrc } from '../../../utils/avatarUrl';
+import { isDocumentScoped } from '../annotationScope';
+import { WholeDocumentChip } from '../WholeDocumentChip';
 import { tokens } from '../../../theme/tokens';
 import { shortRelativeTime } from '../../../utils/relativeTime';
 import { hasNewComments, isUnseen } from '../newSince';
@@ -386,7 +388,7 @@ function AnnotationListItemBase({
                 {annotation.commentCount}
               </Typography>
             </Stack>
-            {region && (
+            {region ? (
               <Typography
                 variant="caption"
                 color="text.secondary"
@@ -394,6 +396,11 @@ function AnnotationListItemBase({
               >
                 p. {region.surfaceIndex + 1}
               </Typography>
+            ) : (
+              // In the flat list (issue #481) the scope must read per card —
+              // collapsed document-scoped rows mark themselves like the
+              // anchored ones mark their page.
+              isDocumentScoped(annotation) && <WholeDocumentChip compact />
             )}
           </Stack>
         </Stack>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -139,7 +139,7 @@ describe('AnnotationPanel', () => {
     expect(
       within(screen.getByTestId('annotation-item-a-replied')).getByTestId('unseen-dot'),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('section-new-count')).toHaveTextContent('2 new');
+    expect(screen.getByTestId('panel-new-count')).toHaveTextContent('2 new');
   });
 
   it('shows the empty state with the how-to hint when annotating is possible', () => {
@@ -149,7 +149,7 @@ describe('AnnotationPanel', () => {
     ).toBeInTheDocument();
   });
 
-  it('separates document-scoped annotations into their own group (#395)', () => {
+  it('renders one flat list; document-scoped cards carry their own marker (#481)', () => {
     renderPanel({
       annotations: [
         annotation('placed-1'),
@@ -160,9 +160,11 @@ describe('AnnotationPanel', () => {
     });
 
     expect(screen.getByText('Annotations (2)')).toBeInTheDocument();
-    // The anchor-free annotation groups under "Whole document", not the "anchor lost" bucket.
-    expect(screen.getByText('Whole document')).toBeInTheDocument();
-    expect(screen.queryByText('Not placed on this version')).not.toBeInTheDocument();
+    // No section chrome anymore — the scope reads per card (issue #481).
+    expect(screen.queryByText('General remarks — not pinned to a passage')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Anchored to the document/ }),
+    ).not.toBeInTheDocument();
     // The located annotation's collapsed row still shows its page.
     expect(screen.getByText('p. 1')).toBeInTheDocument();
     // The active document-scoped annotation carries the whole-document chip.
@@ -273,15 +275,25 @@ describe('AnnotationPanel', () => {
     expect(screen.queryByLabelText('Author')).not.toBeInTheDocument();
   });
 
-  it('collapses a section on click', () => {
-    renderPanel({ annotations: [annotation('a1')] });
+  it('orders the flat list: document-scoped first, then anchored by position (#481)', () => {
+    renderPanel({
+      annotations: [
+        annotation('page-2', {
+          anchor: { region: { surfaceIndex: 1, box: { x: 0.1, y: 0.1, width: 0.2, height: 0.1 } } },
+        }),
+        annotation('page-1'),
+        annotation('doc-note', { anchor: undefined, placementStatus: undefined }),
+      ],
+    });
 
-    const header = screen.getByRole('button', { name: /Anchored to the document/ });
-    expect(header).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByTestId('annotation-item-a1')).toBeVisible();
-
-    fireEvent.click(header);
-    expect(header).toHaveAttribute('aria-expanded', 'false');
+    const ids = screen
+      .getAllByTestId(/annotation-item-/)
+      .map((el) => el.getAttribute('data-testid'));
+    expect(ids).toEqual([
+      'annotation-item-doc-note',
+      'annotation-item-page-1',
+      'annotation-item-page-2',
+    ]);
   });
 
   it('passes the chosen classification to onCreate (issue #403)', () => {

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -20,15 +20,12 @@
  */
 
 import { useMemo, useState } from 'react';
-import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import ButtonBase from '@mui/material/ButtonBase';
 import Collapse from '@mui/material/Collapse';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/material/styles';
-import { ChevronRight, FileText, Link2, NotebookPen, Plus } from 'lucide-react';
+import { NotebookPen, Plus } from 'lucide-react';
 import type {
   AnnotationPriority,
   AnnotationType,
@@ -39,9 +36,8 @@ import { AnnotationStatus } from '../../../api/generated';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
-import { compareAnnotationsByPosition } from '../viewer/anchoring';
+import { ToneBadge } from '../../admin/ToneBadge';
 import { isUnseen } from '../newSince';
-import { isDocumentScoped } from '../annotationScope';
 import type { BuildPermalink } from '../useReviewPermalink';
 import { useConfirmPlacement } from '../../../api/hooks/useAnnotations';
 import { AnnotationListItem } from './AnnotationListItem';
@@ -52,7 +48,7 @@ import type { FilterAuthor } from './PanelFilterBar';
 import { PanelFilterBar } from './PanelFilterBar';
 import { ReanchorBanner } from './ReanchorBanner';
 import type { AnnotationFilters } from './panelFilters';
-import { EMPTY_FILTERS, matchesFilters } from './panelFilters';
+import { EMPTY_FILTERS, matchesFilters, comparePanelOrder } from './panelFilters';
 import { ResolveBar } from './ResolveBar';
 import {
   mayReopenAnnotation,
@@ -112,110 +108,6 @@ interface AnnotationPanelProps {
 }
 
 /** A collapsible, counted group of annotation cards (prototype sidebar section). */
-function PanelSection({
-  title,
-  subtitle,
-  icon,
-  count,
-  newCount = 0,
-  defaultOpen = true,
-  children,
-}: {
-  title: string;
-  subtitle?: string;
-  icon: ReactNode;
-  count: number;
-  /** Unseen entries in this group (issue #307) — rendered as "· n new". */
-  newCount?: number;
-  defaultOpen?: boolean;
-  children: ReactNode;
-}) {
-  const theme = useTheme();
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <Box>
-      <ButtonBase
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        sx={{
-          width: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
-          textAlign: 'left',
-          borderRadius: 1,
-          px: 0.5,
-          py: 0.75,
-          '&:focus-visible': { boxShadow: theme.qnop.focusRing },
-        }}
-      >
-        <ChevronRight
-          size={14}
-          aria-hidden
-          style={{
-            color: theme.palette.text.secondary,
-            flexShrink: 0,
-            transform: open ? 'rotate(90deg)' : 'none',
-            transition: 'transform 150ms ease',
-          }}
-        />
-        <Box
-          aria-hidden
-          sx={{
-            width: 24,
-            height: 24,
-            borderRadius: 1,
-            display: 'grid',
-            placeItems: 'center',
-            bgcolor: theme.qnop.badge.blue.bg,
-            color: theme.qnop.brand.blue,
-            flexShrink: 0,
-          }}
-        >
-          {icon}
-        </Box>
-        <Box sx={{ minWidth: 0, flex: 1 }}>
-          <Typography variant="subtitle2" sx={{ lineHeight: 1.25 }}>
-            {title}
-          </Typography>
-          {subtitle && (
-            <Typography variant="caption" color="text.secondary">
-              {subtitle}
-            </Typography>
-          )}
-        </Box>
-        <Typography
-          variant="caption"
-          sx={{
-            color: 'text.secondary',
-            bgcolor: theme.qnop.surface2,
-            borderRadius: 99,
-            px: 0.75,
-            fontVariantNumeric: 'tabular-nums',
-            flexShrink: 0,
-          }}
-        >
-          {count}
-        </Typography>
-        {newCount > 0 && (
-          <Typography
-            variant="caption"
-            data-testid="section-new-count"
-            sx={{ color: theme.qnop.brand.blue, fontWeight: 600, flexShrink: 0 }}
-          >
-            · {newCount} new
-          </Typography>
-        )}
-      </ButtonBase>
-      <Collapse in={open} unmountOnExit>
-        <Stack spacing={1.5} sx={{ pt: 1 }}>
-          {children}
-        </Stack>
-      </Collapse>
-    </Box>
-  );
-}
-
 /**
  * The right-hand review panel: the composer for a pending mark, a status
  * filter, and the annotations of the viewed version grouped into collapsible
@@ -281,22 +173,19 @@ export function AnnotationPanel({
   // Sort + status-filter once per (annotations, filter) change, not on every
   // render (e.g. a hover or selection): the list can be large and the sort is
   // O(n log n) (issue #334).
-  const { located, documentScoped, hiddenByFilter } = useMemo(() => {
+  const { visible, hiddenByFilter } = useMemo(() => {
     const matches = (annotation: AnnotationView) =>
       matchesFilters(annotation, filters, authorNameOf(annotation));
-    const sorted = [...annotations].sort(compareAnnotationsByPosition);
-    // Located annotations anchor to a passage; document-scoped ones (issue #395) apply to the
-    // whole document — no anchor, never orphaned — and group on their own.
-    const locatedItems = sorted.filter((a) => !isDocumentScoped(a) && matches(a));
-    const documentScopedItems = sorted.filter((a) => isDocumentScoped(a) && matches(a));
+    // ONE flat list (issue #481): document-scoped remarks lead, then anchored
+    // ones by document position — each card carries its own scope marker.
+    const items = [...annotations].sort(comparePanelOrder).filter(matches);
     return {
-      located: locatedItems,
-      documentScoped: documentScopedItems,
-      hiddenByFilter:
-        annotations.length > 0 && locatedItems.length + documentScopedItems.length === 0,
+      visible: items,
+      hiddenByFilter: annotations.length > 0 && items.length === 0,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- authorNameOf derives from the inputs below
   }, [annotations, filters, userId, displayName]);
+  const newCount = visible.filter((a) => isUnseen(a, previousSeenAt, userId)).length;
 
   // Under a non-OPEN policy (issue #413) only the annotation's author and the
   // owner may reply; the composer is suppressed for everyone else. (A PRIVATE
@@ -375,18 +264,39 @@ export function AnnotationPanel({
       description="Marks and their discussion on this version."
       frameless={frameless}
       action={
-        // Raise a whole-document task without a selection (issue #395) — a quiet peer to the
-        // text-selection gesture, offered while the latest version is open for review.
-        onNewDocumentNote && !readOnly && !reviewClosed ? (
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<Plus size={15} />}
-            onClick={onNewDocumentNote}
-          >
-            Global annotation
-          </Button>
-        ) : undefined
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+          {newCount > 0 && (
+            // The header's fresh-arrivals cue (issue #481): the per-section
+            // "n new" counts collapse into one badge that breathes gently.
+            <Box
+              data-testid="panel-new-count"
+              sx={{
+                '@keyframes panelNewPulse': {
+                  '0%, 100%': { opacity: 1 },
+                  '50%': { opacity: 0.6 },
+                },
+                animation: 'panelNewPulse 2.4s ease-in-out infinite',
+                '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+              }}
+            >
+              <ToneBadge tone="blue" label={`${newCount} new`} />
+            </Box>
+          )}
+          {
+            // Raise a whole-document task without a selection (issue #395) — a quiet peer to the
+            // text-selection gesture, offered while the latest version is open for review.
+            onNewDocumentNote && !readOnly && !reviewClosed ? (
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<Plus size={15} />}
+                onClick={onNewDocumentNote}
+              >
+                Global annotation
+              </Button>
+            ) : undefined
+          }
+        </Stack>
       }
     >
       <Stack spacing={1.5}>
@@ -425,28 +335,7 @@ export function AnnotationPanel({
             No annotations match this filter.
           </Typography>
         )}
-        {documentScoped.length > 0 && (
-          <PanelSection
-            title="Whole document"
-            subtitle="General remarks — not pinned to a passage"
-            icon={<FileText size={13} aria-hidden />}
-            count={documentScoped.length}
-            newCount={documentScoped.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
-          >
-            {documentScoped.map(renderItem)}
-          </PanelSection>
-        )}
-        {located.length > 0 && (
-          <PanelSection
-            title="Anchored to the document"
-            subtitle="Placed on this version"
-            icon={<Link2 size={13} aria-hidden />}
-            count={located.length}
-            newCount={located.filter((a) => isUnseen(a, previousSeenAt, userId)).length}
-          >
-            {located.map(renderItem)}
-          </PanelSection>
-        )}
+        {visible.map(renderItem)}
       </Stack>
     </SectionCard>
   );

--- a/qnop-ui/src/components/reviews/panel/panelFilters.test.ts
+++ b/qnop-ui/src/components/reviews/panel/panelFilters.test.ts
@@ -27,7 +27,13 @@ import {
   AnnotationType,
   PlacementStatus,
 } from '../../../api/generated';
-import { EMPTY_FILTERS, activeFacetCount, matchesFilters, reanchorSummary } from './panelFilters';
+import {
+  EMPTY_FILTERS,
+  activeFacetCount,
+  comparePanelOrder,
+  matchesFilters,
+  reanchorSummary,
+} from './panelFilters';
 
 const annotation = (overrides: Partial<AnnotationView> = {}): AnnotationView => ({
   id: 'a1',
@@ -152,5 +158,29 @@ describe('placement facet & re-anchoring summary (issue #326)', () => {
       total: 3,
     });
     expect(reanchorSummary([placed]).total).toBe(0);
+  });
+});
+
+describe('comparePanelOrder (issue #481)', () => {
+  const doc = (id: string, createdAt: string) => annotation({ id, anchor: undefined, createdAt });
+  const placed = (id: string, surfaceIndex: number, y = 0.1) =>
+    annotation({
+      id,
+      anchor: { region: { surfaceIndex, box: { x: 0.1, y, width: 0.2, height: 0.1 } } },
+    });
+
+  it('leads with document-scoped remarks (oldest first), then anchored by position', () => {
+    const list = [
+      placed('p2', 1),
+      doc('d-late', '2026-07-02T10:00:00Z'),
+      placed('p1', 0),
+      doc('d-early', '2026-07-01T10:00:00Z'),
+    ];
+    expect(list.sort(comparePanelOrder).map((a) => a.id)).toEqual([
+      'd-early',
+      'd-late',
+      'p1',
+      'p2',
+    ]);
   });
 });

--- a/qnop-ui/src/components/reviews/panel/panelFilters.ts
+++ b/qnop-ui/src/components/reviews/panel/panelFilters.ts
@@ -27,6 +27,8 @@ import {
   PlacementStatus,
 } from '../../../api/generated';
 import { stripMarkdown } from '../../../utils/markdown';
+import { isDocumentScoped } from '../annotationScope';
+import { compareAnnotationsByPosition } from '../viewer/anchoring';
 
 /** The panel's filter facets (issue #403); `null`/`'all'`/`''` mean "any". */
 export interface AnnotationFilters {
@@ -111,4 +113,17 @@ export function reanchorSummary(annotations: AnnotationView[]) {
       annotation.placementStatus === PlacementStatus.Failed,
   ).length;
   return { moved, orphaned, total: moved + orphaned };
+}
+
+/**
+ * The flat panel order (issue #481): document-scoped remarks lead — they have
+ * no position and read like a preface — oldest first, then anchored
+ * annotations by their document position (unchanged from the sectioned view).
+ */
+export function comparePanelOrder(a: AnnotationView, b: AnnotationView): number {
+  const aScoped = isDocumentScoped(a);
+  const bScoped = isDocumentScoped(b);
+  if (aScoped !== bScoped) return aScoped ? -1 : 1;
+  if (aScoped && bScoped) return a.createdAt.localeCompare(b.createdAt);
+  return compareAnnotationsByPosition(a, b);
 }


### PR DESCRIPTION
Closes #481.

## What

The annotation panel's two-section split — **"Whole document"** vs **"Anchored to the document"** — is gone. All annotations render in **one continuous list**; the scope reads per card instead of per group. Shared by the side panel and the focus drawer, so one change covers both.

## Decisions

- **Order** (the one thing the issue asked to settle): document-scoped remarks lead — they carry no position and read like a preface — oldest first, then anchored annotations by document position, exactly as before within the group. Implemented as `comparePanelOrder` in `panelFilters` (unit-tested); `compareAnnotationsByPosition` is untouched for its other callers.
- **Per-card scope, unmistakable**: the expanded head keeps its "Whole document" chip and quoted passage; **collapsed document-scoped rows now carry the compact "Whole doc" chip** in the spot where anchored rows show their page — previously the collapsed row had no marker at all (caught during the visual pass).
- **Unseen accounting** moves from per-section counts to one gently pulsing **"n new"** badge in the panel header (`prefers-reduced-motion` safe). Filters and empty states are untouched.
- The now-unused collapsible `PanelSection` component is removed (net −47 lines).

## Tests & verification

- Section tests replaced by flat-list ones: no section chrome, merged order (document-scoped → p.1 → p.2), chip on document-scoped cards, header badge count; plus a `comparePanelOrder` unit test.
- Full gates green: `pnpm lint` + `tsc` + 767 vitest tests.
- Verified live in both surfaces (side panel + focus drawer) on a review with 2 document-scoped and 6 anchored annotations across 3 pages.

## Test plan

- [x] No "Whole document" / "Anchored to the document" headers in panel or focus drawer
- [x] Document-scoped rows show the "Whole doc" chip collapsed and expanded; anchored rows keep quote + page
- [x] Merged order: document-scoped (oldest first), then by document position
- [x] Filter, empty states and the "n new" count still work

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)