### PR TITLE
feat(scheduler): admin maintenance-scheduler dashboard (#524)

### DIFF
--- a/docs/adr/0045-scheduler-jobs-dashboard.md
+++ b/docs/adr/0045-scheduler-jobs-dashboard.md
@@ -1,0 +1,45 @@
+# ADR-0045: Scheduler-jobs dashboard — an operator gate in front of the maintenance sweeps
+
+- **Status:** Accepted
+- **Date:** 2026-07-19
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+qnop runs five `@Scheduled` maintenance sweeps, each fronted by a ShedLock `@SchedulerLock` (ADR-0029): the e-mail-verification, password-reset, refresh-token and revoked-access-token purges, and the storage orphan reaper (ADR-0036). Until now these were fire-and-forget: no operator could see whether they run, when they last ran, or pause one that misbehaves — and no one could trigger a purge on demand. Issue #524 asks for an admin dashboard at `/admin/scheduler` that lists the sweeps with their cron and last-run outcome and offers three controls: enable/disable, a dry-run toggle (for the reaper), and run-now.
+
+The two internal poller/reaper jobs of the durable job queue (ADR-0033) are **deliberately excluded** — they are engine internals, not operator-facing maintenance. So the catalogue is exactly those five sweeps.
+
+Three design questions drove the decision:
+
+1. **Where does per-job operator state live?** The cron, display name and dry-run capability are static (code); the enabled flag, dry-run setting and last-run outcome are mutable (an admin changes them, a run produces them).
+2. **How do the sweeps route through the operator state without a Spring self-invocation trap** — the classic problem where an in-bean call bypasses the `@Transactional`/gate proxy?
+3. **How are operator actions audited** without drowning the trail?
+
+## Decision
+
+**A `SchedulerService` gate, a `scheduler_job` row per catalogued job, and a static `SchedulerJobCatalog`.**
+
+- **Static vs. mutable split.** `SchedulerJobCatalog` holds the five `SchedulerJobDefinition`s (id, display name, description, cron, dry-run capability) as a closed, in-code set. The `scheduler_job` table (migration 0017) holds only what changes: `enabled`, `dry_run`, and the last run's outcome (`last_run_at`, `last_outcome`, `last_trigger`, `last_detail`). The primary key is the natural `jobId` — the same string used as the `@SchedulerLock` name — so the id is a single source of truth: the catalogue constants double as the compile-time-constant lock names on the sweep methods. Rows are seeded idempotently at start-up (`SchedulerJobBootstrap`); an existing row's settings survive a restart.
+
+- **The gate owns transactions programmatically, not with `@Transactional`.** Each sweep's `@Scheduled`/`@SchedulerLock` method now just calls `schedulerService.runScheduled(jobId)`. The gate reads the operator state, runs the work, and records the outcome as **three independent units** via a `TransactionTemplate`. The unit of work is a `SchedulerWork` runnable **registered by the owning service** (`SchedulerJobBinding`) and invoked inside the gate's own transaction — so there is no self-invocation caveat (the runnable is called from a different bean), and `SchedulerService` depends on no sweep service (no dependency cycle). Recording the outcome in a **separate** transaction from the work means a work rollback can never erase a failure record.
+
+- **Fail-open.** If the state read throws (a broken `scheduler_job` table, a transient DB error), the gate runs the sweep anyway. Maintenance keeps the system healthy; a stuck control table must never silently stop it.
+
+- **Run-now is an explicit override.** `runNow` runs the sweep regardless of `enabled`, under the job's ShedLock lock (acquired programmatically) so it never overlaps a scheduled run or a second manual trigger — a contended lock is a `409`. A work failure is reported as a `FAILURE` outcome on the returned job, not a 5xx: the admin sees what happened rather than a stack trace.
+
+- **Audit only operator actions.** Setting changes (`scheduler.job.updated`) and manual runs (`scheduler.job.run`) are written to the SYSTEM audit stream (ADR-0043). Scheduled runs are **not** audited — five rows a day forever would drown the trail — their outcome lives on the `scheduler_job` row instead.
+
+Authorization is the existing central rule: `/api/v1/admin/**` requires `ADMIN`. The frontend adds an `/admin/scheduler` page (a job card per sweep: cron chip, enabled switch, dry-run switch for the reaper, run-now, and a last-run outcome badge).
+
+## Consequences
+
+- **Positive.** Operators get visibility and control with no new infrastructure (no Redis, no scheduler engine) — one Postgres table and a thin gate. The static/mutable split keeps the catalogue in code (type-safe, no migration to add a job's metadata) while settings persist. The transaction discipline keeps the complex logic DB-free-testable (the guardrail): `SchedulerServiceTest` exercises enable/disable, fail-open, dry-run guard, locking and audit with a mock transaction manager and no database.
+- **Neutral.** The dashboard shows each job's **default** cron; an operator who overrides `qnop.s3.reaper-cron` sees the default string, not the override. Acceptable — the cron is informational, and the effective-configuration page (issue #522) is the authority on overrides.
+- **Negative / deferred.** There is no per-job run **history** (only the most recent outcome) and no scheduled-run auditing; if compliance later needs a full run log, it is an additive table, not a redesign. Editing a cron from the UI is out of scope — crons stay in configuration.
+
+## Alternatives considered
+
+- **`@Transactional` on the gate + `REQUIRES_NEW` for the outcome.** Rejected: the sweep methods calling their own gate would hit the Spring self-invocation trap, and `REQUIRES_NEW` self-calls silently don't start a new transaction. The programmatic `TransactionTemplate` sidesteps both.
+- **A row (or setting) per job with the cron stored in the DB.** Rejected as premature: crons are deployment configuration, not per-instance operator state; storing them invites drift from the `@Scheduled` annotations that actually fire.
+- **Auditing every scheduled run.** Rejected: it floods the AUDITOR trail with routine noise; the `scheduler_job` row already carries the last outcome, and only operator-initiated actions are audit-worthy.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@ Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-reco
 | [0041](0041-datetime-l10n-policy.md) | Date/time L10n: store UTC, transport ISO-with-offset, render in the user's zone | Accepted |
 | [0042](0042-audit-trail-exposure.md) | Audit-trail exposure: the AUDITOR read surface and its boundary | Accepted |
 | [0043](0043-system-audit-stream.md) | System-audit stream: generalising the audit trail beyond documents | Accepted |
+| [0045](0045-scheduler-jobs-dashboard.md) | Scheduler-jobs dashboard: an operator gate in front of the maintenance sweeps | Accepted |
 
 ## Template
 

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -129,6 +129,15 @@ tags:
       (no user) renders as *System*. This is the document-review trail only —
       a system-level audit stream (logins, settings, user administration) is a
       separate, future effort.
+  - name: AdminScheduler
+    description: |
+      The maintenance-scheduler dashboard (issue #524, ADR-0045): the fixed set
+      of background sweeps (token purges, the storage orphan reaper) with their
+      cron, enabled state, dry-run setting, and last-run outcome. An admin can
+      enable/disable a sweep, toggle the reaper's dry-run mode, or trigger an
+      immediate run-now (an explicit override that runs regardless of the
+      enabled flag). Manual runs and setting changes are written to the SYSTEM
+      audit stream (ADR-0043). ADMIN only.
 paths:
   /config:
     get:
@@ -2184,6 +2193,124 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /admin/scheduler:
+    get:
+      tags:
+        - AdminScheduler
+      summary: List scheduled maintenance jobs (ADMIN)
+      description: |
+        Every catalogued maintenance sweep with its static metadata (display
+        name, description, cron, dry-run capability) and current operator state
+        (enabled, dry-run, and the outcome of the most recent run). ADMIN only.
+      operationId: listSchedulerJobs
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The scheduler jobs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchedulerJobListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/scheduler/{jobId}:
+    parameters:
+      - name: jobId
+        in: path
+        required: true
+        description: The catalogued job id.
+        schema:
+          type: string
+          maxLength: 64
+    patch:
+      tags:
+        - AdminScheduler
+      summary: Update a scheduled job's operator settings (ADMIN)
+      description: |
+        Enables or disables the scheduled tick, and/or toggles dry-run mode. A
+        null field is left unchanged. Dry-run may only be set on a
+        dry-run-capable job (the storage reaper) — otherwise 400. ADMIN only.
+      operationId: updateSchedulerJob
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SchedulerJobUpdateRequest'
+      responses:
+        '200':
+          description: The updated job
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchedulerJob'
+        '400':
+          description: Dry-run requested for a job that does not support it
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Unknown job id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /admin/scheduler/{jobId}/run:
+    parameters:
+      - name: jobId
+        in: path
+        required: true
+        description: The catalogued job id.
+        schema:
+          type: string
+          maxLength: 64
+    post:
+      tags:
+        - AdminScheduler
+      summary: Run a scheduled job now (ADMIN)
+      description: |
+        Triggers an immediate run of the sweep — an explicit override that runs
+        regardless of the enabled flag, under the job's distributed lock so it
+        never overlaps a scheduled run or another manual trigger. Returns the
+        job with its refreshed last-run outcome. The run itself never fails the
+        request: a work error is reported as a `FAILURE` outcome on the returned
+        job, not a 5xx. ADMIN only.
+      operationId: runSchedulerJob
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The job after the run, with its refreshed outcome
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchedulerJob'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Unknown job id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: A run is already in progress
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /documents:
     get:
       tags:
@@ -4382,6 +4509,82 @@ components:
         - total
         - page
         - size
+    SchedulerJob:
+      type: object
+      description: |
+        One scheduled maintenance sweep (issue #524, ADR-0045): static catalogue
+        metadata joined with the current operator state and last-run outcome.
+      properties:
+        jobId:
+          type: string
+          description: The catalogued job id (also the distributed-lock name).
+        displayName:
+          type: string
+          description: Human label for the dashboard.
+        description:
+          type: string
+          description: One sentence on what the sweep does.
+        cron:
+          type: string
+          description: The cron expression the sweep fires on (informational).
+        supportsDryRun:
+          type: boolean
+          description: Whether the job honours a report-only dry-run mode.
+        enabled:
+          type: boolean
+          description: Whether the scheduled tick runs. A run-now ignores this.
+        dryRun:
+          type: boolean
+          description: Whether a dry-run-capable job runs report-only.
+        lastRunAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the job last actually ran, or null if never.
+        lastOutcome:
+          type: string
+          nullable: true
+          description: Outcome of the last run — SUCCESS or FAILURE, or null.
+        lastTrigger:
+          type: string
+          nullable: true
+          description: What triggered the last run — SCHEDULED or MANUAL, or null.
+        lastDetail:
+          type: string
+          nullable: true
+          description: Short detail for the last run (e.g. "dry-run" or a failure summary).
+      required:
+        - jobId
+        - displayName
+        - description
+        - cron
+        - supportsDryRun
+        - enabled
+        - dryRun
+    SchedulerJobListResponse:
+      type: object
+      description: The full set of catalogued maintenance jobs, in a stable order.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SchedulerJob'
+      required:
+        - items
+    SchedulerJobUpdateRequest:
+      type: object
+      description: |
+        A partial change to a job's operator settings; a null field is left
+        unchanged. `dryRun` may only be set true for a dry-run-capable job.
+      properties:
+        enabled:
+          type: boolean
+          nullable: true
+          description: Enable or disable the scheduled tick.
+        dryRun:
+          type: boolean
+          nullable: true
+          description: Toggle report-only dry-run mode (dry-run-capable jobs only).
     AdminUserCreateRequest:
       type: object
       description: |

--- a/qnop-app/src/main/java/io/qnop/web/SchedulerController.java
+++ b/qnop-app/src/main/java/io/qnop/web/SchedulerController.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.endpoint.AdminSchedulerApi;
+import io.qnop.api.v1.model.ErrorResponse;
+import io.qnop.api.v1.model.SchedulerJob;
+import io.qnop.api.v1.model.SchedulerJobListResponse;
+import io.qnop.api.v1.model.SchedulerJobUpdateRequest;
+import io.qnop.service.scheduler.DryRunNotSupportedException;
+import io.qnop.service.scheduler.SchedulerJobBusyException;
+import io.qnop.service.scheduler.SchedulerJobNotFoundException;
+import io.qnop.service.scheduler.SchedulerService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The admin maintenance-scheduler dashboard ({@code /api/v1/admin/scheduler}), implementing the
+ * generated {@link AdminSchedulerApi} contract (issue #524, ADR-0045). Authorization is enforced
+ * centrally by the security chain ({@code /api/v1/admin/**} requires {@code ADMIN}); a {@code
+ * MEMBER} never reaches these methods (403). A thin mapping over {@link SchedulerService}, which
+ * owns the gate, the transactions and the SYSTEM audit writes.
+ */
+@RestController
+public class SchedulerController implements AdminSchedulerApi {
+
+  private final SchedulerService scheduler;
+
+  public SchedulerController(SchedulerService scheduler) {
+    this.scheduler = scheduler;
+  }
+
+  @Override
+  public ResponseEntity<SchedulerJobListResponse> listSchedulerJobs() {
+    return ResponseEntity.ok(
+        new SchedulerJobListResponse()
+            .items(scheduler.list().stream().map(SchedulerController::toDto).toList()));
+  }
+
+  @Override
+  public ResponseEntity<SchedulerJob> updateSchedulerJob(
+      String jobId, SchedulerJobUpdateRequest request) {
+    return ResponseEntity.ok(
+        toDto(
+            scheduler.updateSettings(
+                CurrentUser.requireUserId(), jobId, request.getEnabled(), request.getDryRun())));
+  }
+
+  @Override
+  public ResponseEntity<SchedulerJob> runSchedulerJob(String jobId) {
+    return ResponseEntity.ok(toDto(scheduler.runNow(CurrentUser.requireUserId(), jobId)));
+  }
+
+  @ExceptionHandler(SchedulerJobNotFoundException.class)
+  public ResponseEntity<ErrorResponse> onNotFound(SchedulerJobNotFoundException ex) {
+    return error(HttpStatus.NOT_FOUND, "SCHEDULER_JOB_NOT_FOUND", ex.getMessage());
+  }
+
+  @ExceptionHandler(DryRunNotSupportedException.class)
+  public ResponseEntity<ErrorResponse> onDryRunUnsupported(DryRunNotSupportedException ex) {
+    return error(HttpStatus.BAD_REQUEST, "DRY_RUN_NOT_SUPPORTED", ex.getMessage());
+  }
+
+  @ExceptionHandler(SchedulerJobBusyException.class)
+  public ResponseEntity<ErrorResponse> onBusy(SchedulerJobBusyException ex) {
+    return error(HttpStatus.CONFLICT, "SCHEDULER_JOB_BUSY", ex.getMessage());
+  }
+
+  private static SchedulerJob toDto(SchedulerService.SchedulerJobView view) {
+    return new SchedulerJob()
+        .jobId(view.jobId())
+        .displayName(view.displayName())
+        .description(view.description())
+        .cron(view.cron())
+        .supportsDryRun(view.supportsDryRun())
+        .enabled(view.enabled())
+        .dryRun(view.dryRun())
+        .lastRunAt(toOffset(view.lastRunAt()))
+        .lastOutcome(view.lastOutcome())
+        .lastTrigger(view.lastTrigger())
+        .lastDetail(view.lastDetail());
+  }
+
+  private static OffsetDateTime toOffset(java.time.Instant instant) {
+    return instant == null ? null : instant.atOffset(ZoneOffset.UTC);
+  }
+
+  private static ResponseEntity<ErrorResponse> error(
+      HttpStatus status, String code, String message) {
+    return ResponseEntity.status(status)
+        .body(new ErrorResponse().code(code).message(message).timestamp(OffsetDateTime.now()));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/scheduler/SchedulerApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/scheduler/SchedulerApiIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.scheduler;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * The admin scheduler dashboard over the wire (issue #524, ADR-0045): the ADMIN role gate (a MEMBER
+ * is forbidden), listing the fixed catalogue, enabling/disabling and the dry-run capability guard,
+ * unknown-job 404s, and a run-now that reports its outcome on the returned job.
+ */
+class SchedulerApiIT extends SeededIntegrationTest {
+
+  private static final String SCHEDULER = "/api/v1/admin/scheduler";
+  private static final String REFRESH_TOKEN_SWEEP = "refreshTokenSweep";
+  private static final String STORAGE_ORPHAN_REAPER = "storageOrphanReaper";
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  @Test
+  @DisplayName("a MEMBER is forbidden — the dashboard is ADMIN-only")
+  void memberForbidden() throws Exception {
+    mockMvc.perform(as(get(SCHEDULER), MEMBER_ID)).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("an unauthenticated caller is unauthorized")
+  void requiresAuth() throws Exception {
+    mockMvc.perform(get(SCHEDULER)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("an ADMIN lists the full catalogue, including the dry-run-capable reaper")
+  void adminListsCatalogue() throws Exception {
+    mockMvc
+        .perform(as(get(SCHEDULER), ADMIN_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items", hasSize(5)))
+        .andExpect(jsonPath("$.items[*].jobId", hasItem(STORAGE_ORPHAN_REAPER)))
+        .andExpect(jsonPath("$.items[*].jobId", hasItem(REFRESH_TOKEN_SWEEP)));
+  }
+
+  @Test
+  @DisplayName("an ADMIN can disable a scheduled sweep")
+  void adminDisablesSweep() throws Exception {
+    mockMvc
+        .perform(
+            as(patch(SCHEDULER + "/" + REFRESH_TOKEN_SWEEP), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"enabled\":false}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.jobId").value(REFRESH_TOKEN_SWEEP))
+        .andExpect(jsonPath("$.enabled").value(false));
+  }
+
+  @Test
+  @DisplayName("dry-run is rejected for a job that does not support it (400)")
+  void dryRunRejectedForTokenSweep() throws Exception {
+    mockMvc
+        .perform(
+            as(patch(SCHEDULER + "/" + REFRESH_TOKEN_SWEEP), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"dryRun\":true}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("DRY_RUN_NOT_SUPPORTED"));
+  }
+
+  @Test
+  @DisplayName("dry-run is accepted for the storage reaper")
+  void dryRunAcceptedForReaper() throws Exception {
+    mockMvc
+        .perform(
+            as(patch(SCHEDULER + "/" + STORAGE_ORPHAN_REAPER), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"dryRun\":true}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.dryRun").value(true))
+        .andExpect(jsonPath("$.supportsDryRun").value(true));
+  }
+
+  @Test
+  @DisplayName("an unknown job id is a 404 on update")
+  void unknownJobUpdate404() throws Exception {
+    mockMvc
+        .perform(
+            as(patch(SCHEDULER + "/nope"), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"enabled\":false}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("SCHEDULER_JOB_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("run-now executes the sweep and reports a SUCCESS outcome on the returned job")
+  void runNowReportsOutcome() throws Exception {
+    mockMvc
+        .perform(as(post(SCHEDULER + "/" + REFRESH_TOKEN_SWEEP + "/run"), ADMIN_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.jobId").value(REFRESH_TOKEN_SWEEP))
+        .andExpect(jsonPath("$.lastOutcome").value("SUCCESS"))
+        .andExpect(jsonPath("$.lastTrigger").value("MANUAL"));
+  }
+
+  @Test
+  @DisplayName("run-now on an unknown job id is a 404")
+  void runNowUnknown404() throws Exception {
+    mockMvc.perform(as(post(SCHEDULER + "/nope/run"), ADMIN_ID)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("a run-now surfaces on the SYSTEM audit stream for an AUDITOR")
+  void runNowAudited() throws Exception {
+    mockMvc
+        .perform(as(post(SCHEDULER + "/" + REFRESH_TOKEN_SWEEP + "/run"), ADMIN_ID))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(
+            as(get("/api/v1/audit/events").param("eventType", "scheduler.job.run"), AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(1))
+        .andExpect(jsonPath("$.items[0].scope").value("SYSTEM"))
+        .andExpect(jsonPath("$.items[0].actorId").value(ADMIN_ID.toString()));
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/service/RefreshTokenServiceTest.java
+++ b/qnop-app/src/test/java/io/qnop/service/RefreshTokenServiceTest.java
@@ -31,6 +31,7 @@ import io.qnop.entity.RefreshToken;
 import io.qnop.repository.RefreshTokenRepository;
 import io.qnop.security.JwtKeyService;
 import io.qnop.security.QnopProperties;
+import io.qnop.service.scheduler.SchedulerService;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
@@ -46,6 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RefreshTokenServiceTest {
 
   @Mock private RefreshTokenRepository repository;
+  @Mock private SchedulerService scheduler;
 
   private RefreshTokenService service;
 
@@ -64,7 +66,7 @@ class RefreshTokenServiceTest {
                 null),
             new QnopProperties.Cors(null));
     RefreshTokenHasher hasher = new RefreshTokenHasher(new JwtKeyService(properties));
-    service = new RefreshTokenService(repository, hasher, properties);
+    service = new RefreshTokenService(repository, hasher, properties, scheduler);
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/entity/SchedulerJob.java
+++ b/qnop-core/src/main/java/io/qnop/entity/SchedulerJob.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
+import java.util.Objects;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * The operator-controlled state of one scheduled maintenance sweep (issue #524, ADR-0045).
+ *
+ * <p>The static catalogue of jobs — their display name, cron expression and dry-run capability —
+ * lives in code ({@code SchedulerJobCatalog}); this row holds only what an admin can change and
+ * what the last run produced: whether the scheduled tick is {@link #enabled}, whether the reaper
+ * runs in {@link #dryRun} mode, and the outcome of the most recent run ({@link #lastRunAt}, {@link
+ * #lastOutcome}, {@link #lastTrigger}, {@link #lastDetail}). The primary key is the natural {@code
+ * jobId} — the same string used as the ShedLock name — so there is exactly one row per catalogued
+ * job, seeded idempotently at start-up.
+ *
+ * <p>JPA runs {@code ddl-auto=none}; this mapping matches migration 0017 exactly.
+ */
+@Entity
+@Table(name = "scheduler_job")
+public class SchedulerJob {
+
+  @Id
+  @Column(name = "job_id", nullable = false, updatable = false, length = 64)
+  private String jobId;
+
+  /** Whether the scheduled tick runs; a manual run-now ignores this (explicit operator intent). */
+  @Column(name = "enabled", nullable = false)
+  private boolean enabled;
+
+  /** For a dry-run-capable job (the reaper), report-only mode: compute but do not delete. */
+  @Column(name = "dry_run", nullable = false)
+  private boolean dryRun;
+
+  /** When the job last actually ran (a skipped-because-disabled tick does not touch this). */
+  @Column(name = "last_run_at")
+  private Instant lastRunAt;
+
+  /**
+   * Outcome of the last run — the {@code RunOutcome} name (SUCCESS / FAILURE), or null if never.
+   */
+  @Column(name = "last_outcome", length = 16)
+  private String lastOutcome;
+
+  /** What triggered the last run — the {@code RunTrigger} name (SCHEDULED / MANUAL), or null. */
+  @Column(name = "last_trigger", length = 16)
+  private String lastTrigger;
+
+  /** Optional short detail for the last run (e.g. {@code "dry-run"} or a failure summary). */
+  @Column(name = "last_detail", length = 512)
+  private String lastDetail;
+
+  @Version
+  @Column(name = "version", nullable = false)
+  private long version;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  protected SchedulerJob() {
+    // for JPA
+  }
+
+  private SchedulerJob(String jobId, boolean enabled, boolean dryRun) {
+    this.jobId = jobId;
+    this.enabled = enabled;
+    this.dryRun = dryRun;
+  }
+
+  /** A freshly seeded job row: enabled, not in dry-run, never run yet. */
+  public static SchedulerJob seed(String jobId) {
+    return new SchedulerJob(jobId, true, false);
+  }
+
+  /** Applies operator settings; a null argument leaves that setting unchanged. */
+  public void updateSettings(Boolean enabled, Boolean dryRun) {
+    if (enabled != null) {
+      this.enabled = enabled;
+    }
+    if (dryRun != null) {
+      this.dryRun = dryRun;
+    }
+  }
+
+  /** Records the outcome of a run that actually executed (not a disabled-skip). */
+  public void recordRun(Instant at, String outcome, String trigger, String detail) {
+    this.lastRunAt = at;
+    this.lastOutcome = outcome;
+    this.lastTrigger = trigger;
+    this.lastDetail = detail;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public boolean isDryRun() {
+    return dryRun;
+  }
+
+  public Instant getLastRunAt() {
+    return lastRunAt;
+  }
+
+  public String getLastOutcome() {
+    return lastOutcome;
+  }
+
+  public String getLastTrigger() {
+    return lastTrigger;
+  }
+
+  public String getLastDetail() {
+    return lastDetail;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SchedulerJob other)) {
+      return false;
+    }
+    return jobId != null && jobId.equals(other.jobId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(jobId);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/SchedulerJobRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/SchedulerJobRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.SchedulerJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Data access for the operator-controlled scheduler-job state (issue #524, ADR-0045). Keyed by the
+ * natural {@code jobId} string; there is exactly one row per catalogued job, seeded at start-up.
+ */
+public interface SchedulerJobRepository extends JpaRepository<SchedulerJob, String> {}

--- a/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/RefreshTokenService.java
@@ -23,6 +23,8 @@ package io.qnop.service;
 import io.qnop.entity.RefreshToken;
 import io.qnop.repository.RefreshTokenRepository;
 import io.qnop.security.QnopProperties;
+import io.qnop.service.scheduler.SchedulerJobCatalog;
+import io.qnop.service.scheduler.SchedulerService;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
@@ -58,13 +60,18 @@ public class RefreshTokenService {
   private final RefreshTokenRepository repository;
   private final RefreshTokenHasher hasher;
   private final QnopProperties properties;
+  private final SchedulerService scheduler;
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   public RefreshTokenService(
-      RefreshTokenRepository repository, RefreshTokenHasher hasher, QnopProperties properties) {
+      RefreshTokenRepository repository,
+      RefreshTokenHasher hasher,
+      QnopProperties properties,
+      SchedulerService scheduler) {
     this.repository = repository;
     this.hasher = hasher;
     this.properties = properties;
+    this.scheduler = scheduler;
   }
 
   /** Issues a fresh refresh token in a new family (initial login). */
@@ -120,9 +127,13 @@ public class RefreshTokenService {
    * security purpose (reuse detection) is moot after expiry.
    */
   @Scheduled(cron = "0 40 3 * * *")
-  @SchedulerLock(name = "refreshTokenSweep", lockAtMostFor = "PT5M")
-  @Transactional
+  @SchedulerLock(name = SchedulerJobCatalog.REFRESH_TOKEN_SWEEP, lockAtMostFor = "PT5M")
   public void sweepExpired() {
+    scheduler.runScheduled(SchedulerJobCatalog.REFRESH_TOKEN_SWEEP);
+  }
+
+  /** The raw purge, run inside the scheduler gate's transaction (issue #524). */
+  public void sweepExpiredOnce() {
     repository.deleteExpiredBefore(Instant.now());
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TokenRevocationService.java
@@ -27,6 +27,8 @@ import io.qnop.entity.User;
 import io.qnop.repository.RevokedTokenRepository;
 import io.qnop.repository.UserRepository;
 import io.qnop.security.QnopProperties;
+import io.qnop.service.scheduler.SchedulerJobCatalog;
+import io.qnop.service.scheduler.SchedulerService;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -51,14 +53,17 @@ public class TokenRevocationService {
 
   private final RevokedTokenRepository revokedTokenRepository;
   private final UserRepository userRepository;
+  private final SchedulerService scheduler;
   private final Cache<String, Boolean> revokedJtiCache;
 
   public TokenRevocationService(
       RevokedTokenRepository revokedTokenRepository,
       UserRepository userRepository,
-      QnopProperties properties) {
+      QnopProperties properties,
+      SchedulerService scheduler) {
     this.revokedTokenRepository = revokedTokenRepository;
     this.userRepository = userRepository;
+    this.scheduler = scheduler;
     this.revokedJtiCache =
         Caffeine.newBuilder()
             .maximumSize(CACHE_MAX_SIZE)
@@ -118,9 +123,13 @@ public class TokenRevocationService {
    * {@code exp} validation regardless, so dropping its denylist row is safe.
    */
   @Scheduled(cron = "0 45 3 * * *")
-  @SchedulerLock(name = "revokedTokenSweep", lockAtMostFor = "PT5M")
-  @Transactional
+  @SchedulerLock(name = SchedulerJobCatalog.REVOKED_TOKEN_SWEEP, lockAtMostFor = "PT5M")
   public void sweepExpired() {
+    scheduler.runScheduled(SchedulerJobCatalog.REVOKED_TOKEN_SWEEP);
+  }
+
+  /** The raw purge, run inside the scheduler gate's transaction (issue #524). */
+  public void sweepExpiredOnce() {
     revokedTokenRepository.deleteExpiredBefore(Instant.now());
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/auth/EmailVerificationTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/EmailVerificationTokenService.java
@@ -23,6 +23,8 @@ package io.qnop.service.auth;
 import io.qnop.entity.EmailVerificationToken;
 import io.qnop.entity.User;
 import io.qnop.repository.EmailVerificationTokenRepository;
+import io.qnop.service.scheduler.SchedulerJobCatalog;
+import io.qnop.service.scheduler.SchedulerService;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -52,9 +54,12 @@ public class EmailVerificationTokenService {
   private static final SecureRandom RANDOM = new SecureRandom();
 
   private final EmailVerificationTokenRepository tokens;
+  private final SchedulerService scheduler;
 
-  public EmailVerificationTokenService(EmailVerificationTokenRepository tokens) {
+  public EmailVerificationTokenService(
+      EmailVerificationTokenRepository tokens, SchedulerService scheduler) {
     this.tokens = tokens;
+    this.scheduler = scheduler;
   }
 
   /** Issues a fresh token for {@code user}, superseding any earlier unconsumed one. */
@@ -91,11 +96,19 @@ public class EmailVerificationTokenService {
     return user;
   }
 
-  /** Daily off-peak purge of expired rows so the table does not grow unbounded. */
+  /**
+   * Daily off-peak purge of expired rows so the table does not grow unbounded. Routed through the
+   * scheduler gate (issue #524) so an admin can disable it or trigger a run-now; the gate owns the
+   * transaction around {@link #sweepOnce()}.
+   */
   @Scheduled(cron = "0 30 3 * * *")
-  @SchedulerLock(name = "emailVerificationTokenSweep", lockAtMostFor = "PT5M")
-  @Transactional
+  @SchedulerLock(name = SchedulerJobCatalog.EMAIL_VERIFICATION_TOKEN_SWEEP, lockAtMostFor = "PT5M")
   public void sweep() {
+    scheduler.runScheduled(SchedulerJobCatalog.EMAIL_VERIFICATION_TOKEN_SWEEP);
+  }
+
+  /** The raw purge, run inside the scheduler gate's transaction (issue #524). */
+  public void sweepOnce() {
     tokens.deleteByExpiresAtBefore(Instant.now());
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetTokenService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetTokenService.java
@@ -25,6 +25,8 @@ import io.qnop.entity.User;
 import io.qnop.repository.PasswordResetTokenRepository;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.scheduler.SchedulerJobCatalog;
+import io.qnop.service.scheduler.SchedulerService;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -54,11 +56,15 @@ public class PasswordResetTokenService {
 
   private final PasswordResetTokenRepository tokens;
   private final ApplicationSettingsService settings;
+  private final SchedulerService scheduler;
 
   public PasswordResetTokenService(
-      PasswordResetTokenRepository tokens, ApplicationSettingsService settings) {
+      PasswordResetTokenRepository tokens,
+      ApplicationSettingsService settings,
+      SchedulerService scheduler) {
     this.tokens = tokens;
     this.settings = settings;
+    this.scheduler = scheduler;
   }
 
   /** Issues a fresh reset token for {@code user}, superseding any earlier unconsumed one. */
@@ -94,10 +100,19 @@ public class PasswordResetTokenService {
     return user;
   }
 
+  /**
+   * Daily off-peak purge of expired reset tokens, routed through the scheduler gate (issue #524) so
+   * an admin can disable it or trigger a run-now; the gate owns the transaction around {@link
+   * #sweepOnce()}.
+   */
   @Scheduled(cron = "0 35 3 * * *")
-  @SchedulerLock(name = "passwordResetTokenSweep", lockAtMostFor = "PT5M")
-  @Transactional
+  @SchedulerLock(name = SchedulerJobCatalog.PASSWORD_RESET_TOKEN_SWEEP, lockAtMostFor = "PT5M")
   public void sweep() {
+    scheduler.runScheduled(SchedulerJobCatalog.PASSWORD_RESET_TOKEN_SWEEP);
+  }
+
+  /** The raw purge, run inside the scheduler gate's transaction (issue #524). */
+  public void sweepOnce() {
     tokens.deleteByExpiresAtBefore(Instant.now());
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/DryRunNotSupportedException.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/DryRunNotSupportedException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+/** Dry-run was requested for a job that does not support it (issue #524) — maps to 400. */
+public class DryRunNotSupportedException extends RuntimeException {
+  public DryRunNotSupportedException(String jobId) {
+    super("Scheduler job does not support dry-run: " + jobId);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/RunOutcome.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/RunOutcome.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+/**
+ * The result of attempting to run a maintenance job (issue #524, ADR-0045). {@link #SUCCESS} and
+ * {@link #FAILURE} are recorded on the {@code scheduler_job} row; {@link #SKIPPED_DISABLED} is a
+ * scheduled tick that did nothing because the job is disabled — it is <em>not</em> recorded (the
+ * previous run's outcome is preserved, and the disabled flag itself explains the silence).
+ */
+public enum RunOutcome {
+  SUCCESS,
+  FAILURE,
+  SKIPPED_DISABLED
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/RunTrigger.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/RunTrigger.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+/**
+ * What caused a maintenance job to run (issue #524, ADR-0045). {@link #SCHEDULED} is the cron tick,
+ * which honours the job's {@code enabled} flag; {@link #MANUAL} is an admin's run-now, which is an
+ * explicit override and runs regardless of {@code enabled}. Only {@code MANUAL} runs are written to
+ * the SYSTEM audit stream (ADR-0043) — scheduled runs would flood the trail; their outcome lives on
+ * the {@code scheduler_job} row.
+ */
+public enum RunTrigger {
+  SCHEDULED,
+  MANUAL
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBinding.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBinding.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+import io.qnop.service.RefreshTokenService;
+import io.qnop.service.TokenRevocationService;
+import io.qnop.service.auth.EmailVerificationTokenService;
+import io.qnop.service.auth.PasswordResetTokenService;
+import io.qnop.service.storage.StorageService;
+import org.springframework.stereotype.Component;
+
+/**
+ * Binds each catalogued job id to the runnable that performs it (issue #524, ADR-0045).
+ * Registration lives here — one wiring point — rather than in each sweep service, so {@link
+ * SchedulerService} depends on no service (no dependency cycle) and the owning services stay free
+ * of scheduler plumbing. Constructor-time registration completes before any cron tick or run-now
+ * can fire.
+ *
+ * <p>The token sweeps ignore the dry-run flag; only the storage reaper honours it.
+ */
+@Component
+public class SchedulerJobBinding {
+
+  public SchedulerJobBinding(
+      SchedulerService scheduler,
+      EmailVerificationTokenService emailVerificationTokens,
+      PasswordResetTokenService passwordResetTokens,
+      RefreshTokenService refreshTokens,
+      TokenRevocationService revokedTokens,
+      StorageService storage) {
+    scheduler.register(
+        SchedulerJobCatalog.EMAIL_VERIFICATION_TOKEN_SWEEP,
+        dryRun -> emailVerificationTokens.sweepOnce());
+    scheduler.register(
+        SchedulerJobCatalog.PASSWORD_RESET_TOKEN_SWEEP, dryRun -> passwordResetTokens.sweepOnce());
+    scheduler.register(
+        SchedulerJobCatalog.REFRESH_TOKEN_SWEEP, dryRun -> refreshTokens.sweepExpiredOnce());
+    scheduler.register(
+        SchedulerJobCatalog.REVOKED_TOKEN_SWEEP, dryRun -> revokedTokens.sweepExpiredOnce());
+    scheduler.register(SchedulerJobCatalog.STORAGE_ORPHAN_REAPER, storage::reapOrphansOnce);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBootstrap.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBootstrap.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+import io.qnop.entity.SchedulerJob;
+import io.qnop.repository.SchedulerJobRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Seeds a {@code scheduler_job} row for every catalogued job at start-up (issue #524, ADR-0045).
+ * Idempotent: an existing row (with its operator settings and last-run history) is left untouched,
+ * so a restart never resets an admin's toggles. A fresh install gets every job enabled and not in
+ * dry-run. Missing rows are harmless anyway — the gate fails open — but seeding means the dashboard
+ * shows the full set immediately.
+ */
+@Component
+public class SchedulerJobBootstrap implements ApplicationRunner {
+
+  private static final Logger log = LoggerFactory.getLogger(SchedulerJobBootstrap.class);
+
+  private final SchedulerJobRepository jobs;
+
+  public SchedulerJobBootstrap(SchedulerJobRepository jobs) {
+    this.jobs = jobs;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    int seeded = 0;
+    for (String jobId : SchedulerJobCatalog.jobIds()) {
+      if (!jobs.existsById(jobId)) {
+        jobs.save(SchedulerJob.seed(jobId));
+        seeded++;
+      }
+    }
+    if (seeded > 0) {
+      log.info("Seeded {} scheduler-job row(s).", seeded);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBusyException.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBusyException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+/**
+ * A manual run-now could not acquire the job's distributed lock because a run (scheduled or another
+ * manual trigger) is already in progress (issue #524) — maps to 409.
+ */
+public class SchedulerJobBusyException extends RuntimeException {
+  public SchedulerJobBusyException(String jobId) {
+    super("Scheduler job is already running: " + jobId);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The fixed catalogue of maintenance sweeps the scheduler dashboard surfaces (issue #524,
+ * ADR-0045). The set is closed and lives in code: each {@link SchedulerJobDefinition} names a job,
+ * its cron, and whether it is dry-run-capable. The two internal poller/reaper jobs of the durable
+ * job queue (ADR-0033) are deliberately excluded — they are engine internals, not operator-facing
+ * maintenance.
+ *
+ * <p>The {@code jobId} constants are compile-time-constant strings so they double as the
+ * {@code @SchedulerLock} names on the owning service methods — one source of truth, no drift.
+ */
+public final class SchedulerJobCatalog {
+
+  public static final String EMAIL_VERIFICATION_TOKEN_SWEEP = "emailVerificationTokenSweep";
+  public static final String PASSWORD_RESET_TOKEN_SWEEP = "passwordResetTokenSweep";
+  public static final String REFRESH_TOKEN_SWEEP = "refreshTokenSweep";
+  public static final String REVOKED_TOKEN_SWEEP = "revokedTokenSweep";
+  public static final String STORAGE_ORPHAN_REAPER = "storageOrphanReaper";
+
+  private static final List<SchedulerJobDefinition> DEFINITIONS =
+      List.of(
+          new SchedulerJobDefinition(
+              EMAIL_VERIFICATION_TOKEN_SWEEP,
+              "Email-verification token sweep",
+              "Purges expired e-mail verification tokens so the table does not grow unbounded.",
+              "0 30 3 * * *",
+              false),
+          new SchedulerJobDefinition(
+              PASSWORD_RESET_TOKEN_SWEEP,
+              "Password-reset token sweep",
+              "Purges expired password-reset tokens once they can no longer be redeemed.",
+              "0 35 3 * * *",
+              false),
+          new SchedulerJobDefinition(
+              REFRESH_TOKEN_SWEEP,
+              "Refresh token sweep",
+              "Deletes expired refresh tokens; reuse-detection is moot once a token has expired.",
+              "0 40 3 * * *",
+              false),
+          new SchedulerJobDefinition(
+              REVOKED_TOKEN_SWEEP,
+              "Revoked access-token sweep",
+              "Drops revoked access-token denylist rows once their own expiry has passed.",
+              "0 45 3 * * *",
+              false),
+          new SchedulerJobDefinition(
+              STORAGE_ORPHAN_REAPER,
+              "Storage orphan reaper",
+              "Deletes uploaded-but-uncommitted storage objects older than the grace period.",
+              "0 30 3 * * *",
+              true));
+
+  private static final List<String> IDS =
+      DEFINITIONS.stream().map(SchedulerJobDefinition::jobId).toList();
+
+  private SchedulerJobCatalog() {}
+
+  /** All catalogued jobs, in a stable dashboard order. */
+  public static List<SchedulerJobDefinition> definitions() {
+    return DEFINITIONS;
+  }
+
+  /** The catalogued job ids, in the same stable order. */
+  public static List<String> jobIds() {
+    return IDS;
+  }
+
+  /** The definition for a job id, if it is catalogued. */
+  public static Optional<SchedulerJobDefinition> find(String jobId) {
+    return DEFINITIONS.stream().filter(definition -> definition.jobId().equals(jobId)).findFirst();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobDefinition.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobDefinition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+/**
+ * The static metadata for one catalogued maintenance job (issue #524, ADR-0045) — the parts that
+ * live in code and never change at runtime.
+ *
+ * @param jobId the natural id, identical to the ShedLock name and the {@code scheduler_job} row key
+ * @param displayName a human label for the dashboard
+ * @param description one sentence on what the sweep does and why
+ * @param cron the default cron expression the sweep fires on (informational for the dashboard)
+ * @param supportsDryRun whether the job honours a report-only dry-run mode (only the reaper does)
+ */
+public record SchedulerJobDefinition(
+    String jobId, String displayName, String description, String cron, boolean supportsDryRun) {}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobNotFoundException.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+/** A scheduler job id that is not in the fixed catalogue (issue #524) — maps to 404. */
+public class SchedulerJobNotFoundException extends RuntimeException {
+  public SchedulerJobNotFoundException(String jobId) {
+    super("Unknown scheduler job: " + jobId);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerService.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerService.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.SchedulerJob;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.SchedulerJobRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * The operator gate in front of the scheduled maintenance sweeps (issue #524, ADR-0045).
+ *
+ * <p>Every sweep routes through {@link #runScheduled(String)} on its cron tick; the dashboard
+ * drives {@link #updateSettings} (enable/disable, dry-run) and {@link #runNow} (an explicit manual
+ * override). The gate reads the operator state from the {@code scheduler_job} row, records each
+ * real run's outcome back onto that row, and — for manual runs and setting changes only — writes to
+ * the SYSTEM audit stream (ADR-0043). Scheduled runs deliberately do not audit: five rows a day
+ * forever would drown the trail, and their outcome already lives on the row.
+ *
+ * <h2>Transaction discipline (the architecture guardrail)</h2>
+ *
+ * <p>The gate is intentionally <em>not</em> a {@code @Transactional} bean. It owns transactions
+ * programmatically through a {@link TransactionTemplate}, which lets it run three independent units
+ * per job: read the state, run the work, then record the outcome. Because the outcome is recorded
+ * in a <em>separate</em> transaction from the work, a work rollback can never erase the failure
+ * record — and no Spring self-invocation caveat applies, since the work {@link SchedulerWork}
+ * runnable is supplied by the owning service and invoked inside the gate's own transaction.
+ *
+ * <h2>Fail-open</h2>
+ *
+ * <p>If the state read fails (a broken {@code scheduler_job} table, a transient DB error), the gate
+ * runs the job anyway. Maintenance sweeps keep the system healthy; a stuck control table must never
+ * silently stop them.
+ */
+@Service
+public class SchedulerService {
+
+  private static final Logger log = LoggerFactory.getLogger(SchedulerService.class);
+
+  /** Audit event types on the SYSTEM stream. */
+  static final String AUDIT_RUN = "scheduler.job.run";
+
+  static final String AUDIT_UPDATED = "scheduler.job.updated";
+
+  /** Cap on how long a manual run may hold its lock before ShedLock reclaims it defensively. */
+  private static final Duration MANUAL_LOCK_AT_MOST = Duration.ofMinutes(10);
+
+  private static final int MAX_DETAIL_LENGTH = 512;
+
+  private final SchedulerJobRepository jobs;
+  private final AuditEventRepository auditEvents;
+  private final LockProvider lockProvider;
+  private final TransactionTemplate tx;
+  private final Map<String, SchedulerWork> works = new ConcurrentHashMap<>();
+
+  public SchedulerService(
+      SchedulerJobRepository jobs,
+      AuditEventRepository auditEvents,
+      LockProvider lockProvider,
+      PlatformTransactionManager transactionManager) {
+    this.jobs = jobs;
+    this.auditEvents = auditEvents;
+    this.lockProvider = lockProvider;
+    this.tx = new TransactionTemplate(transactionManager);
+  }
+
+  /** One dashboard row: the static catalogue metadata joined with the mutable operator state. */
+  public record SchedulerJobView(
+      String jobId,
+      String displayName,
+      String description,
+      String cron,
+      boolean supportsDryRun,
+      boolean enabled,
+      boolean dryRun,
+      Instant lastRunAt,
+      String lastOutcome,
+      String lastTrigger,
+      String lastDetail) {}
+
+  /**
+   * Registers the unit of work for a job; called once at start-up by {@code SchedulerJobBinding}.
+   * The gate never invokes a job it has no runnable for.
+   */
+  public void register(String jobId, SchedulerWork work) {
+    works.put(jobId, work);
+  }
+
+  /**
+   * The cron entry point for a sweep: runs it honouring the {@code enabled} flag, or skips silently
+   * when disabled. Called from the {@code @Scheduled}/{@code @SchedulerLock} method, so the
+   * distributed lock is already held.
+   */
+  public RunOutcome runScheduled(String jobId) {
+    return execute(jobId, RunTrigger.SCHEDULED, null);
+  }
+
+  /**
+   * An admin's run-now: an explicit override that runs the job regardless of {@code enabled}, under
+   * the job's distributed lock so it never overlaps a scheduled run or another manual trigger.
+   *
+   * @throws SchedulerJobNotFoundException if the id is not catalogued (404)
+   * @throws SchedulerJobBusyException if a run is already in progress (409)
+   */
+  public SchedulerJobView runNow(UUID actorId, String jobId) {
+    SchedulerJobDefinition definition = requireDefinition(jobId);
+    LockConfiguration lockConfiguration =
+        new LockConfiguration(Instant.now(), jobId, MANUAL_LOCK_AT_MOST, Duration.ZERO);
+    Optional<SimpleLock> lock = lockProvider.lock(lockConfiguration);
+    if (lock.isEmpty()) {
+      throw new SchedulerJobBusyException(jobId);
+    }
+    try {
+      execute(jobId, RunTrigger.MANUAL, actorId);
+    } finally {
+      lock.get().unlock();
+    }
+    return viewOf(definition, jobs.findById(jobId).orElse(null));
+  }
+
+  /**
+   * Applies operator settings to a job (a null field leaves that setting unchanged), audits the
+   * change, and returns the fresh view.
+   *
+   * @throws SchedulerJobNotFoundException if the id is not catalogued (404)
+   * @throws DryRunNotSupportedException if dry-run is requested for a job that cannot dry-run (400)
+   */
+  public SchedulerJobView updateSettings(
+      UUID actorId, String jobId, Boolean enabled, Boolean dryRun) {
+    SchedulerJobDefinition definition = requireDefinition(jobId);
+    if (Boolean.TRUE.equals(dryRun) && !definition.supportsDryRun()) {
+      throw new DryRunNotSupportedException(jobId);
+    }
+    SchedulerJob saved =
+        tx.execute(
+            status -> {
+              SchedulerJob job = jobs.findById(jobId).orElseGet(() -> SchedulerJob.seed(jobId));
+              job.updateSettings(enabled, dryRun);
+              SchedulerJob persisted = jobs.save(job);
+              auditEvents.save(
+                  AuditEvent.system(
+                      AUDIT_UPDATED,
+                      actorId,
+                      "{\"jobId\":\""
+                          + jobId
+                          + "\",\"enabled\":"
+                          + persisted.isEnabled()
+                          + ",\"dryRun\":"
+                          + persisted.isDryRun()
+                          + "}"));
+              return persisted;
+            });
+    return viewOf(definition, saved);
+  }
+
+  /** The full dashboard list: every catalogued job with its current operator state. */
+  public List<SchedulerJobView> list() {
+    Map<String, SchedulerJob> rows =
+        tx.execute(
+            status ->
+                jobs.findAllById(SchedulerJobCatalog.jobIds()).stream()
+                    .collect(
+                        java.util.stream.Collectors.toMap(
+                            SchedulerJob::getJobId, Function.identity())));
+    Map<String, SchedulerJob> byId = rows == null ? Map.of() : rows;
+    return SchedulerJobCatalog.definitions().stream()
+        .map(definition -> viewOf(definition, byId.get(definition.jobId())))
+        .toList();
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private RunOutcome execute(String jobId, RunTrigger trigger, UUID actorId) {
+    SchedulerWork work = works.get(jobId);
+    if (work == null) {
+      // A catalogued job with no registered runnable is a wiring bug, not a runtime input error.
+      log.error("No work registered for scheduler job {}; skipping {} run", jobId, trigger);
+      return RunOutcome.FAILURE;
+    }
+    JobState state = readState(jobId);
+    if (trigger == RunTrigger.SCHEDULED && !state.enabled()) {
+      log.debug("Scheduler job {} is disabled; skipping scheduled run", jobId);
+      return RunOutcome.SKIPPED_DISABLED;
+    }
+    boolean dryRun = state.dryRun() && supportsDryRun(jobId);
+    try {
+      tx.executeWithoutResult(status -> work.run(dryRun));
+    } catch (RuntimeException e) {
+      log.error("Scheduler job {} ({}) failed", jobId, trigger, e);
+      recordOutcome(jobId, RunOutcome.FAILURE, trigger, summarize(e), actorId);
+      return RunOutcome.FAILURE;
+    }
+    recordOutcome(jobId, RunOutcome.SUCCESS, trigger, dryRun ? "dry-run" : null, actorId);
+    return RunOutcome.SUCCESS;
+  }
+
+  /** Reads the enabled/dry-run state; fails open (run the job) on any read error. */
+  private JobState readState(String jobId) {
+    try {
+      JobState state =
+          tx.execute(
+              status ->
+                  jobs.findById(jobId)
+                      .map(job -> new JobState(job.isEnabled(), job.isDryRun()))
+                      .orElse(new JobState(true, false)));
+      return state == null ? new JobState(true, false) : state;
+    } catch (RuntimeException e) {
+      log.warn("Could not read scheduler state for {}; failing open (running)", jobId, e);
+      return new JobState(true, false);
+    }
+  }
+
+  /**
+   * Records a run's outcome on the row (best-effort, in its own transaction so a work rollback can
+   * never erase it) and, for a manual run, on the SYSTEM audit stream. A failure to record is
+   * logged but never masks the run itself.
+   */
+  private void recordOutcome(
+      String jobId, RunOutcome outcome, RunTrigger trigger, String detail, UUID actorId) {
+    try {
+      tx.executeWithoutResult(
+          status -> {
+            SchedulerJob job = jobs.findById(jobId).orElseGet(() -> SchedulerJob.seed(jobId));
+            job.recordRun(Instant.now(), outcome.name(), trigger.name(), detail);
+            jobs.save(job);
+            if (trigger == RunTrigger.MANUAL) {
+              auditEvents.save(
+                  AuditEvent.system(
+                      AUDIT_RUN,
+                      actorId,
+                      "{\"jobId\":\""
+                          + jobId
+                          + "\",\"outcome\":\""
+                          + outcome.name()
+                          + "\",\"dryRun\":"
+                          + "dry-run".equals(detail)
+                          + "}"));
+            }
+          });
+    } catch (RuntimeException e) {
+      log.error("Failed to record outcome for scheduler job {}", jobId, e);
+    }
+  }
+
+  private boolean supportsDryRun(String jobId) {
+    return SchedulerJobCatalog.find(jobId)
+        .map(SchedulerJobDefinition::supportsDryRun)
+        .orElse(false);
+  }
+
+  private SchedulerJobDefinition requireDefinition(String jobId) {
+    return SchedulerJobCatalog.find(jobId)
+        .orElseThrow(() -> new SchedulerJobNotFoundException(jobId));
+  }
+
+  private static String summarize(RuntimeException e) {
+    String message = e.getMessage();
+    String summary =
+        message == null
+            ? e.getClass().getSimpleName()
+            : e.getClass().getSimpleName() + ": " + message;
+    return summary.length() <= MAX_DETAIL_LENGTH
+        ? summary
+        : summary.substring(0, MAX_DETAIL_LENGTH);
+  }
+
+  private static SchedulerJobView viewOf(SchedulerJobDefinition definition, SchedulerJob row) {
+    return new SchedulerJobView(
+        definition.jobId(),
+        definition.displayName(),
+        definition.description(),
+        definition.cron(),
+        definition.supportsDryRun(),
+        row == null || row.isEnabled(),
+        row != null && row.isDryRun(),
+        row == null ? null : row.getLastRunAt(),
+        row == null ? null : row.getLastOutcome(),
+        row == null ? null : row.getLastTrigger(),
+        row == null ? null : row.getLastDetail());
+  }
+
+  private record JobState(boolean enabled, boolean dryRun) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerWork.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerWork.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+/**
+ * The unit of work a maintenance job performs, registered with {@link SchedulerService} by the
+ * owning service (issue #524, ADR-0045). It is called <em>inside</em> a fresh transaction the
+ * scheduler owns, so implementations do their raw repository work and need no transaction of their
+ * own. The {@code dryRun} flag is honoured only by dry-run-capable jobs (the storage reaper); the
+ * token sweeps ignore it.
+ */
+@FunctionalInterface
+public interface SchedulerWork {
+  void run(boolean dryRun);
+}

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
@@ -23,6 +23,8 @@ package io.qnop.service.storage;
 import io.qnop.entity.StorageObject;
 import io.qnop.entity.StorageObjectStatus;
 import io.qnop.repository.StorageObjectRepository;
+import io.qnop.service.scheduler.SchedulerJobCatalog;
+import io.qnop.service.scheduler.SchedulerService;
 import io.qnop.spi.storage.StorageContent;
 import io.qnop.spi.storage.StorageException;
 import io.qnop.spi.storage.StorageProvider;
@@ -63,12 +65,17 @@ public class StorageService {
   private final StorageProvider provider;
   private final StorageObjectRepository repository;
   private final S3Properties properties;
+  private final SchedulerService scheduler;
 
   public StorageService(
-      StorageProvider provider, StorageObjectRepository repository, S3Properties properties) {
+      StorageProvider provider,
+      StorageObjectRepository repository,
+      S3Properties properties,
+      SchedulerService scheduler) {
     this.provider = provider;
     this.repository = repository;
     this.properties = properties;
+    this.scheduler = scheduler;
   }
 
   /**
@@ -155,23 +162,39 @@ public class StorageService {
 
   /**
    * Deletes objects left uploaded-but-uncommitted past the grace period (ADR-0036). Runs off-peak,
-   * single-instance via ShedLock (ADR-0029); tests invoke it directly. The object is removed before
-   * its row, so a crash mid-sweep simply retries next run (delete is idempotent).
+   * single-instance via ShedLock (ADR-0029). Routed through the scheduler gate (issue #524) so an
+   * admin can disable it, put it in dry-run, or trigger a run-now; the gate owns the transaction
+   * around {@link #reapOrphansOnce(boolean)}.
    */
   @Scheduled(cron = "${qnop.s3.reaper-cron:0 30 3 * * *}")
-  @SchedulerLock(name = "storageOrphanReaper", lockAtMostFor = "PT10M")
-  @Transactional
+  @SchedulerLock(name = SchedulerJobCatalog.STORAGE_ORPHAN_REAPER, lockAtMostFor = "PT10M")
   public void reapOrphans() {
+    scheduler.runScheduled(SchedulerJobCatalog.STORAGE_ORPHAN_REAPER);
+  }
+
+  /**
+   * The raw reaper pass, run inside the scheduler gate's transaction (issue #524). The object is
+   * removed before its row, so a crash mid-sweep simply retries next run (delete is idempotent). In
+   * {@code dryRun} mode it counts what would be deleted but deletes nothing — a safe operator
+   * probe.
+   */
+  public void reapOrphansOnce(boolean dryRun) {
     Instant cutoff = Instant.now().minus(properties.reaperGracePeriod());
     List<StorageObject> orphans =
         repository.findByStatusAndCreatedAtBefore(StorageObjectStatus.PENDING, cutoff);
+    if (orphans.isEmpty()) {
+      return;
+    }
+    if (dryRun) {
+      log.info(
+          "Storage orphan reaper (dry-run) would delete {} uncommitted object(s).", orphans.size());
+      return;
+    }
     for (StorageObject orphan : orphans) {
       provider.delete(orphan.getObjectKey());
       repository.delete(orphan);
     }
-    if (!orphans.isEmpty()) {
-      log.info("Storage orphan reaper deleted {} uncommitted object(s).", orphans.size());
-    }
+    log.info("Storage orphan reaper deleted {} uncommitted object(s).", orphans.size());
   }
 
   /**

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -59,6 +59,9 @@ databaseChangeLog:
   - include:
       file: migrations/0016-audit-scope-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0017-scheduler-job-schema.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/migrations/0017-scheduler-job-schema.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0017-scheduler-job-schema.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2026-present devtank42 GmbH
+#
+# This file is part of qnop (Qualified Notes on Papers).
+#
+# qnop is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with qnop. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Operator-controlled state for the scheduled maintenance sweeps (issue #524,
+# ADR-0045). The static catalogue (display name, cron, dry-run capability) lives
+# in code; this table holds only what an admin can change (enabled, dry_run) and
+# the outcome of the most recent run. One row per catalogued job, keyed by the
+# natural job_id (the ShedLock name), seeded idempotently at start-up. JPA runs
+# ddl-auto=none, so the entity mapping (io.qnop.entity.SchedulerJob) must match
+# these definitions exactly.
+databaseChangeLog:
+  - changeSet:
+      id: 0017-scheduler-job
+      author: qnop
+      comment: Scheduler-job operator state (enabled / dry-run / last-run outcome), issue #524.
+      changes:
+        - createTable:
+            tableName: scheduler_job
+            columns:
+              - column:
+                  name: job_id
+                  type: VARCHAR(64)
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: enabled
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints: { nullable: false }
+              - column:
+                  name: dry_run
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints: { nullable: false }
+              - column: { name: last_run_at, type: TIMESTAMP WITH TIME ZONE }
+              - column: { name: last_outcome, type: VARCHAR(16) }
+              - column: { name: last_trigger, type: VARCHAR(16) }
+              - column: { name: last_detail, type: VARCHAR(512) }
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints: { nullable: false }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints: { nullable: false }

--- a/qnop-core/src/test/java/io/qnop/service/TokenRevocationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TokenRevocationServiceTest.java
@@ -35,6 +35,7 @@ import io.qnop.entity.User;
 import io.qnop.repository.RevokedTokenRepository;
 import io.qnop.repository.UserRepository;
 import io.qnop.security.QnopProperties;
+import io.qnop.service.scheduler.SchedulerService;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -60,13 +61,14 @@ class TokenRevocationServiceTest {
 
   @Mock private RevokedTokenRepository revokedTokens;
   @Mock private UserRepository users;
+  @Mock private SchedulerService scheduler;
 
   private final UUID userId = UUID.randomUUID();
   private TokenRevocationService service;
 
   @BeforeEach
   void setUp() {
-    service = new TokenRevocationService(revokedTokens, users, properties());
+    service = new TokenRevocationService(revokedTokens, users, properties(), scheduler);
   }
 
   @Test

--- a/qnop-core/src/test/java/io/qnop/service/auth/EmailVerificationTokenServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/auth/EmailVerificationTokenServiceTest.java
@@ -30,6 +30,7 @@ import io.qnop.entity.EmailVerificationToken;
 import io.qnop.entity.User;
 import io.qnop.repository.EmailVerificationTokenRepository;
 import io.qnop.service.auth.EmailVerificationTokenService.InvalidVerificationTokenException;
+import io.qnop.service.scheduler.SchedulerService;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -44,12 +45,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class EmailVerificationTokenServiceTest {
 
   @Mock private EmailVerificationTokenRepository tokens;
+  @Mock private SchedulerService scheduler;
   private EmailVerificationTokenService service;
   private final User user = User.internal("Jane", "jane@example.com", "jane", "hash");
 
   @BeforeEach
   void setUp() {
-    service = new EmailVerificationTokenService(tokens);
+    service = new EmailVerificationTokenService(tokens, scheduler);
   }
 
   @Test

--- a/qnop-core/src/test/java/io/qnop/service/auth/PasswordResetTokenServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/auth/PasswordResetTokenServiceTest.java
@@ -33,6 +33,7 @@ import io.qnop.repository.PasswordResetTokenRepository;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.auth.PasswordResetTokenService.InvalidPasswordResetTokenException;
+import io.qnop.service.scheduler.SchedulerService;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -48,12 +49,13 @@ class PasswordResetTokenServiceTest {
 
   @Mock private PasswordResetTokenRepository tokens;
   @Mock private ApplicationSettingsService settings;
+  @Mock private SchedulerService scheduler;
   private PasswordResetTokenService service;
   private final User user = User.internal("Jane", "jane@example.com", "jane", "hash");
 
   @BeforeEach
   void setUp() {
-    service = new PasswordResetTokenService(tokens, settings);
+    service = new PasswordResetTokenService(tokens, settings, scheduler);
   }
 
   @Test

--- a/qnop-core/src/test/java/io/qnop/service/scheduler/SchedulerServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/scheduler/SchedulerServiceTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.SchedulerJob;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.SchedulerJobRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+/**
+ * DB-free unit tests for the scheduler gate (issue #524, ADR-0045): the enabled/disabled semantics,
+ * fail-open, dry-run capability guard, manual-run locking, and the SYSTEM audit writes. A mock
+ * {@link PlatformTransactionManager} runs each {@code TransactionTemplate} callback in-line, so the
+ * gate's logic is exercised without a real database.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SchedulerServiceTest {
+
+  private static final String TOKEN_JOB = SchedulerJobCatalog.REFRESH_TOKEN_SWEEP;
+  private static final String REAPER_JOB = SchedulerJobCatalog.STORAGE_ORPHAN_REAPER;
+
+  @Mock private SchedulerJobRepository jobs;
+  @Mock private AuditEventRepository auditEvents;
+  @Mock private LockProvider lockProvider;
+  @Mock private PlatformTransactionManager transactionManager;
+
+  private SchedulerService scheduler;
+
+  @BeforeEach
+  void setUp() {
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    scheduler = new SchedulerService(jobs, auditEvents, lockProvider, transactionManager);
+  }
+
+  @Test
+  @DisplayName(
+      "a scheduled run of an enabled job runs the work and records SUCCESS without auditing")
+  void scheduledRunEnabled() {
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB);
+    when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
+    AtomicInteger runs = new AtomicInteger();
+    scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
+
+    RunOutcome outcome = scheduler.runScheduled(TOKEN_JOB);
+
+    assertThat(outcome).isEqualTo(RunOutcome.SUCCESS);
+    assertThat(runs).hasValue(1);
+    assertThat(job.getLastOutcome()).isEqualTo("SUCCESS");
+    assertThat(job.getLastTrigger()).isEqualTo("SCHEDULED");
+    verify(jobs).save(job);
+    verify(auditEvents, never()).save(any()); // scheduled runs never audit
+  }
+
+  @Test
+  @DisplayName("a scheduled run of a disabled job is skipped: no work, no record")
+  void scheduledRunDisabled() {
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB);
+    job.updateSettings(false, null);
+    when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
+    AtomicInteger runs = new AtomicInteger();
+    scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
+
+    RunOutcome outcome = scheduler.runScheduled(TOKEN_JOB);
+
+    assertThat(outcome).isEqualTo(RunOutcome.SKIPPED_DISABLED);
+    assertThat(runs).hasValue(0);
+    verify(jobs, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("a failing work records FAILURE and returns FAILURE without throwing")
+  void workFailureIsRecordedNotThrown() {
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB);
+    when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
+    scheduler.register(
+        TOKEN_JOB,
+        dryRun -> {
+          throw new IllegalStateException("boom");
+        });
+
+    RunOutcome outcome = scheduler.runScheduled(TOKEN_JOB);
+
+    assertThat(outcome).isEqualTo(RunOutcome.FAILURE);
+    assertThat(job.getLastOutcome()).isEqualTo("FAILURE");
+    assertThat(job.getLastDetail()).contains("boom");
+  }
+
+  @Test
+  @DisplayName("the state read failing open still runs the job")
+  void failsOpenWhenStateUnreadable() {
+    when(jobs.findById(TOKEN_JOB))
+        .thenThrow(new RuntimeException("db down"))
+        .thenReturn(Optional.empty()); // recordOutcome's own read
+    AtomicInteger runs = new AtomicInteger();
+    scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
+
+    RunOutcome outcome = scheduler.runScheduled(TOKEN_JOB);
+
+    assertThat(outcome).isEqualTo(RunOutcome.SUCCESS);
+    assertThat(runs).hasValue(1);
+  }
+
+  @Test
+  @DisplayName("run-now runs a disabled job (explicit override), audits, and unlocks")
+  void runNowOverridesDisabledAndAudits() {
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB);
+    job.updateSettings(false, null);
+    when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
+    SimpleLock lock = org.mockito.Mockito.mock(SimpleLock.class);
+    when(lockProvider.lock(any())).thenReturn(Optional.of(lock));
+    AtomicInteger runs = new AtomicInteger();
+    scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
+    UUID actor = UUID.randomUUID();
+
+    SchedulerService.SchedulerJobView view = scheduler.runNow(actor, TOKEN_JOB);
+
+    assertThat(runs).hasValue(1);
+    assertThat(view.lastOutcome()).isEqualTo("SUCCESS");
+    verify(lock).unlock();
+    ArgumentCaptor<AuditEvent> captor = ArgumentCaptor.forClass(AuditEvent.class);
+    verify(auditEvents).save(captor.capture());
+    assertThat(captor.getValue().getActorId()).isEqualTo(actor);
+    assertThat(captor.getValue().getEventType()).isEqualTo("scheduler.job.run");
+  }
+
+  @Test
+  @DisplayName("run-now returns 409 semantics when the lock is already held")
+  void runNowBusy() {
+    when(lockProvider.lock(any())).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> scheduler.runNow(UUID.randomUUID(), TOKEN_JOB))
+        .isInstanceOf(SchedulerJobBusyException.class);
+  }
+
+  @Test
+  @DisplayName("an unknown job id is a not-found error")
+  void unknownJobIsNotFound() {
+    assertThatThrownBy(() -> scheduler.runNow(UUID.randomUUID(), "nope"))
+        .isInstanceOf(SchedulerJobNotFoundException.class);
+    assertThatThrownBy(() -> scheduler.updateSettings(UUID.randomUUID(), "nope", true, null))
+        .isInstanceOf(SchedulerJobNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("dry-run on a non-capable job is rejected")
+  void dryRunRejectedForIncapableJob() {
+    assertThatThrownBy(() -> scheduler.updateSettings(UUID.randomUUID(), TOKEN_JOB, null, true))
+        .isInstanceOf(DryRunNotSupportedException.class);
+    verify(jobs, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("update persists settings and audits the change")
+  void updatePersistsAndAudits() {
+    SchedulerJob job = SchedulerJob.seed(REAPER_JOB);
+    when(jobs.findById(REAPER_JOB)).thenReturn(Optional.of(job));
+    when(jobs.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    UUID actor = UUID.randomUUID();
+
+    SchedulerService.SchedulerJobView view =
+        scheduler.updateSettings(actor, REAPER_JOB, false, true);
+
+    assertThat(view.enabled()).isFalse();
+    assertThat(view.dryRun()).isTrue();
+    ArgumentCaptor<AuditEvent> captor = ArgumentCaptor.forClass(AuditEvent.class);
+    verify(auditEvents).save(captor.capture());
+    assertThat(captor.getValue().getEventType()).isEqualTo("scheduler.job.updated");
+  }
+
+  @Test
+  @DisplayName("list joins the static catalogue with the persisted rows")
+  void listJoinsCatalogueAndRows() {
+    SchedulerJob reaper = SchedulerJob.seed(REAPER_JOB);
+    reaper.updateSettings(false, true);
+    when(jobs.findAllById(any())).thenReturn(List.of(reaper));
+
+    List<SchedulerService.SchedulerJobView> views = scheduler.list();
+
+    assertThat(views).hasSize(SchedulerJobCatalog.definitions().size());
+    SchedulerService.SchedulerJobView reaperView =
+        views.stream().filter(v -> v.jobId().equals(REAPER_JOB)).findFirst().orElseThrow();
+    assertThat(reaperView.enabled()).isFalse();
+    assertThat(reaperView.dryRun()).isTrue();
+    assertThat(reaperView.supportsDryRun()).isTrue();
+    // A job with no row defaults to enabled, not dry-run.
+    SchedulerService.SchedulerJobView tokenView =
+        views.stream().filter(v -> v.jobId().equals(TOKEN_JOB)).findFirst().orElseThrow();
+    assertThat(tokenView.enabled()).isTrue();
+    assertThat(tokenView.dryRun()).isFalse();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/storage/StorageServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/StorageServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import io.qnop.entity.StorageObject;
 import io.qnop.repository.StorageObjectRepository;
+import io.qnop.service.scheduler.SchedulerService;
 import io.qnop.spi.storage.StorageProvider;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -52,7 +53,8 @@ class StorageServiceTest {
   private final StorageProvider provider = mock(StorageProvider.class);
   private final StorageObjectRepository repository = mock(StorageObjectRepository.class);
   private final StorageService storage =
-      new StorageService(provider, repository, mock(S3Properties.class));
+      new StorageService(
+          provider, repository, mock(S3Properties.class), mock(SchedulerService.class));
 
   private static InputStream content() {
     return new ByteArrayInputStream("some qnop document bytes".getBytes());

--- a/qnop-ui/src/api/config.ts
+++ b/qnop-ui/src/api/config.ts
@@ -24,6 +24,7 @@ import {
   AdminConfigurationApi,
   AdminEmailApi,
   AdminOidcProvidersApi,
+  AdminSchedulerApi,
   AdminSettingsApi,
   AdminTeamsApi,
   AdminUsersApi,
@@ -101,6 +102,7 @@ export const adminTeamsApi = new AdminTeamsApi(undefined, undefined, axiosInstan
 export const teamsApi = new TeamsApi(undefined, undefined, axiosInstance);
 export const adminSettingsApi = new AdminSettingsApi(undefined, undefined, axiosInstance);
 export const adminConfigurationApi = new AdminConfigurationApi(undefined, undefined, axiosInstance);
+export const adminSchedulerApi = new AdminSchedulerApi(undefined, undefined, axiosInstance);
 export const adminOidcProvidersApi = new AdminOidcProvidersApi(undefined, undefined, axiosInstance);
 export const adminEmailApi = new AdminEmailApi(undefined, undefined, axiosInstance);
 export const documentsApi = new DocumentsApi(undefined, undefined, axiosInstance);

--- a/qnop-ui/src/api/hooks/useAdminScheduler.test.tsx
+++ b/qnop-ui/src/api/hooks/useAdminScheduler.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SchedulerJob, SchedulerJobListResponse } from '../generated';
+import {
+  schedulerKeys,
+  useRunSchedulerJob,
+  useSchedulerJobs,
+  useUpdateSchedulerJob,
+} from './useAdminScheduler';
+import { adminSchedulerApi } from '../config';
+
+const REAPER: SchedulerJob = {
+  jobId: 'storageOrphanReaper',
+  displayName: 'Storage orphan reaper',
+  description: 'Deletes uncommitted objects.',
+  cron: '0 30 3 * * *',
+  supportsDryRun: true,
+  enabled: true,
+  dryRun: false,
+};
+
+const LIST: SchedulerJobListResponse = { items: [REAPER] };
+
+vi.mock('../config', () => ({
+  adminSchedulerApi: {
+    listSchedulerJobs: vi.fn(),
+    updateSchedulerJob: vi.fn(),
+    runSchedulerJob: vi.fn(),
+  },
+}));
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrapperWith(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('schedulerKeys', () => {
+  it('namespaces the scheduler query', () => {
+    expect(schedulerKeys.all).toEqual(['admin', 'scheduler']);
+  });
+});
+
+describe('useSchedulerJobs', () => {
+  it('fetches the catalogue', async () => {
+    vi.mocked(adminSchedulerApi.listSchedulerJobs).mockResolvedValue({ data: LIST } as Awaited<
+      ReturnType<typeof adminSchedulerApi.listSchedulerJobs>
+    >);
+
+    const { result } = renderHook(() => useSchedulerJobs(), { wrapper: wrapperWith(makeClient()) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.items).toHaveLength(1);
+  });
+});
+
+describe('useUpdateSchedulerJob', () => {
+  it('sends the partial change and merges the result into the cached list', async () => {
+    const updated: SchedulerJob = { ...REAPER, dryRun: true };
+    vi.mocked(adminSchedulerApi.updateSchedulerJob).mockResolvedValue({
+      data: updated,
+    } as Awaited<ReturnType<typeof adminSchedulerApi.updateSchedulerJob>>);
+
+    const queryClient = makeClient();
+    queryClient.setQueryData(schedulerKeys.all, LIST);
+
+    const { result } = renderHook(() => useUpdateSchedulerJob(), {
+      wrapper: wrapperWith(queryClient),
+    });
+    await result.current.mutateAsync({ jobId: REAPER.jobId, dryRun: true });
+
+    expect(adminSchedulerApi.updateSchedulerJob).toHaveBeenCalledWith({
+      jobId: 'storageOrphanReaper',
+      schedulerJobUpdateRequest: { enabled: undefined, dryRun: true },
+    });
+    const cached = queryClient.getQueryData<SchedulerJobListResponse>(schedulerKeys.all);
+    expect(cached?.items[0].dryRun).toBe(true);
+  });
+});
+
+describe('useRunSchedulerJob', () => {
+  it('runs the job and refreshes its cached row with the outcome', async () => {
+    const ran: SchedulerJob = { ...REAPER, lastOutcome: 'SUCCESS', lastTrigger: 'MANUAL' };
+    vi.mocked(adminSchedulerApi.runSchedulerJob).mockResolvedValue({ data: ran } as Awaited<
+      ReturnType<typeof adminSchedulerApi.runSchedulerJob>
+    >);
+
+    const queryClient = makeClient();
+    queryClient.setQueryData(schedulerKeys.all, LIST);
+
+    const { result } = renderHook(() => useRunSchedulerJob(), {
+      wrapper: wrapperWith(queryClient),
+    });
+    await result.current.mutateAsync(REAPER.jobId);
+
+    expect(adminSchedulerApi.runSchedulerJob).toHaveBeenCalledWith({
+      jobId: 'storageOrphanReaper',
+    });
+    const cached = queryClient.getQueryData<SchedulerJobListResponse>(schedulerKeys.all);
+    expect(cached?.items[0].lastOutcome).toBe('SUCCESS');
+  });
+
+  it('leaves an unseeded cache untouched', async () => {
+    const ran: SchedulerJob = { ...REAPER, lastOutcome: 'SUCCESS' };
+    vi.mocked(adminSchedulerApi.runSchedulerJob).mockResolvedValue({ data: ran } as Awaited<
+      ReturnType<typeof adminSchedulerApi.runSchedulerJob>
+    >);
+
+    const queryClient = makeClient(); // no list cached yet
+    const { result } = renderHook(() => useRunSchedulerJob(), {
+      wrapper: wrapperWith(queryClient),
+    });
+    await result.current.mutateAsync(REAPER.jobId);
+
+    expect(queryClient.getQueryData(schedulerKeys.all)).toBeUndefined();
+  });
+});

--- a/qnop-ui/src/api/hooks/useAdminScheduler.ts
+++ b/qnop-ui/src/api/hooks/useAdminScheduler.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { SchedulerJob, SchedulerJobListResponse } from '../generated';
+import { adminSchedulerApi } from '../config';
+
+export const schedulerKeys = {
+  all: ['admin', 'scheduler'] as const,
+};
+
+/**
+ * The catalogue of maintenance sweeps with their operator state (issue #524).
+ * Window-focus refetch is off so a background refetch never clobbers an
+ * in-flight toggle; the list refreshes on mount and after each mutation.
+ */
+export function useSchedulerJobs() {
+  return useQuery<SchedulerJobListResponse>({
+    queryKey: schedulerKeys.all,
+    queryFn: async () => {
+      const response = await adminSchedulerApi.listSchedulerJobs();
+      return response.data;
+    },
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** Merges one updated job back into the cached list without a round-trip. */
+function replaceJob(previous: SchedulerJobListResponse | undefined, job: SchedulerJob) {
+  if (!previous) {
+    return previous;
+  }
+  return {
+    ...previous,
+    items: previous.items.map((item) => (item.jobId === job.jobId ? job : item)),
+  };
+}
+
+/** Enables/disables a sweep or toggles its dry-run mode; a null field is unchanged. */
+export function useUpdateSchedulerJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { jobId: string; enabled?: boolean; dryRun?: boolean }) => {
+      const response = await adminSchedulerApi.updateSchedulerJob({
+        jobId: input.jobId,
+        schedulerJobUpdateRequest: { enabled: input.enabled, dryRun: input.dryRun },
+      });
+      return response.data;
+    },
+    onSuccess: (job) => {
+      queryClient.setQueryData<SchedulerJobListResponse>(schedulerKeys.all, (previous) =>
+        replaceJob(previous, job),
+      );
+    },
+  });
+}
+
+/** Triggers an immediate run; the returned job carries its refreshed last-run outcome. */
+export function useRunSchedulerJob() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (jobId: string) => {
+      const response = await adminSchedulerApi.runSchedulerJob({ jobId });
+      return response.data;
+    },
+    onSuccess: (job) => {
+      queryClient.setQueryData<SchedulerJobListResponse>(schedulerKeys.all, (previous) =>
+        replaceJob(previous, job),
+      );
+    },
+  });
+}

--- a/qnop-ui/src/components/admin/scheduler/SchedulerJobCard.test.tsx
+++ b/qnop-ui/src/components/admin/scheduler/SchedulerJobCard.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { SchedulerJob } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { SchedulerJobCard } from './SchedulerJobCard';
+
+const BASE: SchedulerJob = {
+  jobId: 'storageOrphanReaper',
+  displayName: 'Storage orphan reaper',
+  description: 'Deletes uncommitted objects.',
+  cron: '0 30 3 * * *',
+  supportsDryRun: true,
+  enabled: true,
+  dryRun: false,
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>;
+}
+
+function renderCard(job: SchedulerJob, handlers = {}) {
+  const props = {
+    job,
+    saving: false,
+    running: false,
+    onToggleEnabled: vi.fn(),
+    onToggleDryRun: vi.fn(),
+    onRunNow: vi.fn(),
+    ...handlers,
+  };
+  render(<SchedulerJobCard {...props} />, { wrapper });
+  return props;
+}
+
+describe('SchedulerJobCard', () => {
+  it('shows the cron and a dry-run switch for a capable job', () => {
+    renderCard(BASE);
+    expect(screen.getByText('0 30 3 * * *')).toBeTruthy();
+    expect(screen.getByLabelText('Dry-run Storage orphan reaper')).toBeTruthy();
+  });
+
+  it('hides the dry-run switch for a job that does not support it', () => {
+    renderCard({ ...BASE, supportsDryRun: false });
+    expect(screen.queryByLabelText('Dry-run Storage orphan reaper')).toBeNull();
+  });
+
+  it('renders a success badge with the last-run detail for a successful run', () => {
+    renderCard({
+      ...BASE,
+      lastOutcome: 'SUCCESS',
+      lastTrigger: 'MANUAL',
+      lastRunAt: '2026-01-01T00:00:00Z',
+    });
+    expect(screen.getByText('Success')).toBeTruthy();
+    expect(screen.getByText(/Ran manually/)).toBeTruthy();
+  });
+
+  it('surfaces the failure detail for a failed run', () => {
+    renderCard({ ...BASE, lastOutcome: 'FAILURE', lastDetail: 'IllegalStateException: boom' });
+    expect(screen.getByText('Failed')).toBeTruthy();
+    expect(screen.getByText('IllegalStateException: boom')).toBeTruthy();
+  });
+
+  it('shows "Never run" when the job has no history', () => {
+    renderCard(BASE);
+    expect(screen.getByText('Never run')).toBeTruthy();
+  });
+
+  it('invokes the handlers on interaction', () => {
+    const onToggleEnabled = vi.fn();
+    const onRunNow = vi.fn();
+    renderCard(BASE, { onToggleEnabled, onRunNow });
+
+    fireEvent.click(screen.getByLabelText('Enable Storage orphan reaper'));
+    fireEvent.click(screen.getByRole('button', { name: 'Run now' }));
+
+    expect(onToggleEnabled).toHaveBeenCalledWith(BASE);
+    expect(onRunNow).toHaveBeenCalledWith(BASE);
+  });
+});

--- a/qnop-ui/src/components/admin/scheduler/SchedulerJobCard.tsx
+++ b/qnop-ui/src/components/admin/scheduler/SchedulerJobCard.tsx
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { CheckCircle2, MinusCircle, Play, XCircle } from 'lucide-react';
+import type { SchedulerJob } from '../../../api/generated';
+import { useFormatters } from '../../../hooks/useFormatters';
+import { ToneBadge, type BadgeTone } from '../ToneBadge';
+
+interface SchedulerJobCardProps {
+  job: SchedulerJob;
+  /** True while this job's toggle mutation is in flight. */
+  saving: boolean;
+  /** True while this job's run-now is in flight. */
+  running: boolean;
+  onToggleEnabled: (job: SchedulerJob) => void;
+  onToggleDryRun: (job: SchedulerJob) => void;
+  onRunNow: (job: SchedulerJob) => void;
+}
+
+/** The last-run outcome as a coloured pill: green success, red failure, neutral "never run". */
+function outcomeBadge(job: SchedulerJob) {
+  if (job.lastOutcome === 'SUCCESS') {
+    return { tone: 'green' as BadgeTone, label: 'Success', icon: <CheckCircle2 size={13} /> };
+  }
+  if (job.lastOutcome === 'FAILURE') {
+    return { tone: 'red' as BadgeTone, label: 'Failed', icon: <XCircle size={13} /> };
+  }
+  return { tone: 'neutral' as BadgeTone, label: 'Never run', icon: <MinusCircle size={13} /> };
+}
+
+/**
+ * One maintenance sweep as a self-contained control card (issue #524): its name,
+ * purpose and cron, an enabled switch, an optional dry-run switch (reaper only),
+ * a run-now button, and the last-run outcome. Purely presentational — the page
+ * owns the mutations and toasts.
+ */
+export function SchedulerJobCard({
+  job,
+  saving,
+  running,
+  onToggleEnabled,
+  onToggleDryRun,
+  onRunNow,
+}: SchedulerJobCardProps) {
+  const theme = useTheme();
+  const { formatRelative } = useFormatters();
+  const badge = outcomeBadge(job);
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: { xs: 2, sm: 2.5 },
+        borderRadius: '14px',
+        opacity: job.enabled ? 1 : 0.72,
+        transition: 'opacity 150ms',
+      }}
+    >
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={2}
+        sx={{ justifyContent: 'space-between', alignItems: { md: 'flex-start' } }}
+      >
+        {/* Identity: name, cron chip, purpose. */}
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+            <Typography variant="h2" sx={{ fontSize: 16 }}>
+              {job.displayName}
+            </Typography>
+            <Box
+              component="code"
+              sx={{
+                fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                fontSize: 12,
+                px: 0.75,
+                py: 0.25,
+                borderRadius: 1,
+                bgcolor: theme.qnop.surface2,
+                color: 'text.secondary',
+                border: '1px solid',
+                borderColor: 'divider',
+              }}
+            >
+              {job.cron}
+            </Box>
+          </Stack>
+          <Typography color="text.secondary" sx={{ fontSize: 13.5, mt: 0.5 }}>
+            {job.description}
+          </Typography>
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ alignItems: 'center', mt: 1.25, flexWrap: 'wrap', rowGap: 0.5 }}
+          >
+            <ToneBadge tone={badge.tone} label={badge.label} icon={badge.icon} />
+            {job.lastRunAt && (
+              <Typography color="text.secondary" sx={{ fontSize: 12.5 }}>
+                {job.lastTrigger === 'MANUAL' ? 'Ran manually' : 'Last run'}{' '}
+                {formatRelative(job.lastRunAt)}
+              </Typography>
+            )}
+            {job.lastOutcome === 'FAILURE' && job.lastDetail && (
+              <Typography
+                color="error.main"
+                sx={{ fontSize: 12.5, fontFamily: 'ui-monospace, monospace' }}
+                title={job.lastDetail}
+              >
+                {job.lastDetail}
+              </Typography>
+            )}
+          </Stack>
+        </Box>
+
+        {/* Controls: enabled, optional dry-run, run-now. */}
+        <Stack
+          direction={{ xs: 'row', md: 'column' }}
+          spacing={{ xs: 2, md: 1 }}
+          sx={{ alignItems: { xs: 'center', md: 'flex-end' }, flexShrink: 0, flexWrap: 'wrap' }}
+          divider={<Divider orientation="vertical" flexItem sx={{ display: { md: 'none' } }} />}
+        >
+          <Stack
+            direction="column"
+            spacing={0}
+            sx={{ alignItems: { xs: 'flex-start', md: 'flex-end' } }}
+          >
+            <FormControlLabel
+              sx={{ m: 0 }}
+              labelPlacement="start"
+              control={
+                <Switch
+                  size="small"
+                  checked={job.enabled}
+                  disabled={saving}
+                  onChange={() => onToggleEnabled(job)}
+                  slotProps={{ input: { 'aria-label': `Enable ${job.displayName}` } }}
+                />
+              }
+              label={
+                <Typography sx={{ fontSize: 13, mr: 1 }}>
+                  {job.enabled ? 'Enabled' : 'Disabled'}
+                </Typography>
+              }
+            />
+            {job.supportsDryRun && (
+              <FormControlLabel
+                sx={{ m: 0 }}
+                labelPlacement="start"
+                control={
+                  <Switch
+                    size="small"
+                    checked={job.dryRun}
+                    disabled={saving}
+                    onChange={() => onToggleDryRun(job)}
+                    slotProps={{ input: { 'aria-label': `Dry-run ${job.displayName}` } }}
+                  />
+                }
+                label={<Typography sx={{ fontSize: 13, mr: 1 }}>Dry run</Typography>}
+              />
+            )}
+          </Stack>
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={running}
+            startIcon={
+              running ? <CircularProgress size={14} color="inherit" /> : <Play size={15} />
+            }
+            onClick={() => onRunNow(job)}
+          >
+            Run now
+          </Button>
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+}

--- a/qnop-ui/src/components/shell/navConfig.test.ts
+++ b/qnop-ui/src/components/shell/navConfig.test.ts
@@ -51,6 +51,7 @@ describe('visibleNavGroups', () => {
       'oidc-providers',
       'email',
       'mail-templates',
+      'scheduler',
       'audit',
     ]);
   });

--- a/qnop-ui/src/components/shell/navConfig.tsx
+++ b/qnop-ui/src/components/shell/navConfig.tsx
@@ -20,6 +20,7 @@
  */
 
 import {
+  CalendarClock,
   FileText,
   KeyRound,
   LayoutDashboard,
@@ -112,6 +113,13 @@ export const NAV_GROUPS: NavGroup[] = [
         label: 'Mail templates',
         path: '/admin/mail-templates',
         icon: Mail,
+        roles: ['ADMIN'],
+      },
+      {
+        id: 'scheduler',
+        label: 'Scheduler',
+        path: '/admin/scheduler',
+        icon: CalendarClock,
         roles: ['ADMIN'],
       },
       {

--- a/qnop-ui/src/pages/admin/SchedulerPage.test.tsx
+++ b/qnop-ui/src/pages/admin/SchedulerPage.test.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SchedulerJob } from '../../api/generated';
+import { buildTheme } from '../../theme/theme';
+import { SchedulerPage } from './SchedulerPage';
+
+const { updateMutate, runMutate, useSchedulerJobsMock } = vi.hoisted(() => ({
+  updateMutate: vi.fn(),
+  runMutate: vi.fn(),
+  useSchedulerJobsMock: vi.fn(),
+}));
+
+const REFRESH: SchedulerJob = {
+  jobId: 'refreshTokenSweep',
+  displayName: 'Refresh token sweep',
+  description: 'Deletes expired refresh tokens.',
+  cron: '0 40 3 * * *',
+  supportsDryRun: false,
+  enabled: true,
+  dryRun: false,
+};
+
+const REAPER: SchedulerJob = {
+  jobId: 'storageOrphanReaper',
+  displayName: 'Storage orphan reaper',
+  description: 'Deletes uncommitted objects.',
+  cron: '0 30 3 * * *',
+  supportsDryRun: true,
+  enabled: true,
+  dryRun: false,
+};
+
+vi.mock('../../api/hooks/useAdminScheduler', () => ({
+  useSchedulerJobs: () => useSchedulerJobsMock(),
+  useUpdateSchedulerJob: () => ({ mutateAsync: updateMutate }),
+  useRunSchedulerJob: () => ({ mutateAsync: runMutate }),
+}));
+
+vi.mock('../../components/admin/scheduler/SchedulerJobCard', () => ({
+  SchedulerJobCard: ({
+    job,
+    onToggleEnabled,
+    onToggleDryRun,
+    onRunNow,
+  }: {
+    job: SchedulerJob;
+    onToggleEnabled: (j: SchedulerJob) => void;
+    onToggleDryRun: (j: SchedulerJob) => void;
+    onRunNow: (j: SchedulerJob) => void;
+  }) => (
+    <div>
+      <span>{job.displayName}</span>
+      <button onClick={() => onToggleEnabled(job)}>enable-{job.jobId}</button>
+      <button onClick={() => onToggleDryRun(job)}>dryrun-{job.jobId}</button>
+      <button onClick={() => onRunNow(job)}>run-{job.jobId}</button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  updateMutate.mockReset().mockResolvedValue(undefined);
+  runMutate.mockReset().mockResolvedValue({ ...REFRESH, lastOutcome: 'SUCCESS' });
+  useSchedulerJobsMock.mockReset().mockReturnValue({
+    data: { items: [REFRESH, REAPER] },
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+  });
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+const renderPage = () => render(<SchedulerPage />, { wrapper });
+
+describe('SchedulerPage', () => {
+  it('lists the catalogued jobs', () => {
+    renderPage();
+    expect(screen.getByText('Refresh token sweep')).toBeTruthy();
+    expect(screen.getByText('Storage orphan reaper')).toBeTruthy();
+  });
+
+  it('shows a progress bar while refetching', () => {
+    useSchedulerJobsMock.mockReturnValue({
+      data: { items: [REFRESH, REAPER] },
+      isLoading: false,
+      isFetching: true,
+      isError: false,
+    });
+    renderPage();
+    expect(screen.getByRole('progressbar')).toBeTruthy();
+  });
+
+  it('shows an error alert when the jobs cannot be loaded', () => {
+    useSchedulerJobsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+    });
+    renderPage();
+    expect(screen.getByText('The scheduled jobs could not be loaded.')).toBeTruthy();
+    expect(screen.queryByText('Refresh token sweep')).toBeNull();
+  });
+
+  it('disables a sweep and surfaces a success toast', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'enable-refreshTokenSweep' }));
+
+    await waitFor(() =>
+      expect(updateMutate).toHaveBeenCalledWith({ jobId: 'refreshTokenSweep', enabled: false }),
+    );
+    expect(await screen.findByText('Refresh token sweep disabled.')).toBeTruthy();
+  });
+
+  it('toggles the reaper dry-run and surfaces a success toast', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'dryrun-storageOrphanReaper' }));
+
+    await waitFor(() =>
+      expect(updateMutate).toHaveBeenCalledWith({ jobId: 'storageOrphanReaper', dryRun: true }),
+    );
+    expect(await screen.findByText('Dry run on for Storage orphan reaper.')).toBeTruthy();
+  });
+
+  it('runs a job and reports success', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'run-refreshTokenSweep' }));
+
+    await waitFor(() => expect(runMutate).toHaveBeenCalledWith('refreshTokenSweep'));
+    expect(await screen.findByText('Refresh token sweep ran.')).toBeTruthy();
+  });
+
+  it('reports a run that returns a FAILURE outcome as an error toast', async () => {
+    runMutate.mockResolvedValue({ ...REFRESH, lastOutcome: 'FAILURE' });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'run-refreshTokenSweep' }));
+
+    const alert = await screen.findByText('Refresh token sweep ran but reported a failure.');
+    expect(alert.closest('.MuiAlert-colorError')).toBeTruthy();
+  });
+
+  it('reports a run that throws as an error toast', async () => {
+    runMutate.mockRejectedValue(new Error('boom'));
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'run-refreshTokenSweep' }));
+
+    const alert = await screen.findByText('The job could not be started.');
+    expect(alert.closest('.MuiAlert-colorError')).toBeTruthy();
+  });
+});

--- a/qnop-ui/src/pages/admin/SchedulerPage.tsx
+++ b/qnop-ui/src/pages/admin/SchedulerPage.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import LinearProgress from '@mui/material/LinearProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { FlaskConical, ListChecks, Power, TriangleAlert } from 'lucide-react';
+import type { SchedulerJob } from '../../api/generated';
+import {
+  useRunSchedulerJob,
+  useSchedulerJobs,
+  useUpdateSchedulerJob,
+} from '../../api/hooks/useAdminScheduler';
+import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { useToast } from '../../components/admin/layout/useToast';
+import { SchedulerJobCard } from '../../components/admin/scheduler/SchedulerJobCard';
+import { StatStrip, type StatTile } from '../../components/dashboard/StatStrip';
+import { apiErrorMessage } from '../../utils/apiError';
+
+/**
+ * Admin maintenance-scheduler dashboard (issue #524, ADR-0045): the fixed set of
+ * background sweeps, each with its cron, enabled switch, dry-run toggle (reaper
+ * only), a run-now button and the last-run outcome. Enabling/disabling and
+ * run-now go straight to the SYSTEM audit stream.
+ */
+export function SchedulerPage() {
+  const { data, isLoading, isFetching, isError } = useSchedulerJobs();
+  const updateJob = useUpdateSchedulerJob();
+  const runJob = useRunSchedulerJob();
+  const { toast, notify, clear } = useToast();
+
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [runningId, setRunningId] = useState<string | null>(null);
+
+  const jobs = data?.items ?? [];
+  const tiles: StatTile[] = [
+    { label: 'Jobs', value: jobs.length, icon: ListChecks },
+    { label: 'Enabled', value: jobs.filter((j) => j.enabled).length, icon: Power, tone: 'success' },
+    {
+      label: 'Dry run',
+      value: jobs.filter((j) => j.dryRun).length,
+      icon: FlaskConical,
+      tone: 'accent',
+    },
+    {
+      label: 'Failing',
+      value: jobs.filter((j) => j.lastOutcome === 'FAILURE').length,
+      icon: TriangleAlert,
+      tone: 'danger',
+    },
+  ];
+
+  const applyUpdate = async (
+    job: SchedulerJob,
+    change: { enabled?: boolean; dryRun?: boolean },
+    message: string,
+  ) => {
+    setSavingId(job.jobId);
+    try {
+      await updateJob.mutateAsync({ jobId: job.jobId, ...change });
+      notify(message);
+    } catch (err) {
+      notify(apiErrorMessage(err, 'The change could not be saved.'), 'error');
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const onToggleEnabled = (job: SchedulerJob) =>
+    applyUpdate(
+      job,
+      { enabled: !job.enabled },
+      `${job.displayName} ${job.enabled ? 'disabled' : 'enabled'}.`,
+    );
+
+  const onToggleDryRun = (job: SchedulerJob) =>
+    applyUpdate(
+      job,
+      { dryRun: !job.dryRun },
+      `Dry run ${job.dryRun ? 'off' : 'on'} for ${job.displayName}.`,
+    );
+
+  const onRunNow = async (job: SchedulerJob) => {
+    setRunningId(job.jobId);
+    try {
+      const result = await runJob.mutateAsync(job.jobId);
+      if (result.lastOutcome === 'FAILURE') {
+        notify(`${job.displayName} ran but reported a failure.`, 'error');
+      } else {
+        notify(`${job.displayName} ran.`);
+      }
+    } catch (err) {
+      notify(apiErrorMessage(err, 'The job could not be started.'), 'error');
+    } finally {
+      setRunningId(null);
+    }
+  };
+
+  return (
+    <Stack spacing={3}>
+      <PageHeader
+        title="Scheduler"
+        description="Background maintenance sweeps — token purges and the storage orphan reaper. Disable a sweep, put the reaper in dry-run, or run one on demand."
+      />
+
+      {!isError && jobs.length > 0 && <StatStrip tiles={tiles} />}
+
+      <Box sx={{ height: 3 }}>{isFetching && !isLoading && <LinearProgress />}</Box>
+
+      {isError ? (
+        <Alert severity="error">The scheduled jobs could not be loaded.</Alert>
+      ) : isLoading ? (
+        <Typography color="text.secondary" sx={{ fontSize: 14 }}>
+          Loading…
+        </Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          {jobs.map((job) => (
+            <SchedulerJobCard
+              key={job.jobId}
+              job={job}
+              saving={savingId === job.jobId}
+              running={runningId === job.jobId}
+              onToggleEnabled={onToggleEnabled}
+              onToggleDryRun={onToggleDryRun}
+              onRunNow={onRunNow}
+            />
+          ))}
+        </Stack>
+      )}
+
+      <AdminToast toast={toast} onClose={clear} />
+    </Stack>
+  );
+}

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -36,6 +36,7 @@ import { MailTemplatesListPage } from '../pages/admin/MailTemplatesListPage';
 import { OidcProvidersPage } from '../pages/admin/OidcProvidersPage';
 import { SettingsPage } from '../pages/admin/SettingsPage';
 import { ConfigurationPage } from '../pages/admin/ConfigurationPage';
+import { SchedulerPage } from '../pages/admin/SchedulerPage';
 import { UsersPage } from '../pages/admin/UsersPage';
 import { TeamsPage } from '../pages/admin/TeamsPage';
 import { TeamDetailPage } from '../pages/admin/TeamDetailPage';
@@ -175,6 +176,14 @@ export const router = createBrowserRouter([
         element: (
           <AdminRoute>
             <ConfigurationPage />
+          </AdminRoute>
+        ),
+      },
+      {
+        path: 'admin/scheduler',
+        element: (
+          <AdminRoute>
+            <SchedulerPage />
           </AdminRoute>
         ),
       },

--- a/qnop-ui/vitest.config.ts
+++ b/qnop-ui/vitest.config.ts
@@ -59,6 +59,10 @@ export default defineConfig({
         'src/pages/admin/ConfigurationPage.tsx',
         'src/pages/admin/BrandingPage.tsx',
         'src/pages/admin/OidcProvidersPage.tsx',
+        // The maintenance-scheduler dashboard (issue #524): the page owns the
+        // toggle/run-now orchestration and toasts; its presentational job card
+        // stays on its own component test.
+        'src/pages/admin/SchedulerPage.tsx',
         // Team-lead self-management surface (issue #470): the "My Teams" landing
         // and detail pages own the orchestration/state; the add-member dialog
         // stays on its own component test.

--- a/testdata/db/clean.sql
+++ b/testdata/db/clean.sql
@@ -25,5 +25,9 @@ TRUNCATE TABLE annotation_placement, comment, annotation, audit_event,
 TRUNCATE TABLE team_membership, team, oidc_provider, user_setting, application_asset
                RESTART IDENTITY CASCADE;
 
+-- Scheduler-job operator state (issue #524): seeded at start-up and mutated by
+-- the dashboard, so reset it per test for deterministic assertions. No FK deps.
+TRUNCATE TABLE scheduler_job RESTART IDENTITY CASCADE;
+
 DELETE FROM user_avatar;
 DELETE FROM qnop_user;


### PR DESCRIPTION
## Summary

Adds the admin **maintenance-scheduler dashboard** at `/admin/scheduler` (issue #524): the five background sweeps (token purges + the storage orphan reaper) with their cron, enabled state, dry-run setting and last-run outcome, and controls to enable/disable a sweep, put the reaper in dry-run, or run one on demand.

> **Stacked on #526** (base branch `feat/issue-524-audit-scope`, the SYSTEM-audit-stream prereq). GitHub will retarget this PR to `main` once #526 merges — review that one first.

## Design (ADR-0045)

An operator gate — `SchedulerService` — fronts every sweep:

- **Static vs. mutable split.** `SchedulerJobCatalog` holds the five job definitions (id / cron / dry-run capability) in code; its id constants double as the `@SchedulerLock` names (one source of truth). The `scheduler_job` table (migration **0017**) holds only what an admin changes and what the last run produced. Rows are seeded idempotently at start-up; settings survive a restart.
- **Transactions, not `@Transactional`.** The gate is deliberately not a transactional bean — it drives a `TransactionTemplate` for three independent units (read state → run work → record outcome). Recording the outcome in a separate transaction means a work rollback can never erase a failure record, and there is no Spring self-invocation trap: the work is a `SchedulerWork` runnable registered by the owning service and invoked from another bean (so `SchedulerService` depends on no sweep service — no dependency cycle). **Fails open** if the control table is unreadable — maintenance must never silently stop.
- **Run-now is an explicit override.** It ignores the enabled flag, runs under the job's distributed lock (a contended lock → `409`), and reports a work error as a `FAILURE` outcome on the returned job, not a 5xx.
- **Audit only operator actions.** Setting changes (`scheduler.job.updated`) and manual runs (`scheduler.job.run`) go to the SYSTEM audit stream (ADR-0043); scheduled runs don't — five rows a day forever would drown the trail — their outcome lives on the row.

The two internal job-queue poller/reaper jobs (ADR-0033) are deliberately excluded.

## Changes

- **Domain** (`qnop-core`): `SchedulerJob` entity + `SchedulerJobRepository` + migration 0017; `SchedulerJobCatalog`, `SchedulerService`, `SchedulerWork`/`SchedulerJobDefinition`, `RunTrigger`/`RunOutcome`, `SchedulerJobBootstrap`, `SchedulerJobBinding`; three domain exceptions.
- **Wiring**: the five `@Scheduled` sweeps now route through the gate; raw work extracted to public `*Once()` methods (reaper gains a `dryRun` mode). Five service constructors take the gate (test constructors updated).
- **Web** (`qnop-app`): OpenAPI `AdminScheduler` tag + `GET /admin/scheduler`, `PATCH /{jobId}`, `POST /{jobId}/run`; `SchedulerController` (ADMIN; 400 dry-run guard, 404, 409).
- **Frontend** (`qnop-ui`): `/admin/scheduler` page (StatStrip + a job card per sweep), `useAdminScheduler` hooks, nav entry + route.
- **ADR-0045**; `scheduler_job` added to the test `clean.sql` for per-test isolation.

## Test plan

- [x] Backend: compile (core + app), **ArchUnit**, **Spotless**, `SchedulerServiceTest` (gate: enable/disable, fail-open, dry-run guard, locking, audit) + adjusted service unit tests — green locally.
- [x] Frontend: `tsc`, ESLint, Prettier, Vitest (hooks + page + card, 28 tests); scheduler files 98% stmt / 82% branch.
- [ ] CI: `SchedulerApiIT` (ADMIN 200 / MEMBER 403 / dry-run guard / unknown 404 / run-now outcome / SYSTEM-audit) — needs Docker (Testcontainers), runs in CI.

Closes #524

🤖 Co-Author: Claude (Opus 4.x) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
