### PR TITLE
feat(users): readable profile URLs via an immutable user slug

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1589,6 +1589,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /users/by-slug/{slug}:
+    get:
+      tags:
+        - Users
+      summary: Resolve a user's public profile by its slug
+      description: |
+        Resolves a colleague's workspace-public profile by the immutable,
+        human-readable profile slug (issue #486), auto-derived from the display
+        name at account creation. Matching ignores case. Slugs never look like
+        UUIDs, so `/users/{userId}` and this route can share links safely.
+      operationId: getUserProfileBySlug
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          description: The profile slug (kebab-case, 3-64 characters).
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 64
+      responses:
+        '200':
+          description: The user's public profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicUserProfile'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Unknown slug
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /users/me:
     get:
       tags:
@@ -3629,6 +3666,13 @@ components:
           format: uuid
         displayName:
           type: string
+        slug:
+          type: string
+          nullable: true
+          description: >-
+            Immutable, human-readable profile slug (issue #486), auto-derived
+            from the display name at account creation. Null only for accounts
+            created before slugs existed.
         avatarUrl:
           type: string
           nullable: true

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4404,6 +4404,12 @@ components:
             The author's REAL user id — null when the review anonymises this
             author towards the caller (issue #413); the client links and loads
             avatars only when present.
+        authorSlug:
+          type: string
+          nullable: true
+          description: >-
+            The author's profile slug (issue #486) for pretty profile links —
+            null under the same anonymity rule as `authorId`.
         authorAvatarUrl:
           type: string
           nullable: true
@@ -4450,6 +4456,12 @@ components:
           format: uuid
           nullable: true
           description: The actor's REAL user id — null when anonymised (issue #413).
+        actorSlug:
+          type: string
+          nullable: true
+          description: >-
+            The actor's profile slug (issue #486) for pretty profile links —
+            null under the same anonymity rule as `actorId`.
         actorAvatarUrl:
           type: string
           nullable: true

--- a/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
+++ b/qnop-app/src/main/java/io/qnop/web/CurrentUserController.java
@@ -76,29 +76,39 @@ public class CurrentUserController implements UsersApi {
   @Override
   public ResponseEntity<PublicUserProfile> getUserProfile(UUID userId) {
     CurrentUser.requireUserId(); // signed-in colleagues only, any role
-    PublicProfileService.PublicProfileView profile = publicProfiles.getProfile(userId);
-    return ResponseEntity.ok(
-        new PublicUserProfile()
-            .id(profile.id())
-            .displayName(profile.displayName())
-            .avatarUrl(AvatarUrls.forUser(userId, avatars.updatedAt(userId).orElse(null)))
-            .createdAt(profile.createdAt().atOffset(java.time.ZoneOffset.UTC))
-            .stats(
-                new PublicUserStats()
-                    .reviewsOwned((int) profile.stats().reviewsOwned())
-                    .reviewsParticipating((int) profile.stats().reviewsParticipating())
-                    .annotationsRaised((int) profile.stats().annotationsRaised())
-                    .annotationsResolved((int) profile.stats().annotationsResolved())
-                    .commentsWritten((int) profile.stats().commentsWritten()))
-            .teams(
-                profile.teams().stream()
-                    .map(
-                        team ->
-                            new PublicUserTeam()
-                                .id(team.id())
-                                .name(team.name())
-                                .role(PublicUserTeam.RoleEnum.fromValue(team.role())))
-                    .toList()));
+    return ResponseEntity.ok(toPublicUserProfile(publicProfiles.getProfile(userId)));
+  }
+
+  @Override
+  public ResponseEntity<PublicUserProfile> getUserProfileBySlug(String slug) {
+    CurrentUser.requireUserId(); // signed-in colleagues only, any role
+    return ResponseEntity.ok(toPublicUserProfile(publicProfiles.getProfileBySlug(slug)));
+  }
+
+  private PublicUserProfile toPublicUserProfile(PublicProfileService.PublicProfileView profile) {
+    UUID userId = profile.id();
+    return new PublicUserProfile()
+        .id(userId)
+        .displayName(profile.displayName())
+        .slug(profile.slug())
+        .avatarUrl(AvatarUrls.forUser(userId, avatars.updatedAt(userId).orElse(null)))
+        .createdAt(profile.createdAt().atOffset(java.time.ZoneOffset.UTC))
+        .stats(
+            new PublicUserStats()
+                .reviewsOwned((int) profile.stats().reviewsOwned())
+                .reviewsParticipating((int) profile.stats().reviewsParticipating())
+                .annotationsRaised((int) profile.stats().annotationsRaised())
+                .annotationsResolved((int) profile.stats().annotationsResolved())
+                .commentsWritten((int) profile.stats().commentsWritten()))
+        .teams(
+            profile.teams().stream()
+                .map(
+                    team ->
+                        new PublicUserTeam()
+                            .id(team.id())
+                            .name(team.name())
+                            .role(PublicUserTeam.RoleEnum.fromValue(team.role())))
+                .toList());
   }
 
   @ExceptionHandler(UserNotFoundException.class)

--- a/qnop-app/src/main/java/io/qnop/web/DashboardController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DashboardController.java
@@ -65,6 +65,7 @@ public class DashboardController implements DashboardApi {
         .documentTitle(view.documentTitle())
         .documentSlug(view.documentSlug())
         .authorId(view.authorId())
+        .authorSlug(view.authorSlug())
         .authorAvatarUrl(avatarUrlOf(view.authorId()))
         .authorDisplayName(view.authorDisplayName())
         .body(view.body())
@@ -79,6 +80,7 @@ public class DashboardController implements DashboardApi {
         .documentTitle(view.documentTitle())
         .documentSlug(view.documentSlug())
         .actorId(view.actorId())
+        .actorSlug(view.actorSlug())
         .actorAvatarUrl(avatarUrlOf(view.actorId()))
         .actorDisplayName(view.actorDisplayName())
         .createdAt(view.createdAt().atOffset(ZoneOffset.UTC));

--- a/qnop-app/src/test/java/io/qnop/review/DashboardApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DashboardApiIT.java
@@ -122,7 +122,37 @@ class DashboardApiIT extends SeededIntegrationTest {
         .andExpect(jsonPath("$.replies[1].body").value("will do"))
         .andExpect(jsonPath("$.replies[1].annotationId").value(mine))
         .andExpect(jsonPath("$.replies[1].authorId").value(AUDITOR_ID.toString()))
+        .andExpect(jsonPath("$.replies[1].authorSlug").value("avery-auditor"))
         .andExpect(jsonPath("$.replies[1].authorDisplayName").value("Avery Auditor"));
+  }
+
+  @Test
+  @DisplayName("anonymised identities carry no slug either (#486)")
+  void anonymisedIdentitiesCarryNoSlug() throws Exception {
+    Document document = new Document(MEMBER_ID, "Anonymous review");
+    document.setAnonymous(true);
+    documents.save(document);
+    participants.save(ReviewParticipant.forUser(document.getId(), AUDITOR_ID));
+    versions.save(
+        new DocumentVersion(
+            document.getId(),
+            1,
+            "sha256/cc/feedface",
+            "feedface",
+            "application/pdf",
+            10L,
+            MEMBER_ID));
+    String mine = createAnnotation(document.getId(), MEMBER_ID, "please clarify");
+    addComment(mine, AUDITOR_ID, "will do");
+
+    mockMvc
+        .perform(as(get("/api/v1/dashboard"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.replies[0].body").value("will do"))
+        // The pseudonymised author exposes neither id nor slug — a slug would
+        // deanonymise just as surely as the id (issue #413/#486).
+        .andExpect(jsonPath("$.replies[0].authorId").doesNotExist())
+        .andExpect(jsonPath("$.replies[0].authorSlug").doesNotExist());
   }
 
   @Test
@@ -149,6 +179,7 @@ class DashboardApiIT extends SeededIntegrationTest {
         // annotation.created is filtered out.
         .andExpect(jsonPath("$.activity[0].type").value("annotation.resolved"))
         .andExpect(jsonPath("$.activity[0].actorId").value(MEMBER_ID.toString()))
+        .andExpect(jsonPath("$.activity[0].actorSlug").value("mia-member"))
         .andExpect(jsonPath("$.activity[0].actorDisplayName").value("Mia Member"));
 
     mockMvc

--- a/qnop-app/src/test/java/io/qnop/web/UserProfileApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/UserProfileApiIT.java
@@ -59,10 +59,67 @@ class UserProfileApiIT extends SeededIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(MEMBER_ID.toString()))
         .andExpect(jsonPath("$.displayName").value("Mia Member"))
+        .andExpect(jsonPath("$.slug").value("mia-member"))
         .andExpect(jsonPath("$.createdAt").exists())
         // The lean slice: nothing beyond name, avatar and tenure.
         .andExpect(jsonPath("$.email").doesNotExist())
         .andExpect(jsonPath("$.role").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("resolves the profile by its slug, ignoring case (#486)")
+  void resolvesBySlug() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/users/by-slug/MIA-member")
+                .header("Authorization", "Bearer " + token(AUDITOR_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(MEMBER_ID.toString()))
+        .andExpect(jsonPath("$.slug").value("mia-member"))
+        .andExpect(jsonPath("$.displayName").value("Mia Member"))
+        .andExpect(jsonPath("$.stats").exists());
+
+    mockMvc
+        .perform(
+            get("/api/v1/users/by-slug/no-such-slug")
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("allocates collision-suffixed slugs at account creation (#486)")
+  void allocatesSuffixedSlugOnCollision() throws Exception {
+    // Seeded "Mia Member" already owns mia-member; two namesakes join after her.
+    createAdminUser("Mia Member", "mia2", "mia2@example.com");
+    createAdminUser("Mia Member", "mia3", "mia3@example.com");
+
+    mockMvc
+        .perform(
+            get("/api/v1/users/by-slug/mia-member-2")
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("Mia Member"));
+    mockMvc
+        .perform(
+            get("/api/v1/users/by-slug/mia-member-3")
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk());
+  }
+
+  private void createAdminUser(String displayName, String username, String email) throws Exception {
+    String body =
+        """
+        {"displayName":"%s","username":"%s","email":"%s",\
+        "role":"MEMBER","initialPassword":"a-strong-pass-1"}"""
+            .formatted(displayName, username, email);
+    mockMvc
+        .perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post(
+                    "/api/v1/admin/users")
+                .header("Authorization", "Bearer " + token(ADMIN_ID))
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isCreated());
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/entity/User.java
+++ b/qnop-core/src/main/java/io/qnop/entity/User.java
@@ -84,6 +84,15 @@ public class User {
   @Column(name = "last_login_at")
   private Instant lastLoginAt;
 
+  /**
+   * Immutable, human-readable profile slug (issue #486): kebab-case, globally unique
+   * case-insensitively, never UUID-shaped. Auto-derived from the display name at account creation
+   * ({@code io.qnop.service.UserSlugService}); null only for rows predating slugs. Format and
+   * uniqueness are pinned in Liquibase (migration 0001), not here (ADR-0020).
+   */
+  @Column(name = "slug", length = 64, updatable = false)
+  private String slug;
+
   @CreationTimestamp
   @Column(name = "created_at", nullable = false, updatable = false)
   private Instant createdAt;
@@ -141,6 +150,15 @@ public class User {
 
   public void setDisplayName(String displayName) {
     this.displayName = displayName;
+  }
+
+  public String getSlug() {
+    return slug;
+  }
+
+  /** Set once at account creation (the column is {@code updatable = false}). */
+  public void setSlug(String slug) {
+    this.slug = slug;
   }
 
   public String getEmail() {

--- a/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
@@ -57,6 +57,10 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   /** Resolves a user by the profile slug (issue #486) — uniqueness is per LOWER(slug). */
   Optional<User> findBySlugIgnoreCase(String slug);
 
+  /** Batch id→slug resolution for pretty profile links (issue #486). */
+  @Query("SELECT new io.qnop.repository.UserSlug(u.id, u.slug) FROM User u WHERE u.id IN :ids")
+  List<UserSlug> findSlugsByIdIn(@Param("ids") Collection<UUID> ids);
+
   /** True when the profile slug is already claimed, ignoring case (issue #486). */
   boolean existsBySlugIgnoreCase(String slug);
 

--- a/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
@@ -54,6 +54,12 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   /** Finds an internal user by exact username. */
   Optional<User> findByUsernameAndSource(String username, UserSource source);
 
+  /** Resolves a user by the profile slug (issue #486) — uniqueness is per LOWER(slug). */
+  Optional<User> findBySlugIgnoreCase(String slug);
+
+  /** True when the profile slug is already claimed, ignoring case (issue #486). */
+  boolean existsBySlugIgnoreCase(String slug);
+
   /**
    * Paginated admin search (issues #104/#124): an optional case-insensitive match on display name,
    * email or username, plus optional role and enabled-status filters. {@code q} must be passed

--- a/qnop-core/src/main/java/io/qnop/repository/UserSlug.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserSlug.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/** A user's id paired with just their profile slug (issue #486 pretty profile links). */
+public record UserSlug(UUID id, String slug) {}

--- a/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/AdminUserService.java
@@ -73,18 +73,21 @@ public class AdminUserService {
   private final PasswordEncoder passwordEncoder;
   private final PasswordResetFlowService passwordResetFlow;
   private final RefreshTokenService refreshTokens;
+  private final UserSlugService slugs;
 
   public AdminUserService(
       UserRepository users,
       OidcIdentityRepository oidcIdentities,
       PasswordEncoder passwordEncoder,
       PasswordResetFlowService passwordResetFlow,
-      RefreshTokenService refreshTokens) {
+      RefreshTokenService refreshTokens,
+      UserSlugService slugs) {
     this.users = users;
     this.oidcIdentities = oidcIdentities;
     this.passwordEncoder = passwordEncoder;
     this.passwordResetFlow = passwordResetFlow;
     this.refreshTokens = refreshTokens;
+    this.slugs = slugs;
   }
 
   /** A paginated, optionally filtered/sorted slice of users for the admin list. */
@@ -132,6 +135,7 @@ public class AdminUserService {
     User user = User.internal(displayName, normalizedEmail, username, passwordHash);
     user.setRole(requireRole(roleName));
     user.setEnabled(true);
+    user.setSlug(slugs.allocate(displayName));
     // Invited users have not chosen a password yet; password-set users must rotate the admin-chosen
     // one on first login. Either way the account must change its password before normal use.
     user.setPasswordChangeRequired(true);

--- a/qnop-core/src/main/java/io/qnop/service/PublicProfileService.java
+++ b/qnop-core/src/main/java/io/qnop/service/PublicProfileService.java
@@ -68,7 +68,21 @@ public class PublicProfileService {
 
   @Transactional(readOnly = true)
   public PublicProfileView getProfile(UUID id) {
-    User user = users.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+    return buildProfile(users.findById(id).orElseThrow(() -> new UserNotFoundException(id)));
+  }
+
+  /**
+   * Resolves a profile by the immutable, case-insensitively unique profile slug (issue #486).
+   * Unknown slugs answer the same 404 as unknown ids.
+   */
+  @Transactional(readOnly = true)
+  public PublicProfileView getProfileBySlug(String slug) {
+    return buildProfile(
+        users.findBySlugIgnoreCase(slug).orElseThrow(() -> new UserNotFoundException(slug)));
+  }
+
+  private PublicProfileView buildProfile(User user) {
+    UUID id = user.getId();
     PublicStatsView stats =
         new PublicStatsView(
             documents.countByOwnerId(id),
@@ -79,13 +93,14 @@ public class PublicProfileService {
     List<UserTeamView> teams =
         teamMemberships.findTeamsOfUser(id).stream().map(UserTeamView::of).toList();
     return new PublicProfileView(
-        user.getId(), user.getDisplayName(), user.getCreatedAt(), stats, teams);
+        id, user.getDisplayName(), user.getSlug(), user.getCreatedAt(), stats, teams);
   }
 
-  /** The public slice served by {@code GET /users/{userId}}. */
+  /** The public slice served by {@code GET /users/{userId}} and {@code /users/by-slug/{slug}}. */
   public record PublicProfileView(
       UUID id,
       String displayName,
+      String slug,
       Instant createdAt,
       PublicStatsView stats,
       List<UserTeamView> teams) {}

--- a/qnop-core/src/main/java/io/qnop/service/UserNotFoundException.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserNotFoundException.java
@@ -22,10 +22,14 @@ package io.qnop.service;
 
 import java.util.UUID;
 
-/** Thrown when a user lookup by id finds no matching {@code qnop_user} row. */
+/** Thrown when a user lookup by id or profile slug finds no matching {@code qnop_user} row. */
 public class UserNotFoundException extends RuntimeException {
 
   public UserNotFoundException(UUID id) {
     super("User not found: " + id);
+  }
+
+  public UserNotFoundException(String slug) {
+    super("User not found: slug=" + slug);
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/UserService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserService.java
@@ -45,10 +45,12 @@ public class UserService {
 
   private final UserRepository users;
   private final PasswordEncoder passwordEncoder;
+  private final UserSlugService slugs;
 
-  public UserService(UserRepository users, PasswordEncoder passwordEncoder) {
+  public UserService(UserRepository users, PasswordEncoder passwordEncoder, UserSlugService slugs) {
     this.users = users;
     this.passwordEncoder = passwordEncoder;
+    this.slugs = slugs;
   }
 
   /** Creates a disabled internal user with the given role, pending email verification. */
@@ -60,6 +62,7 @@ public class UserService {
         User.internal(name, normalizeEmail(email), username, passwordEncoder.encode(rawPassword));
     user.setRole(role);
     user.setEnabled(false);
+    user.setSlug(slugs.allocate(name));
     return users.save(user);
   }
 
@@ -132,6 +135,7 @@ public class UserService {
   public User provisionExternal(String displayName, String email) {
     User user = User.external(displayName, normalizeEmail(email));
     user.setEnabled(true);
+    user.setSlug(slugs.allocate(displayName));
     return users.save(user);
   }
 
@@ -168,6 +172,7 @@ public class UserService {
     admin.setRole(UserRole.ADMIN);
     admin.setEnabled(true);
     admin.setPasswordChangeRequired(passwordChangeRequired);
+    admin.setSlug(slugs.allocate(displayName));
     return users.save(admin);
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/UserSlugService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSlugService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * Allocates a free profile slug at account creation (issue #486): the {@link UserSlugs}-derived
+ * base, or the first free {@code base-n} candidate on collision. Every creation path
+ * (self-registration, OIDC provisioning, bootstrap admin, admin create) allocates through here so
+ * derivation and collision handling never drift apart.
+ *
+ * <p>The check-then-save window is racy in theory; {@code ux_qnop_user_slug_lower} backstops it, so
+ * two simultaneous registrations of the same display name can fail one request but never produce a
+ * duplicate slug.
+ */
+@Service
+public class UserSlugService {
+
+  private final UserRepository users;
+
+  public UserSlugService(UserRepository users) {
+    this.users = users;
+  }
+
+  /** The first free slug for a display name (participates in the caller's transaction). */
+  public String allocate(String displayName) {
+    String base = UserSlugs.derive(displayName);
+    for (int attempt = 1; ; attempt++) {
+      String candidate = UserSlugs.candidate(base, attempt);
+      if (!users.existsBySlugIgnoreCase(candidate)) {
+        return candidate;
+      }
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/UserSlugs.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSlugs.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import java.text.Normalizer;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Pure, DB-free derivation of profile slugs from display names (issue #486). The output always
+ * satisfies the {@code ck_qnop_user_slug} shape (kebab-case, 3-64 characters) and is never
+ * UUID-shaped, since routes resolve UUID-shaped segments as user ids. Uniqueness is NOT handled
+ * here — {@link UserSlugService} probes {@link #candidate(String, int)} against the database.
+ */
+public final class UserSlugs {
+
+  static final int MAX_LENGTH = 64;
+  private static final int MIN_LENGTH = 3;
+
+  /** Base for names that slugify to nothing (e.g. purely non-Latin symbols). */
+  private static final String FALLBACK = "user";
+
+  private static final Pattern MARKS = Pattern.compile("\\p{M}+");
+  private static final Pattern NON_ALNUM = Pattern.compile("[^a-z0-9]+");
+  private static final Pattern EDGE_HYPHENS = Pattern.compile("^-+|-+$");
+  private static final Pattern TRAILING_HYPHENS = Pattern.compile("-+$");
+  private static final Pattern UUID_SHAPE =
+      Pattern.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+
+  private UserSlugs() {}
+
+  /**
+   * Derives the base slug for a display name: diacritics folded (NFKD), lowercased, every
+   * non-alphanumeric run collapsed to a single hyphen. Too-short (and, defensively, UUID-shaped)
+   * results are suffixed with {@code -user}; empty results fall back to {@code user}.
+   */
+  public static String derive(String displayName) {
+    String folded =
+        displayName == null
+            ? ""
+            : MARKS
+                .matcher(Normalizer.normalize(displayName, Normalizer.Form.NFKD))
+                .replaceAll("")
+                .toLowerCase(Locale.ROOT);
+    String base = EDGE_HYPHENS.matcher(NON_ALNUM.matcher(folded).replaceAll("-")).replaceAll("");
+    if (base.isEmpty()) {
+      return FALLBACK;
+    }
+    if (base.length() < MIN_LENGTH || UUID_SHAPE.matcher(base).matches()) {
+      base = base + "-" + FALLBACK;
+    }
+    return truncate(base);
+  }
+
+  /**
+   * The n-th collision candidate for a base slug: the base itself for attempt 1, {@code base-n}
+   * afterwards — truncating the base so the suffixed result stays within {@value #MAX_LENGTH}
+   * characters without a doubled hyphen.
+   */
+  public static String candidate(String base, int attempt) {
+    if (attempt <= 1) {
+      return base;
+    }
+    String suffix = "-" + attempt;
+    String head = base;
+    if (head.length() + suffix.length() > MAX_LENGTH) {
+      head =
+          TRAILING_HYPHENS.matcher(head.substring(0, MAX_LENGTH - suffix.length())).replaceAll("");
+    }
+    return head + suffix;
+  }
+
+  private static String truncate(String slug) {
+    if (slug.length() <= MAX_LENGTH) {
+      return slug;
+    }
+    return TRAILING_HYPHENS.matcher(slug.substring(0, MAX_LENGTH)).replaceAll("");
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/DashboardService.java
@@ -32,11 +32,15 @@ import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.CommentRepository;
 import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.repository.UserSlug;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
 import org.springframework.data.domain.PageRequest;
@@ -84,18 +88,21 @@ public class DashboardService {
   private final CommentRepository comments;
   private final AuditEventRepository auditEvents;
   private final ReviewIdentityResolver identity;
+  private final UserRepository users;
 
   public DashboardService(
       DocumentRepository documents,
       AnnotationRepository annotations,
       CommentRepository comments,
       AuditEventRepository auditEvents,
-      ReviewIdentityResolver identity) {
+      ReviewIdentityResolver identity,
+      UserRepository users) {
     this.documents = documents;
     this.annotations = annotations;
     this.comments = comments;
     this.auditEvents = auditEvents;
     this.identity = identity;
+    this.users = users;
   }
 
   /**
@@ -110,6 +117,7 @@ public class DashboardService {
       String documentTitle,
       String documentSlug,
       UUID authorId,
+      String authorSlug,
       String authorDisplayName,
       String body,
       String annotationExcerpt,
@@ -122,6 +130,7 @@ public class DashboardService {
       String documentTitle,
       String documentSlug,
       UUID actorId,
+      String actorSlug,
       String actorDisplayName,
       Instant createdAt) {}
 
@@ -169,6 +178,7 @@ public class DashboardService {
     Map<UUID, Annotation> annotationById =
         annotations.findAllById(annotationIds).stream()
             .collect(toMap(Annotation::getId, annotation -> annotation));
+    Map<UUID, String> slugById = slugsOf(latest.stream().map(Comment::getAuthorId).toList());
     // The thread's opening line as context — batched like the views do (#393).
     Map<UUID, String> contextByAnnotation =
         comments.findFirstByAnnotationIdIn(annotationIds).stream()
@@ -183,13 +193,15 @@ public class DashboardService {
               Document document = documentById.get(annotation.getDocumentId());
               ReviewIdentityResolver.ReviewIdentities documentIdentities =
                   identitiesOf.apply(document.getId());
+              UUID realAuthor = realIdOrNull(documentIdentities, comment.getAuthorId());
               return new ReplyView(
                   comment.getId(),
                   comment.getAnnotationId(),
                   document.getId(),
                   document.getTitle(),
                   document.getSlug(),
-                  realIdOrNull(documentIdentities, comment.getAuthorId()),
+                  realAuthor,
+                  realAuthor == null ? null : slugById.get(realAuthor),
                   documentIdentities.displayName(comment.getAuthorId()),
                   excerpt(comment.getBody(), REPLY_EXCERPT_CHARS),
                   contextByAnnotation.get(comment.getAnnotationId()),
@@ -207,6 +219,7 @@ public class DashboardService {
     List<AuditEvent> events =
         auditEvents.findByDocumentIdInAndEventTypeInOrderByCreatedAtDesc(
             documentIds, FEED_EVENT_TYPES, PageRequest.of(0, MAX_ACTIVITY * 3));
+    Map<UUID, String> slugById = slugsOf(events.stream().map(AuditEvent::getActorId).toList());
     return events.stream()
         .filter(event -> !actor.equals(event.getActorId()))
         .filter(event -> visibleActivity(event, documentById.get(event.getDocumentId()), actor))
@@ -216,14 +229,17 @@ public class DashboardService {
               Document document = documentById.get(event.getDocumentId());
               ReviewIdentityResolver.ReviewIdentities documentIdentities =
                   identitiesOf.apply(document.getId());
+              UUID realActor =
+                  event.getActorId() == null
+                      ? null
+                      : realIdOrNull(documentIdentities, event.getActorId());
               return new ActivityView(
                   event.getEventType(),
                   document.getId(),
                   document.getTitle(),
                   document.getSlug(),
-                  event.getActorId() == null
-                      ? null
-                      : realIdOrNull(documentIdentities, event.getActorId()),
+                  realActor,
+                  realActor == null ? null : slugById.get(realActor),
                   event.getActorId() == null
                       ? null
                       : documentIdentities.displayName(event.getActorId()),
@@ -255,6 +271,20 @@ public class DashboardService {
   private static UUID realIdOrNull(
       ReviewIdentityResolver.ReviewIdentities identities, UUID userId) {
     return userId.equals(identities.exposedAuthorId(userId)) ? userId : null;
+  }
+
+  /**
+   * Batch id→slug map for pretty profile links (issue #486). Fed the CANDIDATE ids (pre-anonymity);
+   * the mappers only read entries for identities they expose anyway, so nothing anonymised leaks.
+   */
+  private Map<UUID, String> slugsOf(Collection<UUID> candidateIds) {
+    List<UUID> ids = candidateIds.stream().filter(Objects::nonNull).distinct().toList();
+    if (ids.isEmpty()) {
+      return Map.of();
+    }
+    return users.findSlugsByIdIn(ids).stream()
+        .filter(row -> row.slug() != null)
+        .collect(toMap(UserSlug::id, UserSlug::slug));
   }
 
   private static String excerpt(String body, int max) {

--- a/qnop-core/src/main/resources/db/changelog/migrations/0001-identity-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0001-identity-schema.yaml
@@ -50,6 +50,10 @@ databaseChangeLog:
                   constraints: { nullable: false }
               - column: { name: password_invalidated_before, type: TIMESTAMP WITH TIME ZONE }
               - column: { name: last_login_at, type: TIMESTAMP WITH TIME ZONE }
+              # Immutable, human-readable profile slug (issue #486), auto-derived
+              # from the display name at account creation; nullable only for rows
+              # predating slugs. Uniqueness/format pinned by the SQL block below.
+              - column: { name: slug, type: VARCHAR(64) }
               - column:
                   name: created_at
                   type: TIMESTAMP WITH TIME ZONE
@@ -81,6 +85,10 @@ databaseChangeLog:
                 ON qnop_user (LOWER(email)) WHERE source = 'INTERNAL';
               CREATE UNIQUE INDEX ux_qnop_user_username_internal
                 ON qnop_user (username) WHERE source = 'INTERNAL';
+              CREATE UNIQUE INDEX ux_qnop_user_slug_lower
+                ON qnop_user (LOWER(slug)) WHERE slug IS NOT NULL;
+              ALTER TABLE qnop_user ADD CONSTRAINT ck_qnop_user_slug
+                CHECK (slug IS NULL OR (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$' AND length(slug) BETWEEN 3 AND 64));
 
   - changeSet:
       id: 0001-identity-oidc-provider

--- a/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
@@ -60,9 +60,15 @@ class AdminUserServiceTest {
   private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
   private final PasswordResetFlowService passwordResetFlow = mock(PasswordResetFlowService.class);
   private final RefreshTokenService refreshTokens = mock(RefreshTokenService.class);
+  // The mocked repository reports every slug candidate free, so the base slug wins (issue #486).
   private final AdminUserService service =
       new AdminUserService(
-          users, oidcIdentities, passwordEncoder, passwordResetFlow, refreshTokens);
+          users,
+          oidcIdentities,
+          passwordEncoder,
+          passwordResetFlow,
+          refreshTokens,
+          new UserSlugService(users));
 
   private void noClash() {
     when(users.existsByEmailIgnoreCaseAndSource(any(), any())).thenReturn(false);

--- a/qnop-core/src/test/java/io/qnop/service/UserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/UserServiceTest.java
@@ -42,7 +42,9 @@ class UserServiceTest {
 
   private final UserRepository users = mock(UserRepository.class);
   private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
-  private final UserService service = new UserService(users, passwordEncoder);
+  // The mocked repository reports every slug candidate free, so the base slug wins (issue #486).
+  private final UserService service =
+      new UserService(users, passwordEncoder, new UserSlugService(users));
 
   @Test
   @DisplayName("getProfile returns an entity-free view with role and source as names")

--- a/qnop-core/src/test/java/io/qnop/service/UserSlugsTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/UserSlugsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Profile-slug derivation (issue #486): kebab-case, 3-64 chars, never UUID-shaped. */
+class UserSlugsTest {
+
+  @Test
+  @DisplayName("derives a kebab-case slug from a display name")
+  void derivesKebabCase() {
+    assertThat(UserSlugs.derive("Anna Krause")).isEqualTo("anna-krause");
+    assertThat(UserSlugs.derive("  J.  R.  R.  Tolkien ")).isEqualTo("j-r-r-tolkien");
+    assertThat(UserSlugs.derive("O'Brien, Seán")).isEqualTo("o-brien-sean");
+  }
+
+  @Test
+  @DisplayName("folds diacritics instead of dropping the letters")
+  void foldsDiacritics() {
+    assertThat(UserSlugs.derive("Åsa Ödegård-Müller")).isEqualTo("asa-odegard-muller");
+    assertThat(UserSlugs.derive("François Nuñez")).isEqualTo("francois-nunez");
+  }
+
+  @Test
+  @DisplayName("falls back for names that slugify to nothing or too little")
+  void fallsBack() {
+    assertThat(UserSlugs.derive(null)).isEqualTo("user");
+    assertThat(UserSlugs.derive("   ")).isEqualTo("user");
+    assertThat(UserSlugs.derive("霞")).isEqualTo("user");
+    assertThat(UserSlugs.derive("Al")).isEqualTo("al-user");
+  }
+
+  @Test
+  @DisplayName("never yields a UUID-shaped slug (routes resolve those as ids)")
+  void neverUuidShaped() {
+    assertThat(UserSlugs.derive("123e4567-e89b-12d3-a456-426614174000"))
+        .isEqualTo("123e4567-e89b-12d3-a456-426614174000-user");
+  }
+
+  @Test
+  @DisplayName("truncates to 64 characters without a trailing hyphen")
+  void truncates() {
+    String slug = UserSlugs.derive("x".repeat(63) + " tail");
+    assertThat(slug).hasSize(63).isEqualTo("x".repeat(63));
+  }
+
+  @Test
+  @DisplayName("suffixes collision candidates, keeping the total within 64 characters")
+  void collisionCandidates() {
+    assertThat(UserSlugs.candidate("anna-krause", 1)).isEqualTo("anna-krause");
+    assertThat(UserSlugs.candidate("anna-krause", 2)).isEqualTo("anna-krause-2");
+    assertThat(UserSlugs.candidate("anna-krause", 13)).isEqualTo("anna-krause-13");
+
+    String longBase = "x".repeat(64);
+    String candidate = UserSlugs.candidate(longBase, 2);
+    assertThat(candidate).hasSize(64).endsWith("-2").doesNotContain("--");
+  }
+}

--- a/qnop-ui/src/components/dashboard/ActivityCard.tsx
+++ b/qnop-ui/src/components/dashboard/ActivityCard.tsx
@@ -93,6 +93,7 @@ export function ActivityCard({ activity }: ActivityCardProps) {
                   <Box sx={{ pt: '1px', flexShrink: 0 }}>
                     <PersonLink
                       userId={item.actorId}
+                      slug={item.actorSlug}
                       name={item.actorDisplayName ?? 'Someone'}
                       avatarUrl={item.actorAvatarUrl}
                       size={20}

--- a/qnop-ui/src/components/dashboard/PersonLink.test.tsx
+++ b/qnop-ui/src/components/dashboard/PersonLink.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { useAuthStore } from '../../stores/authStore';
+import { PersonLink } from './PersonLink';
+
+const ANNA_ID = '123e4567-e89b-12d3-a456-426614174000';
+const SELF_ID = '999e4567-e89b-12d3-a456-426614174999';
+
+function renderLink(props: Parameters<typeof PersonLink>[0]) {
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter>
+        <PersonLink {...props} />
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  useAuthStore.setState({ userId: SELF_ID });
+});
+
+describe('PersonLink profile targets (issues #454, #486)', () => {
+  it('prefers the profile slug for the link target', () => {
+    renderLink({ userId: ANNA_ID, slug: 'anna-krause', name: 'Anna Krause' });
+    expect(screen.getByRole('link', { name: "View Anna Krause's profile" })).toHaveAttribute(
+      'href',
+      '/users/anna-krause',
+    );
+  });
+
+  it('falls back to the id for accounts without a slug', () => {
+    renderLink({ userId: ANNA_ID, name: 'Anna Krause' });
+    expect(screen.getByRole('link', { name: "View Anna Krause's profile" })).toHaveAttribute(
+      'href',
+      `/users/${ANNA_ID}`,
+    );
+  });
+
+  it('links yourself to /profile regardless of the slug', () => {
+    renderLink({ userId: SELF_ID, slug: 'me-myself', name: 'Me Myself' });
+    expect(screen.getByRole('link', { name: "View Me Myself's profile" })).toHaveAttribute(
+      'href',
+      '/profile',
+    );
+  });
+
+  it('renders pseudonymised identities without any link', () => {
+    renderLink({ name: 'Reviewer 2' });
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('Reviewer 2')).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/dashboard/PersonLink.tsx
+++ b/qnop-ui/src/components/dashboard/PersonLink.tsx
@@ -32,6 +32,11 @@ interface PersonLinkProps {
    * (issue #413), which then render as a plain avatar+name without a link.
    */
   userId?: string | null;
+  /**
+   * The person's profile slug (issue #486) — preferred over the id for the
+   * link target, absent under the same anonymity rule.
+   */
+  slug?: string | null;
   name: string;
   /** Server-built avatar URL (null when none is uploaded). */
   avatarUrl?: string | null;
@@ -43,11 +48,13 @@ interface PersonLinkProps {
 /**
  * A person as the product shows people (issue #454): avatar and bold name in
  * one unit, linking to the profile — `/profile` for yourself, the colleague's
- * `/users/{id}` page otherwise. Pseudonymised identities stay unlinked and
- * initials-only, so anonymity never leaks through a click.
+ * `/users/{slug}` page otherwise (falling back to the id for accounts without
+ * a slug). Pseudonymised identities stay unlinked and initials-only, so
+ * anonymity never leaks through a click.
  */
 export function PersonLink({
   userId,
+  slug,
   name,
   avatarUrl,
   size = 26,
@@ -55,7 +62,7 @@ export function PersonLink({
 }: PersonLinkProps) {
   const theme = useTheme();
   const selfId = useAuthStore((s) => s.userId);
-  const to = userId ? (userId === selfId ? '/profile' : `/users/${userId}`) : null;
+  const to = userId ? (userId === selfId ? '/profile' : `/users/${slug ?? userId}`) : null;
 
   const body = (
     <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', minWidth: 0 }}>

--- a/qnop-ui/src/components/dashboard/RepliesCard.tsx
+++ b/qnop-ui/src/components/dashboard/RepliesCard.tsx
@@ -92,6 +92,7 @@ export function RepliesCard({ replies }: RepliesCardProps) {
                     >
                       <PersonLink
                         userId={reply.authorId}
+                        slug={reply.authorSlug}
                         name={reply.authorDisplayName ?? 'Participant'}
                         avatarUrl={reply.authorAvatarUrl}
                       />

--- a/qnop-ui/src/pages/UserProfilePage.test.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AxiosResponse } from 'axios';
+import type { PublicUserProfile } from '../api/generated';
+import { usersApi } from '../api/config';
+import { buildTheme } from '../theme/theme';
+import { useAuthStore } from '../stores/authStore';
+import { UserProfilePage } from './UserProfilePage';
+
+vi.mock('../api/config', () => ({
+  usersApi: {
+    getUserProfile: vi.fn(),
+    getUserProfileBySlug: vi.fn(),
+  },
+}));
+
+const ANNA_ID = '123e4567-e89b-12d3-a456-426614174000';
+const SELF_ID = '999e4567-e89b-12d3-a456-426614174999';
+
+function profile(overrides: Partial<PublicUserProfile> = {}): PublicUserProfile {
+  return {
+    id: ANNA_ID,
+    displayName: 'Anna Krause',
+    slug: 'anna-krause',
+    createdAt: '2026-01-05T09:10:00Z',
+    stats: {
+      reviewsOwned: 1,
+      reviewsParticipating: 2,
+      annotationsRaised: 3,
+      annotationsResolved: 1,
+      commentsWritten: 4,
+    },
+    teams: [],
+    ...overrides,
+  };
+}
+
+function respond(data: PublicUserProfile) {
+  return Promise.resolve({ data } as AxiosResponse<PublicUserProfile>);
+}
+
+function LocationProbe() {
+  return <div data-testid="location">{useLocation().pathname}</div>;
+}
+
+function renderPage(segment: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/users/${segment}`]}>
+          <Routes>
+            <Route
+              path="/users/:userId"
+              element={
+                <>
+                  <UserProfilePage />
+                  <LocationProbe />
+                </>
+              }
+            />
+            <Route path="/profile" element={<div data-testid="own-profile" />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({ userId: SELF_ID });
+});
+
+describe('UserProfilePage slug URLs (issue #486)', () => {
+  it('resolves a slug segment via the by-slug endpoint and keeps the pretty URL', async () => {
+    vi.mocked(usersApi.getUserProfileBySlug).mockReturnValue(respond(profile()) as never);
+
+    renderPage('anna-krause');
+
+    expect(await screen.findByText('Anna Krause')).toBeInTheDocument();
+    expect(usersApi.getUserProfileBySlug).toHaveBeenCalledWith({ slug: 'anna-krause' });
+    expect(usersApi.getUserProfile).not.toHaveBeenCalled();
+    expect(screen.getByTestId('location')).toHaveTextContent('/users/anna-krause');
+  });
+
+  it('canonicalises a UUID visit to the slug URL without refetching', async () => {
+    vi.mocked(usersApi.getUserProfile).mockReturnValue(respond(profile()) as never);
+
+    renderPage(ANNA_ID);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent('/users/anna-krause'),
+    );
+    expect(screen.getByText('Anna Krause')).toBeInTheDocument();
+    expect(usersApi.getUserProfile).toHaveBeenCalledWith({ userId: ANNA_ID });
+    // The slug cache entry was seeded before the replace — no second fetch.
+    expect(usersApi.getUserProfileBySlug).not.toHaveBeenCalled();
+  });
+
+  it('stays on the UUID URL for profiles without a slug', async () => {
+    vi.mocked(usersApi.getUserProfile).mockReturnValue(
+      respond(profile({ slug: undefined })) as never,
+    );
+
+    renderPage(ANNA_ID);
+
+    expect(await screen.findByText('Anna Krause')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent(`/users/${ANNA_ID}`);
+  });
+
+  it('redirects the own slug to /profile once the payload identifies the viewer', async () => {
+    vi.mocked(usersApi.getUserProfileBySlug).mockReturnValue(
+      respond(profile({ id: SELF_ID, displayName: 'Me Myself', slug: 'me-myself' })) as never,
+    );
+
+    renderPage('me-myself');
+
+    expect(await screen.findByTestId('own-profile')).toBeInTheDocument();
+  });
+
+  it('redirects the own id to /profile without fetching', () => {
+    renderPage(SELF_ID);
+
+    expect(screen.getByTestId('own-profile')).toBeInTheDocument();
+    expect(usersApi.getUserProfile).not.toHaveBeenCalled();
+    expect(usersApi.getUserProfileBySlug).not.toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/pages/UserProfilePage.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.tsx
@@ -39,8 +39,9 @@ import {
   UserCheck,
   Users,
 } from 'lucide-react';
-import { Navigate, useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { PublicUserProfile } from '../api/generated';
 import { usersApi } from '../api/config';
 import { useAuthStore } from '../stores/authStore';
@@ -65,24 +66,51 @@ const fadeUp = {
   },
 };
 
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const profileKey = (segment: string) => ['users', 'public-profile', segment] as const;
+
 /**
  * A colleague's workspace-public profile (issues #454, #473): the campaign's
  * player-card language — identity hero with team affiliations, the
  * contribution scoreboard and the achievement stickers, all fed by the
- * server's ADR-0038-safe aggregates. Your own id redirects to `/profile`.
+ * server's ADR-0038-safe aggregates. Your own profile redirects to `/profile`.
+ *
+ * The `/users/:userId` segment accepts an id OR the profile slug (issue
+ * #486, the ReviewParamGate convention): UUID-shaped segments resolve by id,
+ * anything else via the by-slug endpoint — and an id visit is canonicalised
+ * to the pretty slug URL once the profile is known.
  */
 export function UserProfilePage() {
   const theme = useTheme();
-  const { userId } = useParams<{ userId: string }>();
+  const { userId: segment = '' } = useParams<{ userId: string }>();
+  const isId = UUID_SHAPE.test(segment);
   const selfId = useAuthStore((s) => s.userId);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const profileQuery = useQuery<PublicUserProfile>({
-    queryKey: ['users', 'public-profile', userId],
+    queryKey: profileKey(segment),
     queryFn: async () => {
-      const response = await usersApi.getUserProfile({ userId: userId as string });
+      const response = isId
+        ? await usersApi.getUserProfile({ userId: segment })
+        : await usersApi.getUserProfileBySlug({ slug: segment });
       return response.data;
     },
-    enabled: Boolean(userId) && userId !== selfId,
+    enabled: segment !== '' && segment !== selfId,
+    // Keeps the canonical UUID→slug replace below fetch-free: the seeded
+    // cache entry is still fresh when the slug URL mounts.
+    staleTime: 30_000,
   });
+
+  // Canonicalise /users/<uuid> to /users/<slug>: seed the slug's cache entry
+  // first so the replace renders instantly instead of refetching.
+  const loadedSlug = profileQuery.data?.slug;
+  useEffect(() => {
+    if (isId && loadedSlug && profileQuery.data) {
+      queryClient.setQueryData(profileKey(loadedSlug), profileQuery.data);
+      navigate(`/users/${loadedSlug}`, { replace: true });
+    }
+  }, [isId, loadedSlug, profileQuery.data, queryClient, navigate]);
 
   const blue = theme.qnop.brand.blue;
   const dark = theme.qnop.mode === 'dark';
@@ -93,7 +121,9 @@ export function UserProfilePage() {
     '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
   });
 
-  if (userId && userId === selfId) {
+  // Own profile: the id short-circuits before fetching; a slug visit is
+  // recognised once the payload's id matches.
+  if ((segment !== '' && segment === selfId) || profileQuery.data?.id === selfId) {
     return <Navigate to="/profile" replace />;
   }
   if (profileQuery.isPending) {

--- a/testdata/db/seed.sql
+++ b/testdata/db/seed.sql
@@ -17,31 +17,31 @@
 -- Users: one per role / source / state.
 -- ---------------------------------------------------------------------------
 INSERT INTO qnop_user
-  (id, display_name, email, source, username, password_hash, enabled,
+  (id, display_name, slug, email, source, username, password_hash, enabled,
    password_change_required, role, last_login_at, created_at, updated_at, version)
 VALUES
-  ('a0000000-0000-0000-0000-000000000001', 'Ada Admin', 'admin@qnop.test', 'INTERNAL',
+  ('a0000000-0000-0000-0000-000000000001', 'Ada Admin', 'ada-admin', 'admin@qnop.test', 'INTERNAL',
    'admin', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true,
    false, 'ADMIN', TIMESTAMPTZ '2026-02-01 09:00:00+00', TIMESTAMPTZ '2026-01-01 08:00:00+00', TIMESTAMPTZ '2026-01-01 08:00:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000008', 'Boss Admin', 'admin2@qnop.test', 'INTERNAL',
+  ('a0000000-0000-0000-0000-000000000008', 'Boss Admin', 'boss-admin', 'admin2@qnop.test', 'INTERNAL',
    'admin2', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true,
    false, 'ADMIN', NULL, TIMESTAMPTZ '2026-01-01 08:05:00+00', TIMESTAMPTZ '2026-01-01 08:05:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000002', 'Mia Member', 'member@qnop.test', 'INTERNAL',
+  ('a0000000-0000-0000-0000-000000000002', 'Mia Member', 'mia-member', 'member@qnop.test', 'INTERNAL',
    'member', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true,
    false, 'MEMBER', TIMESTAMPTZ '2026-02-02 12:30:00+00', TIMESTAMPTZ '2026-01-01 08:10:00+00', TIMESTAMPTZ '2026-01-01 08:10:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000003', 'Max Member', 'member2@qnop.test', 'INTERNAL',
+  ('a0000000-0000-0000-0000-000000000003', 'Max Member', 'max-member', 'member2@qnop.test', 'INTERNAL',
    'member2', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true,
    false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-01 08:15:00+00', TIMESTAMPTZ '2026-01-01 08:15:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000004', 'Avery Auditor', 'auditor@qnop.test', 'INTERNAL',
+  ('a0000000-0000-0000-0000-000000000004', 'Avery Auditor', 'avery-auditor', 'auditor@qnop.test', 'INTERNAL',
    'auditor', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true,
    false, 'AUDITOR', NULL, TIMESTAMPTZ '2026-01-01 08:20:00+00', TIMESTAMPTZ '2026-01-01 08:20:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000005', 'Dana Disabled', 'disabled@qnop.test', 'INTERNAL',
+  ('a0000000-0000-0000-0000-000000000005', 'Dana Disabled', 'dana-disabled', 'disabled@qnop.test', 'INTERNAL',
    'disabled', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', false,
    false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-01 08:25:00+00', TIMESTAMPTZ '2026-01-01 08:25:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000006', 'Pat Pending', 'pwchange@qnop.test', 'INTERNAL',
+  ('a0000000-0000-0000-0000-000000000006', 'Pat Pending', 'pat-pending', 'pwchange@qnop.test', 'INTERNAL',
    'pwchange', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true,
    true, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-01 08:30:00+00', TIMESTAMPTZ '2026-01-01 08:30:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000007', 'Ext Ernal', 'external@qnop.test', 'EXTERNAL',
+  ('a0000000-0000-0000-0000-000000000007', 'Ext Ernal', 'ext-ernal', 'external@qnop.test', 'EXTERNAL',
    NULL, NULL, true,
    false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-01 08:35:00+00', TIMESTAMPTZ '2026-01-01 08:35:00+00', 0);
 
@@ -97,29 +97,29 @@ VALUES
 -- MEMBER only: SeededAdminUsersIT pins the ADMIN (2) and AUDITOR (1) counts.
 -- ---------------------------------------------------------------------------
 INSERT INTO qnop_user
-  (id, display_name, email, source, username, password_hash, enabled,
+  (id, display_name, slug, email, source, username, password_hash, enabled,
    password_change_required, role, last_login_at, created_at, updated_at, version)
 VALUES
-  ('a0000000-0000-0000-0000-000000000009', 'Nora Weber',    'nora@qnop.test',  'INTERNAL', 'nora',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:00:00+00', TIMESTAMPTZ '2026-01-05 09:00:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000000a', 'Felix Braun',   'felix@qnop.test', 'INTERNAL', 'felix', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:01:00+00', TIMESTAMPTZ '2026-01-05 09:01:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000000b', 'Lena Fischer',  'lena@qnop.test',  'INTERNAL', 'lena',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:02:00+00', TIMESTAMPTZ '2026-01-05 09:02:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000000c', 'Jonas Keller',  'jonas@qnop.test', 'INTERNAL', 'jonas', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:03:00+00', TIMESTAMPTZ '2026-01-05 09:03:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000000d', 'Clara Vogt',    'clara@qnop.test', 'INTERNAL', 'clara', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:04:00+00', TIMESTAMPTZ '2026-01-05 09:04:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000000e', 'Paul Richter',  'paul@qnop.test',  'INTERNAL', 'paul',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:05:00+00', TIMESTAMPTZ '2026-01-05 09:05:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000000f', 'Ida Hoffmann',  'ida@qnop.test',   'INTERNAL', 'ida',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:06:00+00', TIMESTAMPTZ '2026-01-05 09:06:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000010', 'Tom Schneider', 'tom@qnop.test',   'INTERNAL', 'tom',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:07:00+00', TIMESTAMPTZ '2026-01-05 09:07:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000011', 'Eva Brandt',    'eva@qnop.test',   'INTERNAL', 'eva',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:08:00+00', TIMESTAMPTZ '2026-01-05 09:08:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000012', 'Nils Weiss',    'nils@qnop.test',  'INTERNAL', 'nils',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:09:00+00', TIMESTAMPTZ '2026-01-05 09:09:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000013', 'Anna Krause',   'anna@qnop.test',  'INTERNAL', 'anna',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:10:00+00', TIMESTAMPTZ '2026-01-05 09:10:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000014', 'Ben Roth',      'ben@qnop.test',   'INTERNAL', 'ben',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:11:00+00', TIMESTAMPTZ '2026-01-05 09:11:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000015', 'Marie Lang',    'marie@qnop.test', 'INTERNAL', 'marie', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:12:00+00', TIMESTAMPTZ '2026-01-05 09:12:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000016', 'Leo Hartmann',  'leo@qnop.test',   'INTERNAL', 'leo',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:13:00+00', TIMESTAMPTZ '2026-01-05 09:13:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000017', 'Sofia Berg',    'sofia@qnop.test', 'INTERNAL', 'sofia', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:14:00+00', TIMESTAMPTZ '2026-01-05 09:14:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000018', 'Emil Franke',   'emil@qnop.test',  'INTERNAL', 'emil',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:15:00+00', TIMESTAMPTZ '2026-01-05 09:15:00+00', 0),
-  ('a0000000-0000-0000-0000-000000000019', 'Greta Simon',   'greta@qnop.test', 'INTERNAL', 'greta', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:16:00+00', TIMESTAMPTZ '2026-01-05 09:16:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000001a', 'Oskar Thiel',   'oskar@qnop.test', 'INTERNAL', 'oskar', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:17:00+00', TIMESTAMPTZ '2026-01-05 09:17:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000001b', 'Julia Winter',  'julia@qnop.test', 'INTERNAL', 'julia', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:18:00+00', TIMESTAMPTZ '2026-01-05 09:18:00+00', 0),
-  ('a0000000-0000-0000-0000-00000000001c', 'David Sommer',  'david@qnop.test', 'INTERNAL', 'david', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:19:00+00', TIMESTAMPTZ '2026-01-05 09:19:00+00', 0);
+  ('a0000000-0000-0000-0000-000000000009', 'Nora Weber',    'nora-weber', 'nora@qnop.test',  'INTERNAL', 'nora',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:00:00+00', TIMESTAMPTZ '2026-01-05 09:00:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000a', 'Felix Braun',   'felix-braun', 'felix@qnop.test', 'INTERNAL', 'felix', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:01:00+00', TIMESTAMPTZ '2026-01-05 09:01:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000b', 'Lena Fischer',  'lena-fischer', 'lena@qnop.test',  'INTERNAL', 'lena',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:02:00+00', TIMESTAMPTZ '2026-01-05 09:02:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000c', 'Jonas Keller',  'jonas-keller', 'jonas@qnop.test', 'INTERNAL', 'jonas', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:03:00+00', TIMESTAMPTZ '2026-01-05 09:03:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000d', 'Clara Vogt',    'clara-vogt', 'clara@qnop.test', 'INTERNAL', 'clara', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:04:00+00', TIMESTAMPTZ '2026-01-05 09:04:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000e', 'Paul Richter',  'paul-richter', 'paul@qnop.test',  'INTERNAL', 'paul',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:05:00+00', TIMESTAMPTZ '2026-01-05 09:05:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000000f', 'Ida Hoffmann',  'ida-hoffmann', 'ida@qnop.test',   'INTERNAL', 'ida',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:06:00+00', TIMESTAMPTZ '2026-01-05 09:06:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000010', 'Tom Schneider', 'tom-schneider', 'tom@qnop.test',   'INTERNAL', 'tom',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:07:00+00', TIMESTAMPTZ '2026-01-05 09:07:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000011', 'Eva Brandt',    'eva-brandt', 'eva@qnop.test',   'INTERNAL', 'eva',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:08:00+00', TIMESTAMPTZ '2026-01-05 09:08:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000012', 'Nils Weiss',    'nils-weiss', 'nils@qnop.test',  'INTERNAL', 'nils',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:09:00+00', TIMESTAMPTZ '2026-01-05 09:09:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000013', 'Anna Krause',   'anna-krause', 'anna@qnop.test',  'INTERNAL', 'anna',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:10:00+00', TIMESTAMPTZ '2026-01-05 09:10:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000014', 'Ben Roth',      'ben-roth', 'ben@qnop.test',   'INTERNAL', 'ben',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:11:00+00', TIMESTAMPTZ '2026-01-05 09:11:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000015', 'Marie Lang',    'marie-lang', 'marie@qnop.test', 'INTERNAL', 'marie', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:12:00+00', TIMESTAMPTZ '2026-01-05 09:12:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000016', 'Leo Hartmann',  'leo-hartmann', 'leo@qnop.test',   'INTERNAL', 'leo',   '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:13:00+00', TIMESTAMPTZ '2026-01-05 09:13:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000017', 'Sofia Berg',    'sofia-berg', 'sofia@qnop.test', 'INTERNAL', 'sofia', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:14:00+00', TIMESTAMPTZ '2026-01-05 09:14:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000018', 'Emil Franke',   'emil-franke', 'emil@qnop.test',  'INTERNAL', 'emil',  '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:15:00+00', TIMESTAMPTZ '2026-01-05 09:15:00+00', 0),
+  ('a0000000-0000-0000-0000-000000000019', 'Greta Simon',   'greta-simon', 'greta@qnop.test', 'INTERNAL', 'greta', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:16:00+00', TIMESTAMPTZ '2026-01-05 09:16:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000001a', 'Oskar Thiel',   'oskar-thiel', 'oskar@qnop.test', 'INTERNAL', 'oskar', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:17:00+00', TIMESTAMPTZ '2026-01-05 09:17:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000001b', 'Julia Winter',  'julia-winter', 'julia@qnop.test', 'INTERNAL', 'julia', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:18:00+00', TIMESTAMPTZ '2026-01-05 09:18:00+00', 0),
+  ('a0000000-0000-0000-0000-00000000001c', 'David Sommer',  'david-sommer', 'david@qnop.test', 'INTERNAL', 'david', '$2a$10$MGmtbGfpKSL2Ev2Bl8XxzOu/D4yAsfZaVchQlI2meWVmp9O3LKBV6', true, false, 'MEMBER', NULL, TIMESTAMPTZ '2026-01-05 09:19:00+00', TIMESTAMPTZ '2026-01-05 09:19:00+00', 0);
 
 -- ---------------------------------------------------------------------------
 -- Crowd teams (issue #401): five departments, 3 crowd users each (one LEAD),


### PR DESCRIPTION
Closes #486.

## What

Profile URLs were bare UUIDs (`/users/a0000000-…-13`). Every user now owns an immutable, human-readable profile slug, and profile links across the app land on the pretty URL directly: `/users/anna-krause`.

### Data model & derivation

- `qnop_user.slug` — case-insensitively unique (`LOWER(slug)` index), shape pinned by CHECK (kebab-case, 3–64 chars, never UUID-shaped), `updatable = false`; mirrors the document slug rules from #411. Amended into the 0001 identity changeset (pre-prod convention).
- `UserSlugs` derives the base from the display name — NFKD diacritic folding (`Åsa Ödegård-Müller` → `asa-odegard-muller`), fallbacks for empty/too-short/UUID-shaped results, 64-char truncation — fully unit-tested. `UserSlugService` allocates the first free candidate (`anna-krause`, `anna-krause-2`, …), backstopped by the unique index against races.
- All **four** creation paths allocate through the same service: self-registration, OIDC provisioning, bootstrap admin, admin create. Seeded users get stable slugs in `testdata/db/seed.sql` (shared by ITs and local dev).

### API

- New `GET /users/by-slug/{slug}` (case-insensitive, 404 for unknown slugs — as non-enumerable as ids); `PublicUserProfile` carries the slug. Old UUID URLs keep working forever.
- Dashboard replies/activity carry `authorSlug`/`actorSlug`, resolved in one batch query per list — and only for identities the caller may see anyway: **a pseudonymised identity exposes neither id nor slug** (a slug would deanonymise just as surely, issue #413/ADR-0038), proven by a dedicated anonymity IT.

### Frontend

- `/users/:userId` accepts an id or a slug (the ReviewParamGate convention: UUID-shaped → by id, else by slug). A UUID visit is canonicalised to the slug URL, fetch-free via a seeded query-cache entry.
- `PersonLink` — the app's single profile-link builder — prefers the slug for its target, falls back to the id for pre-slug accounts, links yourself to `/profile`, and keeps pseudonymised identities unlinked.
- Own profile redirects to `/profile` for both address forms.

## Tests

- `UserSlugsTest`: derivation, diacritics, fallbacks, UUID-shape guard, truncation, collision candidates.
- `UserProfileApiIT`: resolution by slug (case-insensitive), 404, collision suffixes across real account creation.
- `DashboardApiIT`: slugs on replies/activity + the anonymity no-leak case.
- `UserProfilePage` + `PersonLink` component tests: slug routing, canonical replace without refetch, self-redirects, unlinked pseudonyms.
- Full gates green: `./gradlew build`, `pnpm lint` + `tsc` + 779 vitest tests.

## Test plan

- [x] `/users/anna-krause` deep-link renders the profile; unknown slug 404s
- [x] UUID visit canonicalises to the slug URL (verified live in the browser)
- [x] Dashboard activity/replies links point at `/users/<slug>` directly; click lands without a UUID hop
- [x] Own slug and own id both redirect to `/profile`
- [x] Anonymous-review identities expose neither id nor slug
- [x] Local dev DB hand-fixed per pre-prod convention (column, index, backfill, checksum reset)

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)