### PR TITLE
feat(ui): configuration filter clear button + shared ClearableSearchField

### DIFF
--- a/qnop-ui/src/components/ClearableSearchField.test.tsx
+++ b/qnop-ui/src/components/ClearableSearchField.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { ReactNode } from 'react';
+import { buildTheme } from '../theme/theme';
+import { ClearableSearchField } from './ClearableSearchField';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>;
+}
+
+describe('ClearableSearchField', () => {
+  it('shows no clear button while the field is empty', () => {
+    render(<ClearableSearchField value="" onValueChange={vi.fn()} />, { wrapper });
+
+    expect(screen.queryByRole('button', { name: 'Clear search' })).toBeNull();
+  });
+
+  it('propagates typed input through onValueChange', () => {
+    const onValueChange = vi.fn();
+    render(<ClearableSearchField value="" onValueChange={onValueChange} />, { wrapper });
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'qnop' } });
+
+    expect(onValueChange).toHaveBeenCalledWith('qnop');
+  });
+
+  it('clears via onValueChange by default once text is present', () => {
+    const onValueChange = vi.fn();
+    render(<ClearableSearchField value="qnop" onValueChange={onValueChange} />, { wrapper });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+
+    expect(onValueChange).toHaveBeenCalledWith('');
+  });
+
+  it('prefers a custom onClear and clearLabel', () => {
+    const onValueChange = vi.fn();
+    const onClear = vi.fn();
+    render(
+      <ClearableSearchField
+        value="qnop"
+        onValueChange={onValueChange}
+        onClear={onClear}
+        clearLabel="Clear filter"
+      />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filter' }));
+
+    expect(onClear).toHaveBeenCalled();
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('applies inputAriaLabel and maxLength to the input element', () => {
+    render(
+      <ClearableSearchField
+        value=""
+        onValueChange={vi.fn()}
+        inputAriaLabel="Search users"
+        maxLength={256}
+      />,
+      { wrapper },
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Search users' });
+    expect(input.getAttribute('maxlength')).toBe('256');
+  });
+});

--- a/qnop-ui/src/components/ClearableSearchField.tsx
+++ b/qnop-ui/src/components/ClearableSearchField.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import TextField, { type TextFieldProps } from '@mui/material/TextField';
+import { Search, X } from 'lucide-react';
+
+interface ClearableSearchFieldProps extends Omit<
+  TextFieldProps,
+  'value' | 'onChange' | 'select' | 'multiline' | 'slotProps'
+> {
+  /** The controlled input value. */
+  value: string;
+  /** Called with the new value on every keystroke. */
+  onValueChange: (value: string) => void;
+  /**
+   * Called when the clear button is clicked; defaults to `onValueChange('')`.
+   * Provide one when clearing must do more — e.g. skip a debounce or reset paging.
+   */
+  onClear?: () => void;
+  /** aria-label of the clear button. */
+  clearLabel?: string;
+  /** Hide the leading search icon (e.g. when the field's label already says "Search"). */
+  hideSearchIcon?: boolean;
+  /** aria-label on the input element itself. */
+  inputAriaLabel?: string;
+  /** Maximum input length. */
+  maxLength?: number;
+}
+
+/**
+ * The app-wide search/filter text field (issue #541): a leading search icon
+ * and an X clear button that appears once text is entered — one markup for
+ * the teams, users and configuration searches (and future ones) instead of a
+ * hand-rolled copy per page.
+ */
+export function ClearableSearchField({
+  value,
+  onValueChange,
+  onClear,
+  clearLabel = 'Clear search',
+  hideSearchIcon = false,
+  inputAriaLabel,
+  maxLength,
+  ...textFieldProps
+}: ClearableSearchFieldProps) {
+  return (
+    <TextField
+      size="small"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+      slotProps={{
+        htmlInput: maxLength === undefined ? undefined : { maxLength },
+        input: {
+          'aria-label': inputAriaLabel,
+          startAdornment: hideSearchIcon ? undefined : (
+            <InputAdornment position="start">
+              <Search size={16} aria-hidden />
+            </InputAdornment>
+          ),
+          endAdornment: value ? (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label={clearLabel}
+                size="small"
+                edge="end"
+                onClick={onClear ?? (() => onValueChange(''))}
+              >
+                <X size={16} />
+              </IconButton>
+            </InputAdornment>
+          ) : undefined,
+        },
+      }}
+      {...textFieldProps}
+    />
+  );
+}

--- a/qnop-ui/src/pages/admin/ConfigurationPage.tsx
+++ b/qnop-ui/src/pages/admin/ConfigurationPage.tsx
@@ -22,8 +22,6 @@
 import { useMemo, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
@@ -31,11 +29,11 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { Clock, Info, Search, ServerCog, X } from 'lucide-react';
+import { Clock, Info, ServerCog } from 'lucide-react';
+import { ClearableSearchField } from '../../components/ClearableSearchField';
 import type { ConfigurationEntry, ConfigurationGroup } from '../../api/generated';
 import { useAdminConfiguration } from '../../api/hooks/useAdminConfiguration';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
@@ -289,33 +287,12 @@ export function ConfigurationPage() {
         only whether they are configured.
       </Alert>
 
-      <TextField
+      <ClearableSearchField
         value={query}
-        onChange={(event) => setQuery(event.target.value)}
+        onValueChange={setQuery}
         placeholder="Filter by property path or environment variable…"
-        size="small"
+        clearLabel="Clear filter"
         fullWidth
-        slotProps={{
-          input: {
-            startAdornment: (
-              <InputAdornment position="start">
-                <Search size={16} aria-hidden />
-              </InputAdornment>
-            ),
-            endAdornment: query ? (
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label="Clear filter"
-                  size="small"
-                  edge="end"
-                  onClick={() => setQuery('')}
-                >
-                  <X size={16} />
-                </IconButton>
-              </InputAdornment>
-            ) : undefined,
-          },
-        }}
         sx={{ maxWidth: 460 }}
       />
 

--- a/qnop-ui/src/pages/admin/ConfigurationPage.tsx
+++ b/qnop-ui/src/pages/admin/ConfigurationPage.tsx
@@ -22,6 +22,7 @@
 import { useMemo, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
@@ -34,7 +35,7 @@ import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { Clock, Info, Search, ServerCog } from 'lucide-react';
+import { Clock, Info, Search, ServerCog, X } from 'lucide-react';
 import type { ConfigurationEntry, ConfigurationGroup } from '../../api/generated';
 import { useAdminConfiguration } from '../../api/hooks/useAdminConfiguration';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
@@ -301,6 +302,18 @@ export function ConfigurationPage() {
                 <Search size={16} aria-hidden />
               </InputAdornment>
             ),
+            endAdornment: query ? (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="Clear filter"
+                  size="small"
+                  edge="end"
+                  onClick={() => setQuery('')}
+                >
+                  <X size={16} />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
           },
         }}
         sx={{ maxWidth: 460 }}

--- a/qnop-ui/src/pages/admin/TeamsPage.tsx
+++ b/qnop-ui/src/pages/admin/TeamsPage.tsx
@@ -24,7 +24,6 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
 import LinearProgress from '@mui/material/LinearProgress';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -38,9 +37,9 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { MoreVertical, Search, SquarePen, Trash2, UsersRound, X } from 'lucide-react';
+import { MoreVertical, SquarePen, Trash2, UsersRound } from 'lucide-react';
+import { ClearableSearchField } from '../../components/ClearableSearchField';
 import { useNavigate } from 'react-router-dom';
 import type { AdminTeamSummary } from '../../api/generated';
 import { useDeleteTeam, useTeams } from '../../api/hooks/useTeams';
@@ -127,33 +126,11 @@ export function TeamsPage() {
         }
       />
 
-      <TextField
+      <ClearableSearchField
         value={search}
-        onChange={(e) => setSearch(e.target.value)}
+        onValueChange={setSearch}
         placeholder="Search by name or description"
-        size="small"
         sx={{ maxWidth: 420 }}
-        slotProps={{
-          input: {
-            startAdornment: (
-              <InputAdornment position="start">
-                <Search size={16} />
-              </InputAdornment>
-            ),
-            endAdornment: search ? (
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label="Clear search"
-                  size="small"
-                  edge="end"
-                  onClick={() => setSearch('')}
-                >
-                  <X size={16} />
-                </IconButton>
-              </InputAdornment>
-            ) : undefined,
-          },
-        }}
       />
 
       <Paper variant="outlined" sx={{ overflow: 'hidden' }}>

--- a/qnop-ui/src/pages/admin/UsersPage.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.tsx
@@ -23,8 +23,6 @@ import { useEffect, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
 import LinearProgress from '@mui/material/LinearProgress';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
@@ -32,7 +30,8 @@ import Stack from '@mui/material/Stack';
 import TablePagination from '@mui/material/TablePagination';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { Search, UserPlus, X } from 'lucide-react';
+import { UserPlus } from 'lucide-react';
+import { ClearableSearchField } from '../../components/ClearableSearchField';
 import type { AdminUserSummary, UserRole } from '../../api/generated';
 import {
   useAdminUsers,
@@ -188,34 +187,12 @@ export function UsersPage() {
       />
 
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} sx={{ flexWrap: 'wrap' }}>
-        <TextField
+        <ClearableSearchField
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onValueChange={setSearch}
           placeholder="Search by name, email or username"
-          size="small"
+          inputAriaLabel="Search users"
           sx={{ flex: 1, minWidth: 240, maxWidth: 420 }}
-          slotProps={{
-            input: {
-              'aria-label': 'Search users',
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={16} />
-                </InputAdornment>
-              ),
-              endAdornment: search ? (
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="Clear search"
-                    size="small"
-                    edge="end"
-                    onClick={() => setSearch('')}
-                  >
-                    <X size={16} />
-                  </IconButton>
-                </InputAdornment>
-              ) : undefined,
-            },
-          }}
         />
         <TextField
           select


### PR DESCRIPTION
Closes #541.

Two commits:

1. **Clear button for the /admin/configuration filter** — the same X end adornment the other searches offer (`aria-label: Clear filter`).
2. **Extract `ClearableSearchField`** — the teams, users and configuration pages each hand-rolled the same search-icon + clear-button markup; it now lives in one shared component (`src/components/ClearableSearchField.tsx`) and replaces all three copies. API covers the existing variants: `clearLabel`, `inputAriaLabel`, `maxLength`, `hideSearchIcon`, and an `onClear` override for clears that must also skip a debounce or reset paging. Clear-button aria-labels are preserved, so existing page tests pass unchanged.

The audit (#544) and reviews (#545) search fields live on parallel branches and will switch to the shared component in a small follow-up once everything is merged.

## Test plan
- [x] 5 new component tests (visibility, typing, default clear, custom onClear/clearLabel, aria/maxLength)
- [x] Existing teams/users/configuration page tests pass unchanged (clear-button interactions included)
- [x] Full frontend gate green: 967 tests / 141 files, lint, prettier, typecheck

🤖 Co-Author: Claude (Fable 5) via Claude Code