### PR TITLE
docs: prune all documentation to the current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,17 @@ Read `docs/ARCHITECTURE.md` and `docs/adr/` first — they hold the binding deci
 
 Commits are signed off (`git commit -s`, DCO). See `CONTRIBUTING.md`.
 
-## Current state — Phase 1 (identity & administration shipped)
+## Current state
 
-The Spring Boot server **boots and runs** (PostgreSQL + Liquibase + JPA, ADR-0020) with the full identity & administration layer of epic #7 in place — `io.qnop.entity` (JPA model), `io.qnop.repository` (Spring Data), `io.qnop.service` (business services) and the framework-light `io.qnop.security` (crypto/key-derivation, ADR-0022) are all populated. **Shipped:** local login with JWT access + rotating refresh tokens and revocation (ADR-0026), OIDC/OAuth2 providers, self-registration, email verification and password reset, auth rate limiting (ADR-0027), users & teams, application settings (ADR-0025), mail templates, branding upload with SVG sanitization (ADR-0028; assets stored as Postgres `bytea`, ADR-0024), profile avatars (ADR-0031), ShedLock distributed scheduling (ADR-0029) and optimistic concurrency control (ADR-0030). The REST contract is OpenAPI-first (ADR-0021) and the `qnop-ui` SPA (login, profile, admin surfaces) consumes it; `/config` exposes the running edition.
+The Spring Boot server **boots and runs** (PostgreSQL + Liquibase + JPA, ADR-0020) with two shipped verticals:
 
-**Genuinely still pending (do not assume they exist):** the document-review domain core — the review workflow state machine, annotation anchoring/re-anchoring, and the ingest pipeline. The `qnop-spi` extension-point boundary now carries its first published contract, the `StorageProvider` SPI, with the S3/MinIO Community default in `io.qnop.service.storage` (issue #243, ADR-0005/0036) — so MinIO **is now consumed** (object bytes for `document_version.storage_key`), with an upload-then-commit staging registry (`storage_object`) and orphan reaper. `docker-compose.yml` provides local Postgres (+ MinIO) for `bootRun`; the test suite spins up its own Postgres **and MinIO** via **Testcontainers** (Docker required).
+**Identity & administration** (epic #7): local login with JWT access + rotating refresh tokens and revocation (ADR-0026), OIDC/OAuth2 providers, self-registration, email verification and password reset, auth rate limiting (ADR-0027), users & teams, application settings (ADR-0025), mail templates, branding upload with SVG sanitization (ADR-0028; assets as Postgres `bytea`, ADR-0024), profile avatars (ADR-0031), public profiles with slugs (#473/#486), ShedLock scheduling (ADR-0029) and optimistic concurrency control (ADR-0030).
+
+**Document review — the PDF vertical** (epic #241 + follow-ups): server-mediated ingest with the canonical extraction pipeline (ADR-0032) on the durable Postgres job queue (ADR-0033), multi-layer annotation anchoring with fuzzy re-anchoring across versions (ADR-0009, #326/#457), the review workflow state machine (ADR-0011), inter-version diff (ADR-0034), per-review privacy/anonymity (ADR-0038), review e-mail notifications (#316), dashboard (#454), and the full review UI (viewer, panel, focus mode, tasks, compare). Object storage flows through the `StorageProvider` SPI with the S3/MinIO Community default and an upload-then-commit staging registry + orphan reaper (ADR-0005/0036). `qnop-spi` publishes **two** contracts: `StorageProvider` and `DocumentExtractor`.
+
+The REST contract is OpenAPI-first (ADR-0021); the `qnop-ui` SPA consumes the generated client; `GET /api/v1/config` exposes the running edition.
+
+**Genuinely still pending (do not assume they exist):** DOCX/Markdown ingest (ADR-0010 — the code accepts PDF only), enterprise runtime extensions and their packaging (ADR-0039), Redis/search (ADR-0013). `docker-compose.yml` provides local Postgres (+ MinIO) for `bootRun`; the test suite spins up its own Postgres **and MinIO** via **Testcontainers** (Docker required).
 
 ## Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for contributing! qnop is the AGPL-3.0 Community core of an open-core pro
 3. **Never commit or push directly to `main`.** `main` is integration-only and protected; all changes land via Pull Request.
 4. **Open a PR** that references its issue (e.g. `Closes #12`). Keep PRs focused.
 5. **Sign the CLA** on your first PR (see below) — a bot will prompt you.
-6. CI must be green (backend build + ArchUnit + Spotless, frontend lint/build, SPDX check) before merge.
+6. CI must be green before merge — see `.github/workflows/ci.yml` for the authoritative gate set (backend build with ArchUnit/Spotless, dependency audits, frontend checks, docker-compose smoke deployment, SPDX scan).
 
 ## Language
 

--- a/README.md
+++ b/README.md
@@ -2,29 +2,13 @@
 
 An enterprise **document review** system with a browser-first, maximally usable review experience.
 
-Reviewers — individual users or whole teams — mark up lines and regions of a document, comment, and run a coordinated review workflow: comments are accepted or rejected, changes produce new document versions, and a review is finalized once no open annotations remain.
+Reviewers — individual users or whole teams — mark up passages of a document, discuss them, and run a coordinated review workflow: annotations are raised and resolved, changes produce new document versions, and a review is finalized once no open annotations remain. qnop reviews **PDF documents today**; DOCX and Markdown follow the same ingest pipeline later ([ADR-0010](docs/adr/0010-docx-representation-strategy.md), [ADR-0032](docs/adr/0032-document-representation-and-rendering-pipeline.md)).
 
-The focus is on **textual documents first — PDF, Word (DOCX), and Markdown**. Support for further formats (for example images) may follow once the text review workflow is solid, and such formats are a likely **Enterprise** feature rather than part of the Community scope.
-
-> **Status: Phase 1 — identity & administration layer shipped.** The server boots (PostgreSQL + Liquibase + JPA) with the full identity/auth subsystem — local login with JWT access + rotating refresh tokens, revocation, OIDC/OAuth2 providers, self-registration, email verification and password reset, rate limiting — plus users & teams, application settings, mail templates, branding upload (with SVG sanitization) and profile avatars. The document-review domain (ingest, annotation anchoring, the review workflow state machine) is Phase 2. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and the roadmap there.
-
-## Editions
-
-qnop is open-core:
-
-- **Community** (this repo) — **AGPL-3.0**, base features.
-- **Enterprise** — commercial add-ons (e.g. AI reviewers, summarization, duplicate-annotation detection), built in a separate private repository against this repo's published `qnop-spi` artifact.
-- A **SaaS** offering is a future possibility.
-
-## Tech stack
-
-- **Backend**: Java 21 · Gradle (Kotlin DSL) multi-module · Spring Boot 4.x (Phase 1)
-- **Frontend**: Vite · React 19 · TypeScript · MaterialUI (`qnop-ui/`)
-- **Data**: PostgreSQL + Liquibase · S3-compatible object storage (MinIO locally)
+qnop is open-core: this repository is the **AGPL-3.0 Community edition**; commercial add-ons live in a separate private repository built against the published `qnop-spi` contract.
 
 ## Getting started
 
-Requires JDK 21, Node 24 + pnpm, and Docker. **Docker must be running for the backend test suite** — tests boot a real PostgreSQL via Testcontainers (ADR-0020).
+Requires JDK 21, Node 24 + pnpm, and Docker. **Docker must be running for the backend test suite** — tests boot real PostgreSQL and MinIO containers via Testcontainers (ADR-0020).
 
 ```bash
 # Local infrastructure (Postgres for bootRun + MinIO)
@@ -44,30 +28,11 @@ set -a; source .env; set +a
 cd qnop-ui && pnpm install && pnpm dev
 ```
 
-> **Postgres 18 data volume.** `postgres:18` stores its cluster under
-> `/var/lib/postgresql/<major>/docker` and refuses a mount at the old
-> `…/data` path, so compose mounts `qnop_pgdata:/var/lib/postgresql` (issue #407).
-> A `qnop_pgdata` volume created before this change won't start — the simplest fix
-> is a fresh volume (`docker compose down -v`, then `docker compose up -d`); to keep
-> existing data instead, copy the old cluster's `18/` directory into it (recipe in
-> issue #407).
-
-## Repository layout
-
-```
-qnop-spi/            # published plugin contract (Spring-free)
-qnop-api/            # published REST contract: DTOs + OpenAPI (Spring-free)
-qnop-core/           # entity/ repository/ service/  (the Spring backend core)
-qnop-app/            # @RestControllers + Spring Boot bootstrap (the runnable)
-build-logic/         # Gradle convention plugins
-qnop-ui/             # Vite + React + MUI SPA
-docs/ARCHITECTURE.md # the map
-docs/adr/            # architecture decision records
-```
+Architecture, module map, and stack: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) · decisions: [`docs/adr/`](docs/adr/README.md)
 
 ## Contributing
 
-Issue → feature branch → PR; never commit to `main`. All changes are reviewed and CI-gated. See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the [ADRs](docs/adr/README.md).
+Issue → feature branch → PR; never commit to `main`. All changes are reviewed and CI-gated. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 qnop ("Qualified Notes on Papers") is an enterprise **document review** system. Reviewers (individual users or teams) mark up lines/regions of a document, comment, and run a coordinated review workflow: comments are accepted or rejected, changes produce new document versions, and a review finalizes when no open annotations remain.
 
-**Supported formats — text first.** The initial scope is reviewing **textual documents: PDF, DOCX, and Markdown (`.md`)**. Other formats (e.g. images, and possibly more later) may follow once the text workflow is solid; those additional formats are a likely **Enterprise** feature rather than Community scope. The ingest → extract/anchor → render pipeline is designed so a new format is an added implementation behind the existing seams (cf. [ADR-0009](adr/0009-multi-layer-annotation-anchoring.md), [ADR-0010](adr/0010-docx-representation-strategy.md)), not a core rewrite.
+**Supported formats — PDF today, text first.** qnop reviews **PDF documents**; DOCX and Markdown are decided-but-pending additions on the same pipeline ([ADR-0010](adr/0010-docx-representation-strategy.md), [ADR-0032](adr/0032-document-representation-and-rendering-pipeline.md)). Other formats (e.g. images) may follow once the text workflow is solid and are a likely **Enterprise** feature rather than Community scope. The ingest → extract/anchor → render pipeline is designed so a new format is an added implementation behind the existing seams ([ADR-0009](adr/0009-multi-layer-annotation-anchoring.md)), not a core rewrite.
 
 This document is the map. The binding decisions and their rationale live as [ADRs](adr/README.md); this overview links to them rather than repeating them.
 
@@ -49,34 +49,35 @@ Two modules are versioned, externally-consumable stability surfaces:
 
 ## Frontend
 
-A Vite + React + TypeScript + MaterialUI SPA (`qnop-ui/`) talking to the Spring REST API. Enterprise UI will be separated mirroring the backend ([ADR-0014](adr/0014-frontend-enterprise-separation.md)).
+A Vite + React + TypeScript + MaterialUI SPA (`qnop-ui/`) talking to the Spring REST API. Enterprise UI extensions load at runtime as ESM modules against a published `qnop-ui-spi` ([ADR-0014](adr/0014-frontend-enterprise-separation.md), finalized by [ADR-0039](adr/0039-enterprise-packaging-and-runtime-extensions.md)).
 
 ## Persistence topology
 
 - **PostgreSQL** — relational data: users, teams, documents (metadata), versions, reviews, annotations (anchor payload as `jsonb`), workflow state, audit log.
 - **S3-compatible object storage** — binary documents, never in Postgres ([ADR-0005](adr/0005-binary-documents-in-object-storage.md)).
+- **Durable job queue on Postgres** — extraction, re-anchoring and mail jobs run through a `job` table with SKIP LOCKED workers ([ADR-0033](adr/0033-durable-async-job-execution-on-postgres.md)); scheduled work coordinates via ShedLock ([ADR-0029](adr/0029-distributed-scheduler-locks.md)).
+- **Object-storage staging** — uploads stage through a `storage_object` registry with an orphan reaper ([ADR-0036](adr/0036-object-storage-lifecycle-staging-and-reaper.md)).
 - **Redis / OpenSearch / pgvector** — deliberately deferred ([ADR-0013](adr/0013-redis-and-search-deferred.md)).
 
-## Core concepts (to be implemented in Phase 1)
+## Core concepts
 
-- **Immutable versions** — a content change creates a new `DocumentVersion`; old versions are never mutated.
-- **Annotation anchoring** — multi-layer (text-quote + position + layout), with per-version `AnnotationPlacement` so annotations survive re-versioning ([ADR-0009](adr/0009-multi-layer-annotation-anchoring.md)).
-- **Review workflow** — explicit domain state machine; `FINALIZED` only when zero open annotations ([ADR-0011](adr/0011-review-workflow-state-model.md)).
-- **DOCX handling** — strategy still open ([ADR-0010](adr/0010-docx-representation-strategy.md)).
+- **Immutable versions** — a content change creates a new `DocumentVersion`; old versions are never mutated. Uploads flow through the canonical ingest/extraction pipeline ([ADR-0032](adr/0032-document-representation-and-rendering-pipeline.md)) on the durable job queue ([ADR-0033](adr/0033-durable-async-job-execution-on-postgres.md)).
+- **Annotation anchoring** — multi-layer (text-quote + position + layout), with per-version `AnnotationPlacement` and fuzzy re-anchoring across versions ([ADR-0009](adr/0009-multi-layer-annotation-anchoring.md)); inter-version diffs power the compare view ([ADR-0034](adr/0034-inter-version-diff.md)).
+- **Review workflow** — explicit domain state machine; `FINALIZED` only when zero open annotations ([ADR-0011](adr/0011-review-workflow-state-model.md)); per-review anonymity and thread participation policies ([ADR-0038](adr/0038-per-review-privacy.md)).
+- **DOCX handling** — converts to PDF on ingest and reuses the canonical pipeline ([ADR-0010](adr/0010-docx-representation-strategy.md), not yet implemented).
 
-## Phase roadmap
+## Current state & deferred
 
-- **Phase 0 (this milestone)** — repo conventions, ADRs, governance; compiling Gradle multi-module skeleton (modules are placeholders); local infra (`docker-compose`); frontend shell; CI. **No domain code, SPI, or bootable server yet.**
-- **Phase 1** — domain core + workflow state machine; SPI interfaces + Community defaults; bootable Spring Boot server (Postgres/Liquibase/S3, `/api/edition`); ingest pipeline; basic anchoring; auth.
-- **Phase 2** — fuzzy re-anchoring, real-time presence (Redis), caching.
-- **Phase 3+** — enterprise AI modules, license entitlements, search/pgvector as needed.
+**Shipped:** the identity & administration layer (local JWT auth with rotating refresh tokens, OIDC providers, self-registration/verification/reset, rate limiting, users & teams, settings, mail templates, branding, avatars) and the full **PDF review vertical** — ingest + extraction jobs, anchoring and re-anchoring, the review workflow state machine, inter-version diff, review notifications, dashboard, and the complete review UI. `qnop-spi` publishes two contracts (`StorageProvider`, `DocumentExtractor`) with Community defaults.
+
+**Deferred:** DOCX/Markdown ingest ([ADR-0010](adr/0010-docx-representation-strategy.md)), Redis/search ([ADR-0013](adr/0013-redis-and-search-deferred.md)), enterprise runtime extensions and their packaging ([ADR-0039](adr/0039-enterprise-packaging-and-runtime-extensions.md)).
 
 ## Stack summary
 
 | Layer | Choice |
 |-------|--------|
-| Backend | Java 21, Spring Boot 4.x (Phase 1), Gradle (Kotlin DSL) multi-module |
+| Backend | Java 21, Spring Boot 4.x, Gradle (Kotlin DSL) multi-module |
 | Persistence | PostgreSQL + Liquibase; S3/MinIO object storage |
 | Frontend | Vite, React 19, TypeScript, MaterialUI |
 | Build/quality | Convention plugins, Spotless (google-java-format), ArchUnit, JUnit 5 |
-| CI | GitHub Actions: backend build + ArchUnit + Spotless, frontend lint/build, SPDX scan |
+| CI | GitHub Actions (`.github/workflows/ci.yml`): backend build (ArchUnit + Spotless), OWASP dependency audit, frontend lint/format/test/build + audit, docker-compose smoke deploy (incl. OIDC login), SPDX scan |

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -22,3 +22,7 @@ Every important architecture decision is captured as a numbered ADR in `docs/adr
 
 - **Document only in the wiki / PRs** — rejected: not versioned with the code, hard to audit.
 - **No formal record** — rejected: the open-core/AGPL decisions in particular need a defensible paper trail.
+
+## Amendment (2026-07-16, in-file amendments)
+
+Practice has established a refinement mechanism this ADR did not spell out: an Accepted ADR may be **amended in place** with a dated, clearly-labelled `## Amendment (YYYY-MM-DD, …)` section appended at the end of the file (as done across ADR-0009, ADR-0011, ADR-0017, ADR-0033, ADR-0035). Amendments record refinements and implementation-time precisions; the decision text above them stays untouched. A **genuine reversal** still requires either a superseding ADR or an amendment that explicitly flags itself as reversing (as the 2026-07-05 amendment to ADR-0011 does).

--- a/docs/adr/0007-spdx-dco-license-scanning.md
+++ b/docs/adr/0007-spdx-dco-license-scanning.md
@@ -23,3 +23,7 @@ An open-core business under AGPL-3.0 depends on (a) being able to prove which co
 ## Alternatives considered
 
 - **No header/scan policy** — rejected: risks silent contamination and loss of relicensing rights.
+
+## Amendment (2026-07-16, license scanner still pending)
+
+The full dependency-license scanner promised "once real dependencies land" (e.g. ScanCode/ORT or a Gradle license plugin) is still not wired into CI — the check in place remains the SPDX-header job. Tracked in issue #498.

--- a/docs/adr/0008-contribution-and-branching-workflow.md
+++ b/docs/adr/0008-contribution-and-branching-workflow.md
@@ -33,3 +33,10 @@ Commit messages follow Conventional Commits (`type: subject`).
 
 - **Commit straight to `main` for small changes** — rejected: breaks traceability and the protected-branch guarantee.
 - **Trunk-based with no PR** — rejected: loses mandatory review and the issue trail.
+
+## Amendment (2026-07-16, branch types & attribution form)
+
+Two alignments with the repo working rules (`CLAUDE.md`):
+
+- **Branch types** follow [Conventional Branch](https://conventionalbranch.org/): the set is `{feat, fix, hotfix, release, chore}` (`feat`/`fix` being the accepted short forms of `feature`/`bugfix`), lowercase + hyphens, optional issue number (e.g. `feat/issue-123-new-login`). The `docs/…` prefix sketched in rule 3 is not part of the set; documentation changes ride `chore/…` or `feat/…` branches.
+- **Attribution is English throughout:** commits carry `Co-Authored-By: Claude <noreply@anthropic.com>`; issues and PRs carry `🤖 Co-Author: Claude (Opus 4.x) via Claude Code` (replacing the German `🤖 Mitarbeit: …` example in rule 4).

--- a/docs/adr/0011-review-workflow-state-model.md
+++ b/docs/adr/0011-review-workflow-state-model.md
@@ -27,7 +27,7 @@ DRAFT → IN_REVIEW → CHANGES_REQUESTED → IN_REVIEW (after new version) → 
 ```
 
 - **Core invariant:** transition to `FINALIZED` is allowed only when there are **zero** annotations in status `OPEN` — *and* no `AnnotationPlacement` is still `PENDING` (re-anchoring must have completed, [ADR-0033](0033-durable-async-job-execution-on-postgres.md)). This is a domain invariant, not a controller check.
-- Annotation lifecycle is a small sub-machine: `OPEN → ACCEPTED | REJECTED` (owner-decided), which drives `IN_REVIEW → CHANGES_REQUESTED`.
+- Annotation lifecycle is a small sub-machine: `OPEN → ACCEPTED | REJECTED` (owner-decided) *(reversed by the 2026-07-05 amendment below)*, which drives `IN_REVIEW → CHANGES_REQUESTED` *(reversed by the 2026-07-05 amendment below)*.
 - Every transition emits an append-only `AuditEvent`.
 
 ## Rationale

--- a/docs/adr/0012-edition-vs-entitlements.md
+++ b/docs/adr/0012-edition-vs-entitlements.md
@@ -19,3 +19,7 @@ Beyond *which* edition is running (Community vs. Enterprise), the commercial edi
 ## Status note
 
 Recorded now to fix the gating approach before any commercial code exists. Implementation is out of scope until the enterprise repo and bootable server exist. Obtain IP-counsel review of the AGPL boundary before first commercial release.
+
+## Amendment (2026-07-16)
+
+The `/api/edition` endpoint sketched above materialized as `GET /api/v1/config`.

--- a/docs/adr/0013-redis-and-search-deferred.md
+++ b/docs/adr/0013-redis-and-search-deferred.md
@@ -1,6 +1,6 @@
 # ADR-0013: Redis & search index deferred
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-13
 - **Deciders:** qnop core team
 

--- a/docs/adr/0014-frontend-enterprise-separation.md
+++ b/docs/adr/0014-frontend-enterprise-separation.md
@@ -17,3 +17,7 @@ AGPL-3.0 extends to the JavaScript bundle shipped to the browser. The open-core 
 ## Status note
 
 Recorded now because it's an easily-forgotten consequence of AGPL on shipped JS. No enterprise UI exists yet; the slot mechanism is designed when the first edition-specific component is needed. Include the frontend boundary in the IP-counsel review.
+
+## Amendment (2026-07-16)
+
+The private-npm-package bullet was finalized differently: enterprise UI plugs in via runtime ESM extensions per [ADR-0039](0039-enterprise-packaging-and-runtime-extensions.md) §3; build-time composition of a private npm package remains the documented fallback.

--- a/docs/adr/0017-renovate-dependency-automation.md
+++ b/docs/adr/0017-renovate-dependency-automation.md
@@ -55,3 +55,7 @@ The original `GITHUB_TOKEN` model could push branches but **never opened PRs** (
 An App installation token is a distinct identity: it is not bound by the Actions-can't-create-PRs policy, and its PRs trigger consumer CI normally. The model stays **single-repo** — the installation token is scoped to the calling repo, preserving the "own/self-hosted instance, no cross-repo write" property. We still avoid the Mend-hosted SaaS App; this is our own App under org control.
 
 **Consequence:** onboarding a new repo to Renovate now also requires installing the App and adding the two secrets, not just the workflow stub. The trade-off buys working PRs *with* CI, which the `GITHUB_TOKEN` model could not provide.
+
+## Amendment (2026-07-16): frontend lockfile
+
+The frontend lockfile noted as missing under *Consequences* (`qnop-ui/pnpm-lock.yaml`) has since been committed; Renovate updates it as part of its npm PRs.

--- a/docs/adr/0023-identity-and-access-model.md
+++ b/docs/adr/0023-identity-and-access-model.md
@@ -1,4 +1,4 @@
-# ADR-0021: Identity & access model (schema level)
+# ADR-0023: Identity & access model (schema level)
 
 - **Status:** Accepted
 - **Date:** 2026-06-14

--- a/docs/adr/0025-application-settings-architecture.md
+++ b/docs/adr/0025-application-settings-architecture.md
@@ -28,3 +28,7 @@ The application needs operator-configurable global settings (general, upload, tr
 - **DB-only definition (drop the registry, derive types from rows).** Rejected: defaults/validation/enum-options are behavior that belongs in code; a registry gives compile-time exhaustiveness.
 - **Per-request DB reads / a cache abstraction (Caffeine).** Rejected as premature: the settings set is tiny and changes rarely; an `AtomicReference` snapshot is simpler and allocation-free on reads.
 - **A native Postgres enum for `value_type`.** Rejected: a `VARCHAR` + `CHECK` (issue #13) matches the project's enum convention and avoids Postgres enum migration friction.
+
+## Amendment (2026-07-16, role naming)
+
+The guarding role named `SUPERADMIN` above landed as **`ADMIN`** within the global `ADMIN`/`MEMBER`/`AUDITOR` role model: there is no `SUPERADMIN` in the code, and `SecurityConfiguration` guards `/api/v1/admin/**` with `hasRole("ADMIN")`.

--- a/docs/adr/0028-branding-upload-and-svg-sanitization.md
+++ b/docs/adr/0028-branding-upload-and-svg-sanitization.md
@@ -26,3 +26,7 @@ Issue #15 introduced the `application_asset` storage (one row per `BrandingSlot`
 - **A third-party SVG/HTML sanitizer.** Rejected: no well-maintained permissive-licensed pure-Java SVG sanitizer fits, and an allowlist over the JAXP parser is small, auditable, and dependency-free (keeps the AGPL/commercial boundary clean, ADR-0007).
 - **Object storage for branding bytes.** Already rejected in ADR-0024 (branding is config-like; keep it in Postgres).
 - **Generating the endpoints from OpenAPI.** Rejected for these two: multipart upload and binary ETag/304 responses are awkward to express and add no value to the JSON contract consumers.
+
+## Amendment (2026-07-16, role naming)
+
+The "superadmin" role named above landed as **`ADMIN`** — see the 2026-07-16 amendment to [ADR-0025](0025-application-settings-architecture.md).

--- a/docs/adr/0031-profile-avatar-storage.md
+++ b/docs/adr/0031-profile-avatar-storage.md
@@ -96,3 +96,7 @@ Rationale:
 - **Reuse `application_asset` (branding's table).** Rejected: its schema is
   slot-keyed and config-scoped; per-user avatars want a `user_id`-keyed table
   with a cascading FK.
+
+## Amendment (2026-07-16)
+
+The "mandated but entirely unbuilt" characterization of the ADR-0005 seam under *Context* is historical: the `StorageProvider` SPI and its S3/MinIO Community default have since shipped (issue #243, [ADR-0036](0036-object-storage-lifecycle-staging-and-reaper.md)).

--- a/docs/adr/0032-document-representation-and-rendering-pipeline.md
+++ b/docs/adr/0032-document-representation-and-rendering-pipeline.md
@@ -51,3 +51,7 @@ The review surface must show a document **faithfully** (legal/compliance documen
 - **A — Render the original in the client and derive anchoring there (PDF.js text layer live).** Rejected as the authority: format-specific (images/DOCX each need a bespoke client path), and re-anchoring would still need server-side text. We keep client rendering for *pixels only*.
 - **B — A canonical server-rendered representation the client displays (DOCX/PDF → unified HTML).** Rejected for the core: loses the original's exact layout, which is non-negotiable for the documents qnop reviews.
 - **Storing only text-quote anchors, no boxes.** Rejected: images have no quotes, and visually locating a highlight needs geometry; region/box anchoring must be a first-class, always-present layer.
+
+## Amendment (2026-07-16, shipped vs. planned extractors)
+
+Decision point 4 lists the intended Community extractor set; as of this date only the **PDF extractor** (`PdfBoxDocumentExtractor`) is shipped. The Markdown and DOCX extractors remain planned Community scope per [ADR-0010](0010-docx-representation-strategy.md). The **image** extractor's placement (Community vs. Enterprise) was re-opened by the PDF-first roadmap decision and is no longer settled by this ADR.

--- a/docs/adr/0035-esignature-approval-enterprise-feature.md
+++ b/docs/adr/0035-esignature-approval-enterprise-feature.md
@@ -27,7 +27,7 @@ E-signature is an **enterprise-only feature, layered *after* content finalizatio
 
 ## Consequences
 
-- **The community core needs zero signature-specific work.** The feature is fully additive over the generic enterprise seams. The only core prerequisites already exist (the version content-hash, read access to the finalized version and participants) **except** the generic enterprise-Liquibase seam, which does not exist yet and is tracked in **#254** (needed before any enterprise schema lands; not a blocker for the PDF slice).
+- **The community core needs zero signature-specific work.** The feature is fully additive over the generic enterprise seams. The only core prerequisites already exist (the version content-hash, read access to the finalized version and participants) **except** the generic enterprise-Liquibase seam, which does not exist yet and is tracked in **#254** *(shipped since — see [ADR-0039](0039-enterprise-packaging-and-runtime-extensions.md) §2 / issue #254)* (needed before any enterprise schema lands; not a blocker for the PDF slice).
 - DocuSign's proprietary SDK lives in `qnop-enterprise`, never in the AGPL core ([ADR-0007](0007-spdx-dco-license-scanning.md)).
 - Sovereignty is preserved: customers choose an EU/on-prem-capable provider.
 - "Legally binding" remains regulatorily deep — eIDAS levels, PAdES-LTV / long-term validation, Schrems-II data-transfer constraints, per-signature cost — a substantial enterprise module, deliberately out of community scope.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,6 +8,11 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 - **Proposed** — the direction is set, but details are deferred to a later phase. Not yet binding.
 - **Superseded by ADR-NNNN** — replaced.
 
+Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-record-architecture-decisions.md)):
+
+- An Accepted ADR may carry dated, clearly-labelled `## Amendment (YYYY-MM-DD, …)` sections appended at the end of the file. Amendments refine; only an amendment explicitly flagged as reversing (or a superseding ADR) may reverse a decision.
+- **Accepted (finalized by NNNN)** in the index marks a direction-setting ADR whose deferred details were later pinned by ADR-NNNN.
+
 ## Index
 
 | ADR | Title | Status |
@@ -24,7 +29,7 @@ Important architecture decisions are recorded here as ADRs (see [ADR-0001](0001-
 | [0010](0010-docx-representation-strategy.md) | DOCX representation strategy | Accepted |
 | [0011](0011-review-workflow-state-model.md) | Review workflow & domain model | Accepted |
 | [0012](0012-edition-vs-entitlements.md) | Edition vs. entitlements / license gating | Accepted (finalized by 0039) |
-| [0013](0013-redis-and-search-deferred.md) | Redis & search index deferred | Proposed |
+| [0013](0013-redis-and-search-deferred.md) | Redis & search index deferred | Accepted |
 | [0014](0014-frontend-enterprise-separation.md) | Frontend enterprise separation | Accepted (finalized by 0039) |
 | [0015](0015-published-rest-api-contract-module.md) | Published REST API contract module (qnop-api) | Accepted |
 | [0016](0016-contributor-license-agreement.md) | Contributor License Agreement enforced via CLA Assistant | Accepted |

--- a/qnop-ui/README.md
+++ b/qnop-ui/README.md
@@ -1,73 +1,24 @@
-# React + TypeScript + Vite
+# qnop-ui
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The qnop web frontend: a Vite + React 19 + TypeScript + MaterialUI SPA consuming the qnop REST API through a generated `typescript-axios` client (OpenAPI-first, ADR-0021).
 
-Currently, two official plugins are available:
+## Prerequisites
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+- Node 24 + **pnpm**
+- A JDK on the PATH — `pnpm generate:api` runs the OpenAPI generator (a Java tool) against `../qnop-api/src/main/resources/openapi/openapi.yaml`
+- A running backend (`./gradlew :qnop-app:bootRun` from the repo root) for `pnpm dev`
 
-## React Compiler
+## Commands
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+```bash
+pnpm install
+pnpm dev            # generate:api + Vite dev server (proxies /api to :8080)
+pnpm build          # generate:api + tsc -b + vite build
+pnpm typecheck      # generate:api + tsc -b --noEmit
+pnpm test           # vitest (watch) · pnpm test:run for one-shot
+pnpm lint           # eslint
+pnpm format         # prettier --write · pnpm format:check
+pnpm generate:api   # regenerate the typed API client
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x';
-import reactDom from 'eslint-plugin-react-dom';
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
-```
+Conventions, architecture and decisions live in the repo root: [`../README.md`](../README.md), [`../docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md), [`../docs/adr/`](../docs/adr/README.md).


### PR DESCRIPTION
## Summary

Complete review and cleanup of the documentation for the first release (#494): everything describes the **current** state of the project — roadmap phases, shipped-feature announcements and stale plans are gone.

- **README.md** rewritten to be minimal: what qnop is (PDF today), getting started, pointers to architecture docs, contributing, license.
- **docs/ARCHITECTURE.md**: "Current state & deferred" replaces the phase roadmap; core concepts in present tense; persistence section covers ADR-0033/0036; CI described as it runs today.
- **CLAUDE.md**: current-state section rewritten (document-review core shipped; genuinely pending: DOCX/Markdown, ADR-0039 runtime extensions, Redis/search).
- **qnop-ui/README.md**: real README instead of the Vite boilerplate.
- **CONTRIBUTING.md**: CI gate description now points at `ci.yml`.
- **15 ADR files** touched without deleting history: dated amendments (2026-07-16) where reality moved on, 0013 Proposed→Accepted, corrected internal links, extended status legend in `docs/adr/README.md`.

Closes #494

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)