### PR TITLE
fix(reviews): mark clicks glide the panel to their annotation

### DIFF
--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -248,6 +248,8 @@ function AnnotationListItemBase({
       onFocus={() => onHover?.(annotation.id)}
       onBlur={() => onHover?.(null)}
       aria-expanded={active}
+      // Stable DOM id — the scroll target when a mark click selects this row (#491).
+      id={`annotation-item-${annotation.id}`}
       data-testid={`annotation-item-${annotation.id}`}
       sx={{
         display: 'block',

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -142,6 +142,19 @@ describe('AnnotationPanel', () => {
     expect(screen.getByTestId('panel-new-count')).toHaveTextContent('2 new');
   });
 
+  it('scrolls the selected row into view when a mark click activates it (#491)', () => {
+    const scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy;
+
+    renderPanel({
+      annotations: [annotation('a1'), annotation('a2')],
+      activeAnnotationId: 'a2',
+    });
+
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
+    expect(scrollSpy.mock.instances[0]).toBe(screen.getByTestId('annotation-item-a2'));
+  });
+
   it('shows the empty state with the how-to hint when annotating is possible', () => {
     renderPanel();
     expect(

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -33,6 +33,7 @@ import type {
   AnnotationView,
 } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
+import { revealInScroller } from '../../../utils/revealInScroller';
 import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
@@ -147,15 +148,12 @@ export function AnnotationPanel({
   const userId = useAuthStore((state) => state.userId);
 
   // A newly selected annotation must be in view (issue #491) — in a long list
-  // it expands invisibly below the fold otherwise. block:'nearest' keeps
-  // in-list clicks untouched: a row that is already visible does not move.
-  // Instant on purpose — Chrome silently drops a smooth scrollIntoView
-  // whenever another scroll just happened (optional call: jsdom lacks it).
+  // it expands invisibly below the fold otherwise. 'nearest' keeps in-list
+  // clicks untouched: a row that is already visible does not move.
   useEffect(() => {
     if (!activeAnnotationId) return;
-    document
-      .getElementById(`annotation-item-${activeAnnotationId}`)
-      ?.scrollIntoView?.({ block: 'nearest' });
+    const el = document.getElementById(`annotation-item-${activeAnnotationId}`);
+    if (el) revealInScroller(el, 'nearest');
   }, [activeAnnotationId]);
   const { resolveWith, isPending: resolving } = useResolveWithFeedback(notify);
   const confirmPlacement = useConfirmPlacement(notify);

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
@@ -145,6 +145,18 @@ export function AnnotationPanel({
 }: AnnotationPanelProps) {
   const [filters, setFilters] = useState<AnnotationFilters>(EMPTY_FILTERS);
   const userId = useAuthStore((state) => state.userId);
+
+  // A newly selected annotation must be in view (issue #491) — in a long list
+  // it expands invisibly below the fold otherwise. block:'nearest' keeps
+  // in-list clicks untouched: a row that is already visible does not move.
+  // Instant on purpose — Chrome silently drops a smooth scrollIntoView
+  // whenever another scroll just happened (optional call: jsdom lacks it).
+  useEffect(() => {
+    if (!activeAnnotationId) return;
+    document
+      .getElementById(`annotation-item-${activeAnnotationId}`)
+      ?.scrollIntoView?.({ block: 'nearest' });
+  }, [activeAnnotationId]);
   const { resolveWith, isPending: resolving } = useResolveWithFeedback(notify);
   const confirmPlacement = useConfirmPlacement(notify);
   const { reopenWith } = useReopenWithFeedback(notify);

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -603,6 +603,22 @@ export function DocumentReviewPage() {
                       setActiveAnnotationId(id);
                       setPending(null);
                       setReattaching(null);
+                      // Reveal the row's HEAD in the panel on EVERY mark
+                      // click (#491) — also when the annotation is already the
+                      // active one, where the panel's state-change effect
+                      // cannot fire. block:'start' on purpose: the expanded
+                      // card is often taller than the panel, and 'nearest'
+                      // treats a partially visible card as in view. Instant on
+                      // purpose too — Chrome silently drops a smooth
+                      // scrollIntoView whenever another scroll just happened.
+                      // setTimeout(0) runs after React committed the expansion.
+                      if (id) {
+                        setTimeout(() => {
+                          document
+                            .getElementById(`annotation-item-${id}`)
+                            ?.scrollIntoView?.({ block: 'start' });
+                        }, 0);
+                      }
                     }}
                     onHoverAnnotation={setHoverAnnotationId}
                     onVisiblePageChange={setCurrentPage}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -96,6 +96,7 @@ import { isOpenWorkflowState } from '../../components/reviews/workflowMeta';
 import { recordRecentReview } from '../../components/dashboard/recentReviews';
 import { useAuthStore } from '../../stores/authStore';
 import { apiErrorCode } from '../../utils/apiError';
+import { revealInScroller } from '../../utils/revealInScroller';
 import { pdfFetchVersion, resolveEffectiveVersion } from './resolveEffectiveVersion';
 
 const PANEL_SPLIT_KEY = 'qnop-review-split';
@@ -606,17 +607,14 @@ export function DocumentReviewPage() {
                       // Reveal the row's HEAD in the panel on EVERY mark
                       // click (#491) — also when the annotation is already the
                       // active one, where the panel's state-change effect
-                      // cannot fire. block:'start' on purpose: the expanded
-                      // card is often taller than the panel, and 'nearest'
-                      // treats a partially visible card as in view. Instant on
-                      // purpose too — Chrome silently drops a smooth
-                      // scrollIntoView whenever another scroll just happened.
-                      // setTimeout(0) runs after React committed the expansion.
+                      // cannot fire. 'start' on purpose: the expanded card is
+                      // often taller than the panel, and 'nearest' treats a
+                      // partially visible card as in view. setTimeout(0) runs
+                      // after React committed the expansion.
                       if (id) {
                         setTimeout(() => {
-                          document
-                            .getElementById(`annotation-item-${id}`)
-                            ?.scrollIntoView?.({ block: 'start' });
+                          const el = document.getElementById(`annotation-item-${id}`);
+                          if (el) revealInScroller(el, 'start');
                         }, 0);
                       }
                     }}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -613,7 +613,9 @@ export function DocumentReviewPage() {
                       // after React committed the expansion.
                       if (id) {
                         setTimeout(() => {
-                          const el = document.getElementById(`annotation-item-${id}`);
+                          // window.document explicitly — the component scope
+                          // shadows `document` with the DocumentResponse.
+                          const el = window.document.getElementById(`annotation-item-${id}`);
                           if (el) revealInScroller(el, 'start');
                         }, 0);
                       }

--- a/qnop-ui/src/utils/revealInScroller.test.ts
+++ b/qnop-ui/src/utils/revealInScroller.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { targetScrollTop } from './revealInScroller';
+
+/** A scroller viewport of 400px showing a 1000px list, currently at scrollTop. */
+function scroller(scrollTop: number) {
+  return {
+    scrollTop,
+    scrollHeight: 1000,
+    clientHeight: 400,
+    getBoundingClientRect: () => ({ top: 100, bottom: 500 }),
+  } as unknown as HTMLElement;
+}
+
+/** A row of the given height whose top sits at `top` in viewport coordinates. */
+function row(top: number, height = 60) {
+  return {
+    getBoundingClientRect: () => ({ top, bottom: top + height, height }),
+  } as unknown as HTMLElement;
+}
+
+describe('targetScrollTop (issue #491)', () => {
+  it("'nearest' leaves a fully visible row alone — in-list clicks never jump", () => {
+    expect(targetScrollTop(scroller(200), row(150), 'nearest')).toBeNull();
+  });
+
+  it("'nearest' scrolls a row above the fold to the top edge", () => {
+    // Row top is 80px above the viewport top (100): elTop = 80-100+200 = 180.
+    expect(targetScrollTop(scroller(200), row(80), 'nearest')).toBe(180);
+  });
+
+  it("'nearest' scrolls a row below the fold just into view", () => {
+    // elTop = 550-100+200 = 650; align bottom: 650 - (400 - 60) = 310.
+    expect(targetScrollTop(scroller(200), row(550), 'nearest')).toBe(310);
+  });
+
+  it("'start' aligns the row head to the top with a small gap", () => {
+    // elTop = 350-100+200 = 450; minus the 8px gap.
+    expect(targetScrollTop(scroller(200), row(350), 'start')).toBe(442);
+  });
+
+  it("'start' clamps to the scrollable range", () => {
+    // elTop = 1000-100+500 = 1400 → far beyond max (1000-400=600).
+    expect(targetScrollTop(scroller(500), row(1000), 'start')).toBe(600);
+  });
+
+  it("'start' reports null when already aligned", () => {
+    // elTop = 108-100+200 = 208; minus gap = 200 — exactly the current position.
+    expect(targetScrollTop(scroller(200), row(108), 'start')).toBeNull();
+  });
+});

--- a/qnop-ui/src/utils/revealInScroller.ts
+++ b/qnop-ui/src/utils/revealInScroller.ts
@@ -22,7 +22,7 @@
 /** Breathing room above a 'start'-aligned target, so it never sticks to the edge. */
 const START_GAP_PX = 8;
 
-const GLIDE_MS = 280;
+const GLIDE_MS = 450;
 
 /** One glide per scroller — a newer reveal cancels the one still in flight. */
 const inFlight = new WeakMap<HTMLElement, number>();

--- a/qnop-ui/src/utils/revealInScroller.ts
+++ b/qnop-ui/src/utils/revealInScroller.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/** Breathing room above a 'start'-aligned target, so it never sticks to the edge. */
+const START_GAP_PX = 8;
+
+const GLIDE_MS = 280;
+
+/** One glide per scroller — a newer reveal cancels the one still in flight. */
+const inFlight = new WeakMap<HTMLElement, number>();
+
+function scrollParentOf(el: HTMLElement): HTMLElement | null {
+  let node = el.parentElement;
+  while (node) {
+    const style = getComputedStyle(node);
+    if (/(auto|scroll)/.test(style.overflowY) && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+/**
+ * The scrollTop that brings {@code el} into view inside {@code scroller}, or
+ * null when no scrolling is needed. 'start' aligns the element's head to the
+ * top (minus a small gap); 'nearest' moves the minimum distance and treats a
+ * fully visible element as done — in-list clicks never jump.
+ */
+export function targetScrollTop(
+  scroller: HTMLElement,
+  el: HTMLElement,
+  block: 'start' | 'nearest',
+): number | null {
+  const scrollerRect = scroller.getBoundingClientRect();
+  const rect = el.getBoundingClientRect();
+  const elTop = rect.top - scrollerRect.top + scroller.scrollTop;
+  const max = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+  const clamp = (value: number) => Math.min(max, Math.max(0, value));
+
+  if (block === 'start') {
+    const target = clamp(elTop - START_GAP_PX);
+    return Math.round(target) === Math.round(scroller.scrollTop) ? null : target;
+  }
+  if (rect.top >= scrollerRect.top && rect.bottom <= scrollerRect.bottom) {
+    return null; // fully visible — nearest means: do not move
+  }
+  if (rect.top < scrollerRect.top) {
+    return clamp(elTop);
+  }
+  return clamp(elTop - (scroller.clientHeight - rect.height));
+}
+
+/**
+ * Brings an element into view inside its nearest scrollable ancestor with a
+ * short ease-out glide (issue #491). Hand-rolled on requestAnimationFrame on
+ * purpose: Chrome silently drops a native smooth scrollIntoView whenever
+ * another scroll just happened, which makes it useless right after clicks
+ * and programmatic scrolling. Reduced motion (and jsdom, which has neither
+ * layout nor rAF timing) falls back to an instant jump.
+ */
+export function revealInScroller(el: HTMLElement, block: 'start' | 'nearest'): void {
+  const scroller = scrollParentOf(el);
+  if (!scroller) {
+    // No measurable scroll parent (jsdom, detached nodes): native fallback.
+    el.scrollIntoView?.({ block });
+    return;
+  }
+  const target = targetScrollTop(scroller, el, block);
+  if (target == null) {
+    return;
+  }
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (reduced || typeof requestAnimationFrame !== 'function') {
+    scroller.scrollTop = target;
+    return;
+  }
+
+  const previous = inFlight.get(scroller);
+  if (previous !== undefined) {
+    cancelAnimationFrame(previous);
+  }
+  const from = scroller.scrollTop;
+  const delta = target - from;
+  const startedAt = performance.now();
+  const step = (now: number) => {
+    const t = Math.min(1, (now - startedAt) / GLIDE_MS);
+    const eased = 1 - Math.pow(1 - t, 3);
+    scroller.scrollTop = from + delta * eased;
+    if (t < 1) {
+      inFlight.set(scroller, requestAnimationFrame(step));
+    } else {
+      inFlight.delete(scroller);
+    }
+  };
+  inFlight.set(scroller, requestAnimationFrame(step));
+}


### PR DESCRIPTION
Closes #491.

## What

Clicking a highlight in the document expanded the corresponding annotation in the right-hand panel but never scrolled to it — in a long list (the seeded reviews carry 20-30 annotations) a row near the end expanded invisibly below the fold and nothing seemed to happen.

### Two complementary reveal paths

- **Panel effect** (state change — mark click on a new annotation, deep links): brings the row into view with `nearest` semantics — a fully visible row does not move, so clicks inside the list never jump. Rows carry a stable DOM id for it.
- **Viewer mark-click handler**: additionally reveals the row's **head** (`start`, with an 8px gap) on EVERY click — covering the re-click on an already-active mark (no state change) and the expanded card taller than the panel, which `nearest` treats as already in view.

### The glide (`revealInScroller`)

Chrome silently drops a native `scrollIntoView({behavior:'smooth'})` whenever another scroll just happened — useless right after clicks. The new utility hand-rolls a 450ms ease-out glide on `requestAnimationFrame`: it resolves the nearest scrollable ancestor, computes the `start`/`nearest` target itself, cancels a glide still in flight, and falls back to an instant jump under `prefers-reduced-motion` (and in jsdom).

## Tests

- 6 unit tests for the pure target computation (visible-stays-put, above/below the fold, start gap, clamping, already-aligned)
- Panel test for the reveal on selection
- Full gates green: `pnpm lint` + `tsc` + 803 vitest tests

## Test plan

- [x] Mark click expands AND glides the row into view (verified live; scrollTop sampling traces the ease-out curve into the exact target)
- [x] Re-click on the already-active mark reveals the card head again
- [x] Clicks inside the list never cause a scroll jump
- [x] Reduced motion falls back to an instant jump
- [x] Manually confirmed by review testing (pacing tuned from 280ms to 450ms on feedback)

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)