### PR TITLE
docs: make Docker Hub the primary image reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ qnop is open-core: this repository is the **AGPL-3.0 Community edition**; commer
 
 ## Installation
 
-The released image is **`ghcr.io/qnophq/qnop-ce`** (multi-arch: amd64/arm64). qnop needs PostgreSQL and an S3-compatible object storage — the repository ships a single-host [`deploy/docker-compose.yml`](deploy/docker-compose.yml) wiring all three:
+The released image is **[`qnophq/qnop-ce`](https://hub.docker.com/r/qnophq/qnop-ce)** on Docker Hub (multi-arch: amd64/arm64), mirrored to `ghcr.io/qnophq/qnop-ce`. qnop needs PostgreSQL and an S3-compatible object storage — the repository ships a single-host [`deploy/docker-compose.yml`](deploy/docker-compose.yml) wiring all three:
 
 ```bash
 curl -fsSLO https://raw.githubusercontent.com/qnophq/qnop/main/deploy/docker-compose.yml
@@ -44,7 +44,7 @@ docker compose logs qnop | tail -5
 
 Open `http://localhost:8080`, sign in, change the password.
 
-The full environment contract, TLS/reverse-proxy guidance, backups and upgrade notes live in the [deployment guide](docs/DEPLOYMENT.md). Rolling development builds of `main` are published as `ghcr.io/qnophq/qnop-ce:main` for evaluation — production deployments pin a release version.
+The full environment contract, TLS/reverse-proxy guidance, backups and upgrade notes live in the [deployment guide](docs/DEPLOYMENT.md). Rolling development builds of `main` are published to GHCR only, as `ghcr.io/qnophq/qnop-ce:main`, for evaluation — production deployments pin a release version.
 
 ## Developing
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# Deployer-facing compose for qnop (ADR-0040): the released image from GHCR
-# plus PostgreSQL and MinIO. This is a single-host starting point — see
-# docs/DEPLOYMENT.md for the full environment contract, TLS/reverse-proxy
-# guidance and upgrade notes.
+# Deployer-facing compose for qnop (ADR-0040): the released image from
+# Docker Hub (mirrored to ghcr.io/qnophq/qnop-ce) plus PostgreSQL and
+# MinIO. This is a single-host starting point — see docs/DEPLOYMENT.md
+# for the full environment contract, TLS/reverse-proxy guidance and
+# upgrade notes.
 #
 # Pin the version:            QNOP_VERSION=1.0.0 docker compose up -d
 # REQUIRED before first run:  QNOP_AUTH_JWT_SECRET and QNOP_AUTH_ENCRYPTION_KEY
@@ -14,7 +15,7 @@
 
 services:
   qnop:
-    image: ghcr.io/qnophq/qnop-ce:${QNOP_VERSION:-latest}
+    image: docker.io/qnophq/qnop-ce:${QNOP_VERSION:-latest}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deploying qnop
 
-How to run the released qnop container (`ghcr.io/qnophq/qnop-ce`, ADR-0040). One image serves the REST API **and** the embedded web UI on port `8080`.
+How to run the released qnop container ([`qnophq/qnop-ce`](https://hub.docker.com/r/qnophq/qnop-ce) on Docker Hub, mirrored to `ghcr.io/qnophq/qnop-ce`; ADR-0040). One image serves the REST API **and** the embedded web UI on port `8080`.
 
 The fastest start is [`deploy/docker-compose.yml`](../deploy/docker-compose.yml) — the released image plus PostgreSQL and MinIO on a single host:
 
@@ -18,7 +18,7 @@ docker compose up -d
 
 In practice, put those values in an env file you keep out of version control and pass `--env-file`.
 
-Besides the release tags, every green CI build of `main` publishes a snapshot image under the moving `main` tag (immutable `sha-*` tags exist for pinning). Snapshots are for evaluation and pre-release testing — production deployments pin a release version.
+Besides the release tags, every green CI build of `main` publishes a snapshot image to GHCR only, under the moving `ghcr.io/qnophq/qnop-ce:main` tag (immutable `sha-*` tags exist for pinning) — to run one, point the compose `image:` at the GHCR path. Snapshots are for evaluation and pre-release testing — production deployments pin a release version.
 
 ## Environment contract
 


### PR DESCRIPTION
Closes #520.

Since release 1.0.0 the container image is published to Docker Hub ([`qnophq/qnop-ce`](https://hub.docker.com/r/qnophq/qnop-ce)) as the primary registry, with GHCR as the mirror. The deployer-facing docs still presented GHCR as the released image — this PR flips the ordering:

- **README.md** — installation section now points at Docker Hub and names GHCR as the mirror; clarifies that rolling `main` snapshot builds are published to GHCR only.
- **docs/DEPLOYMENT.md** — same registry ordering; notes that running a snapshot requires pointing the compose `image:` at the GHCR path.
- **deploy/docker-compose.yml** — default image is now `docker.io/qnophq/qnop-ce:${QNOP_VERSION:-latest}`. Fully qualified on purpose: unqualified names are only guaranteed to resolve to Docker Hub under Docker itself, while e.g. Podman consults its `unqualified-search-registries`.

No code changes — docs and deploy config only.

## Test plan

- [x] Verified `qnophq/qnop-ce` tags `1.0.0`/`1.0`/`latest` (amd64+arm64) exist on Docker Hub
- [x] Confirmed CI snapshot builds (`main`, `sha-*`) go to GHCR only (ci.yml)
- [x] Grep for remaining `ghcr.io` references: rest are intentional (mirror mentions, ADR-0040 history, workflows)

🤖 Co-Author: Claude (Fable 5) via Claude Code