### PR TITLE
fix(release): replace two unresolvable action SHA pins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,12 @@ jobs:
           java-version: 21
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@41ea72cf2eb6e0f26571f65a67f8bc2ada6d9139 # v4.2.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           package_json_file: qnop-ui/package.json
 
       - name: Set up Node 24
-        uses: actions/setup-node@f9d3ae3d38e7dda401ce2aa11a67b40df4e5faaa # v6.0.1
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
The first `v1.0.0` release run failed in **Set up job** — `actions/setup-node@f9d3ae3d…` and `pnpm/action-setup@41ea72cf…` are unresolvable SHAs carried over from the blueprint. Replaced with the pins `ci.yml` uses on every green run (`pnpm/action-setup@0ebf4713… # v6`, `actions/setup-node@48b55a01… # v6`).

Recovery plan after merge: delete the orphaned `v1.0.0` tag (no GitHub release was created; the VERSION commits on main are fine) and re-run prepare-release with 1.0.0 / 1.1.0-SNAPSHOT.

Closes #518

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)