### PR TITLE
feat(users): public profile as a player card — stats, achievements, teams

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -3616,11 +3616,13 @@ components:
           $ref: '#/components/schemas/Anchor'
     PublicUserProfile:
       type: object
-      description: The workspace-public slice of a user (issue #454).
+      description: The workspace-public slice of a user (issues #454, #473).
       required:
         - id
         - displayName
         - createdAt
+        - stats
+        - teams
       properties:
         id:
           type: string
@@ -3633,6 +3635,53 @@ components:
         createdAt:
           type: string
           format: date-time
+        stats:
+          $ref: '#/components/schemas/PublicUserStats'
+        teams:
+          type: array
+          description: Enabled teams the user belongs to, ordered by name.
+          items:
+            $ref: '#/components/schemas/PublicUserTeam'
+    PublicUserStats:
+      type: object
+      description: >-
+        Contribution aggregates for the public profile (issue #473). Activity
+        counters cover NON-anonymous reviews only (ADR-0038 — what anonymity
+        hides never feeds a public number); owned reviews count fully, since
+        ownership is structurally public.
+      required:
+        - reviewsOwned
+        - reviewsParticipating
+        - annotationsRaised
+        - annotationsResolved
+        - commentsWritten
+      properties:
+        reviewsOwned:
+          type: integer
+        reviewsParticipating:
+          type: integer
+        annotationsRaised:
+          type: integer
+        annotationsResolved:
+          type: integer
+        commentsWritten:
+          type: integer
+    PublicUserTeam:
+      type: object
+      description: A team membership shown on the public profile (issue #473).
+      required:
+        - id
+        - name
+        - role
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        role:
+          type: string
+          enum: [LEAD, MEMBER]
     CurrentUserResponse:
       type: object
       description: The authenticated user's own profile.

--- a/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
@@ -24,11 +24,13 @@ import io.qnop.api.v1.endpoint.UsersApi;
 import io.qnop.api.v1.model.CurrentUserResponse;
 import io.qnop.api.v1.model.ErrorResponse;
 import io.qnop.api.v1.model.PublicUserProfile;
+import io.qnop.api.v1.model.PublicUserStats;
+import io.qnop.api.v1.model.PublicUserTeam;
 import io.qnop.api.v1.model.UserRole;
 import io.qnop.api.v1.model.UserSource;
+import io.qnop.service.PublicProfileService;
 import io.qnop.service.UserNotFoundException;
 import io.qnop.service.UserService;
-import io.qnop.service.UserService.PublicUserProfileView;
 import io.qnop.service.UserService.UserProfileView;
 import io.qnop.service.avatar.AvatarService;
 import java.util.UUID;
@@ -47,11 +49,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class CurrentUserController implements UsersApi {
 
   private final UserService users;
+  private final PublicProfileService publicProfiles;
   private final AvatarService avatars;
 
-  public CurrentUserController(UserService users, AvatarService avatars) {
+  public CurrentUserController(
+      UserService users, AvatarService avatars, PublicProfileService publicProfiles) {
     this.users = users;
     this.avatars = avatars;
+    this.publicProfiles = publicProfiles;
   }
 
   @Override
@@ -71,13 +76,29 @@ public class CurrentUserController implements UsersApi {
   @Override
   public ResponseEntity<PublicUserProfile> getUserProfile(UUID userId) {
     CurrentUser.requireUserId(); // signed-in colleagues only, any role
-    PublicUserProfileView profile = users.getPublicProfile(userId);
+    PublicProfileService.PublicProfileView profile = publicProfiles.getProfile(userId);
     return ResponseEntity.ok(
         new PublicUserProfile()
             .id(profile.id())
             .displayName(profile.displayName())
             .avatarUrl(AvatarUrls.forUser(userId, avatars.updatedAt(userId).orElse(null)))
-            .createdAt(profile.createdAt().atOffset(java.time.ZoneOffset.UTC)));
+            .createdAt(profile.createdAt().atOffset(java.time.ZoneOffset.UTC))
+            .stats(
+                new PublicUserStats()
+                    .reviewsOwned((int) profile.stats().reviewsOwned())
+                    .reviewsParticipating((int) profile.stats().reviewsParticipating())
+                    .annotationsRaised((int) profile.stats().annotationsRaised())
+                    .annotationsResolved((int) profile.stats().annotationsResolved())
+                    .commentsWritten((int) profile.stats().commentsWritten()))
+            .teams(
+                profile.teams().stream()
+                    .map(
+                        team ->
+                            new PublicUserTeam()
+                                .id(team.id())
+                                .name(team.name())
+                                .role(PublicUserTeam.RoleEnum.fromValue(team.role())))
+                    .toList()));
   }
 
   @ExceptionHandler(UserNotFoundException.class)

--- a/qnop-app/src/test/java/io/qnop/web/UserProfileApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/UserProfileApiIT.java
@@ -24,6 +24,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.testsupport.SeededIntegrationTest;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +40,14 @@ import org.junit.jupiter.api.Test;
  * name and tenure — never email, role or source — and unknown ids answer 404.
  */
 class UserProfileApiIT extends SeededIntegrationTest {
+
+  @org.springframework.beans.factory.annotation.Autowired private DocumentRepository documents;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  private DocumentVersionRepository versions;
+
+  @org.springframework.beans.factory.annotation.Autowired
+  private ReviewParticipantRepository participants;
 
   @Test
   @DisplayName("serves a colleague's lean profile to any signed-in user")
@@ -49,6 +63,79 @@ class UserProfileApiIT extends SeededIntegrationTest {
         // The lean slice: nothing beyond name, avatar and tenure.
         .andExpect(jsonPath("$.email").doesNotExist())
         .andExpect(jsonPath("$.role").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("aggregates contribution stats, excluding anonymous-review activity (#473)")
+  void statsRespectAnonymity() throws Exception {
+    // A public review with MEMBER's activity...
+    Document open = documents.save(new Document(MEMBER_ID, "Public contract"));
+    participants.save(ReviewParticipant.forUser(open.getId(), AUDITOR_ID));
+    versions.save(
+        new DocumentVersion(
+            open.getId(), 1, "sha256/aa/deadbeef", "deadbeef", "application/pdf", 10L, MEMBER_ID));
+    createAnnotation(open.getId(), AUDITOR_ID);
+    // ...and an ANONYMOUS review where AUDITOR also participates and annotates.
+    Document anon = new Document(MEMBER_ID, "Anonymous review");
+    anon.setAnonymous(true);
+    documents.save(anon);
+    participants.save(ReviewParticipant.forUser(anon.getId(), AUDITOR_ID));
+    versions.save(
+        new DocumentVersion(
+            anon.getId(), 1, "sha256/bb/cafebabe", "cafebabe", "application/pdf", 10L, MEMBER_ID));
+    createAnnotation(anon.getId(), AUDITOR_ID);
+
+    mockMvc
+        .perform(
+            get("/api/v1/users/" + AUDITOR_ID)
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk())
+        // The anonymous review's participation, annotation and comment stay
+        // OUT of the public numbers (ADR-0038).
+        .andExpect(jsonPath("$.stats.reviewsOwned").value(0))
+        .andExpect(jsonPath("$.stats.reviewsParticipating").value(1))
+        .andExpect(jsonPath("$.stats.annotationsRaised").value(1))
+        .andExpect(jsonPath("$.stats.annotationsResolved").value(0))
+        .andExpect(jsonPath("$.stats.commentsWritten").value(1));
+
+    // Ownership is structurally public — the owner's count includes BOTH reviews.
+    mockMvc
+        .perform(
+            get("/api/v1/users/" + MEMBER_ID)
+                .header("Authorization", "Bearer " + token(AUDITOR_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.stats.reviewsOwned").value(2));
+  }
+
+  @Test
+  @DisplayName("lists the user's enabled teams with their role, ordered by name (#473)")
+  void teamsWithRoles() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/users/" + MEMBER_ID)
+                .header("Authorization", "Bearer " + token(AUDITOR_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.teams[0].name").value("Alpha"))
+        .andExpect(jsonPath("$.teams[0].role").exists());
+
+    // A user in no team carries an empty list.
+    mockMvc
+        .perform(
+            get("/api/v1/users/" + EXTERNAL_ID)
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.teams", org.hamcrest.Matchers.hasSize(0)));
+  }
+
+  private void createAnnotation(java.util.UUID documentId, java.util.UUID author) throws Exception {
+    mockMvc
+        .perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post(
+                    "/api/v1/documents/" + documentId + "/annotations")
+                .header("Authorization", "Bearer " + token(author))
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .content("{\"versionNumber\":1,\"anchor\":null,\"comment\":\"a concern\"}"))
+        .andExpect(status().isCreated());
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/repository/AnnotationRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/AnnotationRepository.java
@@ -71,4 +71,17 @@ public interface AnnotationRepository extends JpaRepository<Annotation, UUID> {
           + " GROUP BY a.documentId")
   List<DocumentAnnotationCounts> countVisibleByDocumentIds(
       @Param("documentIds") Collection<UUID> documentIds, @Param("actor") UUID actor);
+
+  /** Annotations the user raised in NON-anonymous reviews (ADR-0038, issue #473). */
+  @Query(
+      "SELECT count(a) FROM Annotation a, Document d"
+          + " WHERE d.id = a.documentId AND a.authorId = :authorId AND d.anonymous = false")
+  long countPublicByAuthor(@Param("authorId") UUID authorId);
+
+  /** Resolved annotations the user authored in NON-anonymous reviews (issue #473). */
+  @Query(
+      "SELECT count(a) FROM Annotation a, Document d"
+          + " WHERE d.id = a.documentId AND a.authorId = :authorId AND d.anonymous = false"
+          + " AND a.status = io.qnop.entity.AnnotationStatus.RESOLVED")
+  long countPublicResolvedByAuthor(@Param("authorId") UUID authorId);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/CommentRepository.java
@@ -107,4 +107,11 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
       @Param("documentIds") Collection<UUID> documentIds,
       @Param("viewer") UUID viewer,
       Pageable pageable);
+
+  /** Comments the user wrote in NON-anonymous reviews (ADR-0038, issue #473). */
+  @Query(
+      "SELECT count(c) FROM Comment c, Annotation a, Document d"
+          + " WHERE a.id = c.annotationId AND d.id = a.documentId"
+          + " AND c.authorId = :authorId AND d.anonymous = false")
+  long countPublicByAuthor(@Param("authorId") UUID authorId);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -67,4 +67,7 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
           + " OR EXISTS (SELECT 1 FROM ReviewParticipant pt, TeamMembership m"
           + "   WHERE pt.documentId = d.id AND pt.teamId = m.teamId AND m.userId = :actor))")
   Page<Document> findVisibleTo(@Param("actor") UUID actor, @Param("q") String q, Pageable pageable);
+
+  /** Reviews the user owns — ownership is structurally public, anonymous ones included (#473). */
+  long countByOwnerId(UUID ownerId);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/ReviewParticipantRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/ReviewParticipantRepository.java
@@ -80,4 +80,10 @@ public interface ReviewParticipantRepository extends JpaRepository<ReviewPartici
   @Query(VIEW_SELECT + " WHERE p.documentId IN :documentIds ORDER BY p.createdAt")
   List<ParticipantProjection> findViewsByDocumentIds(
       @Param("documentIds") Collection<UUID> documentIds);
+
+  /** Direct participations in NON-anonymous reviews (ADR-0038, issue #473). */
+  @Query(
+      "SELECT count(p) FROM ReviewParticipant p, Document d"
+          + " WHERE d.id = p.documentId AND p.userId = :userId AND d.anonymous = false")
+  long countPublicParticipations(@Param("userId") UUID userId);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/TeamMembershipRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/TeamMembershipRepository.java
@@ -49,4 +49,12 @@ public interface TeamMembershipRepository extends JpaRepository<TeamMembership, 
       "SELECT new io.qnop.repository.TeamMemberCount(m.teamId, COUNT(m)) "
           + "FROM TeamMembership m WHERE m.teamId IN :teamIds GROUP BY m.teamId")
   List<TeamMemberCount> countMembersByTeamIds(@Param("teamIds") Collection<UUID> teamIds);
+
+  /** The user's enabled teams with their role there, ordered by name (issue #473). */
+  @Query(
+      "SELECT new io.qnop.repository.UserTeamProjection(t.id, t.name, m.teamRole)"
+          + " FROM TeamMembership m, Team t"
+          + " WHERE t.id = m.teamId AND m.userId = :userId AND t.enabled = true"
+          + " ORDER BY t.name")
+  java.util.List<UserTeamProjection> findTeamsOfUser(@Param("userId") UUID userId);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/UserTeamProjection.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserTeamProjection.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.TeamRole;
+import java.util.UUID;
+
+/** One team a user belongs to, with their role — the public profile's affiliation row (#473). */
+public record UserTeamProjection(UUID teamId, String teamName, TeamRole teamRole) {}

--- a/qnop-core/src/main/java/io/qnop/service/PublicProfileService.java
+++ b/qnop-core/src/main/java/io/qnop/service/PublicProfileService.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.entity.User;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.repository.TeamMembershipRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.repository.UserTeamProjection;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The workspace-public profile (issues #454, #473): identity plus contribution aggregates and team
+ * affiliations. Activity counters cover NON-anonymous reviews only (ADR-0038) — a public number
+ * must never let anyone infer what anonymity hides; owned reviews count fully, since ownership is
+ * structurally public. Team rosters are workspace-visible through the principal directory, so the
+ * profile only aggregates what any member could already query.
+ */
+@Service
+public class PublicProfileService {
+
+  private final UserRepository users;
+  private final DocumentRepository documents;
+  private final ReviewParticipantRepository participants;
+  private final AnnotationRepository annotations;
+  private final CommentRepository comments;
+  private final TeamMembershipRepository teamMemberships;
+
+  public PublicProfileService(
+      UserRepository users,
+      DocumentRepository documents,
+      ReviewParticipantRepository participants,
+      AnnotationRepository annotations,
+      CommentRepository comments,
+      TeamMembershipRepository teamMemberships) {
+    this.users = users;
+    this.documents = documents;
+    this.participants = participants;
+    this.annotations = annotations;
+    this.comments = comments;
+    this.teamMemberships = teamMemberships;
+  }
+
+  @Transactional(readOnly = true)
+  public PublicProfileView getProfile(UUID id) {
+    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    PublicStatsView stats =
+        new PublicStatsView(
+            documents.countByOwnerId(id),
+            participants.countPublicParticipations(id),
+            annotations.countPublicByAuthor(id),
+            annotations.countPublicResolvedByAuthor(id),
+            comments.countPublicByAuthor(id));
+    List<UserTeamView> teams =
+        teamMemberships.findTeamsOfUser(id).stream().map(UserTeamView::of).toList();
+    return new PublicProfileView(
+        user.getId(), user.getDisplayName(), user.getCreatedAt(), stats, teams);
+  }
+
+  /** The public slice served by {@code GET /users/{userId}}. */
+  public record PublicProfileView(
+      UUID id,
+      String displayName,
+      Instant createdAt,
+      PublicStatsView stats,
+      List<UserTeamView> teams) {}
+
+  /** Contribution aggregates; see the class doc for the anonymity rule. */
+  public record PublicStatsView(
+      long reviewsOwned,
+      long reviewsParticipating,
+      long annotationsRaised,
+      long annotationsResolved,
+      long commentsWritten) {}
+
+  /** One team affiliation with the user's role there. */
+  public record UserTeamView(UUID id, String name, String role) {
+    static UserTeamView of(UserTeamProjection row) {
+      return new UserTeamView(row.teamId(), row.teamName(), row.teamRole().name());
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -108,17 +108,6 @@ public class UserService {
    * The lean, workspace-public slice of a user (issue #454): what any signed-in user may see about
    * a colleague — display name and tenure, nothing more (no email, role or source).
    */
-  @Transactional(readOnly = true)
-  public PublicUserProfileView getPublicProfile(UUID id) {
-    return users
-        .findById(id)
-        .map(u -> new PublicUserProfileView(u.getId(), u.getDisplayName(), u.getCreatedAt()))
-        .orElseThrow(() -> new UserNotFoundException(id));
-  }
-
-  /** The public slice served by {@code GET /users/{userId}} (issue #454). */
-  public record PublicUserProfileView(UUID id, String displayName, Instant createdAt) {}
-
   /** Activates a user after successful email verification. */
   @Transactional
   public User enable(UUID id) {

--- a/qnop-ui/src/components/profile/AchievementRow.tsx
+++ b/qnop-ui/src/components/profile/AchievementRow.tsx
@@ -25,7 +25,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import type { LucideIcon } from 'lucide-react';
-import { BellRing, Rocket, Smile, Trophy, Users } from 'lucide-react';
+import { BellRing, Eye, MessagesSquare, Rocket, Smile, Trophy, Users } from 'lucide-react';
 import type { Achievement } from './profileModel';
 
 const BADGE_ICONS: Record<string, LucideIcon> = {
@@ -34,6 +34,8 @@ const BADGE_ICONS: Record<string, LucideIcon> = {
   closer: Trophy,
   face: Smile,
   'tuned-in': BellRing,
+  voice: MessagesSquare,
+  'sharp-eye': Eye,
 };
 
 const BADGE_TONE: Record<string, 'blue' | 'warning' | 'success'> = {
@@ -42,6 +44,8 @@ const BADGE_TONE: Record<string, 'blue' | 'warning' | 'success'> = {
   closer: 'warning',
   face: 'blue',
   'tuned-in': 'success',
+  voice: 'blue',
+  'sharp-eye': 'warning',
 };
 
 /**

--- a/qnop-ui/src/components/profile/profileModel.test.ts
+++ b/qnop-ui/src/components/profile/profileModel.test.ts
@@ -21,7 +21,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type { DocumentSummary } from '../../api/generated';
-import { profileAchievements, profileStats } from './profileModel';
+import { profileAchievements, profileStats, publicProfileAchievements } from './profileModel';
 
 const ME = 'user-me';
 
@@ -69,5 +69,41 @@ describe('profileModel (issue #469)', () => {
     });
     expect(achievements.every((a) => !a.earned)).toBe(true);
     expect(achievements.find((a) => a.key === 'liftoff')?.caption).toBe('Start your first review');
+  });
+});
+
+describe('publicProfileAchievements (issue #473)', () => {
+  const stats = (overrides: Partial<import('../../api/generated').PublicUserStats> = {}) => ({
+    reviewsOwned: 0,
+    reviewsParticipating: 0,
+    annotationsRaised: 0,
+    annotationsResolved: 0,
+    commentsWritten: 0,
+    ...overrides,
+  });
+
+  it('locks everything for an inactive user with third-person captions', () => {
+    const achievements = publicProfileAchievements(stats());
+    expect(achievements.every((a) => !a.earned)).toBe(true);
+    expect(achievements.find((a) => a.key === 'liftoff')?.caption).toBe('No review started yet');
+  });
+
+  it('applies the milestone thresholds for voice and sharp eye', () => {
+    const below = publicProfileAchievements(stats({ commentsWritten: 9, annotationsRaised: 24 }));
+    expect(below.find((a) => a.key === 'voice')?.earned).toBe(false);
+    expect(below.find((a) => a.key === 'sharp-eye')?.earned).toBe(false);
+
+    const at = publicProfileAchievements(stats({ commentsWritten: 10, annotationsRaised: 25 }));
+    expect(at.find((a) => a.key === 'voice')?.earned).toBe(true);
+    expect(at.find((a) => a.key === 'sharp-eye')?.earned).toBe(true);
+  });
+
+  it('earns the shared badges from server aggregates', () => {
+    const achievements = publicProfileAchievements(
+      stats({ reviewsOwned: 1, reviewsParticipating: 2, annotationsResolved: 3 }),
+    );
+    expect(achievements.find((a) => a.key === 'liftoff')?.earned).toBe(true);
+    expect(achievements.find((a) => a.key === 'crew')?.earned).toBe(true);
+    expect(achievements.find((a) => a.key === 'closer')?.earned).toBe(true);
   });
 });

--- a/qnop-ui/src/components/profile/profileModel.ts
+++ b/qnop-ui/src/components/profile/profileModel.ts
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { DocumentSummary } from '../../api/generated';
+import type { DocumentSummary, PublicUserStats } from '../../api/generated';
 
 /** One achievement sticker on the player card (issue #469). */
 export interface Achievement {
@@ -92,6 +92,57 @@ export function profileAchievements(state: {
         ? 'Review mails keep you posted'
         : 'Switch review notifications on',
       earned: state.notificationsOn,
+    },
+  ];
+}
+
+/** Milestones for the voice / sharp-eye badges (issue #473). */
+const VOICE_MILESTONE = 10;
+const SHARP_EYE_MILESTONE = 25;
+
+/**
+ * The PUBLIC profile's achievements (issue #473), derived from the server's
+ * contribution aggregates — captions read in the third person, and the
+ * private badges (avatar, notifications) stay off a colleague's page.
+ */
+export function publicProfileAchievements(stats: PublicUserStats): Achievement[] {
+  return [
+    {
+      key: 'liftoff',
+      title: 'Liftoff',
+      caption: stats.reviewsOwned > 0 ? 'Started a review' : 'No review started yet',
+      earned: stats.reviewsOwned > 0,
+    },
+    {
+      key: 'crew',
+      title: 'Crew member',
+      caption: stats.reviewsParticipating > 0 ? 'Joined a review crew' : 'Not on a crew yet',
+      earned: stats.reviewsParticipating > 0,
+    },
+    {
+      key: 'closer',
+      title: 'Closer',
+      caption:
+        stats.annotationsResolved > 0 ? 'Resolved a raised concern' : 'No concern settled yet',
+      earned: stats.annotationsResolved > 0,
+    },
+    {
+      key: 'voice',
+      title: 'Voice',
+      caption:
+        stats.commentsWritten >= VOICE_MILESTONE
+          ? `${VOICE_MILESTONE}+ comments in discussions`
+          : `Earned at ${VOICE_MILESTONE} comments`,
+      earned: stats.commentsWritten >= VOICE_MILESTONE,
+    },
+    {
+      key: 'sharp-eye',
+      title: 'Sharp eye',
+      caption:
+        stats.annotationsRaised >= SHARP_EYE_MILESTONE
+          ? `${SHARP_EYE_MILESTONE}+ annotations raised`
+          : `Earned at ${SHARP_EYE_MILESTONE} annotations`,
+      earned: stats.annotationsRaised >= SHARP_EYE_MILESTONE,
     },
   ];
 }

--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -59,6 +59,7 @@ export function AppShell() {
   const reviewsListMatch = useMatch('/reviews');
   const adminMatch = useMatch('/admin/*');
   const profileMatch = useMatch('/profile');
+  const userProfileMatch = useMatch('/users/:userId');
   // The new-review wizard (#469 polish) spans the full width too — it lays out
   // as form + launch-checklist rail.
   const wizardMatch = Boolean(reviewMatch && reviewMatch.params.documentId === 'new');
@@ -68,6 +69,7 @@ export function AppShell() {
     Boolean(reviewsListMatch) ||
     Boolean(adminMatch) ||
     Boolean(profileMatch) ||
+    Boolean(userProfileMatch) ||
     wizardMatch;
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {

--- a/qnop-ui/src/pages/UserProfilePage.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.tsx
@@ -21,25 +21,55 @@
 
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
-import { CalendarDays } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import {
+  CalendarDays,
+  CheckCircle2,
+  Crown,
+  FileText,
+  MessagesSquare,
+  NotebookPen,
+  UserCheck,
+  Users,
+} from 'lucide-react';
 import { Navigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import type { PublicUserProfile } from '../api/generated';
 import { usersApi } from '../api/config';
 import { useAuthStore } from '../stores/authStore';
+import { AchievementRow } from '../components/profile/AchievementRow';
+import { publicProfileAchievements } from '../components/profile/profileModel';
 import { UserAvatar } from '../components/shell/UserAvatar';
 
 const SINCE_FORMAT = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
 
+const STAT_TILES: { key: keyof PublicUserProfile['stats']; label: string; icon: LucideIcon }[] = [
+  { key: 'reviewsOwned', label: 'Reviews owned', icon: FileText },
+  { key: 'reviewsParticipating', label: 'Reviewing', icon: UserCheck },
+  { key: 'annotationsRaised', label: 'Annotations raised', icon: NotebookPen },
+  { key: 'annotationsResolved', label: 'Resolved', icon: CheckCircle2 },
+  { key: 'commentsWritten', label: 'Comments', icon: MessagesSquare },
+];
+
+const fadeUp = {
+  '@keyframes publicProfileFadeUp': {
+    from: { opacity: 0, transform: 'translateY(10px)' },
+    to: { opacity: 1, transform: 'translateY(0)' },
+  },
+};
+
 /**
- * A colleague's workspace-public profile (issue #454): the person behind the
- * avatars and names linked across the dashboards — display name, picture and
- * tenure, deliberately nothing more. Your own id redirects to the full
- * {@code /profile}.
+ * A colleague's workspace-public profile (issues #454, #473): the campaign's
+ * player-card language — identity hero with team affiliations, the
+ * contribution scoreboard and the achievement stickers, all fed by the
+ * server's ADR-0038-safe aggregates. Your own id redirects to `/profile`.
  */
 export function UserProfilePage() {
   const theme = useTheme();
@@ -54,72 +84,206 @@ export function UserProfilePage() {
     enabled: Boolean(userId) && userId !== selfId,
   });
 
+  const blue = theme.qnop.brand.blue;
+  const dark = theme.qnop.mode === 'dark';
+  const stagger = (index: number) => ({
+    ...fadeUp,
+    animation: `publicProfileFadeUp 0.45s ${theme.transitions.easing.easeOut} both`,
+    animationDelay: `${index * 90}ms`,
+    '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+  });
+
   if (userId && userId === selfId) {
     return <Navigate to="/profile" replace />;
   }
   if (profileQuery.isPending) {
-    return <Skeleton variant="rounded" height={220} sx={{ maxWidth: 560 }} />;
+    return (
+      <Stack spacing={2.5}>
+        <Skeleton variant="rounded" height={210} />
+        <Skeleton variant="rounded" height={92} />
+        <Skeleton variant="rounded" height={130} />
+      </Stack>
+    );
   }
   if (profileQuery.isError || !profileQuery.data) {
     return <Alert severity="error">This user does not exist.</Alert>;
   }
 
   const profile = profileQuery.data;
+  const achievements = publicProfileAchievements(profile.stats);
+  const earnedCount = achievements.filter((a) => a.earned).length;
+
   return (
-    <Stack spacing={0} sx={{ maxWidth: 560 }}>
-      {/* A soft identity band — the avatar palette's tint as atmosphere. */}
-      <Box
+    <Stack spacing={2.5} data-testid="public-profile">
+      {/* Identity hero: the player card a colleague sees. */}
+      <Paper
+        variant="outlined"
         sx={{
-          height: 84,
-          borderRadius: '14px 14px 0 0',
-          background: `linear-gradient(120deg, ${alpha(theme.qnop.brand.blue, 0.16)}, ${alpha(
-            theme.qnop.brand.blue,
-            0.04,
-          )})`,
-          border: '1px solid',
-          borderBottom: 'none',
-          borderColor: 'divider',
-        }}
-      />
-      <Stack
-        spacing={1.5}
-        sx={{
-          px: 3,
-          pb: 3,
-          border: '1px solid',
-          borderTop: 'none',
-          borderColor: 'divider',
-          borderRadius: '0 0 14px 14px',
+          ...stagger(0),
+          overflow: 'hidden',
+          borderRadius: '16px',
         }}
       >
-        <Box sx={{ mt: -4.5 }}>
-          <Box
-            sx={{
-              display: 'inline-flex',
-              borderRadius: '50%',
-              border: '4px solid',
-              borderColor: 'background.paper',
-            }}
-          >
-            <UserAvatar name={profile.displayName} size={76} imageUrl={profile.avatarUrl ?? null} />
-          </Box>
-        </Box>
-        <Box>
-          <Typography variant="h2" sx={{ fontSize: '1.4rem' }}>
-            {profile.displayName}
-          </Typography>
+        <Box
+          aria-hidden
+          sx={{
+            height: 96,
+            background: `
+              radial-gradient(60% 150% at 80% 0%, ${alpha(blue, dark ? 0.28 : 0.16)} 0%, transparent 100%),
+              linear-gradient(120deg, ${alpha(blue, dark ? 0.18 : 0.1)}, ${alpha(blue, 0.03)})
+            `,
+          }}
+        />
+        <Box sx={{ px: { xs: 2.5, sm: 3 }, pb: 2.5 }}>
           <Stack
-            direction="row"
-            spacing={0.75}
-            sx={{ alignItems: 'center', color: 'text.secondary', mt: 0.5 }}
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={2}
+            sx={{ alignItems: { sm: 'flex-end' }, mt: -5 }}
           >
-            <CalendarDays size={14} aria-hidden />
-            <Typography variant="body2">
-              Member since {SINCE_FORMAT.format(new Date(profile.createdAt))}
-            </Typography>
+            <Box
+              sx={{
+                display: 'inline-flex',
+                borderRadius: '50%',
+                p: '3px',
+                bgcolor: 'background.paper',
+                border: `2px solid ${alpha(blue, 0.45)}`,
+                width: 'fit-content',
+              }}
+            >
+              <UserAvatar
+                name={profile.displayName}
+                size={84}
+                imageUrl={profile.avatarUrl ?? null}
+              />
+            </Box>
+            <Box sx={{ minWidth: 0, pb: 0.5 }}>
+              <Typography variant="h2" sx={{ fontSize: '1.5rem', lineHeight: 1.2 }}>
+                {profile.displayName}
+              </Typography>
+              <Stack
+                direction="row"
+                spacing={0.75}
+                sx={{ alignItems: 'center', color: 'text.secondary', mt: 0.5 }}
+              >
+                <CalendarDays size={14} aria-hidden />
+                <Typography variant="body2">
+                  Member since {SINCE_FORMAT.format(new Date(profile.createdAt))}
+                </Typography>
+              </Stack>
+            </Box>
           </Stack>
+
+          {profile.teams.length > 0 && (
+            <Stack
+              direction="row"
+              spacing={1}
+              useFlexGap
+              sx={{ flexWrap: 'wrap', mt: 2 }}
+              data-testid="profile-teams"
+            >
+              {profile.teams.map((team) => {
+                const lead = team.role === 'LEAD';
+                return (
+                  <Tooltip
+                    key={team.id}
+                    title={lead ? `Leads ${team.name}` : `Member of ${team.name}`}
+                  >
+                    <Chip
+                      size="small"
+                      icon={
+                        lead ? (
+                          <Crown size={13} style={{ color: theme.palette.warning.main }} />
+                        ) : (
+                          <Users size={13} />
+                        )
+                      }
+                      label={team.name}
+                      sx={{
+                        fontWeight: 500,
+                        ...(lead && {
+                          borderColor: alpha(theme.palette.warning.main, 0.5),
+                          bgcolor: alpha(theme.palette.warning.main, dark ? 0.14 : 0.08),
+                        }),
+                      }}
+                      variant="outlined"
+                    />
+                  </Tooltip>
+                );
+              })}
+            </Stack>
+          )}
         </Box>
-      </Stack>
+      </Paper>
+
+      {/* The contribution scoreboard — ADR-0038-safe aggregates. */}
+      <Box
+        sx={{
+          ...stagger(1),
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(5, 1fr)' },
+          gap: 1.5,
+        }}
+      >
+        {STAT_TILES.map(({ key, label, icon: Icon }) => {
+          const value = profile.stats[key];
+          return (
+            <Paper key={key} variant="outlined" sx={{ px: 2, py: 1.5, borderRadius: '12px' }}>
+              <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+                <Box
+                  aria-hidden
+                  sx={{
+                    width: 34,
+                    height: 34,
+                    borderRadius: '10px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                    color: value > 0 ? blue : 'text.secondary',
+                    bgcolor: alpha(
+                      value > 0 ? blue : theme.palette.text.secondary,
+                      dark ? 0.16 : 0.1,
+                    ),
+                  }}
+                >
+                  <Icon size={16} />
+                </Box>
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography
+                    sx={{
+                      fontSize: '1.4rem',
+                      fontWeight: 800,
+                      lineHeight: 1.2,
+                      fontVariantNumeric: 'tabular-nums',
+                      color: value > 0 ? 'text.primary' : 'text.disabled',
+                    }}
+                  >
+                    {value}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" noWrap component="p">
+                    {label}
+                  </Typography>
+                </Box>
+              </Stack>
+            </Paper>
+          );
+        })}
+      </Box>
+
+      {/* Achievements — the same sticker language as the own player card. */}
+      <Paper variant="outlined" sx={{ ...stagger(2), p: { xs: 2.5, sm: 3 }, borderRadius: '16px' }}>
+        <Stack
+          direction="row"
+          spacing={1}
+          sx={{ alignItems: 'baseline', justifyContent: 'space-between', mb: 1.5 }}
+        >
+          <Typography sx={{ fontSize: 14, fontWeight: 700 }}>Achievements</Typography>
+          <Typography variant="caption" color="text.secondary">
+            {earnedCount} of {achievements.length} earned
+          </Typography>
+        </Stack>
+        <AchievementRow achievements={achievements} />
+      </Paper>
     </Stack>
   );
 }


### PR DESCRIPTION
Closes #473.

## What

The public profile (`/users/:userId`) grows from name-and-tenure into the campaign's player card, fed by real backend aggregates.

### Backend (OpenAPI-first)

`GET /users/{id}` now carries:

- **`stats`** — reviews owned, participations, annotations raised/resolved, comments written. **Activity counters aggregate over NON-anonymous reviews only (ADR-0038)**: a public number never lets anyone infer what anonymity hides. Owned reviews count fully — ownership is structurally public. One count query each, no N+1. The IT proves both halves with a public and an anonymous review carrying identical activity.
- **`teams`** — the user's enabled teams with their role (`LEAD`/`MEMBER`), ordered by name. The profile aggregates only what the principal directory already exposes to every workspace member.
- The superseded minimal `UserService.getPublicProfile` is replaced by a dedicated `PublicProfileService`.

### Frontend

- **Identity hero**: gradient band, overlapping ringed avatar, tenure line, and team chips — a LEAD wears an amber crown accent with a "Leads …" tooltip.
- **Contribution scoreboard**: five stat tiles in the dashboard's numbers language (values glow, zeros wait dimmed).
- **Achievements** via the shared `AchievementRow`: Liftoff, Crew member and Closer join two new milestone badges — **Voice** (10+ comments) and **Sharp eye** (25+ annotations) — with third-person captions. The private badges (avatar, notifications) stay off a colleague's page.
- Skeleton/error states, staged entrance behind `prefers-reduced-motion`, both themes tuned, full-width layout; self-id still redirects to `/profile`.

## Tests

- `UserProfileApiIT`: stats correctness incl. the anonymous-review exclusion and the owner-count exception; teams with roles and the empty-team case; existing guards unchanged.
- `profileModel` unit tests for the public achievement derivation and milestone thresholds.
- Full gates green: `./gradlew build`, `pnpm lint` + `tsc` + 770 vitest tests. Verified live in both themes against seeded activity.

## Test plan

- [x] Colleague profile shows hero, team chips, five stats and 5 achievements from real data
- [x] Anonymous-review activity excluded from public counters; owned count complete
- [x] Users without teams/activity render gracefully (dimmed zeros, locked badges)
- [x] Self-id redirects to /profile; unknown user 404; unauthenticated 401

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)