### PR TITLE
feat(admin): storage-consistency dashboard & reconciliation (#523)

### DIFF
--- a/docs/adr/0044-storage-consistency-scan-and-remediation.md
+++ b/docs/adr/0044-storage-consistency-scan-and-remediation.md
@@ -1,0 +1,36 @@
+# ADR-0044: Storage-consistency scan & remediation, and the `StorageProvider.list` SPI extension
+
+- **Status:** Accepted
+- **Date:** 2026-07-19
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+Object storage and the database can drift apart. A document version or attachment row can reference a `storage_key` whose object is gone (data loss — the document can no longer be rendered or downloaded), and an object can linger in the bucket that no row references (cost/leak — left over from a crashed ingest, a failed cleanup, or an out-of-band write). The existing orphan reaper (ADR-0036) only sees the *staging registry*: it deletes uploaded-but-uncommitted `storage_object` rows past a grace period. It cannot see a committed-then-orphaned object, because such an object has no registry row at all, nor can it detect a missing binary.
+
+We want an admin dashboard (issue #523, adapted from Plugwerk's `/admin/storage-consistency`) that reconciles the two and lets an admin remediate — without a heavy new architecture and without endangering review integrity.
+
+## Decision
+
+**1. Extend the `StorageProvider` SPI with a streaming `list(prefix)` — as a `default` method.** The orphan direction needs to enumerate the bucket, which the SPI (`put`/`get`/`exists`/`delete`) could not do. `list` returns a lazy `Stream<StorageListing>` (`key`, `size`, `lastModified`). It is declared `default` (throwing `UnsupportedOperationException`), so it is a **backward-compatible SemVer-minor** change: existing implementors — including any commercial add-on — keep compiling unchanged, and a provider that cannot enumerate its store degrades gracefully. The S3/MinIO Community default overrides it via paginated `ListObjectsV2` and, unlike the other operations, does **not** run discovered keys through the content-addressed key guard (issue #337) — the scan's purpose is to find keys that do not match.
+
+**2. The scan is a pure, streamed diff.** `StorageConsistencyService` loads the referenced set — the union of `document_version.storage_key`, `document_attachment.storage_key` and the `storage_object` registry keys (**including PENDING**, so an in-flight upload never looks like an orphan; avatars/branding are Postgres `bytea`, out of scope) — then *streams* the bucket (never materialising it) through a DB-free static `partition()` that yields orphaned objects and missing keys, with a `max-keys-per-scan` **circuit breaker** that aborts a pathological bucket as HTTP **409**. Missing keys are enriched with document context by a second pure mapper. The bucket stream runs outside any transaction so a long scan never pins a DB connection (the ADR-0004 guardrail).
+
+**3. Remediation deletes orphans only, each re-checked in its own transaction.** `POST /admin/storage-consistency/orphans/delete` deletes given keys; each key is re-checked against all three reference sources inside a `REQUIRES_NEW` transaction immediately before deletion, so a key referenced again since the scan (e.g. a new upload reusing the content, which registers a staging row) is **skipped and reported**, never deleted. Idempotent; partial progress persists. **Missing binaries are report-only** — a missing object is data loss the admin resolves through the existing document/review flows (restore from backup, or explicitly delete the document), never through a destructive shortcut here. The endpoints live under `/api/v1/admin/**` (ADMIN, central gate) and use a request body for keys because content-addressed keys contain slashes.
+
+**4. The reaper is extended to committed-namespace orphans, guarded.** Beyond the admin-triggered dashboard, a scheduled `StorageOrphanReaper` reaps bucket-wide orphans automatically — but **opt-in** (`orphanReaperEnabled`, default off), **dry-run by default**, only touching orphans older than a generous grace period (≫ the longest plausible ingest), bounded per tick, holding a ShedLock (ADR-0029), and deleting through the same in-transaction re-check path.
+
+**5. Remediation is audited as a SYSTEM-scope `audit_event`.** A bucket-wide action is not document-scoped, so each deletion is recorded through the `AuditEvent.system(...)` factory introduced by the audit-scope generalisation (issue #524, ADR-0043): `scope = SYSTEM`, `document_id = null`, event type `storage.orphan.deleted` (actor = the admin, or null for the reaper), plus a structured log line. That change made `document_id` nullable and added a `scope` discriminator with a DB check keeping the two in lock-step, so this ADR builds on it rather than touching the schema itself. Such SYSTEM events also surface in the org-wide audit trail (ADR-0042) with no document title — the intended compliance behaviour.
+
+## Consequences
+
+- **Easier:** committed-namespace orphans and missing binaries are finally visible and (for orphans) remediable; the reaper can clean the bucket automatically once an operator opts in; the SPI grows without breaking implementors.
+- **Harder / accepted:** the scan lists the whole bucket, so it is an admin/scheduled operation, not a hot path; the in-tx re-check narrows but cannot fully close the race with an external object store (accepted — idempotent, best-effort, matches Plugwerk); a missing binary is surfaced but not auto-repairable here by design.
+- **Deferred:** Micrometer counters for the reaper (structured SLF4J for now, matching the existing reaper); CSV/JSON export of the report. (The SYSTEM audit scope this feature needs is no longer deferred — it landed with issue #524 / ADR-0043.)
+
+## Alternatives considered
+
+- **Registry-only reconciliation (no `list`).** Rejected: blind to out-of-band and committed-then-orphaned objects — the honest feature needs a bucket listing.
+- **`list` as an abstract method.** Rejected: it would force every implementor (including Enterprise add-ons) to implement it — a breaking, major-style change; the `default` keeps it a true minor.
+- **Deleting missing-binary rows (as Plugwerk deletes a release row).** Rejected: annotations anchor to versions (ADR-0009) and the workflow depends on version history (ADR-0011); a `document_version` must never be blindly deleted.
+- **SLF4J-only remediation audit.** Rejected in favour of `audit_event` so the actions are queryable and appear in the compliance trail — enabled by the nullable `document_id`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@ Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-reco
 | [0041](0041-datetime-l10n-policy.md) | Date/time L10n: store UTC, transport ISO-with-offset, render in the user's zone | Accepted |
 | [0042](0042-audit-trail-exposure.md) | Audit-trail exposure: the AUDITOR read surface and its boundary | Accepted |
 | [0043](0043-system-audit-stream.md) | System-audit stream: generalising the audit trail beyond documents | Accepted |
+| [0044](0044-storage-consistency-scan-and-remediation.md) | Storage-consistency scan & remediation, and the StorageProvider.list SPI extension | Accepted |
 | [0045](0045-scheduler-jobs-dashboard.md) | Scheduler-jobs dashboard: an operator gate in front of the maintenance sweeps | Accepted |
 
 ## Template

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -65,7 +65,7 @@ tags:
       (LEAD / MEMBER). Teams group reviewers for the review workflow.
   - name: AdminStorageConsistency
     description: |
-      Admin-only storage-consistency dashboard (issue #523, ADR-0043): reconcile
+      Admin-only storage-consistency dashboard (issue #523, ADR-0044): reconcile
       the document binaries in object storage against the database. Reports
       missing binaries (a referenced object that is gone — data loss, report-only)
       and orphaned objects (a stored object no row references — cost/leak), and
@@ -1388,7 +1388,7 @@ paths:
       description: |
         Reconciles every referenced storage key (document versions, attachments,
         and the staging registry) against the bucket listing (issue #523,
-        ADR-0043). Returns missing binaries (referenced but absent — data loss,
+        ADR-0044). Returns missing binaries (referenced but absent — data loss,
         with document context) and orphaned objects (present but unreferenced —
         cost/leak, with size and age), plus totals. The scan is bounded: once it
         streams more than the configured limit it aborts with `409` so a
@@ -3588,7 +3588,7 @@ components:
   schemas:
     StorageConsistencyReport:
       type: object
-      description: The storage-consistency reconciliation report (issue #523, ADR-0043).
+      description: The storage-consistency reconciliation report (issue #523, ADR-0044).
       required:
         - summary
         - missing

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -63,6 +63,14 @@ tags:
       Admin-only team management (issue #105): list/search teams with pagination,
       create / edit / delete teams, and manage memberships with a per-team role
       (LEAD / MEMBER). Teams group reviewers for the review workflow.
+  - name: AdminStorageConsistency
+    description: |
+      Admin-only storage-consistency dashboard (issue #523, ADR-0043): reconcile
+      the document binaries in object storage against the database. Reports
+      missing binaries (a referenced object that is gone — data loss, report-only)
+      and orphaned objects (a stored object no row references — cost/leak), and
+      lets an admin delete orphans with an in-transaction re-check. The scan is
+      bounded by a circuit breaker (HTTP 409 when the bucket is too large).
   - name: Teams
     description: |
       Team self-management for team LEADs (issue #470): a LEAD may view and manage
@@ -1364,6 +1372,77 @@ paths:
           description: Member removed
         '404':
           description: The team has no such member
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/storage-consistency:
+    get:
+      tags:
+        - AdminStorageConsistency
+      summary: Scan object storage for missing binaries and orphaned objects
+      description: |
+        Reconciles every referenced storage key (document versions, attachments,
+        and the staging registry) against the bucket listing (issue #523,
+        ADR-0043). Returns missing binaries (referenced but absent — data loss,
+        with document context) and orphaned objects (present but unreferenced —
+        cost/leak, with size and age), plus totals. The scan is bounded: once it
+        streams more than the configured limit it aborts with `409` so a
+        pathological bucket fails fast instead of hanging.
+      operationId: scanStorageConsistency
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The reconciliation report
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageConsistencyReport'
+        '409':
+          description: The scan exceeded its object limit (code STORAGE_SCAN_LIMIT)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/storage-consistency/orphans/delete:
+    post:
+      tags:
+        - AdminStorageConsistency
+      summary: Delete orphaned storage objects
+      description: |
+        Deletes the given orphaned object keys (single or bulk). Each key is
+        re-checked against every reference source inside its own transaction
+        immediately before deletion, so a key that became referenced since the
+        scan is skipped and returned in `skipped` rather than deleted. Idempotent.
+        Missing binaries are never deletable here. Uses a request body (not a path
+        segment) because content-addressed keys contain slashes.
+      operationId: deleteOrphanedObjects
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrphanDeleteRequest'
+      responses:
+        '200':
+          description: The remediation outcome
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrphanDeleteResponse'
+        '400':
+          description: Invalid input
           content:
             application/json:
               schema:
@@ -3507,6 +3586,138 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
   schemas:
+    StorageConsistencyReport:
+      type: object
+      description: The storage-consistency reconciliation report (issue #523, ADR-0043).
+      required:
+        - summary
+        - missing
+        - orphaned
+      properties:
+        summary:
+          $ref: '#/components/schemas/StorageConsistencySummary'
+        missing:
+          type: array
+          items:
+            $ref: '#/components/schemas/MissingBinary'
+        orphaned:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrphanedObject'
+    StorageConsistencySummary:
+      type: object
+      required:
+        - dbReferencedCount
+        - storageObjectCount
+        - missingCount
+        - orphanedCount
+        - scannedAt
+      properties:
+        dbReferencedCount:
+          type: integer
+          format: int64
+          description: Document-binary references in the database (versions + attachments).
+        storageObjectCount:
+          type: integer
+          format: int64
+          description: Rows in the object-storage staging registry.
+        missingCount:
+          type: integer
+          format: int32
+        orphanedCount:
+          type: integer
+          format: int32
+        scannedAt:
+          type: string
+          format: date-time
+    MissingBinary:
+      type: object
+      description: A referenced binary whose object is gone (data loss); report-only.
+      required:
+        - storageKey
+        - kind
+        - documentId
+      properties:
+        storageKey:
+          type: string
+        kind:
+          type: string
+          description: Which kind of row references the missing binary.
+          enum:
+            - VERSION
+            - ATTACHMENT
+        documentId:
+          type: string
+          format: uuid
+        documentTitle:
+          type: string
+          nullable: true
+        documentSlug:
+          type: string
+          nullable: true
+        versionNumber:
+          type: integer
+          format: int32
+          nullable: true
+          description: Set when kind is VERSION.
+        attachmentName:
+          type: string
+          nullable: true
+          description: Set when kind is ATTACHMENT.
+    OrphanedObject:
+      type: object
+      description: A stored object no database row references (cost/leak).
+      required:
+        - storageKey
+        - size
+        - lastModified
+      properties:
+        storageKey:
+          type: string
+        size:
+          type: integer
+          format: int64
+          description: Object size in bytes.
+        lastModified:
+          type: string
+          format: date-time
+    OrphanDeleteRequest:
+      type: object
+      required:
+        - keys
+      properties:
+        keys:
+          type: array
+          description: The orphan object keys to delete (single or bulk).
+          minItems: 1
+          maxItems: 1000
+          items:
+            type: string
+    OrphanDeleteResponse:
+      type: object
+      required:
+        - deleted
+        - skipped
+      properties:
+        deleted:
+          type: array
+          items:
+            type: string
+        skipped:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkippedOrphan'
+    SkippedOrphan:
+      type: object
+      description: An orphan key not deleted because it was referenced again since the scan.
+      required:
+        - storageKey
+        - reason
+      properties:
+        storageKey:
+          type: string
+        reason:
+          type: string
     WorkflowStatus:
       type: object
       description: |

--- a/qnop-app/src/main/java/io/qnop/web/AdminStorageConsistencyController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminStorageConsistencyController.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AdminStorageConsistencyApi;
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.api.v1.model.MissingBinary;
+import io.qnop.api.v1.model.OrphanDeleteRequest;
+import io.qnop.api.v1.model.OrphanDeleteResponse;
+import io.qnop.api.v1.model.OrphanedObject;
+import io.qnop.api.v1.model.SkippedOrphan;
+import io.qnop.api.v1.model.StorageConsistencyReport;
+import io.qnop.api.v1.model.StorageConsistencySummary;
+import io.qnop.service.storage.StorageConsistencyService;
+import io.qnop.service.storage.StorageConsistencyService.ConsistencyReport;
+import io.qnop.service.storage.StorageConsistencyService.MissingBinaryView;
+import io.qnop.service.storage.StorageConsistencyService.OrphanView;
+import io.qnop.service.storage.StorageRemediationService;
+import io.qnop.service.storage.StorageScanLimitExceededException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin-only storage-consistency dashboard endpoints (issue #523, ADR-0043), implementing the
+ * generated {@link AdminStorageConsistencyApi} — a thin mapping over the scan and remediation
+ * services. Authorization is enforced centrally by the security chain ({@code /api/v1/admin/**}
+ * requires {@code ADMIN}). The scan circuit-breaker surfaces as {@code 409}.
+ */
+@RestController
+public class AdminStorageConsistencyController implements AdminStorageConsistencyApi {
+
+  private final StorageConsistencyService scanner;
+  private final StorageRemediationService remediation;
+
+  public AdminStorageConsistencyController(
+      StorageConsistencyService scanner, StorageRemediationService remediation) {
+    this.scanner = scanner;
+    this.remediation = remediation;
+  }
+
+  @Override
+  public ResponseEntity<StorageConsistencyReport> scanStorageConsistency() {
+    return ResponseEntity.ok(toDto(scanner.scan()));
+  }
+
+  @Override
+  public ResponseEntity<OrphanDeleteResponse> deleteOrphanedObjects(OrphanDeleteRequest request) {
+    StorageRemediationService.RemediationResult result =
+        remediation.deleteOrphans(request.getKeys(), CurrentUser.requireUserId());
+    return ResponseEntity.ok(
+        new OrphanDeleteResponse()
+            .deleted(result.deleted())
+            .skipped(
+                result.skipped().stream()
+                    .map(s -> new SkippedOrphan().storageKey(s.storageKey()).reason(s.reason()))
+                    .toList()));
+  }
+
+  @ExceptionHandler(StorageScanLimitExceededException.class)
+  public ResponseEntity<ErrorResponse> onScanLimit(StorageScanLimitExceededException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(
+            new ErrorResponse()
+                .code(ex.getCode())
+                .message(ex.getMessage())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC)));
+  }
+
+  private static StorageConsistencyReport toDto(ConsistencyReport report) {
+    return new StorageConsistencyReport()
+        .summary(
+            new StorageConsistencySummary()
+                .dbReferencedCount(report.summary().dbReferencedCount())
+                .storageObjectCount(report.summary().storageObjectCount())
+                .missingCount(report.summary().missingCount())
+                .orphanedCount(report.summary().orphanedCount())
+                .scannedAt(report.summary().scannedAt().atOffset(ZoneOffset.UTC)))
+        .missing(
+            report.missing().stream().map(AdminStorageConsistencyController::toMissingDto).toList())
+        .orphaned(
+            report.orphaned().stream()
+                .map(AdminStorageConsistencyController::toOrphanDto)
+                .toList());
+  }
+
+  private static MissingBinary toMissingDto(MissingBinaryView view) {
+    return new MissingBinary()
+        .storageKey(view.storageKey())
+        .kind(MissingBinary.KindEnum.fromValue(view.kind().name()))
+        .documentId(view.documentId())
+        .documentTitle(view.documentTitle())
+        .documentSlug(view.documentSlug())
+        .versionNumber(view.versionNumber())
+        .attachmentName(view.attachmentName());
+  }
+
+  private static OrphanedObject toOrphanDto(OrphanView view) {
+    return new OrphanedObject()
+        .storageKey(view.storageKey())
+        .size(view.size())
+        .lastModified(view.lastModified().atOffset(ZoneOffset.UTC));
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/AdminStorageConsistencyController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminStorageConsistencyController.java
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Admin-only storage-consistency dashboard endpoints (issue #523, ADR-0043), implementing the
+ * Admin-only storage-consistency dashboard endpoints (issue #523, ADR-0044), implementing the
  * generated {@link AdminStorageConsistencyApi} — a thin mapping over the scan and remediation
  * services. Authorization is enforced centrally by the security chain ({@code /api/v1/admin/**}
  * requires {@code ADMIN}). The scan circuit-breaker surfaces as {@code 409}.

--- a/qnop-app/src/test/java/io/qnop/config/ConfigurationTreeBuilderTest.java
+++ b/qnop-app/src/test/java/io/qnop/config/ConfigurationTreeBuilderTest.java
@@ -85,7 +85,12 @@ class ConfigurationTreeBuilderTest {
             Boolean.FALSE,
             Duration.ofHours(1),
             Duration.ofSeconds(60),
-            Duration.ofSeconds(20));
+            Duration.ofSeconds(20),
+            1_000_000,
+            Boolean.FALSE,
+            Boolean.TRUE,
+            Duration.ofHours(24),
+            100);
     HttpClientProperties http = new HttpClientProperties(null, null, null, null, null);
     ReanchoringProperties reanchoring = ReanchoringProperties.defaults();
     RateLimitProperties rateLimit =

--- a/qnop-app/src/test/java/io/qnop/storage/AdminStorageConsistencyIT.java
+++ b/qnop-app/src/test/java/io/qnop/storage/AdminStorageConsistencyIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.storage;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.spi.storage.StorageProvider;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.io.ByteArrayInputStream;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * The admin storage-consistency dashboard over the wire (issue #523, ADR-0043) against a real
+ * MinIO: the ADMIN-only authorization gate, the scan surfacing orphaned + missing binaries, and
+ * orphan deletion with its in-transaction re-check. Uses content-unique keys and CONTAINS
+ * assertions so it stays isolated from whatever else shares the JVM's bucket.
+ */
+class AdminStorageConsistencyIT extends SeededIntegrationTest {
+
+  private static final String SCAN = "/api/v1/admin/storage-consistency";
+  private static final String DELETE = "/api/v1/admin/storage-consistency/orphans/delete";
+
+  @Autowired private StorageProvider provider;
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  private static String keyFor(byte[] content) throws Exception {
+    String hash = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+    return "sha256/" + hash.substring(0, 2) + "/" + hash;
+  }
+
+  /** Writes a bucket object with no database reference — a true orphan. Returns its key. */
+  private String putOrphan() throws Exception {
+    byte[] content = ("orphan-" + UUID.randomUUID()).getBytes(UTF_8);
+    String key = keyFor(content);
+    provider.put(key, new ByteArrayInputStream(content), content.length, "application/pdf");
+    return key;
+  }
+
+  /** Seeds a document version whose storage key is NOT in the bucket — a missing binary. */
+  private String seedMissingVersion(String title) throws Exception {
+    Document document = documents.save(new Document(MEMBER_ID, title));
+    String missingKey = keyFor(("missing-" + UUID.randomUUID()).getBytes(UTF_8));
+    versions.save(
+        new DocumentVersion(
+            document.getId(), 1, missingKey, "deadbeef", "application/pdf", 1234L, MEMBER_ID));
+    return missingKey;
+  }
+
+  private static String deleteBody(String... keys) {
+    String joined = String.join("\",\"", keys);
+    return "{\"keys\":[\"" + joined + "\"]}";
+  }
+
+  @Test
+  @DisplayName("requires authentication")
+  void requiresAuth() throws Exception {
+    mockMvc.perform(get(SCAN)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("a non-admin (MEMBER, AUDITOR) is forbidden")
+  void nonAdminForbidden() throws Exception {
+    mockMvc.perform(as(get(SCAN), MEMBER_ID)).andExpect(status().isForbidden());
+    mockMvc.perform(as(get(SCAN), AUDITOR_ID)).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("an admin scan surfaces orphaned objects and missing binaries")
+  void adminScanFindsOrphanAndMissing() throws Exception {
+    String orphanKey = putOrphan();
+    String missingKey = seedMissingVersion("Lost contract");
+    try {
+      mockMvc
+          .perform(as(get(SCAN), ADMIN_ID))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.orphaned[*].storageKey", hasItem(orphanKey)))
+          .andExpect(jsonPath("$.missing[*].storageKey", hasItem(missingKey)))
+          .andExpect(jsonPath("$.missing[*].documentTitle", hasItem("Lost contract")));
+    } finally {
+      provider.delete(orphanKey);
+    }
+  }
+
+  @Test
+  @DisplayName("an admin deletes an orphan, and it is gone afterwards")
+  void adminDeletesOrphan() throws Exception {
+    String orphanKey = putOrphan();
+
+    mockMvc
+        .perform(
+            as(post(DELETE), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(deleteBody(orphanKey)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.deleted", hasItem(orphanKey)))
+        .andExpect(jsonPath("$.skipped").isEmpty());
+
+    assertThat(provider.exists(orphanKey)).isFalse();
+  }
+
+  @Test
+  @DisplayName("deletion skips a key that is referenced again since the scan (in-tx re-check)")
+  void deleteSkipsReferencedKey() throws Exception {
+    // A key that now has a version row must not be deleted, even if asked.
+    String referencedKey = seedMissingVersion("Still referenced");
+
+    mockMvc
+        .perform(
+            as(post(DELETE), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(deleteBody(referencedKey)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.deleted").isEmpty())
+        .andExpect(jsonPath("$.skipped[0].storageKey").value(referencedKey))
+        .andExpect(jsonPath("$.skipped[0].reason").value("now referenced"));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/storage/AdminStorageConsistencyIT.java
+++ b/qnop-app/src/test/java/io/qnop/storage/AdminStorageConsistencyIT.java
@@ -45,7 +45,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 /**
- * The admin storage-consistency dashboard over the wire (issue #523, ADR-0043) against a real
+ * The admin storage-consistency dashboard over the wire (issue #523, ADR-0044) against a real
  * MinIO: the ADMIN-only authorization gate, the scan surfacing orphaned + missing binaries, and
  * orphan deletion with its in-transaction re-check. Uses content-unique keys and CONTAINS
  * assertions so it stays isolated from whatever else shares the JVM's bucket.

--- a/qnop-app/src/test/java/io/qnop/storage/StorageConsistencyScanLimitIT.java
+++ b/qnop-app/src/test/java/io/qnop/storage/StorageConsistencyScanLimitIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.storage;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.spi.storage.StorageProvider;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.io.ByteArrayInputStream;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * The scan circuit breaker over the wire (issue #523, ADR-0043): with the object limit forced to 1,
+ * a bucket holding more than one object aborts the scan with HTTP 409 and the stable code, rather
+ * than streaming forever.
+ */
+@TestPropertySource(properties = "qnop.s3.consistency-scan-max-keys=1")
+class StorageConsistencyScanLimitIT extends SeededIntegrationTest {
+
+  private static final String SCAN = "/api/v1/admin/storage-consistency";
+
+  @Autowired private StorageProvider provider;
+
+  private void putObject() throws Exception {
+    byte[] content = ("limit-" + UUID.randomUUID()).getBytes(UTF_8);
+    String hash = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(content));
+    provider.put(
+        "sha256/" + hash.substring(0, 2) + "/" + hash,
+        new ByteArrayInputStream(content),
+        content.length,
+        "application/pdf");
+  }
+
+  @Test
+  @DisplayName("aborts with 409 STORAGE_SCAN_LIMIT once the bucket exceeds the object limit")
+  void scanAbortsWith409() throws Exception {
+    putObject();
+    putObject();
+
+    mockMvc
+        .perform(get(SCAN).header("Authorization", "Bearer " + token(ADMIN_ID)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("STORAGE_SCAN_LIMIT"));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/storage/StorageConsistencyScanLimitIT.java
+++ b/qnop-app/src/test/java/io/qnop/storage/StorageConsistencyScanLimitIT.java
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 /**
- * The scan circuit breaker over the wire (issue #523, ADR-0043): with the object limit forced to 1,
+ * The scan circuit breaker over the wire (issue #523, ADR-0044): with the object limit forced to 1,
  * a bucket holding more than one object aborts the scan with HTTP 409 and the stable code, rather
  * than streaming forever.
  */

--- a/qnop-core/src/main/java/io/qnop/repository/AttachmentStorageRef.java
+++ b/qnop-core/src/main/java/io/qnop/repository/AttachmentStorageRef.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/**
+ * A document attachment's storage key with just enough context to explain a missing binary in the
+ * storage-consistency dashboard (issue #523): which document owns it and its file name.
+ */
+public record AttachmentStorageRef(String storageKey, UUID documentId, String fileName) {}

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentAttachmentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentAttachmentRepository.java
@@ -21,13 +21,30 @@
 package io.qnop.repository;
 
 import io.qnop.entity.DocumentAttachment;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Comment image attachments (issue #446). */
 public interface DocumentAttachmentRepository extends JpaRepository<DocumentAttachment, UUID> {
 
   /** Scoped lookup — an attachment is only addressable under its own document. */
   Optional<DocumentAttachment> findByIdAndDocumentId(UUID id, UUID documentId);
+
+  /** Every attachment's storage key, for the storage-consistency referenced set (issue #523). */
+  @Query("SELECT a.storageKey FROM DocumentAttachment a")
+  List<String> findAllStorageKeys();
+
+  /**
+   * Maps missing storage keys back to their document + file name, to explain a data-loss finding.
+   */
+  @Query(
+      "SELECT new io.qnop.repository.AttachmentStorageRef(a.storageKey, a.documentId, a.fileName)"
+          + " FROM DocumentAttachment a WHERE a.storageKey IN :keys")
+  List<AttachmentStorageRef> findAttachmentRefsByStorageKeyIn(
+      @Param("keys") Collection<String> keys);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentVersionRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentVersionRepository.java
@@ -51,4 +51,16 @@ public interface DocumentVersionRepository extends JpaRepository<DocumentVersion
           + " FROM DocumentVersion v WHERE v.documentId IN :documentIds GROUP BY v.documentId")
   List<DocumentMaxVersion> findMaxVersionsByDocumentIds(
       @Param("documentIds") Collection<UUID> documentIds);
+
+  /**
+   * Every version's storage key, for the storage-consistency scan's referenced set (issue #523).
+   */
+  @Query("SELECT v.storageKey FROM DocumentVersion v")
+  List<String> findAllStorageKeys();
+
+  /** Maps missing storage keys back to their document + version, to explain a data-loss finding. */
+  @Query(
+      "SELECT new io.qnop.repository.VersionStorageRef(v.storageKey, v.documentId, v.versionNumber)"
+          + " FROM DocumentVersion v WHERE v.storageKey IN :keys")
+  List<VersionStorageRef> findVersionRefsByStorageKeyIn(@Param("keys") Collection<String> keys);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/StorageObjectRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/StorageObjectRepository.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 /** Data access for the object-storage staging registry (issue #243, ADR-0036). */
 public interface StorageObjectRepository extends JpaRepository<StorageObject, UUID> {
@@ -36,4 +37,12 @@ public interface StorageObjectRepository extends JpaRepository<StorageObject, UU
 
   /** Orphan-reaper query: rows in a given lifecycle state older than the cutoff. */
   List<StorageObject> findByStatusAndCreatedAtBefore(StorageObjectStatus status, Instant cutoff);
+
+  /**
+   * Every tracked object key (any lifecycle state), for the storage-consistency referenced set
+   * (issue #523). Including PENDING rows keeps an in-flight, not-yet-committed upload from ever
+   * looking like a bucket orphan.
+   */
+  @Query("SELECT s.objectKey FROM StorageObject s")
+  List<String> findAllObjectKeys();
 }

--- a/qnop-core/src/main/java/io/qnop/repository/VersionStorageRef.java
+++ b/qnop-core/src/main/java/io/qnop/repository/VersionStorageRef.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import java.util.UUID;
+
+/**
+ * A document version's storage key with just enough context to explain a missing binary in the
+ * storage-consistency dashboard (issue #523): which document and version references the key.
+ */
+public record VersionStorageRef(String storageKey, UUID documentId, int versionNumber) {}

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3Properties.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3Properties.java
@@ -47,6 +47,19 @@ import org.springframework.validation.annotation.Validated;
  *     hung extraction/serving job so it cannot pin a worker indefinitely (issue #314)
  * @param apiCallAttemptTimeout ceiling on a single HTTP attempt before the SDK retries it (default
  *     20s)
+ * @param consistencyScanMaxKeys circuit breaker for the storage-consistency scan (issue #523): the
+ *     scan aborts (HTTP 409) once it has streamed this many objects, so a pathological bucket fails
+ *     fast instead of hanging (default 1,000,000)
+ * @param orphanReaperEnabled whether the scheduled bucket-wide orphan reaper runs at all (issue
+ *     #523; default false — bucket-wide reaping is opt-in, the dashboard remediation is always
+ *     available)
+ * @param orphanReaperDryRun when the reaper runs, only log what it would delete instead of deleting
+ *     (default true — a safe default so enabling the reaper never deletes on the first tick)
+ * @param orphanReaperGracePeriod minimum age (by last-modified) before a bucket orphan is eligible
+ *     for reaping, sized well above the longest plausible ingest so an in-flight upload can never
+ *     look like an orphan (default 24h)
+ * @param orphanReaperMaxDeletes upper bound on deletions per reaper tick, so one run can never
+ *     cascade unbounded (default 100)
  */
 @ConfigurationProperties(prefix = "qnop.s3")
 @Validated
@@ -60,7 +73,12 @@ public record S3Properties(
     Boolean autoCreateBucket,
     Duration reaperGracePeriod,
     Duration apiCallTimeout,
-    Duration apiCallAttemptTimeout) {
+    Duration apiCallAttemptTimeout,
+    Integer consistencyScanMaxKeys,
+    Boolean orphanReaperEnabled,
+    Boolean orphanReaperDryRun,
+    Duration orphanReaperGracePeriod,
+    Integer orphanReaperMaxDeletes) {
 
   public S3Properties {
     endpoint = (endpoint == null || endpoint.isBlank()) ? null : endpoint.trim();
@@ -71,5 +89,11 @@ public record S3Properties(
     apiCallTimeout = apiCallTimeout == null ? Duration.ofSeconds(60) : apiCallTimeout;
     apiCallAttemptTimeout =
         apiCallAttemptTimeout == null ? Duration.ofSeconds(20) : apiCallAttemptTimeout;
+    consistencyScanMaxKeys = consistencyScanMaxKeys == null ? 1_000_000 : consistencyScanMaxKeys;
+    orphanReaperEnabled = orphanReaperEnabled == null ? Boolean.FALSE : orphanReaperEnabled;
+    orphanReaperDryRun = orphanReaperDryRun == null ? Boolean.TRUE : orphanReaperDryRun;
+    orphanReaperGracePeriod =
+        orphanReaperGracePeriod == null ? Duration.ofHours(24) : orphanReaperGracePeriod;
+    orphanReaperMaxDeletes = orphanReaperMaxDeletes == null ? 100 : orphanReaperMaxDeletes;
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3StorageProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3StorageProvider.java
@@ -22,17 +22,20 @@ package io.qnop.service.storage;
 
 import io.qnop.spi.storage.StorageContent;
 import io.qnop.spi.storage.StorageException;
+import io.qnop.spi.storage.StorageListing;
 import io.qnop.spi.storage.StorageProvider;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -117,6 +120,28 @@ public class S3StorageProvider implements StorageProvider {
       return true;
     } catch (S3Exception e) {
       throw new StorageException("Failed to delete object " + key, e);
+    }
+  }
+
+  /**
+   * Lists the bucket under {@code prefix} for the consistency scan (issue #523). Deliberately does
+   * NOT run discovered keys through {@link #requireValidKey} — the scan's whole purpose is to find
+   * objects that do <em>not</em> match the canonical shape (out-of-band writes, leftovers). Uses
+   * the SDK's auto-paginating {@code ListObjectsV2} so the stream stays lazy (one page in memory at
+   * a time); the caller consumes it in a try-with-resources block. Iteration-time S3 failures
+   * surface as the SDK's {@link S3Exception}; the scan service maps them to a scan failure.
+   */
+  @Override
+  public Stream<StorageListing> list(String prefix) {
+    try {
+      return s3
+          .listObjectsV2Paginator(
+              ListObjectsV2Request.builder().bucket(bucket).prefix(prefix).build())
+          .contents()
+          .stream()
+          .map(object -> new StorageListing(object.key(), object.size(), object.lastModified()));
+    } catch (S3Exception e) {
+      throw new StorageException("Failed to list objects under prefix", e);
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageConsistencyService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageConsistencyService.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Service;
 
 /**
  * Reconciles the document binaries in object storage against the database for the admin
- * storage-consistency dashboard (issue #523, ADR-0043). It surfaces two finding classes:
+ * storage-consistency dashboard (issue #523, ADR-0044). It surfaces two finding classes:
  *
  * <ul>
  *   <li><b>Missing binaries</b> — a {@code document_version}/{@code document_attachment} row whose

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageConsistencyService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageConsistencyService.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import static java.util.stream.Collectors.toMap;
+
+import io.qnop.entity.Document;
+import io.qnop.repository.AttachmentStorageRef;
+import io.qnop.repository.DocumentAttachmentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.StorageObjectRepository;
+import io.qnop.repository.VersionStorageRef;
+import io.qnop.spi.storage.StorageListing;
+import io.qnop.spi.storage.StorageProvider;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.springframework.stereotype.Service;
+
+/**
+ * Reconciles the document binaries in object storage against the database for the admin
+ * storage-consistency dashboard (issue #523, ADR-0043). It surfaces two finding classes:
+ *
+ * <ul>
+ *   <li><b>Missing binaries</b> — a {@code document_version}/{@code document_attachment} row whose
+ *       {@code storage_key} is absent from storage (data loss). Report-only.
+ *   <li><b>Orphaned objects</b> — a stored object no database row references (cost/leak).
+ * </ul>
+ *
+ * <p>The referenced set is the union of {@code document_version.storage_key}, {@code
+ * document_attachment.storage_key} and the {@code storage_object} registry keys — including PENDING
+ * staging rows, so an in-flight upload never looks like an orphan. Avatars/branding live in
+ * Postgres {@code bytea} (ADR-0024/0031), not object storage, so they are out of scope.
+ *
+ * <p>The core diff is the pure, DB-free static {@link #partition} (with its circuit breaker) and
+ * the pure {@link #toMissingViews} mapper — both unit-testable without an {@code EntityManager} or
+ * a live bucket (the architecture guardrail, ADR-0004). The bucket is <em>streamed</em> (never
+ * materialised) and, deliberately, outside any long-lived transaction.
+ */
+@Service
+public class StorageConsistencyService {
+
+  /**
+   * The scan lists the whole bucket: by ADR-0005 only document binaries ({@code sha256/…}) are
+   * written here, so any object outside that shape is itself an out-of-band orphan worth surfacing.
+   */
+  static final String SCAN_PREFIX = "";
+
+  private final StorageProvider storage;
+  private final DocumentVersionRepository documentVersions;
+  private final DocumentAttachmentRepository documentAttachments;
+  private final StorageObjectRepository storageObjects;
+  private final DocumentRepository documents;
+  private final int maxKeys;
+
+  public StorageConsistencyService(
+      StorageProvider storage,
+      DocumentVersionRepository documentVersions,
+      DocumentAttachmentRepository documentAttachments,
+      StorageObjectRepository storageObjects,
+      DocumentRepository documents,
+      S3Properties properties) {
+    this.storage = storage;
+    this.documentVersions = documentVersions;
+    this.documentAttachments = documentAttachments;
+    this.storageObjects = storageObjects;
+    this.documents = documents;
+    this.maxKeys = properties.consistencyScanMaxKeys();
+  }
+
+  /** Which kind of row references a missing binary. */
+  public enum MissingKind {
+    VERSION,
+    ATTACHMENT
+  }
+
+  /** A stored object no database row references. */
+  public record OrphanView(String storageKey, long size, Instant lastModified) {}
+
+  /** A referenced binary whose object is gone, with the context an admin needs to act. */
+  public record MissingBinaryView(
+      String storageKey,
+      MissingKind kind,
+      UUID documentId,
+      String documentTitle,
+      String documentSlug,
+      Integer versionNumber,
+      String attachmentName) {}
+
+  public record ConsistencySummary(
+      long dbReferencedCount,
+      long storageObjectCount,
+      int missingCount,
+      int orphanedCount,
+      Instant scannedAt) {}
+
+  public record ConsistencyReport(
+      ConsistencySummary summary, List<MissingBinaryView> missing, List<OrphanView> orphaned) {}
+
+  /**
+   * Runs a full scan: loads the referenced set, streams the bucket, partitions into known/orphaned,
+   * derives the missing set, and enriches missing keys with document context. Throws {@link
+   * StorageScanLimitExceededException} if the bucket exceeds the configured circuit-breaker limit.
+   */
+  public ConsistencyReport scan() {
+    List<String> versionKeys = documentVersions.findAllStorageKeys();
+    List<String> attachmentKeys = documentAttachments.findAllStorageKeys();
+    List<String> registryKeys = storageObjects.findAllObjectKeys();
+
+    Set<String> referenced = new HashSet<>();
+    referenced.addAll(versionKeys);
+    referenced.addAll(attachmentKeys);
+    referenced.addAll(registryKeys);
+
+    // The bucket stream is consumed outside any transaction so a long scan never pins a DB
+    // connection; try-with-resources closes the SDK-backed stream.
+    Partition partition;
+    try (Stream<StorageListing> listing = storage.list(SCAN_PREFIX)) {
+      partition = partition(referenced, listing.iterator(), maxKeys);
+    }
+
+    List<MissingBinaryView> missing = enrichMissing(partition.missingKeys());
+    ConsistencySummary summary =
+        new ConsistencySummary(
+            (long) versionKeys.size() + attachmentKeys.size(),
+            registryKeys.size(),
+            missing.size(),
+            partition.orphaned().size(),
+            Instant.now());
+    return new ConsistencyReport(summary, missing, partition.orphaned());
+  }
+
+  /** The bucket-vs-referenced diff. */
+  record Partition(List<OrphanView> orphaned, Set<String> missingKeys) {}
+
+  /**
+   * The pure diff (DB-free, S3-free): streams the listing once, collecting orphans (not referenced)
+   * and tracking which referenced keys were seen; missing = referenced − seen. The circuit breaker
+   * aborts after {@code maxKeys} streamed objects so a pathological bucket fails fast.
+   */
+  static Partition partition(
+      Set<String> referenced, Iterator<StorageListing> listing, int maxKeys) {
+    Set<String> found = new HashSet<>();
+    List<OrphanView> orphaned = new ArrayList<>();
+    int scanned = 0;
+    while (listing.hasNext()) {
+      StorageListing entry = listing.next();
+      if (++scanned > maxKeys) {
+        throw new StorageScanLimitExceededException(
+            "Storage scan exceeded the limit of " + maxKeys + " objects");
+      }
+      if (referenced.contains(entry.key())) {
+        found.add(entry.key());
+      } else {
+        orphaned.add(new OrphanView(entry.key(), entry.size(), entry.lastModified()));
+      }
+    }
+    Set<String> missing = new HashSet<>(referenced);
+    missing.removeAll(found);
+    return new Partition(orphaned, missing);
+  }
+
+  private List<MissingBinaryView> enrichMissing(Set<String> missingKeys) {
+    if (missingKeys.isEmpty()) {
+      return List.of();
+    }
+    List<VersionStorageRef> versionRefs =
+        documentVersions.findVersionRefsByStorageKeyIn(missingKeys);
+    List<AttachmentStorageRef> attachmentRefs =
+        documentAttachments.findAttachmentRefsByStorageKeyIn(missingKeys);
+
+    Set<UUID> documentIds = new HashSet<>();
+    versionRefs.forEach(ref -> documentIds.add(ref.documentId()));
+    attachmentRefs.forEach(ref -> documentIds.add(ref.documentId()));
+    Map<UUID, Document> documentById =
+        documents.findAllById(documentIds).stream().collect(toMap(Document::getId, doc -> doc));
+
+    return toMissingViews(versionRefs, attachmentRefs, documentById);
+  }
+
+  /**
+   * The pure mapping from missing-key references to views, given the pre-resolved documents —
+   * DB-free so it is unit-testable in isolation. A content-addressed key may be shared by several
+   * rows (dedup), so one missing object can produce several findings, one per affected document.
+   */
+  static List<MissingBinaryView> toMissingViews(
+      List<VersionStorageRef> versionRefs,
+      List<AttachmentStorageRef> attachmentRefs,
+      Map<UUID, Document> documentById) {
+    List<MissingBinaryView> views = new ArrayList<>(versionRefs.size() + attachmentRefs.size());
+    for (VersionStorageRef ref : versionRefs) {
+      Document document = documentById.get(ref.documentId());
+      views.add(
+          new MissingBinaryView(
+              ref.storageKey(),
+              MissingKind.VERSION,
+              ref.documentId(),
+              document == null ? null : document.getTitle(),
+              document == null ? null : document.getSlug(),
+              ref.versionNumber(),
+              null));
+    }
+    for (AttachmentStorageRef ref : attachmentRefs) {
+      Document document = documentById.get(ref.documentId());
+      views.add(
+          new MissingBinaryView(
+              ref.storageKey(),
+              MissingKind.ATTACHMENT,
+              ref.documentId(),
+              document == null ? null : document.getTitle(),
+              document == null ? null : document.getSlug(),
+              null,
+              ref.fileName()));
+    }
+    return views;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageOrphanReaper.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageOrphanReaper.java
@@ -32,7 +32,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Scheduled bucket-wide orphan reaper (issue #523, ADR-0043) — the automated complement to the
+ * Scheduled bucket-wide orphan reaper (issue #523, ADR-0044) — the automated complement to the
  * admin dashboard. Where the existing {@code StorageService} reaper only deletes uploaded-but-
  * uncommitted staging rows it can see in the registry, this one scans the whole bucket and reaps
  * <em>committed-namespace</em> orphans that no database row references at all (e.g. a version

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageOrphanReaper.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageOrphanReaper.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import io.qnop.service.storage.StorageConsistencyService.ConsistencyReport;
+import io.qnop.service.storage.StorageConsistencyService.OrphanView;
+import io.qnop.service.storage.StorageRemediationService.RemediationResult;
+import java.time.Instant;
+import java.util.List;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled bucket-wide orphan reaper (issue #523, ADR-0043) — the automated complement to the
+ * admin dashboard. Where the existing {@code StorageService} reaper only deletes uploaded-but-
+ * uncommitted staging rows it can see in the registry, this one scans the whole bucket and reaps
+ * <em>committed-namespace</em> orphans that no database row references at all (e.g. a version
+ * delete whose object delete failed).
+ *
+ * <p>Guarded for safety: it is opt-in ({@code orphanReaperEnabled}, default off), <b>dry-run by
+ * default</b> (logs instead of deletes), only touches orphans older than a generous grace period
+ * (well above the longest plausible ingest, so an in-flight upload can never look like an orphan),
+ * bounds deletions per tick, holds a ShedLock (ADR-0029) so only one instance runs, and deletes
+ * through the same in-transaction re-check path as the dashboard.
+ */
+@Component
+public class StorageOrphanReaper {
+
+  private static final Logger log = LoggerFactory.getLogger(StorageOrphanReaper.class);
+
+  private final StorageConsistencyService scanner;
+  private final StorageRemediationService remediation;
+  private final S3Properties properties;
+
+  public StorageOrphanReaper(
+      StorageConsistencyService scanner,
+      StorageRemediationService remediation,
+      S3Properties properties) {
+    this.scanner = scanner;
+    this.remediation = remediation;
+    this.properties = properties;
+  }
+
+  @Scheduled(cron = "${qnop.s3.orphan-reaper-cron:0 15 4 * * *}")
+  @SchedulerLock(name = "storageBucketOrphanReaper", lockAtMostFor = "PT30M")
+  public void reap() {
+    if (!properties.orphanReaperEnabled()) {
+      return;
+    }
+    ConsistencyReport report = scanner.scan();
+    Instant cutoff = Instant.now().minus(properties.orphanReaperGracePeriod());
+    List<String> eligible =
+        report.orphaned().stream()
+            .filter(
+                orphan -> orphan.lastModified() != null && orphan.lastModified().isBefore(cutoff))
+            .limit(properties.orphanReaperMaxDeletes())
+            .map(OrphanView::storageKey)
+            .toList();
+
+    if (eligible.isEmpty()) {
+      log.info(
+          "Storage bucket reaper found no eligible orphans (orphans={}, grace={}).",
+          report.orphaned().size(),
+          properties.orphanReaperGracePeriod());
+      return;
+    }
+
+    if (properties.orphanReaperDryRun()) {
+      log.info(
+          "Storage bucket reaper [dry-run]: would delete {} orphan(s) older than {}; enable by "
+              + "setting qnop.s3.orphan-reaper-dry-run=false.",
+          eligible.size(),
+          properties.orphanReaperGracePeriod());
+      return;
+    }
+
+    // A null actor marks the deletion as system-driven in the audit trail.
+    RemediationResult result = remediation.deleteOrphans(eligible, null);
+    log.info(
+        "Storage bucket reaper deleted {} orphan(s), skipped {} (re-referenced since scan).",
+        result.deleted().size(),
+        result.skipped().size());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageRemediationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageRemediationService.java
@@ -38,7 +38,7 @@ import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
- * Deletes orphaned storage objects for the admin dashboard (issue #523, ADR-0043). Each key is
+ * Deletes orphaned storage objects for the admin dashboard (issue #523, ADR-0044). Each key is
  * remediated in <em>its own</em> transaction: the references are re-checked against all three
  * sources immediately before deletion, so a key that became referenced since the scan (e.g. a new
  * upload reusing the same content, which registers a staging row) is skipped and reported back

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageRemediationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageRemediationService.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import io.qnop.entity.AuditEvent;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentAttachmentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.StorageObjectRepository;
+import io.qnop.spi.storage.StorageProvider;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Deletes orphaned storage objects for the admin dashboard (issue #523, ADR-0043). Each key is
+ * remediated in <em>its own</em> transaction: the references are re-checked against all three
+ * sources immediately before deletion, so a key that became referenced since the scan (e.g. a new
+ * upload reusing the same content, which registers a staging row) is skipped and reported back
+ * rather than deleted. Idempotent; every deletion is recorded both as a structured log line and as
+ * a document-less {@link AuditEvent} (nullable {@code document_id}).
+ *
+ * <p>Missing binaries are deliberately never deleted here — a missing object is data loss the admin
+ * resolves through the document/review flows, not a shortcut in this service.
+ */
+@Service
+public class StorageRemediationService {
+
+  /** Audit event type for a dashboard/reaper orphan deletion; detail carries {@code {"key"}}. */
+  public static final String AUDIT_ORPHAN_DELETED = "storage.orphan.deleted";
+
+  private static final Logger log = LoggerFactory.getLogger(StorageRemediationService.class);
+
+  private final StorageProvider storage;
+  private final DocumentVersionRepository documentVersions;
+  private final DocumentAttachmentRepository documentAttachments;
+  private final StorageObjectRepository storageObjects;
+  private final AuditEventRepository auditEvents;
+  private final TransactionTemplate requiresNew;
+
+  public StorageRemediationService(
+      StorageProvider storage,
+      DocumentVersionRepository documentVersions,
+      DocumentAttachmentRepository documentAttachments,
+      StorageObjectRepository storageObjects,
+      AuditEventRepository auditEvents,
+      PlatformTransactionManager transactionManager) {
+    this.storage = storage;
+    this.documentVersions = documentVersions;
+    this.documentAttachments = documentAttachments;
+    this.storageObjects = storageObjects;
+    this.auditEvents = auditEvents;
+    this.requiresNew = new TransactionTemplate(transactionManager);
+    this.requiresNew.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+  }
+
+  /** A key that was NOT deleted, with the reason (kept on screen so the admin sees why). */
+  public record Skipped(String storageKey, String reason) {}
+
+  /** The outcome of a remediation request: what was deleted and what was skipped, with reasons. */
+  public record RemediationResult(List<String> deleted, List<Skipped> skipped) {}
+
+  /**
+   * Deletes each given orphan key that is still unreferenced. {@code actorId} is the acting admin
+   * (or null for the scheduled reaper). Duplicate keys are collapsed. Partial progress persists —
+   * one key's failure or skip does not roll back the others.
+   */
+  public RemediationResult deleteOrphans(Collection<String> keys, UUID actorId) {
+    List<String> deleted = new ArrayList<>();
+    List<Skipped> skipped = new ArrayList<>();
+    for (String key : keys.stream().distinct().toList()) {
+      String reason = requiresNew.execute(status -> deleteOne(key, actorId));
+      if (reason == null) {
+        deleted.add(key);
+      } else {
+        skipped.add(new Skipped(key, reason));
+      }
+    }
+    return new RemediationResult(deleted, skipped);
+  }
+
+  /** Deletes one key inside the caller's fresh transaction; returns null when deleted, else why. */
+  private String deleteOne(String key, UUID actorId) {
+    if (isReferenced(key)) {
+      return "now referenced";
+    }
+    storage.delete(key); // idempotent; external to the transaction
+    // A bucket-wide deletion is not document-scoped: record it as a SYSTEM-scope
+    // audit event with a null document_id (issue #524 / ADR-0043).
+    auditEvents.save(AuditEvent.system(AUDIT_ORPHAN_DELETED, actorId, "{\"key\":\"" + key + "\"}"));
+    log.info("Storage orphan deleted: key={} actor={}", key, actorId);
+    return null;
+  }
+
+  /** Whether any of the three reference sources currently points at {@code key}. */
+  private boolean isReferenced(String key) {
+    List<String> one = List.of(key);
+    return !documentVersions.findVersionRefsByStorageKeyIn(one).isEmpty()
+        || !documentAttachments.findAttachmentRefsByStorageKeyIn(one).isEmpty()
+        || storageObjects.findByObjectKey(key).isPresent();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageScanLimitExceededException.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageScanLimitExceededException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+/**
+ * Raised when a storage-consistency scan streams more objects than the configured circuit-breaker
+ * limit (issue #523): a pathological bucket fails fast rather than hanging. Mapped to HTTP 409 with
+ * the stable code {@link #CODE} so the dashboard can surface a readable warning.
+ */
+public class StorageScanLimitExceededException extends RuntimeException {
+
+  public static final String CODE = "STORAGE_SCAN_LIMIT";
+
+  public StorageScanLimitExceededException(String message) {
+    super(message);
+  }
+
+  public String getCode() {
+    return CODE;
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/storage/StorageConsistencyServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/StorageConsistencyServiceTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.entity.Document;
+import io.qnop.repository.AttachmentStorageRef;
+import io.qnop.repository.VersionStorageRef;
+import io.qnop.service.storage.StorageConsistencyService.MissingBinaryView;
+import io.qnop.service.storage.StorageConsistencyService.MissingKind;
+import io.qnop.service.storage.StorageConsistencyService.OrphanView;
+import io.qnop.service.storage.StorageConsistencyService.Partition;
+import io.qnop.spi.storage.StorageListing;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The pure diff and mapping rules of the storage-consistency scan (issue #523, ADR-0043) —
+ * partitioning known/orphaned/missing, the circuit breaker, and missing-key enrichment — exercised
+ * without a database or a live bucket.
+ */
+class StorageConsistencyServiceTest {
+
+  private static final Instant T = Instant.parse("2026-07-19T10:00:00Z");
+  private static final int NO_LIMIT = Integer.MAX_VALUE;
+
+  private static StorageListing listing(String key) {
+    return new StorageListing(key, 1024L, T);
+  }
+
+  @Test
+  @DisplayName(
+      "partitions a bucket into orphaned objects and missing keys around the referenced set")
+  void partitionsKnownOrphanedMissing() {
+    Set<String> referenced = Set.of("a", "b", "c");
+    // Bucket has a, b (known) and x (orphan); c is referenced but absent (missing).
+    List<StorageListing> bucket = List.of(listing("a"), listing("b"), listing("x"));
+
+    Partition result = StorageConsistencyService.partition(referenced, bucket.iterator(), NO_LIMIT);
+
+    assertThat(result.orphaned()).extracting(OrphanView::storageKey).containsExactly("x");
+    assertThat(result.missingKeys()).containsExactly("c");
+  }
+
+  @Test
+  @DisplayName("an empty bucket makes every referenced key missing")
+  void emptyBucketAllMissing() {
+    Partition result =
+        StorageConsistencyService.partition(
+            Set.of("a", "b"), List.<StorageListing>of().iterator(), NO_LIMIT);
+
+    assertThat(result.orphaned()).isEmpty();
+    assertThat(result.missingKeys()).containsExactlyInAnyOrder("a", "b");
+  }
+
+  @Test
+  @DisplayName("with no references every object is an orphan and nothing is missing")
+  void noReferencesAllOrphaned() {
+    Partition result =
+        StorageConsistencyService.partition(
+            Set.of(), List.of(listing("x"), listing("y")).iterator(), NO_LIMIT);
+
+    assertThat(result.orphaned())
+        .extracting(OrphanView::storageKey)
+        .containsExactlyInAnyOrder("x", "y");
+    assertThat(result.missingKeys()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("an orphan carries its size and last-modified time")
+  void orphanCarriesMetadata() {
+    StorageListing entry = new StorageListing("x", 4096L, T);
+
+    Partition result =
+        StorageConsistencyService.partition(Set.of(), List.of(entry).iterator(), NO_LIMIT);
+
+    assertThat(result.orphaned())
+        .singleElement()
+        .satisfies(
+            orphan -> {
+              assertThat(orphan.size()).isEqualTo(4096L);
+              assertThat(orphan.lastModified()).isEqualTo(T);
+            });
+  }
+
+  @Test
+  @DisplayName("the circuit breaker aborts once more than maxKeys objects have been streamed")
+  void circuitBreakerAborts() {
+    List<StorageListing> bucket = List.of(listing("x"), listing("y"), listing("z"));
+
+    assertThatThrownBy(() -> StorageConsistencyService.partition(Set.of(), bucket.iterator(), 2))
+        .isInstanceOf(StorageScanLimitExceededException.class)
+        .hasMessageContaining("2");
+  }
+
+  @Test
+  @DisplayName("maps missing version and attachment refs to findings with document context")
+  void mapsMissingRefs() {
+    UUID docId = UUID.randomUUID();
+    Document document = new Document(UUID.randomUUID(), "Master services agreement");
+    document.setSlug("msa");
+    // A dedup-shared key referenced by both a version and an attachment yields one finding each.
+    List<VersionStorageRef> versionRefs = List.of(new VersionStorageRef("k1", docId, 3));
+    List<AttachmentStorageRef> attachmentRefs =
+        List.of(new AttachmentStorageRef("k2", docId, "diagram.png"));
+
+    List<MissingBinaryView> views =
+        StorageConsistencyService.toMissingViews(
+            versionRefs, attachmentRefs, Map.of(docId, document));
+
+    assertThat(views).hasSize(2);
+    assertThat(views.get(0))
+        .satisfies(
+            v -> {
+              assertThat(v.kind()).isEqualTo(MissingKind.VERSION);
+              assertThat(v.storageKey()).isEqualTo("k1");
+              assertThat(v.documentTitle()).isEqualTo("Master services agreement");
+              assertThat(v.documentSlug()).isEqualTo("msa");
+              assertThat(v.versionNumber()).isEqualTo(3);
+              assertThat(v.attachmentName()).isNull();
+            });
+    assertThat(views.get(1))
+        .satisfies(
+            v -> {
+              assertThat(v.kind()).isEqualTo(MissingKind.ATTACHMENT);
+              assertThat(v.attachmentName()).isEqualTo("diagram.png");
+              assertThat(v.versionNumber()).isNull();
+            });
+  }
+
+  @Test
+  @DisplayName("an unresolved document leaves title and slug null, never a raw id")
+  void unresolvedDocumentYieldsNulls() {
+    UUID docId = UUID.randomUUID();
+
+    List<MissingBinaryView> views =
+        StorageConsistencyService.toMissingViews(
+            List.of(new VersionStorageRef("k1", docId, 1)), List.of(), Map.of());
+
+    assertThat(views)
+        .singleElement()
+        .satisfies(
+            v -> {
+              assertThat(v.documentTitle()).isNull();
+              assertThat(v.documentSlug()).isNull();
+            });
+  }
+
+  @Test
+  @DisplayName("no missing refs yields no findings")
+  void emptyMissingRefs() {
+    assertThat(StorageConsistencyService.toMissingViews(List.of(), List.of(), Map.of())).isEmpty();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/storage/StorageConsistencyServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/StorageConsistencyServiceTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * The pure diff and mapping rules of the storage-consistency scan (issue #523, ADR-0043) —
+ * The pure diff and mapping rules of the storage-consistency scan (issue #523, ADR-0044) —
  * partitioning known/orphaned/missing, the circuit breaker, and missing-key enrichment — exercised
  * without a database or a live bucket.
  */

--- a/qnop-core/src/test/java/io/qnop/service/storage/StorageOrphanReaperTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/StorageOrphanReaperTest.java
@@ -43,7 +43,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * The scheduled bucket orphan reaper's guards (issue #523, ADR-0043): opt-in, dry-run, grace, cap.
+ * The scheduled bucket orphan reaper's guards (issue #523, ADR-0044): opt-in, dry-run, grace, cap.
  */
 @ExtendWith(MockitoExtension.class)
 class StorageOrphanReaperTest {

--- a/qnop-core/src/test/java/io/qnop/service/storage/StorageOrphanReaperTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/StorageOrphanReaperTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.qnop.service.storage.StorageConsistencyService.ConsistencyReport;
+import io.qnop.service.storage.StorageConsistencyService.ConsistencySummary;
+import io.qnop.service.storage.StorageConsistencyService.OrphanView;
+import io.qnop.service.storage.StorageRemediationService.RemediationResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * The scheduled bucket orphan reaper's guards (issue #523, ADR-0043): opt-in, dry-run, grace, cap.
+ */
+@ExtendWith(MockitoExtension.class)
+class StorageOrphanReaperTest {
+
+  private static final Duration GRACE = Duration.ofHours(24);
+
+  @Mock private StorageConsistencyService scanner;
+  @Mock private StorageRemediationService remediation;
+
+  private static S3Properties props(boolean enabled, boolean dryRun, int maxDeletes) {
+    return new S3Properties(
+        null,
+        null,
+        "bucket",
+        "ak",
+        "sk",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        enabled,
+        dryRun,
+        GRACE,
+        maxDeletes);
+  }
+
+  private static OrphanView orphan(String key, Duration age) {
+    return new OrphanView(key, 1024L, Instant.now().minus(age));
+  }
+
+  private static ConsistencyReport report(OrphanView... orphans) {
+    return new ConsistencyReport(
+        new ConsistencySummary(0, 0, 0, orphans.length, Instant.now()),
+        List.of(),
+        List.of(orphans));
+  }
+
+  @Test
+  @DisplayName("does nothing (not even a scan) when the reaper is disabled")
+  void disabledDoesNothing() {
+    StorageOrphanReaper reaper =
+        new StorageOrphanReaper(scanner, remediation, props(false, true, 100));
+
+    reaper.reap();
+
+    verifyNoInteractions(scanner, remediation);
+  }
+
+  @Test
+  @DisplayName("dry-run scans but never deletes")
+  void dryRunNeverDeletes() {
+    when(scanner.scan()).thenReturn(report(orphan("old", Duration.ofHours(48))));
+    StorageOrphanReaper reaper =
+        new StorageOrphanReaper(scanner, remediation, props(true, true, 100));
+
+    reaper.reap();
+
+    verify(scanner).scan();
+    verifyNoInteractions(remediation);
+  }
+
+  @Test
+  @DisplayName("deletes only orphans older than the grace period, as the system actor")
+  void deletesOnlyAgedOrphans() {
+    when(scanner.scan())
+        .thenReturn(
+            report(
+                orphan("aged", Duration.ofHours(48)), // older than 24h grace → eligible
+                orphan("fresh", Duration.ofHours(1)))); // within grace → protected
+    when(remediation.deleteOrphans(any(), isNull()))
+        .thenReturn(new RemediationResult(List.of("aged"), List.of()));
+    StorageOrphanReaper reaper =
+        new StorageOrphanReaper(scanner, remediation, props(true, false, 100));
+
+    reaper.reap();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> keys = ArgumentCaptor.forClass(List.class);
+    verify(remediation).deleteOrphans(keys.capture(), isNull());
+    assertThat(keys.getValue()).containsExactly("aged");
+  }
+
+  @Test
+  @DisplayName("never exceeds the per-tick delete cap")
+  void respectsMaxDeletes() {
+    when(scanner.scan())
+        .thenReturn(
+            report(
+                orphan("a", Duration.ofHours(48)),
+                orphan("b", Duration.ofHours(48)),
+                orphan("c", Duration.ofHours(48))));
+    when(remediation.deleteOrphans(any(), isNull()))
+        .thenReturn(new RemediationResult(List.of(), List.of()));
+    StorageOrphanReaper reaper =
+        new StorageOrphanReaper(scanner, remediation, props(true, false, 2));
+
+    reaper.reap();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> keys = ArgumentCaptor.forClass(List.class);
+    verify(remediation).deleteOrphans(keys.capture(), isNull());
+    assertThat(keys.getValue()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("skips deletion when nothing is aged enough")
+  void noEligibleNoDelete() {
+    when(scanner.scan()).thenReturn(report(orphan("fresh", Duration.ofMinutes(30))));
+    StorageOrphanReaper reaper =
+        new StorageOrphanReaper(scanner, remediation, props(true, false, 100));
+
+    reaper.reap();
+
+    verify(remediation, never()).deleteOrphans(any(), any());
+  }
+}

--- a/qnop-spi/src/main/java/io/qnop/spi/storage/StorageListing.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/storage/StorageListing.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.spi.storage;
+
+import java.time.Instant;
+
+/**
+ * One entry of a {@link StorageProvider#list(String) storage listing} (issue #523): the object's
+ * opaque key plus the metadata a consistency scan needs to reason about an unreferenced object.
+ *
+ * @param key the object key
+ * @param size the object size in bytes
+ * @param lastModified when the object was last written
+ */
+public record StorageListing(String key, long size, Instant lastModified) {}

--- a/qnop-spi/src/main/java/io/qnop/spi/storage/StorageProvider.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/storage/StorageProvider.java
@@ -61,7 +61,7 @@ public interface StorageProvider {
   boolean delete(String key);
 
   /**
-   * Lists every object whose key starts with {@code prefix} (issue #523, ADR-0043), for the
+   * Lists every object whose key starts with {@code prefix} (issue #523, ADR-0044), for the
    * storage-consistency scan's orphan direction. The returned stream is <em>lazy</em> and may be
    * backed by a network connection: the caller must consume it inside a try-with-resources block so
    * it is closed. Order is unspecified.

--- a/qnop-spi/src/main/java/io/qnop/spi/storage/StorageProvider.java
+++ b/qnop-spi/src/main/java/io/qnop/spi/storage/StorageProvider.java
@@ -22,6 +22,7 @@ package io.qnop.spi.storage;
 
 import java.io.InputStream;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * The object-storage extension point (ADR-0005): store, retrieve, probe and delete binary content
@@ -58,4 +59,22 @@ public interface StorageProvider {
    * @return {@code true} if an object existed and was deleted, {@code false} if there was none
    */
   boolean delete(String key);
+
+  /**
+   * Lists every object whose key starts with {@code prefix} (issue #523, ADR-0043), for the
+   * storage-consistency scan's orphan direction. The returned stream is <em>lazy</em> and may be
+   * backed by a network connection: the caller must consume it inside a try-with-resources block so
+   * it is closed. Order is unspecified.
+   *
+   * <p>This is an additive, backward-compatible extension to the contract (SemVer minor): it is a
+   * {@code default} method that throws {@link UnsupportedOperationException}, so a provider that
+   * cannot enumerate its backing store keeps compiling unchanged and the scan degrades gracefully.
+   * The S3/MinIO Community default overrides it via paginated {@code ListObjectsV2}.
+   *
+   * @param prefix the key prefix to scope the listing to (empty string lists the whole bucket)
+   * @return a lazy stream of the matching objects with their size and last-modified time
+   */
+  default Stream<StorageListing> list(String prefix) {
+    throw new UnsupportedOperationException("This StorageProvider does not support listing");
+  }
 }

--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -26,6 +26,7 @@ import {
   AdminOidcProvidersApi,
   AdminSchedulerApi,
   AdminSettingsApi,
+  AdminStorageConsistencyApi,
   AdminTeamsApi,
   AdminUsersApi,
   AnnotationsApi,
@@ -103,6 +104,11 @@ export const teamsApi = new TeamsApi(undefined, undefined, axiosInstance);
 export const adminSettingsApi = new AdminSettingsApi(undefined, undefined, axiosInstance);
 export const adminConfigurationApi = new AdminConfigurationApi(undefined, undefined, axiosInstance);
 export const adminSchedulerApi = new AdminSchedulerApi(undefined, undefined, axiosInstance);
+export const adminStorageConsistencyApi = new AdminStorageConsistencyApi(
+  undefined,
+  undefined,
+  axiosInstance,
+);
 export const adminOidcProvidersApi = new AdminOidcProvidersApi(undefined, undefined, axiosInstance);
 export const adminEmailApi = new AdminEmailApi(undefined, undefined, axiosInstance);
 export const documentsApi = new DocumentsApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useStorageConsistency.test.tsx
+++ b/qnop-ui/src/api/hooks/useStorageConsistency.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { OrphanDeleteResponse, StorageConsistencyReport } from '../generated';
+import { useDeleteOrphans, useStorageConsistency } from './useStorageConsistency';
+import { adminStorageConsistencyApi } from '../config';
+
+const EMPTY_REPORT: StorageConsistencyReport = {
+  summary: {
+    dbReferencedCount: 0,
+    storageObjectCount: 0,
+    missingCount: 0,
+    orphanedCount: 0,
+    scannedAt: '2026-07-19T10:00:00Z',
+  },
+  missing: [],
+  orphaned: [],
+};
+
+const DELETE_RESULT: OrphanDeleteResponse = { deleted: ['k1'], skipped: [] };
+
+vi.mock('../config', () => ({
+  adminStorageConsistencyApi: {
+    scanStorageConsistency: vi.fn(),
+    deleteOrphanedObjects: vi.fn(),
+  },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useStorageConsistency', () => {
+  it('returns the scan report', async () => {
+    vi.mocked(adminStorageConsistencyApi.scanStorageConsistency).mockResolvedValue({
+      data: EMPTY_REPORT,
+    } as Awaited<ReturnType<typeof adminStorageConsistencyApi.scanStorageConsistency>>);
+
+    const { result } = renderHook(() => useStorageConsistency(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.summary.dbReferencedCount).toBe(0);
+  });
+});
+
+describe('useDeleteOrphans', () => {
+  it('sends the selected keys in the request body', async () => {
+    vi.mocked(adminStorageConsistencyApi.deleteOrphanedObjects).mockResolvedValue({
+      data: DELETE_RESULT,
+    } as Awaited<ReturnType<typeof adminStorageConsistencyApi.deleteOrphanedObjects>>);
+
+    const { result } = renderHook(() => useDeleteOrphans(), { wrapper });
+    result.current.mutate(['k1', 'k2']);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(adminStorageConsistencyApi.deleteOrphanedObjects).toHaveBeenCalledWith({
+      orphanDeleteRequest: { keys: ['k1', 'k2'] },
+    });
+  });
+});

--- a/qnop-ui/src/api/hooks/useStorageConsistency.ts
+++ b/qnop-ui/src/api/hooks/useStorageConsistency.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { OrphanDeleteResponse, StorageConsistencyReport } from '../generated';
+import { adminStorageConsistencyApi } from '../config';
+
+export const storageConsistencyKeys = {
+  all: ['admin', 'storage-consistency'] as const,
+  report: () => [...storageConsistencyKeys.all, 'report'] as const,
+};
+
+/**
+ * Runs the storage-consistency scan (issue #523). The scan lists the whole
+ * bucket, so it is deliberately not refetched on window focus; the page offers
+ * an explicit rescan. A 409 (scan-limit circuit breaker) surfaces as the query
+ * error for the page to render as a warning.
+ */
+export function useStorageConsistency() {
+  return useQuery<StorageConsistencyReport>({
+    queryKey: storageConsistencyKeys.report(),
+    queryFn: async () => {
+      const response = await adminStorageConsistencyApi.scanStorageConsistency();
+      return response.data;
+    },
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+}
+
+/** Deletes orphaned objects (single or bulk), then refreshes the report. */
+export function useDeleteOrphans() {
+  const queryClient = useQueryClient();
+  return useMutation<OrphanDeleteResponse, unknown, string[]>({
+    mutationFn: async (keys: string[]) => {
+      const response = await adminStorageConsistencyApi.deleteOrphanedObjects({
+        orphanDeleteRequest: { keys },
+      });
+      return response.data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: storageConsistencyKeys.all }),
+  });
+}

--- a/qnop-ui/src/components/admin/storage/MissingBinariesTable.tsx
+++ b/qnop-ui/src/components/admin/storage/MissingBinariesTable.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Link from '@mui/material/Link';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import { Link as RouterLink } from 'react-router-dom';
+import type { MissingBinary } from '../../../api/generated';
+import { reviewPath } from '../../dashboard/dashboardModel';
+import { ToneBadge } from '../ToneBadge';
+import { StorageKey } from './StorageKey';
+
+const EM_DASH = '—';
+
+/** The human context for a missing binary — which version or which attachment. */
+function context(binary: MissingBinary): string {
+  if (binary.kind === 'VERSION') {
+    return binary.versionNumber != null ? `Version ${binary.versionNumber}` : 'Version';
+  }
+  return binary.attachmentName ? `Attachment · ${binary.attachmentName}` : 'Attachment';
+}
+
+/**
+ * Missing binaries (issue #523, ADR-0044): referenced objects that are gone —
+ * data loss. Report-only by design; instead of a destructive shortcut each row
+ * links to the affected document so an admin decides (restore from backup, or
+ * delete the document through the review flow).
+ */
+export function MissingBinariesTable({ binaries }: { binaries: MissingBinary[] }) {
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Document</TableCell>
+          <TableCell>Context</TableCell>
+          <TableCell>Storage key</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {binaries.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={3}>
+              <Typography color="text.secondary" sx={{ py: 3, textAlign: 'center' }}>
+                No missing binaries.
+              </Typography>
+            </TableCell>
+          </TableRow>
+        ) : (
+          binaries.map((binary) => (
+            <TableRow key={`${binary.storageKey}:${binary.documentId}`} hover>
+              <TableCell>
+                <Link
+                  component={RouterLink}
+                  to={reviewPath({ id: binary.documentId, slug: binary.documentSlug })}
+                  underline="hover"
+                  sx={{ fontWeight: 600 }}
+                >
+                  {binary.documentTitle ?? EM_DASH}
+                </Link>
+              </TableCell>
+              <TableCell>
+                <ToneBadge
+                  tone={binary.kind === 'VERSION' ? 'blue' : 'neutral'}
+                  label={context(binary)}
+                />
+              </TableCell>
+              <TableCell>
+                <StorageKey value={binary.storageKey} />
+              </TableCell>
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/qnop-ui/src/components/admin/storage/OrphanedObjectsTable.test.tsx
+++ b/qnop-ui/src/components/admin/storage/OrphanedObjectsTable.test.tsx
@@ -84,4 +84,26 @@ describe('OrphanedObjectsTable', () => {
     expect(screen.getByRole('checkbox', { name: 'Select all orphaned objects' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Delete sha256/ab/orphan-one' })).toBeDisabled();
   });
+
+  it('has no pagination for a short list', () => {
+    render(OBJECTS);
+    expect(screen.queryByLabelText('Objects per page')).not.toBeInTheDocument();
+  });
+
+  it('paginates a long list and reveals later rows on the next page', () => {
+    const many: OrphanedObject[] = Array.from({ length: 30 }, (_, i) => ({
+      storageKey: `sha256/xx/orphan-${String(i).padStart(2, '0')}`,
+      size: 1024,
+      lastModified: '2026-07-01T10:00:00Z',
+    }));
+    render(many);
+
+    // Default page size is 25: the first page shows 0..24, not the 26th row.
+    expect(screen.getByLabelText('Select sha256/xx/orphan-00')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Select sha256/xx/orphan-25')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    expect(screen.getByLabelText('Select sha256/xx/orphan-25')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Select sha256/xx/orphan-00')).not.toBeInTheDocument();
+  });
 });

--- a/qnop-ui/src/components/admin/storage/OrphanedObjectsTable.test.tsx
+++ b/qnop-ui/src/components/admin/storage/OrphanedObjectsTable.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import type { OrphanedObject } from '../../../api/generated';
+import { renderWithProviders } from '../../../test/renderWithProviders';
+import { OrphanedObjectsTable } from './OrphanedObjectsTable';
+
+const OBJECTS: OrphanedObject[] = [
+  { storageKey: 'sha256/ab/orphan-one', size: 1024, lastModified: '2026-07-01T10:00:00Z' },
+  {
+    storageKey: 'sha256/cd/orphan-two',
+    size: 5 * 1024 * 1024,
+    lastModified: '2026-07-02T10:00:00Z',
+  },
+];
+
+function render(objects: OrphanedObject[], selected = new Set<string>(), busy = false) {
+  const onToggle = vi.fn();
+  const onToggleAll = vi.fn();
+  const onDeleteOne = vi.fn();
+  renderWithProviders(
+    <OrphanedObjectsTable
+      objects={objects}
+      selected={selected}
+      onToggle={onToggle}
+      onToggleAll={onToggleAll}
+      onDeleteOne={onDeleteOne}
+      busy={busy}
+    />,
+  );
+  return { onToggle, onToggleAll, onDeleteOne };
+}
+
+describe('OrphanedObjectsTable', () => {
+  it('shows an empty state when there are no orphans', () => {
+    render([]);
+    expect(screen.getByText('No orphaned objects.')).toBeInTheDocument();
+  });
+
+  it('renders human-readable sizes', () => {
+    render(OBJECTS);
+    expect(screen.getByText('1 KB')).toBeInTheDocument();
+    expect(screen.getByText('5 MB')).toBeInTheDocument();
+  });
+
+  it('toggles a single row and select-all', () => {
+    const { onToggle, onToggleAll } = render(OBJECTS);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select sha256/ab/orphan-one' }));
+    expect(onToggle).toHaveBeenCalledWith('sha256/ab/orphan-one');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select all orphaned objects' }));
+    expect(onToggleAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes a single object from its row action', () => {
+    const { onDeleteOne } = render(OBJECTS);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete sha256/cd/orphan-two' }));
+    expect(onDeleteOne).toHaveBeenCalledWith('sha256/cd/orphan-two');
+  });
+
+  it('locks the checkboxes and delete actions while busy', () => {
+    render(OBJECTS, new Set(), true);
+    expect(screen.getByRole('checkbox', { name: 'Select all orphaned objects' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete sha256/ab/orphan-one' })).toBeDisabled();
+  });
+});

--- a/qnop-ui/src/components/admin/storage/OrphanedObjectsTable.tsx
+++ b/qnop-ui/src/components/admin/storage/OrphanedObjectsTable.tsx
@@ -19,12 +19,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useState } from 'react';
 import Checkbox from '@mui/material/Checkbox';
 import IconButton from '@mui/material/IconButton';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
+import TableFooter from '@mui/material/TableFooter';
 import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -33,6 +36,9 @@ import type { OrphanedObject } from '../../../api/generated';
 import { useFormatters } from '../../../hooks/useFormatters';
 import { formatBytes } from '../../../utils/formatBytes';
 import { StorageKey } from './StorageKey';
+
+/** Page sizes for the orphaned-objects table; the smallest is also the default. */
+const ROWS_PER_PAGE_OPTIONS = [25, 50, 100] as const;
 
 interface OrphanedObjectsTableProps {
   objects: OrphanedObject[];
@@ -49,6 +55,11 @@ interface OrphanedObjectsTableProps {
  * their size and age. Rows are selectable for a bulk delete, and each has a
  * single-delete action; both are locked while a deletion runs. Keys render
  * monospaced and copyable — never as bare truncated text.
+ *
+ * The list can grow large on a drifted bucket, so it is paginated client-side
+ * (the scan returns one atomic snapshot, so there is nothing to fetch per page).
+ * Selection lives with the parent and therefore persists across pages: the
+ * header checkbox selects/clears <em>every</em> orphan, not just the visible page.
  */
 export function OrphanedObjectsTable({
   objects,
@@ -61,6 +72,19 @@ export function OrphanedObjectsTable({
   const { formatDateTime, formatRelative } = useFormatters();
   const allSelected = objects.length > 0 && selected.size === objects.length;
   const someSelected = selected.size > 0 && !allSelected;
+
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState<number>(ROWS_PER_PAGE_OPTIONS[0]);
+
+  // A delete + rescan can shrink the list past the current page. Clamp during
+  // render (rather than writing state back in an effect) so the slice — and the
+  // page prop MUI receives — always stay in range without an extra render.
+  const pageCount = Math.ceil(objects.length / rowsPerPage);
+  const safePage = Math.min(page, Math.max(0, pageCount - 1));
+
+  const start = safePage * rowsPerPage;
+  const visible = objects.slice(start, start + rowsPerPage);
+  const showPagination = objects.length > ROWS_PER_PAGE_OPTIONS[0];
 
   return (
     <Table size="small">
@@ -91,7 +115,7 @@ export function OrphanedObjectsTable({
             </TableCell>
           </TableRow>
         ) : (
-          objects.map((object) => {
+          visible.map((object) => {
             const key = object.storageKey;
             const checked = selected.has(key);
             return (
@@ -138,6 +162,26 @@ export function OrphanedObjectsTable({
           })
         )}
       </TableBody>
+      {showPagination && (
+        <TableFooter>
+          <TableRow>
+            <TablePagination
+              rowsPerPageOptions={[...ROWS_PER_PAGE_OPTIONS]}
+              count={objects.length}
+              rowsPerPage={rowsPerPage}
+              page={safePage}
+              colSpan={5}
+              labelRowsPerPage="Objects per page"
+              onPageChange={(_, next) => setPage(next)}
+              onRowsPerPageChange={(event) => {
+                setRowsPerPage(parseInt(event.target.value, 10));
+                setPage(0);
+              }}
+              slotProps={{ select: { 'aria-label': 'Objects per page' } }}
+            />
+          </TableRow>
+        </TableFooter>
+      )}
     </Table>
   );
 }

--- a/qnop-ui/src/components/admin/storage/OrphanedObjectsTable.tsx
+++ b/qnop-ui/src/components/admin/storage/OrphanedObjectsTable.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Checkbox from '@mui/material/Checkbox';
+import IconButton from '@mui/material/IconButton';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { Trash2 } from 'lucide-react';
+import type { OrphanedObject } from '../../../api/generated';
+import { useFormatters } from '../../../hooks/useFormatters';
+import { formatBytes } from '../../../utils/formatBytes';
+import { StorageKey } from './StorageKey';
+
+interface OrphanedObjectsTableProps {
+  objects: OrphanedObject[];
+  selected: Set<string>;
+  onToggle: (key: string) => void;
+  onToggleAll: () => void;
+  onDeleteOne: (key: string) => void;
+  /** Locks selection + actions while a deletion is in flight. */
+  busy: boolean;
+}
+
+/**
+ * The orphaned objects (issue #523, ADR-0044): unreferenced stored objects with
+ * their size and age. Rows are selectable for a bulk delete, and each has a
+ * single-delete action; both are locked while a deletion runs. Keys render
+ * monospaced and copyable — never as bare truncated text.
+ */
+export function OrphanedObjectsTable({
+  objects,
+  selected,
+  onToggle,
+  onToggleAll,
+  onDeleteOne,
+  busy,
+}: OrphanedObjectsTableProps) {
+  const { formatDateTime, formatRelative } = useFormatters();
+  const allSelected = objects.length > 0 && selected.size === objects.length;
+  const someSelected = selected.size > 0 && !allSelected;
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell padding="checkbox">
+            <Checkbox
+              checked={allSelected}
+              indeterminate={someSelected}
+              onChange={onToggleAll}
+              disabled={busy || objects.length === 0}
+              slotProps={{ input: { 'aria-label': 'Select all orphaned objects' } }}
+            />
+          </TableCell>
+          <TableCell>Object key</TableCell>
+          <TableCell align="right">Size</TableCell>
+          <TableCell>Last modified</TableCell>
+          <TableCell padding="checkbox" />
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {objects.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={5}>
+              <Typography color="text.secondary" sx={{ py: 3, textAlign: 'center' }}>
+                No orphaned objects.
+              </Typography>
+            </TableCell>
+          </TableRow>
+        ) : (
+          objects.map((object) => {
+            const key = object.storageKey;
+            const checked = selected.has(key);
+            return (
+              <TableRow key={key} hover selected={checked}>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    checked={checked}
+                    onChange={() => onToggle(key)}
+                    disabled={busy}
+                    slotProps={{ input: { 'aria-label': `Select ${key}` } }}
+                  />
+                </TableCell>
+                <TableCell>
+                  <StorageKey value={key} />
+                </TableCell>
+                <TableCell
+                  align="right"
+                  sx={{ whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' }}
+                >
+                  {formatBytes(object.size)}
+                </TableCell>
+                <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                  <Tooltip title={formatDateTime(object.lastModified)}>
+                    <span>{formatRelative(object.lastModified)}</span>
+                  </Tooltip>
+                </TableCell>
+                <TableCell padding="checkbox">
+                  <Tooltip title="Delete this object">
+                    <span>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        onClick={() => onDeleteOne(key)}
+                        disabled={busy}
+                        aria-label={`Delete ${key}`}
+                      >
+                        <Trash2 size={16} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            );
+          })
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/qnop-ui/src/components/admin/storage/StorageKey.tsx
+++ b/qnop-ui/src/components/admin/storage/StorageKey.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import { Check, Copy } from 'lucide-react';
+
+const HEAD = 16;
+const TAIL = 10;
+
+/** Middle-truncates a long key so both the shard and the hash tail stay visible. */
+function shorten(value: string): string {
+  return value.length > HEAD + TAIL + 1 ? `${value.slice(0, HEAD)}…${value.slice(-TAIL)}` : value;
+}
+
+/**
+ * A storage object key (issue #523): monospaced and middle-truncated with the
+ * full value on hover and a copy button — content-addressed keys are long, and
+ * an admin often needs to paste one, so it is never shown as bare cut-off text.
+ */
+export function StorageKey({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    });
+  };
+
+  return (
+    <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', minWidth: 0 }}>
+      <Tooltip title={value}>
+        <Box
+          component="code"
+          sx={{
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 12,
+            color: 'text.secondary',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {shorten(value)}
+        </Box>
+      </Tooltip>
+      <Tooltip title={copied ? 'Copied' : 'Copy key'}>
+        <IconButton size="small" onClick={copy} aria-label="Copy storage key">
+          {copied ? <Check size={13} /> : <Copy size={13} />}
+        </IconButton>
+      </Tooltip>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/shell/navConfig.test.ts
+++ b/qnop-ui/src/components/shell/navConfig.test.ts
@@ -52,6 +52,7 @@ describe('visibleNavGroups', () => {
       'email',
       'mail-templates',
       'scheduler',
+      'storage-consistency',
       'audit',
     ]);
   });

--- a/qnop-ui/src/components/shell/navConfig.tsx
+++ b/qnop-ui/src/components/shell/navConfig.tsx
@@ -22,6 +22,7 @@
 import {
   CalendarClock,
   FileText,
+  HardDrive,
   KeyRound,
   LayoutDashboard,
   Mail,
@@ -120,6 +121,13 @@ export const NAV_GROUPS: NavGroup[] = [
         label: 'Scheduler',
         path: '/admin/scheduler',
         icon: CalendarClock,
+        roles: ['ADMIN'],
+      },
+      {
+        id: 'storage-consistency',
+        label: 'Storage consistency',
+        path: '/admin/storage-consistency',
+        icon: HardDrive,
         roles: ['ADMIN'],
       },
       {

--- a/qnop-ui/src/pages/admin/StorageConsistencyPage.test.tsx
+++ b/qnop-ui/src/pages/admin/StorageConsistencyPage.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import type { StorageConsistencyReport } from '../../api/generated';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { StorageConsistencyPage } from './StorageConsistencyPage';
+
+const { queryState, deleteMutate } = vi.hoisted(() => ({
+  queryState: {
+    data: undefined as StorageConsistencyReport | undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: undefined as unknown,
+    refetch: vi.fn(),
+  },
+  deleteMutate: vi.fn(),
+}));
+
+vi.mock('../../api/hooks/useStorageConsistency', () => ({
+  useStorageConsistency: () => queryState,
+  useDeleteOrphans: () => ({ mutate: deleteMutate, isPending: false }),
+}));
+
+vi.mock('../../components/admin/storage/OrphanedObjectsTable', () => ({
+  OrphanedObjectsTable: ({
+    objects,
+    onToggleAll,
+    onDeleteOne,
+  }: {
+    objects: { storageKey: string }[];
+    onToggleAll: () => void;
+    onDeleteOne: (key: string) => void;
+  }) => (
+    <div data-testid="orphan-table">
+      <span data-testid="orphan-count">{objects.length}</span>
+      <button onClick={onToggleAll}>toggle-all</button>
+      <button onClick={() => onDeleteOne(objects[0].storageKey)}>delete-first</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../components/admin/storage/MissingBinariesTable', () => ({
+  MissingBinariesTable: ({ binaries }: { binaries: unknown[] }) => (
+    <span data-testid="missing-count">{binaries.length}</span>
+  ),
+}));
+
+function report(overrides: Partial<StorageConsistencyReport['summary']>): StorageConsistencyReport {
+  return {
+    summary: {
+      dbReferencedCount: 10,
+      storageObjectCount: 8,
+      missingCount: 0,
+      orphanedCount: 0,
+      scannedAt: '2026-07-19T10:00:00Z',
+      ...overrides,
+    },
+    missing: [],
+    orphaned: [],
+  };
+}
+
+const orphan = (key: string) => ({
+  storageKey: key,
+  size: 1024,
+  lastModified: '2026-07-01T10:00:00Z',
+});
+
+beforeEach(() => {
+  queryState.data = undefined;
+  queryState.isLoading = false;
+  queryState.isFetching = false;
+  queryState.isError = false;
+  queryState.error = undefined;
+  deleteMutate.mockReset();
+});
+
+describe('StorageConsistencyPage', () => {
+  it('renders the header', () => {
+    renderWithProviders(<StorageConsistencyPage />);
+    expect(screen.getByRole('heading', { name: 'Storage consistency' })).toBeInTheDocument();
+  });
+
+  it('shows a scanning placeholder while loading', () => {
+    queryState.isLoading = true;
+    renderWithProviders(<StorageConsistencyPage />);
+    expect(screen.getByText('Scanning…')).toBeInTheDocument();
+  });
+
+  it('surfaces the scan-limit circuit breaker (409) as a warning', () => {
+    queryState.isError = true;
+    queryState.error = { response: { status: 409 } };
+    renderWithProviders(<StorageConsistencyPage />);
+    expect(screen.getByText(/scan was stopped/i)).toBeInTheDocument();
+  });
+
+  it('shows a generic error for a non-409 failure', () => {
+    queryState.isError = true;
+    queryState.error = { response: { status: 500 } };
+    renderWithProviders(<StorageConsistencyPage />);
+    expect(screen.getByText('The storage-consistency scan could not be run.')).toBeInTheDocument();
+  });
+
+  it('shows the all-clear when nothing is missing or orphaned', () => {
+    queryState.data = report({ missingCount: 0, orphanedCount: 0 });
+    renderWithProviders(<StorageConsistencyPage />);
+    expect(screen.getByText('Everything reconciles')).toBeInTheDocument();
+  });
+
+  it('renders both finding tables when there are findings', () => {
+    queryState.data = {
+      ...report({ missingCount: 1, orphanedCount: 2 }),
+      missing: [{ storageKey: 'm1', kind: 'VERSION', documentId: 'd1' }],
+      orphaned: [orphan('o1'), orphan('o2')],
+    };
+    renderWithProviders(<StorageConsistencyPage />);
+    expect(screen.getByTestId('missing-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('orphan-count')).toHaveTextContent('2');
+  });
+
+  it('bulk-deletes the selected orphans after confirmation', () => {
+    queryState.data = {
+      ...report({ orphanedCount: 2 }),
+      orphaned: [orphan('o1'), orphan('o2')],
+    };
+    renderWithProviders(<StorageConsistencyPage />);
+
+    fireEvent.click(screen.getByText('toggle-all'));
+    fireEvent.click(screen.getByRole('button', { name: /Delete selected \(2\)/ }));
+    // Confirm dialog opens; confirm.
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(deleteMutate).toHaveBeenCalledTimes(1);
+    expect(deleteMutate.mock.calls[0][0]).toEqual(expect.arrayContaining(['o1', 'o2']));
+  });
+
+  it('deletes a single orphan from its row action', () => {
+    queryState.data = {
+      ...report({ orphanedCount: 1 }),
+      orphaned: [orphan('only')],
+    };
+    renderWithProviders(<StorageConsistencyPage />);
+
+    fireEvent.click(screen.getByText('delete-first'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(deleteMutate).toHaveBeenCalledTimes(1);
+    expect(deleteMutate.mock.calls[0][0]).toEqual(['only']);
+  });
+});

--- a/qnop-ui/src/pages/admin/StorageConsistencyPage.test.tsx
+++ b/qnop-ui/src/pages/admin/StorageConsistencyPage.test.tsx
@@ -93,6 +93,9 @@ beforeEach(() => {
   queryState.isFetching = false;
   queryState.isError = false;
   queryState.error = undefined;
+  queryState.refetch = vi
+    .fn()
+    .mockResolvedValue({ isError: false, error: undefined, data: undefined });
   deleteMutate.mockReset();
 });
 
@@ -167,5 +170,34 @@ describe('StorageConsistencyPage', () => {
 
     expect(deleteMutate).toHaveBeenCalledTimes(1);
     expect(deleteMutate.mock.calls[0][0]).toEqual(['only']);
+  });
+
+  it('notifies with a summary after a rescan completes', async () => {
+    queryState.data = report({ missingCount: 1, orphanedCount: 2 });
+    queryState.refetch = vi.fn().mockResolvedValue({
+      isError: false,
+      error: undefined,
+      data: report({ missingCount: 1, orphanedCount: 2 }),
+    });
+    renderWithProviders(<StorageConsistencyPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /rescan/i }));
+
+    expect(
+      await screen.findByText(/Rescan complete — 1 missing, 2 orphaned\./),
+    ).toBeInTheDocument();
+  });
+
+  it('notifies with an error when the rescan fails', async () => {
+    queryState.refetch = vi.fn().mockResolvedValue({
+      isError: true,
+      error: { response: { status: 409 } },
+      data: undefined,
+    });
+    renderWithProviders(<StorageConsistencyPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /rescan/i }));
+
+    expect(await screen.findByText(/Rescan stopped/i)).toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/pages/admin/StorageConsistencyPage.tsx
+++ b/qnop-ui/src/pages/admin/StorageConsistencyPage.tsx
@@ -105,6 +105,26 @@ export function StorageConsistencyPage() {
     });
   };
 
+  const handleRescan = () => {
+    void refetch().then((result) => {
+      if (result.isError) {
+        notify(
+          isScanLimit(result.error)
+            ? 'Rescan stopped: the bucket holds more objects than the scan limit.'
+            : 'The storage-consistency scan could not be run.',
+          'error',
+        );
+        return;
+      }
+      const s = result.data?.summary;
+      notify(
+        s
+          ? `Rescan complete — ${s.missingCount} missing, ${s.orphanedCount} orphaned.`
+          : 'Rescan complete.',
+      );
+    });
+  };
+
   const tiles: StatTile[] = [
     { label: 'DB references', value: summary?.dbReferencedCount ?? 0, icon: Database },
     { label: 'Storage objects', value: summary?.storageObjectCount ?? 0, icon: HardDrive },
@@ -137,7 +157,7 @@ export function StorageConsistencyPage() {
                 style={isFetching ? { animation: 'qnop-spin 1s linear infinite' } : undefined}
               />
             }
-            onClick={() => refetch()}
+            onClick={handleRescan}
             disabled={isFetching}
           >
             {isFetching ? 'Scanning…' : 'Rescan'}

--- a/qnop-ui/src/pages/admin/StorageConsistencyPage.tsx
+++ b/qnop-ui/src/pages/admin/StorageConsistencyPage.tsx
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import LinearProgress from '@mui/material/LinearProgress';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import {
+  Boxes,
+  CheckCircle2,
+  Database,
+  FileWarning,
+  HardDrive,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
+import { useDeleteOrphans, useStorageConsistency } from '../../api/hooks/useStorageConsistency';
+import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { SectionCard } from '../../components/admin/layout/SectionCard';
+import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { useToast } from '../../components/admin/layout/useToast';
+import { ConfirmDialog } from '../../components/admin/ConfirmDialog';
+import { ToneBadge } from '../../components/admin/ToneBadge';
+import { StatStrip, type StatTile } from '../../components/dashboard/StatStrip';
+import { MissingBinariesTable } from '../../components/admin/storage/MissingBinariesTable';
+import { OrphanedObjectsTable } from '../../components/admin/storage/OrphanedObjectsTable';
+import { useFormatters } from '../../hooks/useFormatters';
+
+/** Whether a query error is the scan-limit circuit breaker (HTTP 409). */
+function isScanLimit(error: unknown): boolean {
+  return (error as { response?: { status?: number } })?.response?.status === 409;
+}
+
+/**
+ * The storage-consistency dashboard (issue #523, ADR-0044): reconciles document
+ * binaries in object storage against the database. A summary strip, a report-only
+ * "missing binaries" section (data loss), and a remediable "orphaned objects"
+ * section (cost/leak) with bulk selection and confirm dialogs. The scan-limit
+ * circuit breaker surfaces as a readable warning; a fully consistent store shows
+ * a reassuring all-clear.
+ */
+export function StorageConsistencyPage() {
+  const { data, isLoading, isFetching, isError, error, refetch } = useStorageConsistency();
+  const deleteOrphans = useDeleteOrphans();
+  const { formatRelative } = useFormatters();
+  const { toast, notify, clear } = useToast();
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [pendingDelete, setPendingDelete] = useState<string[] | null>(null);
+
+  const summary = data?.summary;
+  const missing = data?.missing ?? [];
+  const orphaned = data?.orphaned ?? [];
+  const busy = deleteOrphans.isPending;
+
+  const toggle = (key: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  const toggleAll = () =>
+    setSelected((prev) =>
+      prev.size === orphaned.length ? new Set() : new Set(orphaned.map((o) => o.storageKey)),
+    );
+
+  const confirmDelete = () => {
+    const keys = pendingDelete ?? [];
+    deleteOrphans.mutate(keys, {
+      onSuccess: (result) => {
+        const skipped = result.skipped.length;
+        notify(
+          `Deleted ${result.deleted.length} object${result.deleted.length === 1 ? '' : 's'}` +
+            (skipped > 0 ? `, skipped ${skipped} (now referenced)` : '.'),
+          skipped > 0 ? 'error' : 'success',
+        );
+        setSelected(new Set());
+      },
+      onError: () => notify('The objects could not be deleted.', 'error'),
+      onSettled: () => setPendingDelete(null),
+    });
+  };
+
+  const tiles: StatTile[] = [
+    { label: 'DB references', value: summary?.dbReferencedCount ?? 0, icon: Database },
+    { label: 'Storage objects', value: summary?.storageObjectCount ?? 0, icon: HardDrive },
+    {
+      label: 'Missing binaries',
+      value: summary?.missingCount ?? 0,
+      icon: FileWarning,
+      tone: 'danger',
+    },
+    { label: 'Orphaned objects', value: summary?.orphanedCount ?? 0, icon: Boxes, tone: 'warning' },
+  ];
+
+  const consistent = summary != null && summary.missingCount === 0 && summary.orphanedCount === 0;
+
+  return (
+    <Stack spacing={3}>
+      <PageHeader
+        title="Storage consistency"
+        description={
+          summary
+            ? `Last scanned ${formatRelative(summary.scannedAt)}.`
+            : 'Reconcile document binaries in object storage against the database.'
+        }
+        action={
+          <Button
+            variant="outlined"
+            startIcon={
+              <RefreshCw
+                size={16}
+                style={isFetching ? { animation: 'qnop-spin 1s linear infinite' } : undefined}
+              />
+            }
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            {isFetching ? 'Scanning…' : 'Rescan'}
+          </Button>
+        }
+      />
+      <style>{'@keyframes qnop-spin { to { transform: rotate(360deg); } }'}</style>
+
+      {isScanLimit(error) ? (
+        <Alert severity="warning">
+          The scan was stopped because the bucket holds more objects than the scan limit. Narrow the
+          scope or raise <code>qnop.s3.consistency-scan-max-keys</code>, then rescan.
+        </Alert>
+      ) : isError ? (
+        <Alert severity="error">The storage-consistency scan could not be run.</Alert>
+      ) : isLoading ? (
+        <Typography color="text.secondary" sx={{ p: 1, fontSize: 14 }}>
+          Scanning…
+        </Typography>
+      ) : (
+        <>
+          <StatStrip tiles={tiles} />
+
+          {consistent && (
+            <SectionCard icon={CheckCircle2} title="Everything reconciles">
+              <Typography color="text.secondary">
+                Every referenced binary is present and no stored object is orphaned.
+              </Typography>
+            </SectionCard>
+          )}
+
+          {missing.length > 0 && (
+            <SectionCard
+              icon={FileWarning}
+              title="Missing binaries"
+              description="Referenced objects that are gone — resolve through the affected document."
+              action={<ToneBadge tone="red" label="Data loss" />}
+            >
+              <Box sx={{ overflowX: 'auto' }}>
+                <MissingBinariesTable binaries={missing} />
+              </Box>
+            </SectionCard>
+          )}
+
+          {orphaned.length > 0 && (
+            <SectionCard
+              icon={Boxes}
+              title="Orphaned objects"
+              description="Stored objects no database row references — safe to delete."
+              action={<ToneBadge tone="amber" label="Unreferenced" />}
+            >
+              <Stack spacing={1.5}>
+                <Box>
+                  <Button
+                    size="small"
+                    color="error"
+                    variant="outlined"
+                    startIcon={<Trash2 size={15} />}
+                    disabled={selected.size === 0 || busy}
+                    onClick={() => setPendingDelete([...selected])}
+                  >
+                    Delete selected ({selected.size})
+                  </Button>
+                </Box>
+                <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+                  <Box sx={{ height: 3 }}>{busy && <LinearProgress />}</Box>
+                  <Box sx={{ overflowX: 'auto' }}>
+                    <OrphanedObjectsTable
+                      objects={orphaned}
+                      selected={selected}
+                      onToggle={toggle}
+                      onToggleAll={toggleAll}
+                      onDeleteOne={(key) => setPendingDelete([key])}
+                      busy={busy}
+                    />
+                  </Box>
+                </Paper>
+              </Stack>
+            </SectionCard>
+          )}
+        </>
+      )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete orphaned objects?"
+        message={
+          `This permanently deletes ${pendingDelete?.length ?? 0} object` +
+          `${(pendingDelete?.length ?? 0) === 1 ? '' : 's'} from storage. Any that became ` +
+          `referenced since the scan are skipped automatically.`
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={confirmDelete}
+        onClose={() => setPendingDelete(null)}
+      />
+      <AdminToast toast={toast} onClose={clear} />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/pages/audit/AuditPage.test.tsx
+++ b/qnop-ui/src/pages/audit/AuditPage.test.tsx
@@ -129,11 +129,23 @@ describe('AuditPage', () => {
     queryState.data = page({ items: [event], total: 1 });
     renderWithProviders(<AuditPage />);
 
-    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Event type' }));
+    const input = screen.getByRole('combobox', { name: 'Event type' });
+    fireEvent.change(input, { target: { value: 'Status' } });
     fireEvent.click(screen.getByRole('option', { name: 'Status changed' }));
 
     expect(lastCall().eventType).toBe('workflow.transition');
     expect(lastCall().page).toBe(0);
+  });
+
+  it('finds the storage-orphan event by searching the type filter', () => {
+    queryState.data = page({ items: [event], total: 1 });
+    renderWithProviders(<AuditPage />);
+
+    const input = screen.getByRole('combobox', { name: 'Event type' });
+    fireEvent.change(input, { target: { value: 'orphan' } });
+    fireEvent.click(screen.getByRole('option', { name: 'Orphaned object deleted' }));
+
+    expect(lastCall().eventType).toBe('storage.orphan.deleted');
   });
 
   it('passes a from-date filter as an ISO instant', () => {

--- a/qnop-ui/src/pages/audit/AuditPage.tsx
+++ b/qnop-ui/src/pages/audit/AuditPage.tsx
@@ -21,12 +21,12 @@
 
 import { useState } from 'react';
 import Alert from '@mui/material/Alert';
+import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Collapse from '@mui/material/Collapse';
 import LinearProgress from '@mui/material/LinearProgress';
-import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import TablePagination from '@mui/material/TablePagination';
@@ -170,24 +170,20 @@ export function AuditPage() {
       </Collapse>
 
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ flexWrap: 'wrap' }}>
-        <TextField
-          select
-          label="Event type"
-          value={eventType}
-          onChange={(e) => {
-            setEventType(e.target.value);
+        <Autocomplete
+          options={AUDIT_EVENT_TYPES}
+          value={eventType || null}
+          onChange={(_, next) => {
+            setEventType(next ?? '');
             setPage(0);
           }}
+          getOptionLabel={(type) => AUDIT_EVENT_META[type]?.label ?? type}
           size="small"
-          sx={{ minWidth: 220 }}
-        >
-          <MenuItem value="">All events</MenuItem>
-          {AUDIT_EVENT_TYPES.map((type) => (
-            <MenuItem key={type} value={type}>
-              {AUDIT_EVENT_META[type].label}
-            </MenuItem>
-          ))}
-        </TextField>
+          sx={{ minWidth: 240 }}
+          renderInput={(params) => (
+            <TextField {...params} label="Event type" placeholder="All events" />
+          )}
+        />
         <TextField
           type="datetime-local"
           label="From"

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -29,6 +29,7 @@ import { RoleRoute } from '../components/auth/RoleRoute';
 import { AuditPage } from '../pages/audit/AuditPage';
 import { HomePage } from '../pages/HomePage';
 import { BrandingPage } from '../pages/admin/BrandingPage';
+import { StorageConsistencyPage } from '../pages/admin/StorageConsistencyPage';
 import { ProfilePage } from '../pages/ProfilePage';
 import { UserProfilePage } from '../pages/UserProfilePage';
 import { EmailServerPage } from '../pages/admin/EmailServerPage';
@@ -226,6 +227,14 @@ export const router = createBrowserRouter([
         element: (
           <AdminRoute>
             <BrandingPage />
+          </AdminRoute>
+        ),
+      },
+      {
+        path: 'admin/storage-consistency',
+        element: (
+          <AdminRoute>
+            <StorageConsistencyPage />
           </AdminRoute>
         ),
       },

--- a/qnop-ui/src/utils/auditDetail.ts
+++ b/qnop-ui/src/utils/auditDetail.ts
@@ -49,10 +49,11 @@ function dueDateChange(from: unknown, to: unknown, formatDate: (iso: string) => 
  * event type gets a purpose-built rendering: a workflow transition reads as
  * `Draft → In review`, a placement as `On version 3`, a due-date change as
  * `Set to <date>` / `<date> → <date>` (dates via the caller's zone-aware
- * formatter), an extraction failure as its reason. Events whose meaning is fully
- * carried by their label (a raised/resolved/reopened annotation, whose only
- * payload is an internal id) render an em dash. Any unknown shape still degrades
- * to a compact `key: value` list, since the vocabulary is open.
+ * formatter), an extraction failure as its reason, a storage-orphan deletion as
+ * its object key. Events whose meaning is fully carried by their label (a
+ * raised/resolved/reopened annotation, whose only payload is an internal id)
+ * render an em dash. Any unknown shape still degrades to a compact `key: value`
+ * list, since the vocabulary is open.
  */
 export function formatAuditDetail(
   eventType: string,
@@ -107,6 +108,8 @@ export function formatAuditDetail(
       return obj.reason !== null && obj.reason !== undefined
         ? `Reason: ${formatValue(obj.reason)}`
         : EM_DASH;
+    case 'storage.orphan.deleted':
+      return obj.key !== null && obj.key !== undefined ? `Object ${formatValue(obj.key)}` : EM_DASH;
     default:
       break;
   }

--- a/qnop-ui/src/utils/auditEvents.ts
+++ b/qnop-ui/src/utils/auditEvents.ts
@@ -32,13 +32,16 @@ export interface AuditEventMeta {
 }
 
 /**
- * The document-review audit vocabulary (ADR-0042), each mapped to a readable
- * label, a plain-language description and a semantic colour. This is the single
- * source the audit table, the event filter and the legend all read from, so the
+ * The audit vocabulary (ADR-0042), each mapped to a readable label, a
+ * plain-language description and a semantic colour. This is the single source
+ * the audit table, the event filter and the legend all read from, so the
  * machine event types (`annotation.created`, …) never reach a human unexplained.
+ * It spans both scopes: the per-document review trail and the SYSTEM-scope
+ * operator stream (issue #524, ADR-0043) — e.g. storage-orphan cleanup.
  *
- * Colour grouping: annotations blue, resolutions/successes green, re-work amber,
- * failures red, document-level changes neutral — so the trail is scannable by hue.
+ * Colour grouping: annotations blue, resolutions/successes green, re-work and
+ * destructive/system actions amber, failures red, document-level changes
+ * neutral — so the trail is scannable by hue.
  */
 export const AUDIT_EVENT_META: Record<string, AuditEventMeta> = {
   'annotation.created': {
@@ -92,6 +95,12 @@ export const AUDIT_EVENT_META: Record<string, AuditEventMeta> = {
     description:
       'Extracting the text from an uploaded version failed; the reason is shown in the details.',
     tone: 'red',
+  },
+  'storage.orphan.deleted': {
+    label: 'Orphaned object deleted',
+    description:
+      'An unreferenced object was deleted from storage during a consistency cleanup (issue #523); the object key is shown in the details.',
+    tone: 'amber',
   },
 };
 

--- a/qnop-ui/src/utils/formatBytes.test.ts
+++ b/qnop-ui/src/utils/formatBytes.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatBytes } from './formatBytes';
+
+describe('formatBytes', () => {
+  it('formats zero and whole bytes without a decimal', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('scales through KB, MB, GB and TB with one decimal', () => {
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(2560)).toBe('2.5 KB');
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5 MB');
+    expect(formatBytes(1.5 * 1024 * 1024 * 1024)).toBe('1.5 GB');
+    expect(formatBytes(3 * 1024 ** 4)).toBe('3 TB');
+  });
+
+  it('renders an em dash for absent or invalid values', () => {
+    expect(formatBytes(null)).toBe('—');
+    expect(formatBytes(undefined)).toBe('—');
+    expect(formatBytes(Number.NaN)).toBe('—');
+    expect(formatBytes(-1)).toBe('—');
+  });
+});

--- a/qnop-ui/src/utils/formatBytes.ts
+++ b/qnop-ui/src/utils/formatBytes.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+
+/**
+ * Formats a byte count as a human-readable size ("2.4 MB", "412 KB", "1.1 GB"),
+ * binary (1024) based. Whole bytes show no decimal; larger units keep one. An
+ * em dash for an absent/invalid value, and "0 B" for zero.
+ */
+export function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null || Number.isNaN(bytes) || bytes < 0) return '—';
+  if (bytes === 0) return '0 B';
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), UNITS.length - 1);
+  const value = bytes / 1024 ** exponent;
+  const rounded = exponent === 0 ? value : Math.round(value * 10) / 10;
+  return `${rounded} ${UNITS[exponent]}`;
+}

--- a/qnop-ui/vitest.config.ts
+++ b/qnop-ui/vitest.config.ts
@@ -63,6 +63,9 @@ export default defineConfig({
         // toggle/run-now orchestration and toasts; its presentational job card
         // stays on its own component test.
         'src/pages/admin/SchedulerPage.tsx',
+        // Storage-consistency dashboard (issue #523). The page owns the scan/
+        // selection/delete orchestration; its presentational tables have their own.
+        'src/pages/admin/StorageConsistencyPage.tsx',
         // Team-lead self-management surface (issue #470): the "My Teams" landing
         // and detail pages own the orchestration/state; the add-member dialog
         // stays on its own component test.


### PR DESCRIPTION
## Summary

Closes #523. Adds the ADMIN-only **`/admin/storage-consistency`** dashboard that reconciles document binaries in object storage against the database, plus the SPI, service, remediation, scheduled reaper and REST surface behind it (ADR-0044).

Two finding classes:
- **Missing binaries** — a `document_version`/`document_attachment` row references a `storage_key` whose object is gone (data loss). **Report-only** — resolved through the affected document, never a destructive shortcut here.
- **Orphaned objects** — an object in the bucket that no row references (cost/leak). **Remediable** — deletable individually or in bulk, each re-checked in its own transaction immediately before deletion so a key that became referenced since the scan is skipped and reported, never deleted.

## What changed

**SPI (`qnop-spi`)**
- `StorageProvider.list(prefix)` added as a **`default` method** (throws `UnsupportedOperationException`) → backward-compatible SemVer-minor; existing/Enterprise implementors keep compiling. New record `StorageListing(key, size, lastModified)`. The S3/MinIO default overrides it via paginated `ListObjectsV2` and, unlike the other ops, does **not** run discovered keys through the content-addressed key guard (the scan's job is to find keys that don't match).

**Backend (`qnop-core`, `qnop-app`)**
- `StorageConsistencyService` — loads the referenced set (union of `document_version.storage_key`, `document_attachment.storage_key`, and the `storage_object` registry incl. PENDING) via string-projection queries, then *streams* the bucket through a DB-free static `partition()` into known/orphaned/missing. A `qnop.s3.consistency-scan-max-keys` **circuit breaker** aborts a pathological bucket as **409**. The bucket stream runs outside any transaction (ADR-0004 guardrail).
- `StorageRemediationService` — per-key `REQUIRES_NEW` re-check → skip-if-referenced else delete; audits each deletion as `storage.orphan.deleted` in `audit_event` with a **null `document_id`** (bucket-wide action, not document-scoped).
- `StorageOrphanReaper` — scheduled bucket-wide orphan reaper, **opt-in + dry-run by default**, generous grace period, per-tick bound, ShedLock-guarded, reusing the same in-tx re-check path.
- REST (OpenAPI-first, `/api/v1/admin/**` = ADMIN): `GET /admin/storage-consistency` (409 on limit) and `POST /admin/storage-consistency/orphans/delete {keys[]}` (request body, since content-addressed keys contain slashes).

**Frontend (`qnop-ui`)**
- `StorageConsistencyPage` — `StatStrip` summary; report-only "missing binaries" section; remediable "orphaned objects" table with bulk selection, destructive `ConfirmDialog`, busy-lock and skip-when-referenced feedback. 409 → readable warning `Alert`; fully reconciled store → all-clear `SectionCard`. New `formatBytes` util, `useStorageConsistency` / `useDeleteOrphans` hooks, `AdminStorageConsistencyApi` client, nav + `AdminRoute` wiring.

**Docs**
- ADR-0044 (0043 is taken by the concurrent #524 audit-scope change).

## Test plan

- [x] Backend `compileJava` (all modules) + `spotlessCheck` — green
- [x] `:qnop-core:test` (incl. `StorageConsistencyServiceTest`, `StorageOrphanReaperTest`) + `ArchitectureRulesTest` — green
- [x] Frontend `tsc -b` (forced), 29 vitest tests, ESLint, Prettier — green
- [ ] CI — Testcontainers ITs (`AdminStorageConsistencyIT`, `StorageConsistencyScanLimitIT`: MinIO authz 401/403, scan surfacing orphaned + missing, orphan delete, in-tx re-check skip, 409 circuit breaker) run under Docker in CI only

## Coordination note

This PR makes `audit_event.document_id` nullable by folding the change into the creating changeset `0011` (the schema is not yet in production). **#524 (PR #526)** introduces the same nullability **plus a `scope` column** via a separate changeset. Both are internally consistent; **whichever of #523/#524 merges second must rebase and reconcile the `0011`/scope divergence.**

🤖 Co-Author: Claude (Opus 4.8) via Claude Code
