### PR TITLE
feat(ui): clear button for the reviews list search field

### DIFF
--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -24,6 +24,7 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
@@ -33,7 +34,7 @@ import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
-import { LayoutGrid, Plus, Rows3, Search } from 'lucide-react';
+import { LayoutGrid, Plus, Rows3, Search, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { DocumentSummary } from '../../api/generated';
 import { useReviews } from '../../api/hooks/useReviews';
@@ -252,6 +253,18 @@ export function ReviewsPage() {
                       <Search size={16} />
                     </InputAdornment>
                   ),
+                  endAdornment: search ? (
+                    <InputAdornment position="end">
+                      <IconButton
+                        aria-label="Clear search"
+                        size="small"
+                        edge="end"
+                        onClick={() => setSearch('')}
+                      >
+                        <X size={16} />
+                      </IconButton>
+                    </InputAdornment>
+                  ) : undefined,
                 },
               }}
             />


### PR DESCRIPTION
Closes #539.

The teams, users and audit search fields already offer an X clear button as an end adornment once text is entered; the reviews list search was the one prominent field without it. Same affordance, same markup (client-side filter, so clearing takes effect immediately).

Note: #545-followup — once this and #546 (shared `ClearableSearchField`, part of the #541 PR) are merged, this field switches to the shared component.

## Test plan
- [x] `pnpm test:run` (reviews suites), `pnpm lint`, `pnpm format:check`, `pnpm tsc -b --noEmit` green

🤖 Co-Author: Claude (Fable 5) via Claude Code