### PR TITLE
fix(ui): add scheduler.job.* events to the audit vocabulary

### DIFF
--- a/qnop-ui/src/utils/auditEvents.test.ts
+++ b/qnop-ui/src/utils/auditEvents.test.ts
@@ -51,6 +51,18 @@ describe('auditEventMeta', () => {
     );
   });
 
+  it('covers the SYSTEM-stream operator events (storage cleanup, scheduler)', () => {
+    expect(AUDIT_EVENT_TYPES).toEqual(
+      expect.arrayContaining([
+        'storage.orphan.deleted',
+        'scheduler.job.run',
+        'scheduler.job.updated',
+      ]),
+    );
+    expect(auditEventMeta('scheduler.job.run').label).toBe('Scheduler job run');
+    expect(auditEventMeta('scheduler.job.updated').label).toBe('Scheduler job updated');
+  });
+
   it('falls back to the raw type and a neutral tone for an unknown event', () => {
     const meta = auditEventMeta('some.future.event');
     expect(meta.label).toBe('some.future.event');

--- a/qnop-ui/src/utils/auditEvents.ts
+++ b/qnop-ui/src/utils/auditEvents.ts
@@ -102,6 +102,18 @@ export const AUDIT_EVENT_META: Record<string, AuditEventMeta> = {
       'An unreferenced object was deleted from storage during a consistency cleanup (issue #523); the object key is shown in the details.',
     tone: 'amber',
   },
+  'scheduler.job.run': {
+    label: 'Scheduler job run',
+    description:
+      'An administrator manually triggered a scheduled maintenance job (“Run now”, issue #524); the job and its outcome are shown in the details.',
+    tone: 'amber',
+  },
+  'scheduler.job.updated': {
+    label: 'Scheduler job updated',
+    description:
+      'An administrator changed a scheduled job’s settings — enabled or disabled it, or toggled its dry-run mode (issue #524).',
+    tone: 'neutral',
+  },
 };
 
 /** The event types in a sensible display order — drives the filter and the legend. */


### PR DESCRIPTION
Closes #535.

The scheduler dashboard (#524) writes `scheduler.job.run` (manual 'Run now') and `scheduler.job.updated` (enabled/dry-run toggles) to the SYSTEM audit stream, but neither was in the UI's audit vocabulary — the trail fell back to the raw dotted machine type and the events were absent from the Event Type filter and the legend.

Both are now in `AUDIT_EVENT_META` with plain-language labels, tooltips and semantic tones (run: amber like the other operator actions; updated: neutral like other settings changes). The filter dropdown and the legend derive from the registry, so they pick the entries up automatically.

## Test plan
- [x] New test pins the SYSTEM-stream events (storage cleanup + scheduler) in the vocabulary and their labels
- [x] `pnpm test:run`, `pnpm lint`, `pnpm format:check` green

🤖 Co-Author: Claude (Fable 5) via Claude Code