### PR TITLE
fix(reviews): resolve the owner's name on the document, not the directory

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4747,6 +4747,13 @@ components:
           description: >-
             The owner's profile slug (issue #486) — structurally public, also in
             anonymous reviews (issue #472). Null for pre-slug accounts.
+        ownerDisplayName:
+          type: string
+          nullable: true
+          description: >-
+            The owner's display name — structurally public, also in anonymous
+            reviews (issue #472). Resolved here so clients never depend on the
+            size-capped principal directory for it.
         workflowState:
           type: string
           description: The review workflow state (state machine lands with #246).

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -253,6 +253,7 @@ public class DocumentsController implements DocumentsApi {
         .threadParticipation(ThreadParticipation.fromValue(view.threadParticipation()))
         .ownerId(view.ownerId())
         .ownerSlug(view.ownerSlug())
+        .ownerDisplayName(view.ownerDisplayName())
         .workflowState(view.workflowState())
         .latestVersionNumber(view.latestVersionNumber())
         .createdAt(view.createdAt().atOffset(ZoneOffset.UTC))

--- a/qnop-app/src/test/java/io/qnop/document/DocumentSlugIT.java
+++ b/qnop-app/src/test/java/io/qnop/document/DocumentSlugIT.java
@@ -88,12 +88,14 @@ class DocumentSlugIT extends AbstractIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.slug").value("q3-contract-review"));
 
-    // Lookup ignores case too.
+    // Lookup ignores case too — and the metadata resolves the owner's identity
+    // itself (structurally public, #472), never via the principal directory.
     mockMvc
         .perform(get("/api/v1/documents/by-slug/{slug}", "Q3-CONTRACT-REVIEW").with(asUser(owner)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(documentId.toString()))
-        .andExpect(jsonPath("$.slug").value("q3-contract-review"));
+        .andExpect(jsonPath("$.slug").value("q3-contract-review"))
+        .andExpect(jsonPath("$.ownerDisplayName", org.hamcrest.Matchers.startsWith("slug-")));
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentAccessService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentAccessService.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,6 +87,7 @@ public class DocumentAccessService {
             .findTopByDocumentIdOrderByVersionNumberDesc(documentId)
             .map(DocumentVersion::getVersionNumber)
             .orElse(0);
+    Optional<User> owner = users.findById(document.getOwnerId());
     return new DocumentView(
         document.getId(),
         document.getTitle(),
@@ -93,8 +95,11 @@ public class DocumentAccessService {
         document.isAnonymous(),
         document.getThreadParticipation().name(),
         document.getOwnerId(),
-        // Structurally public (issue #472) — the owner's pretty profile link (#486).
-        users.findById(document.getOwnerId()).map(User::getSlug).orElse(null),
+        // Structurally public (issue #472): slug for the pretty profile link
+        // (#486) and the display name — resolved HERE so the client never
+        // depends on the size-capped principal directory for the owner.
+        owner.map(User::getSlug).orElse(null),
+        owner.map(User::getDisplayName).orElse(null),
         document.getWorkflowState(),
         latest,
         document.getCreatedAt(),
@@ -232,6 +237,7 @@ public class DocumentAccessService {
       String threadParticipation,
       UUID ownerId,
       String ownerSlug,
+      String ownerDisplayName,
       String workflowState,
       int latestVersionNumber,
       Instant createdAt,

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentUpdateService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentUpdateService.java
@@ -87,6 +87,7 @@ public class DocumentUpdateService {
             .findTopByDocumentIdOrderByVersionNumberDesc(documentId)
             .map(DocumentVersion::getVersionNumber)
             .orElse(0);
+    java.util.Optional<User> owner = users.findById(document.getOwnerId());
     return new DocumentView(
         document.getId(),
         document.getTitle(),
@@ -94,8 +95,9 @@ public class DocumentUpdateService {
         document.isAnonymous(),
         document.getThreadParticipation().name(),
         document.getOwnerId(),
-        // The actor here IS the owner — their own slug, structurally public.
-        users.findById(document.getOwnerId()).map(User::getSlug).orElse(null),
+        // The actor here IS the owner — their own identity, structurally public.
+        owner.map(User::getSlug).orElse(null),
+        owner.map(User::getDisplayName).orElse(null),
         document.getWorkflowState(),
         latest,
         document.getCreatedAt(),

--- a/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
@@ -97,6 +97,7 @@ class AnnotationServiceTest {
         threadParticipation,
         ownerId,
         null,
+        null,
         "IN_REVIEW",
         1,
         null,

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -36,7 +36,6 @@ import { AnnotationStatus, ParticipantKind } from '../../../api/generated';
 import { useConfig } from '../../../api/hooks/useConfig';
 import {
   useParticipants,
-  usePrincipalSearch,
   useTransitionWorkflow,
   useUploadVersion,
   useWorkflow,
@@ -70,6 +69,8 @@ interface ReviewHubHeadProps {
   ownerId: string;
   /** The owner's profile slug (issue #486) — structurally public (#472). */
   ownerSlug?: string | null;
+  /** The owner's display name, resolved on the document (structurally public, #472). */
+  ownerDisplayName?: string | null;
   isOwner: boolean;
   ownUserId: string | null;
   /** True for an anonymous review (issue #422) — the roster is anonymised for non-owners. */
@@ -94,6 +95,7 @@ export function ReviewHubHead({
   documentId,
   ownerId,
   ownerSlug,
+  ownerDisplayName,
   isOwner,
   ownUserId,
   anonymous,
@@ -117,15 +119,13 @@ export function ReviewHubHead({
   const uploadVersion = useUploadVersion(documentId);
 
   const participants = participantsQuery.data?.participants ?? [];
-  // The owner never sits in the participant rows; the principal directory
-  // (names only, #292) resolves them — self by display name.
-  const principals = usePrincipalSearch('').data?.principals ?? [];
   const ownDisplayName = useAuthStore((state) => state.displayName);
   const ownAvatarUrl = useAuthStore((state) => state.avatarUrl);
+  // The owner never sits in the participant rows; their name travels on the
+  // document itself (structurally public, #472) — never resolved via the
+  // size-capped principal directory, which drops users in big workspaces.
   const ownerName =
-    ownerId === ownUserId
-      ? (ownDisplayName ?? 'You')
-      : (principals.find((principal) => principal.id === ownerId)?.displayName ?? 'Owner');
+    ownerId === ownUserId ? (ownDisplayName ?? 'You') : (ownerDisplayName ?? 'Owner');
   const transitions = workflowQuery.data?.allowedTransitions ?? [];
   const maxSizeMb = config?.upload.maxDocumentSizeMb ?? FALLBACK_MAX_SIZE_MB;
 

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -478,6 +478,7 @@ export function DocumentReviewPage() {
             documentId={documentId}
             ownerId={document.ownerId}
             ownerSlug={document.ownerSlug}
+            ownerDisplayName={document.ownerDisplayName}
             isOwner={document.ownerId === userId}
             ownUserId={userId}
             anonymous={document.anonymous ?? false}


### PR DESCRIPTION
Follow-up to #489 (the commit was pushed moments after the merge and missed the train).

## What

The review hub head looked the owner's display name up in the principal directory with an empty query — a **size-capped list**, so in a workspace with more users than the cap, alphabetically late owners (e.g. "Oskar Thiel") fell out of the result and the header degraded to the bare "Owner" fallback. Surfaced immediately by the large manual-test dataset (50 seeded reviews, 19 owners).

- `DocumentResponse` now carries `ownerDisplayName` (structurally public, issue #472 — the owner user is already loaded for `ownerSlug`, so this is the same single lookup)
- the hub head reads the name from the document; the fragile `usePrincipalSearch('')` lookup is gone
- IT asserts the field on the metadata round trip

Verified live: `/reviews/seed-release-notes-core-36` shows "Owner · Oskar Thiel" again, linked to `/users/oskar-thiel`.

Refs #482.

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)