### PR TITLE
docs(release): the encryption salt must be hex-encoded

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,10 +6,11 @@
 # guidance and upgrade notes.
 #
 # Pin the version:            QNOP_VERSION=1.0.0 docker compose up -d
-# REQUIRED before first run:  QNOP_AUTH_JWT_SECRET, QNOP_AUTH_ENCRYPTION_KEY,
-#                             QNOP_AUTH_ENCRYPTION_SALT (>= 32 chars each, e.g.
-#                             `openssl rand -base64 48`) — the server fails
-#                             fast on the CHANGE_ME defaults (ADR-0022).
+# REQUIRED before first run:  QNOP_AUTH_JWT_SECRET and QNOP_AUTH_ENCRYPTION_KEY
+#                             (>= 32 chars, e.g. `openssl rand -base64 48`) and
+#                             QNOP_AUTH_ENCRYPTION_SALT (hex-encoded, e.g.
+#                             `openssl rand -hex 32`) — the server fails fast
+#                             on the CHANGE_ME defaults (ADR-0022).
 
 services:
   qnop:
@@ -33,7 +34,7 @@ services:
       QNOP_S3_AUTO_CREATE_BUCKET: 'true'
       QNOP_AUTH_JWT_SECRET: ${QNOP_AUTH_JWT_SECRET:?generate with `openssl rand -base64 48`}
       QNOP_AUTH_ENCRYPTION_KEY: ${QNOP_AUTH_ENCRYPTION_KEY:?generate with `openssl rand -base64 48`}
-      QNOP_AUTH_ENCRYPTION_SALT: ${QNOP_AUTH_ENCRYPTION_SALT:?generate with `openssl rand -base64 48`}
+      QNOP_AUTH_ENCRYPTION_SALT: ${QNOP_AUTH_ENCRYPTION_SALT:?generate with `openssl rand -hex 32`}
       # Behind a TLS-terminating reverse proxy, uncomment so X-Forwarded-*
       # headers drive scheme/host:
       # QNOP_HTTP_FORWARD_HEADERS_STRATEGY: framework

--- a/deploy/dockerhub-readme.md
+++ b/deploy/dockerhub-readme.md
@@ -29,7 +29,7 @@ QNOP_S3_ACCESS_KEY=qnop \
 QNOP_S3_SECRET_KEY="$(openssl rand -base64 24)" \
 QNOP_AUTH_JWT_SECRET="$(openssl rand -base64 48)" \
 QNOP_AUTH_ENCRYPTION_KEY="$(openssl rand -base64 48)" \
-QNOP_AUTH_ENCRYPTION_SALT="$(openssl rand -base64 48)" \
+QNOP_AUTH_ENCRYPTION_SALT="$(openssl rand -hex 32)" \
 docker compose up -d
 ```
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,7 +12,7 @@ QNOP_S3_ACCESS_KEY=qnop \
 QNOP_S3_SECRET_KEY="$(openssl rand -base64 24)" \
 QNOP_AUTH_JWT_SECRET="$(openssl rand -base64 48)" \
 QNOP_AUTH_ENCRYPTION_KEY="$(openssl rand -base64 48)" \
-QNOP_AUTH_ENCRYPTION_SALT="$(openssl rand -base64 48)" \
+QNOP_AUTH_ENCRYPTION_SALT="$(openssl rand -hex 32)" \
 docker compose up -d
 ```
 
@@ -30,7 +30,7 @@ All configuration is `QNOP_`-prefixed. The server **fails fast at startup** when
 |----------|---------|
 | `QNOP_AUTH_JWT_SECRET` | HMAC secret for access tokens (≥ 32 chars) |
 | `QNOP_AUTH_ENCRYPTION_KEY` | Key material for at-rest encryption of stored secrets (≥ 32 chars) |
-| `QNOP_AUTH_ENCRYPTION_SALT` | Salt for the key derivation (≥ 32 chars) |
+| `QNOP_AUTH_ENCRYPTION_SALT` | Salt for the key derivation (**hex-encoded**, ≥ 16 chars — e.g. `openssl rand -hex 32`) |
 | `QNOP_DB_HOST` / `QNOP_DB_PORT` / `QNOP_DB_NAME` / `QNOP_DB_USERNAME` / `QNOP_DB_PASSWORD` | PostgreSQL connection (Liquibase migrates the schema on startup) |
 | `QNOP_S3_ENDPOINT` / `QNOP_S3_BUCKET` / `QNOP_S3_ACCESS_KEY` / `QNOP_S3_SECRET_KEY` | S3-compatible object storage for document binaries (leave `QNOP_S3_ENDPOINT` empty for AWS S3) |
 


### PR DESCRIPTION
## Summary

Follow-up to #500 — this fix was pushed to the feature branch minutes after the PR was merged, so it never reached `main`.

The deployment quickstart snippets (`docs/DEPLOYMENT.md`, `deploy/dockerhub-readme.md`) and the compose fail-fast hint (`deploy/docker-compose.yml`) suggested `openssl rand -base64 48` for `QNOP_AUTH_ENCRYPTION_SALT`, but the server validates the salt as a **hex-encoded** string (≥ 16 chars) and refuses to start on base64 input:

```
Property: qnop.auth.encryptionSalt
Reason: qnop.auth.encryption-salt must be a hex-encoded string of at least 16 characters
```

Recommend `openssl rand -hex 32` instead and state the hex requirement in the environment contract table. Found while testing the published `main` snapshot image locally.

Refs #495

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)