### PR TITLE
feat(audit): generalise the audit trail into DOCUMENT + SYSTEM scopes (prereq for #524)

### DIFF
--- a/docs/adr/0043-system-audit-stream.md
+++ b/docs/adr/0043-system-audit-stream.md
@@ -1,0 +1,29 @@
+# ADR-0043: System-audit stream — generalising the audit trail beyond documents
+
+- **Status:** Accepted
+- **Date:** 2026-07-19
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+The `audit_event` log (issue #244, ADR-0011) has been **strictly per-document** since it shipped: `document_id` is `NOT NULL`, an `ON DELETE CASCADE` foreign key ties every row to a `document`, and the AUDITOR read surface (ADR-0042) reports the org-wide *document*-review trail. ADR-0042 drew an explicit boundary and **deferred** a "future system-audit stream (logins, settings, user admin — out of scope)".
+
+The scheduler-jobs dashboard (issue #524) is the first feature that needs to record **org-level operator actions with no document**: an admin enabling/disabling a maintenance job, overriding its dry-run flag, or triggering a run-now. These are genuine audit events (who, what, old→new state) that belong in the same trail an AUDITOR/ADMIN already reads — but they have no `document_id`, so they cannot be written to `audit_event` as it stood.
+
+Three options were considered (see issue #524 planning): (A) keep the events out of `audit_event`, recording operator state on the `scheduler_job` row only; (B) generalise `audit_event` with a nullable `document_id` and an explicit scope discriminator; (C) stand up a separate `system_audit_event` table and reader.
+
+## Decision
+
+**Option B.** `audit_event` becomes a two-scope trail:
+
+- `document_id` is now **nullable**. The existing `fk_audit_event_document` (`ON DELETE CASCADE`) is unchanged — a null simply never participates in the cascade.
+- A new **`scope`** column (`VARCHAR(16)`, `NOT NULL`, default `DOCUMENT`) discriminates `DOCUMENT` (the original per-document trail) from `SYSTEM` (org-level operator actions). The default backfills every pre-existing row correctly. A DB **check constraint** (`ck_audit_event_scope_document`) keeps the two in lock-step: a `DOCUMENT` row must have a document, a `SYSTEM` row must not — the discriminator and the foreign key can never disagree.
+- `0011` shipped in v1.0.0, so this is a **new ALTER changeset** (`0016-audit-scope-schema.yaml`), not a fold into the released one.
+- `AuditEvent.system(eventType, actorId, detail)` is the factory for `SYSTEM` rows; the existing 4-arg constructor keeps writing `DOCUMENT` rows unchanged, so none of the ~10 existing call sites move.
+- The AUDITOR read surface (ADR-0042) is unchanged in shape: the org-wide list already returns every row; it now simply also returns `SYSTEM` rows, each carrying `scope` and a null `documentId`/`documentTitle`. Actor identity still resolves to the **real** display name (the ADR-0038 anonymity bypass for compliance applies identically). The `eventType` for scheduler actions is `scheduler.job.{enabled,dry_run,run_now}`.
+
+## Consequences
+
+- **Positive:** the deferred system-audit stream is now real, with one reader, one table, one exposure model — no parallel infrastructure (rejecting C). Compliance sees operator actions and document actions in one place. Future system events (settings changes, user admin) reuse `AuditEvent.system(...)` with no further schema change.
+- **Negative / trade-offs:** `audit_event` is no longer "the document trail" — readers must not assume a non-null `document_id`. The check constraint adds a small write-time cost and must be kept in sync if scopes are ever added. Rejecting A means a schema change on a released table, but A would have split the audit story across two mechanisms, which is exactly what ADR-0042 anticipated folding back together.
+- **Follow-up:** the AUDITOR UI (issue #466) may add an explicit scope filter/label; not required for the events to appear.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,7 @@ Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-reco
 | [0040](0040-release-pipeline-and-spa-embedding.md) | Release pipeline & SPA embedding | Accepted |
 | [0041](0041-datetime-l10n-policy.md) | Date/time L10n: store UTC, transport ISO-with-offset, render in the user's zone | Accepted |
 | [0042](0042-audit-trail-exposure.md) | Audit-trail exposure: the AUDITOR read surface and its boundary | Accepted |
+| [0043](0043-system-audit-stream.md) | System-audit stream: generalising the audit trail beyond documents | Accepted |
 
 ## Template
 

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4172,27 +4172,39 @@ components:
     AuditEvent:
       type: object
       description: >-
-        One entry of the document-review audit trail (issue #466, ADR-0042),
-        with the actor and document resolved to their real display names.
+        One entry of the audit trail (issue #466, ADR-0042), with the actor and
+        document resolved to their real display names. An entry is either
+        DOCUMENT-scoped (the per-document review trail) or SYSTEM-scoped
+        (org-level operator actions with no document; issue #524, ADR-0043).
       required:
         - id
+        - scope
         - eventType
-        - documentId
         - createdAt
       properties:
         id:
           type: string
           format: uuid
           description: The event's time-ordered identifier (UUIDv7).
+        scope:
+          type: string
+          enum: [DOCUMENT, SYSTEM]
+          description: >-
+            Which trail the event belongs to: DOCUMENT (per-document review
+            trail) or SYSTEM (org-level operator actions with no document, e.g.
+            scheduler changes; issue #524, ADR-0043).
         eventType:
           type: string
           description: >-
             The audit event type, e.g. annotation.created, annotation.resolved,
             annotation.reopened, placement.confirmed, placement.reattached,
-            workflow.transition or document.due_date.changed.
+            workflow.transition, document.due_date.changed, or the SYSTEM-scoped
+            scheduler.job.enabled / scheduler.job.dry_run / scheduler.job.run_now.
         documentId:
           type: string
           format: uuid
+          nullable: true
+          description: The event's document; null for a SYSTEM-scoped event.
         documentTitle:
           type: string
           nullable: true

--- a/qnop-app/src/main/java/io/qnop/web/AuditController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AuditController.java
@@ -93,7 +93,7 @@ public class AuditController implements AuditApi {
       AuditLogService.AuditEventView view, Map<UUID, Instant> avatarTimestamps) {
     return new AuditEvent()
         .id(view.id())
-        .scope(AuditEvent.ScopeEnum.fromValue(view.scope().name()))
+        .scope(AuditEvent.ScopeEnum.fromValue(view.scope()))
         .eventType(view.eventType())
         .documentId(view.documentId())
         .documentTitle(view.documentTitle())

--- a/qnop-app/src/main/java/io/qnop/web/AuditController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AuditController.java
@@ -93,6 +93,7 @@ public class AuditController implements AuditApi {
       AuditLogService.AuditEventView view, Map<UUID, Instant> avatarTimestamps) {
     return new AuditEvent()
         .id(view.id())
+        .scope(AuditEvent.ScopeEnum.fromValue(view.scope().name()))
         .eventType(view.eventType())
         .documentId(view.documentId())
         .documentTitle(view.documentTitle())

--- a/qnop-core/src/main/java/io/qnop/entity/AuditEvent.java
+++ b/qnop-core/src/main/java/io/qnop/entity/AuditEvent.java
@@ -22,6 +22,8 @@ package io.qnop.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.Instant;
@@ -40,6 +42,11 @@ import org.hibernate.type.SqlTypes;
  * enterprise-only ones — need no schema change. {@code actorId} is the acting user, or null for
  * system-generated events. {@code detail} is optional jsonb context. Rows are never updated;
  * deleting the document cascades its trail (enforced in Liquibase, ADR-0020).
+ *
+ * <p>The trail carries two coexisting {@link AuditScope scopes} (issue #524, ADR-0043): {@link
+ * AuditScope#DOCUMENT} rows (the original per-document trail) always carry a {@code documentId};
+ * {@link AuditScope#SYSTEM} rows (org-level operator actions, e.g. scheduler toggles) never do. Use
+ * {@link #system(String, UUID, String)} to record the latter.
  */
 @Entity
 @Table(name = "audit_event")
@@ -50,8 +57,16 @@ public class AuditEvent {
   @Column(name = "id", nullable = false, updatable = false)
   private UUID id;
 
-  @Column(name = "document_id", nullable = false, updatable = false)
+  /** The document this event belongs to, or null for {@link AuditScope#SYSTEM} events. */
+  @Column(name = "document_id", updatable = false)
   private UUID documentId;
+
+  /**
+   * Which stream the event belongs to; a DB check keeps it in lock-step with {@code documentId}.
+   */
+  @Enumerated(EnumType.STRING)
+  @Column(name = "scope", nullable = false, length = 16, updatable = false)
+  private AuditScope scope;
 
   @Column(name = "event_type", nullable = false, length = 64, updatable = false)
   private String eventType;
@@ -73,15 +88,38 @@ public class AuditEvent {
     // for JPA
   }
 
+  /** A per-document event ({@link AuditScope#DOCUMENT}); {@code documentId} is required. */
   public AuditEvent(UUID documentId, String eventType, UUID actorId, String detail) {
+    this.documentId = documentId;
+    this.scope = AuditScope.DOCUMENT;
+    this.eventType = eventType;
+    this.actorId = actorId;
+    this.detail = detail;
+  }
+
+  private AuditEvent(
+      AuditScope scope, UUID documentId, String eventType, UUID actorId, String detail) {
+    this.scope = scope;
     this.documentId = documentId;
     this.eventType = eventType;
     this.actorId = actorId;
     this.detail = detail;
   }
 
+  /**
+   * An org-level system event ({@link AuditScope#SYSTEM}) with no document — e.g. a scheduler
+   * toggle or run-now. {@code actorId} is the acting admin, or null for a machine-initiated event.
+   */
+  public static AuditEvent system(String eventType, UUID actorId, String detail) {
+    return new AuditEvent(AuditScope.SYSTEM, null, eventType, actorId, detail);
+  }
+
   public UUID getId() {
     return id;
+  }
+
+  public AuditScope getScope() {
+    return scope;
   }
 
   public UUID getDocumentId() {

--- a/qnop-core/src/main/java/io/qnop/entity/AuditScope.java
+++ b/qnop-core/src/main/java/io/qnop/entity/AuditScope.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+/**
+ * Which stream an {@link AuditEvent} belongs to (issue #524, ADR-0043).
+ *
+ * <p>{@link #DOCUMENT} is the original per-document review trail (ADR-0011): the row always carries
+ * a {@code documentId}. {@link #SYSTEM} is the org-level operator stream (scheduler toggles,
+ * run-now, ...): the row never carries a {@code documentId}. The discriminator is explicit — a
+ * reader never has to infer intent from a null document id — and a DB check constraint keeps the
+ * two in lock-step.
+ */
+public enum AuditScope {
+  DOCUMENT,
+  SYSTEM
+}

--- a/qnop-core/src/main/java/io/qnop/service/audit/AuditLogService.java
+++ b/qnop-core/src/main/java/io/qnop/service/audit/AuditLogService.java
@@ -23,6 +23,7 @@ package io.qnop.service.audit;
 import static java.util.stream.Collectors.toMap;
 
 import io.qnop.entity.AuditEvent;
+import io.qnop.entity.AuditScope;
 import io.qnop.entity.Document;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
@@ -87,6 +88,7 @@ public class AuditLogService {
    */
   public record AuditEventView(
       UUID id,
+      AuditScope scope,
       String eventType,
       UUID documentId,
       String documentTitle,
@@ -185,10 +187,13 @@ public class AuditLogService {
             : users.findSlugsByIdIn(actorIds).stream()
                 .filter(row -> row.slug() != null)
                 .collect(toMap(UserSlug::id, UserSlug::slug));
-    List<UUID> documentIds = events.stream().map(AuditEvent::getDocumentId).distinct().toList();
+    List<UUID> documentIds =
+        events.stream().map(AuditEvent::getDocumentId).filter(Objects::nonNull).distinct().toList();
     Map<UUID, Document> documentById =
-        documents.findAllById(documentIds).stream()
-            .collect(toMap(Document::getId, document -> document));
+        documentIds.isEmpty()
+            ? Map.of()
+            : documents.findAllById(documentIds).stream()
+                .collect(toMap(Document::getId, document -> document));
     return toViews(events, actorNames, actorSlugs, documentById);
   }
 
@@ -212,12 +217,16 @@ public class AuditLogService {
       Map<UUID, String> actorNames,
       Map<UUID, String> actorSlugs,
       Map<UUID, Document> documentById) {
-    Document document = documentById.get(event.getDocumentId());
+    // A SYSTEM-scoped event has no document id; never probe the map with a null key
+    // (an immutable Map.of() rejects it outright).
+    Document document =
+        event.getDocumentId() == null ? null : documentById.get(event.getDocumentId());
     UUID actorId = event.getActorId();
     String actorDisplayName = actorId == null ? SYSTEM_ACTOR_NAME : actorNames.get(actorId);
     String actorSlug = actorId == null ? null : actorSlugs.get(actorId);
     return new AuditEventView(
         event.getId(),
+        event.getScope(),
         event.getEventType(),
         event.getDocumentId(),
         document == null ? null : document.getTitle(),

--- a/qnop-core/src/main/java/io/qnop/service/audit/AuditLogService.java
+++ b/qnop-core/src/main/java/io/qnop/service/audit/AuditLogService.java
@@ -23,7 +23,6 @@ package io.qnop.service.audit;
 import static java.util.stream.Collectors.toMap;
 
 import io.qnop.entity.AuditEvent;
-import io.qnop.entity.AuditScope;
 import io.qnop.entity.Document;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
@@ -88,7 +87,7 @@ public class AuditLogService {
    */
   public record AuditEventView(
       UUID id,
-      AuditScope scope,
+      String scope,
       String eventType,
       UUID documentId,
       String documentTitle,
@@ -226,7 +225,7 @@ public class AuditLogService {
     String actorSlug = actorId == null ? null : actorSlugs.get(actorId);
     return new AuditEventView(
         event.getId(),
-        event.getScope(),
+        event.getScope().name(),
         event.getEventType(),
         event.getDocumentId(),
         document == null ? null : document.getTitle(),

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -56,6 +56,9 @@ databaseChangeLog:
   - include:
       file: migrations/0015-reaction-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0016-audit-scope-schema.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/migrations/0016-audit-scope-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0016-audit-scope-schema.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) 2026-present devtank42 GmbH
+#
+# This file is part of qnop (Qualified Notes on Papers).
+#
+# qnop is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with qnop. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Generalise the append-only audit_event trail into two coexisting scopes
+# (issue #524, ADR-0043): the original per-document review trail (ADR-0011) and
+# a new SYSTEM stream for org-level operator actions with no document (scheduler
+# toggles, run-now, ...). document_id becomes nullable, and an explicit `scope`
+# discriminator is added so a reader never has to infer intent from a null.
+#
+# 0011 already shipped in v1.0.0, so this is a new ALTER changeset (the fold-into-
+# existing rule applies only to unreleased schema).
+databaseChangeLog:
+  - changeSet:
+      id: 0016-audit-event-scope
+      author: qnop
+      comment: >-
+        audit_event: allow system-scoped rows (nullable document_id + scope
+        discriminator) so the trail carries operator actions, not only per-document
+        events (issue #524, ADR-0043).
+      changes:
+        # A discriminator with a DOCUMENT default so every pre-existing row (all
+        # of which are document-scoped) is backfilled correctly by the default.
+        - addColumn:
+            tableName: audit_event
+            columns:
+              - column:
+                  name: scope
+                  type: VARCHAR(16)
+                  defaultValue: DOCUMENT
+                  constraints: { nullable: false }
+        # document_id is now optional: SYSTEM rows carry none. The existing
+        # fk_audit_event_document (ON DELETE CASCADE) keeps document-scoped rows
+        # tied to their document; a null simply never participates in the cascade.
+        - dropNotNullConstraint:
+            tableName: audit_event
+            columnName: document_id
+            columnDataType: UUID
+        # A partial guard: a DOCUMENT row must have a document, a SYSTEM row must
+        # not — the discriminator and the fk can never disagree.
+        - sql:
+            sql: >-
+              ALTER TABLE audit_event ADD CONSTRAINT ck_audit_event_scope_document
+              CHECK ((scope = 'DOCUMENT' AND document_id IS NOT NULL)
+                  OR (scope = 'SYSTEM' AND document_id IS NULL))
+            rollback: ALTER TABLE audit_event DROP CONSTRAINT ck_audit_event_scope_document
+        # System rows are queried on their own; index the discriminator with the
+        # newest-first ordering the reader uses.
+        - createIndex:
+            tableName: audit_event
+            indexName: ix_audit_event_scope_created_at
+            columns:
+              - column: { name: scope }
+              - column: { name: created_at, descending: true }

--- a/qnop-core/src/test/java/io/qnop/service/audit/AuditLogServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/audit/AuditLogServiceTest.java
@@ -30,9 +30,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.qnop.entity.AuditEvent;
+import io.qnop.entity.AuditScope;
 import io.qnop.entity.Document;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.UserDisplayName;
 import io.qnop.repository.UserRepository;
 import io.qnop.service.audit.AuditLogService.AuditEventView;
 import io.qnop.service.audit.AuditLogService.AuditPage;
@@ -106,6 +108,31 @@ class AuditLogServiceTest {
     assertThat(view.actorDisplayName()).isEqualTo("Avery Auditor");
     assertThat(view.actorSlug()).isEqualTo("avery-auditor");
     assertThat(view.detail()).isEqualTo("{\"to\":\"IN_REVIEW\"}");
+    assertThat(view.scope()).isEqualTo(AuditScope.DOCUMENT);
+  }
+
+  @Test
+  @DisplayName("a SYSTEM-scoped event carries no document and is never looked up as one")
+  void systemScopedEventHasNoDocument() {
+    // A scheduler toggle: SYSTEM scope, an acting admin, no document (issue #524, ADR-0043).
+    AuditEvent systemEvent =
+        AuditEvent.system("scheduler.job.enabled", actorId, "{\"job\":\"refreshTokenSweep\"}");
+    when(auditEvents.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of(systemEvent), PageRequest.of(0, 20), 1));
+    when(users.findDisplayNamesByIdIn(List.of(actorId)))
+        .thenReturn(List.of(new UserDisplayName(actorId, "Adele Admin")));
+    when(users.findSlugsByIdIn(List.of(actorId))).thenReturn(List.of());
+
+    AuditEventView view =
+        service.list(null, null, null, null, null, null, null, null).items().get(0);
+
+    assertThat(view.scope()).isEqualTo(AuditScope.SYSTEM);
+    assertThat(view.documentId()).isNull();
+    assertThat(view.documentTitle()).isNull();
+    assertThat(view.documentSlug()).isNull();
+    assertThat(view.actorDisplayName()).isEqualTo("Adele Admin");
+    // A null document id must never reach the document lookup.
+    verify(documents, never()).findAllById(any());
   }
 
   @Test

--- a/qnop-core/src/test/java/io/qnop/service/audit/AuditLogServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/audit/AuditLogServiceTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.qnop.entity.AuditEvent;
-import io.qnop.entity.AuditScope;
 import io.qnop.entity.Document;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
@@ -108,7 +107,7 @@ class AuditLogServiceTest {
     assertThat(view.actorDisplayName()).isEqualTo("Avery Auditor");
     assertThat(view.actorSlug()).isEqualTo("avery-auditor");
     assertThat(view.detail()).isEqualTo("{\"to\":\"IN_REVIEW\"}");
-    assertThat(view.scope()).isEqualTo(AuditScope.DOCUMENT);
+    assertThat(view.scope()).isEqualTo("DOCUMENT");
   }
 
   @Test
@@ -126,7 +125,7 @@ class AuditLogServiceTest {
     AuditEventView view =
         service.list(null, null, null, null, null, null, null, null).items().get(0);
 
-    assertThat(view.scope()).isEqualTo(AuditScope.SYSTEM);
+    assertThat(view.scope()).isEqualTo("SYSTEM");
     assertThat(view.documentId()).isNull();
     assertThat(view.documentTitle()).isNull();
     assertThat(view.documentSlug()).isNull();

--- a/qnop-ui/src/components/audit/AuditTable.test.tsx
+++ b/qnop-ui/src/components/audit/AuditTable.test.tsx
@@ -27,6 +27,7 @@ import { AuditTable } from './AuditTable';
 
 const userEvent: AuditEvent = {
   id: 'e1',
+  scope: 'DOCUMENT',
   eventType: 'workflow.transition',
   documentId: 'doc-1',
   documentTitle: 'Master services agreement',
@@ -40,6 +41,7 @@ const userEvent: AuditEvent = {
 
 const systemEvent: AuditEvent = {
   id: 'e2',
+  scope: 'DOCUMENT',
   eventType: 'extraction.failed',
   documentId: 'doc-2',
   documentTitle: 'Ingest report',

--- a/qnop-ui/src/components/audit/AuditTable.tsx
+++ b/qnop-ui/src/components/audit/AuditTable.tsx
@@ -150,21 +150,32 @@ export function AuditTable({
                   <AuditEventBadge eventType={event.eventType} />
                 </TableCell>
                 <TableCell>
-                  <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center', minWidth: 0 }}>
-                    <Link
-                      component={RouterLink}
-                      to={reviewPath({ id: event.documentId, slug: event.documentSlug })}
-                      underline="hover"
-                      noWrap
-                      sx={{ fontWeight: 600, minWidth: 0 }}
+                  {event.documentId ? (
+                    <Stack
+                      direction="row"
+                      spacing={0.25}
+                      sx={{ alignItems: 'center', minWidth: 0 }}
                     >
-                      {documentTitle}
-                    </Link>
-                    <FilterButton
-                      label={`Filter by ${documentTitle}`}
-                      onClick={() => onFilterDocument(event.documentId, documentTitle)}
-                    />
-                  </Stack>
+                      <Link
+                        component={RouterLink}
+                        to={reviewPath({ id: event.documentId, slug: event.documentSlug })}
+                        underline="hover"
+                        noWrap
+                        sx={{ fontWeight: 600, minWidth: 0 }}
+                      >
+                        {documentTitle}
+                      </Link>
+                      <FilterButton
+                        label={`Filter by ${documentTitle}`}
+                        onClick={() => onFilterDocument(event.documentId!, documentTitle)}
+                      />
+                    </Stack>
+                  ) : (
+                    // A SYSTEM-scoped event (e.g. a scheduler action) has no document.
+                    <Typography color="text.secondary" aria-label="No document">
+                      —
+                    </Typography>
+                  )}
                 </TableCell>
                 <TableCell>
                   <Typography variant="body2" color="text.secondary">

--- a/qnop-ui/src/pages/audit/AuditPage.integration.test.tsx
+++ b/qnop-ui/src/pages/audit/AuditPage.integration.test.tsx
@@ -36,6 +36,7 @@ import { AuditPage } from './AuditPage';
  */
 const systemEvent: AuditEvent = {
   id: 'sys-1',
+  scope: 'DOCUMENT',
   eventType: 'document.extraction.failed',
   documentId: 'doc-1',
   documentTitle: 'Ingest report',
@@ -45,6 +46,7 @@ const systemEvent: AuditEvent = {
 
 const userEvent: AuditEvent = {
   id: 'usr-1',
+  scope: 'DOCUMENT',
   eventType: 'annotation.created',
   documentId: 'doc-2',
   documentTitle: 'Master services agreement',

--- a/qnop-ui/src/pages/audit/AuditPage.test.tsx
+++ b/qnop-ui/src/pages/audit/AuditPage.test.tsx
@@ -71,6 +71,7 @@ function page(overrides: Partial<AuditEventListResponse>): AuditEventListRespons
 
 const event: AuditEvent = {
   id: 'e1',
+  scope: 'DOCUMENT',
   eventType: 'annotation.created',
   documentId: 'doc-1',
   createdAt: '2026-07-01T10:00:00Z',


### PR DESCRIPTION
## Summary

Prerequisite for **#524** (scheduler-jobs dashboard). Generalises the append-only `audit_event` trail from a strictly per-document log into a **two-scope** trail so org-level operator actions with no document can be audited alongside the review trail. This unblocks the scheduler dashboard's requirement to record enable/disable, dry-run and run-now as real audit events, and realises the *system-audit stream* that ADR-0042 explicitly deferred.

Isolated on purpose: it touches a **released** table (`audit_event`, shipped in v1.0.0), so it lands as its own reviewable PR before the scheduler feature is built on top.

## Changes

- **New `0016-audit-scope-schema.yaml` ALTER changeset** (not a fold — `0011` shipped in v1.0.0):
  - `document_id` → **nullable** (the existing `ON DELETE CASCADE` FK is unchanged; a null simply never cascades).
  - New **`scope`** column (`VARCHAR(16)`, `NOT NULL`, default `DOCUMENT`) — the default backfills every existing row correctly.
  - Check constraint `ck_audit_event_scope_document`: a `DOCUMENT` row must have a document, a `SYSTEM` row must not — the discriminator and the FK can never disagree.
  - `(scope, created_at DESC)` index for the system stream.
- **`AuditScope` enum** + **`AuditEvent.system(eventType, actorId, detail)`** factory for `SYSTEM` rows. The existing 4-arg constructor keeps writing `DOCUMENT` rows unchanged, so **none of the ~10 existing call sites move**.
- **`AuditLogService` / `AuditEventView`** and the **OpenAPI `AuditEvent` DTO** gain `scope`; `documentId` is nullable end-to-end; the view mapping never probes a null document id (guards the immutable-map NPE).
- **ADR-0043** records the decision (Option B from the #524 plan).

## Test plan

- [x] `:qnop-core:compileJava` + `:qnop-app:compileJava` (incl. OpenAPI regen) — green locally
- [x] `AuditLogServiceTest` green, incl. a new `systemScopedEventHasNoDocument` case (SYSTEM scope, null document never looked up)
- [x] `spotlessApply` clean
- [ ] CI: full gate (ArchUnit, Spotless, unit + Testcontainers ITs) — Docker not available locally, verified on CI

## Notes for review

- Backward-compatible, additive migration; no data migration needed (the `DOCUMENT` default backfills).
- The AUDITOR read surface (ADR-0042) is unchanged in shape — it now simply also returns `SYSTEM` rows (null `documentId`/`documentTitle`, real actor identity preserved for compliance).
- Follow-up (this PR does **not** close #524): scheduler persistence, gate/auditor/bootstrap, the 5 service integrations, the API, and the `/admin/scheduler` UI land in subsequent PRs.

🤖 Co-Author: Claude (Opus 4.x) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)