### PR TITLE
fix(review): placement actions no longer collapse the annotation

### DIFF
--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { memo } from 'react';
+import { memo, type MouseEvent } from 'react';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
@@ -232,7 +232,16 @@ function AnnotationListItemBase({
       // Expanded, the card hosts real buttons (the head's copy-link) — a
       // <button> may not nest, so the active card is a div with button role.
       component={active ? 'div' : 'button'}
-      onClick={() => {
+      onClick={(event: MouseEvent<HTMLElement>) => {
+        // The expanded card hosts real interactive controls (placement
+        // actions, copy, reactions, profile links). Each stops propagation,
+        // but the row must not depend on every future control remembering to
+        // — a click originating on any interactive descendant never toggles
+        // the card (issue #480).
+        const interactive = (event.target as HTMLElement).closest(
+          'button, a, [role="button"], input, textarea, [contenteditable="true"]',
+        );
+        if (interactive && interactive !== event.currentTarget) return;
         // Selecting quote text inside the card ends with a click on it —
         // don't treat a live selection as a toggle (issue #478).
         const selection = window.getSelection();

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -55,14 +55,17 @@ vi.mock('../../../api/hooks/useComments', () => ({
   useComments: vi.fn().mockReturnValue({ isPending: false, isError: false, data: undefined }),
 }));
 
-const { resolveMutate } = vi.hoisted(() => ({ resolveMutate: vi.fn() }));
+const { resolveMutate, confirmMutate } = vi.hoisted(() => ({
+  resolveMutate: vi.fn(),
+  confirmMutate: vi.fn(),
+}));
 vi.mock('../../../api/hooks/useReviews', () => ({
   useParticipants: vi.fn().mockReturnValue({
     data: { participants: [{ principalId: 'other', displayName: 'Anna Weber' }] },
   }),
 }));
 vi.mock('../../../api/hooks/useAnnotations', () => ({
-  useConfirmPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
+  useConfirmPlacement: vi.fn().mockReturnValue({ mutate: confirmMutate, isPending: false }),
   useReattachPlacement: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
   useResolveAnnotation: () => ({ mutate: resolveMutate, isPending: false }),
   useReopenAnnotation: () => ({ mutate: vi.fn(), isPending: false }),
@@ -70,6 +73,7 @@ vi.mock('../../../api/hooks/useAnnotations', () => ({
 
 beforeEach(() => {
   resolveMutate.mockClear();
+  confirmMutate.mockClear();
   useAuthStore.setState({ userId: null });
 });
 
@@ -211,6 +215,43 @@ describe('AnnotationPanel', () => {
     expect(screen.getByTestId('thread-a1')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('annotation-item-a1'));
     expect(props.onSelect).toHaveBeenCalledWith(null);
+  });
+
+  // Issue #480: placement actions live inside the row's ButtonBase — acting on
+  // a placement must never toggle the card the reviewer is reading.
+  it('keeps the row expanded when "Looks right" confirms a MOVED placement (#480)', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const props = renderPanel({
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Moved })],
+      activeAnnotationId: 'a1',
+      versionNumber: 3,
+    });
+
+    // Exact name: the expanded row is itself role="button" and its accessible
+    // name contains the action's text, so a substring match would be ambiguous.
+    fireEvent.click(screen.getByRole('button', { name: 'Looks right' }));
+
+    expect(confirmMutate).toHaveBeenCalledWith({
+      annotationId: 'a1',
+      versionNumber: 3,
+    });
+    expect(props.onSelect).not.toHaveBeenCalled();
+  });
+
+  it('keeps the row expanded when "Re-attach" arms re-attach mode (#480)', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const onArmReattach = vi.fn();
+    const props = renderPanel({
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Orphaned })],
+      activeAnnotationId: 'a1',
+      versionNumber: 3,
+      onArmReattach,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
+
+    expect(onArmReattach).toHaveBeenCalledWith(expect.objectContaining({ id: 'a1' }));
+    expect(props.onSelect).not.toHaveBeenCalled();
   });
 
   it('filters by status through the filter popover, with a removable chip', () => {

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -440,6 +440,54 @@ describe('DocumentReviewPage deep link', () => {
   });
 });
 
+// Issue #480: placement actions must not collapse the annotation they act on.
+// Arming re-attach clears the selection only in focus mode, where the floating
+// card must make way so the document is selectable.
+describe('DocumentReviewPage placement actions (#480)', () => {
+  afterEach(() => {
+    localStorage.removeItem('qnop-review-view-mode');
+  });
+
+  function seedOrphaned() {
+    seedHappyPath();
+    vi.mocked(useAnnotations).mockReturnValue(
+      asQuery({
+        data: { annotations: [{ ...ANNOTATIONS[0], placementStatus: PlacementStatus.Orphaned }] },
+      }),
+    );
+  }
+
+  it('keeps the annotation expanded when arming re-attach in panel mode', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    seedOrphaned();
+    renderPage('/reviews/doc-1?annotation=a1');
+    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+
+    // Exact name: the expanded row is itself role="button" and its accessible
+    // name contains the action's text, so a substring match would be ambiguous.
+    fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
+
+    expect(screen.getByTestId('reattach-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('still clears the selection and closes the drawer when arming re-attach in focus mode', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    seedOrphaned();
+    renderPage('/reviews/doc-1?annotation=a1&view=focus');
+
+    fireEvent.click(screen.getByRole('button', { name: /Show annotations/ }));
+    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
+    expect(screen.getByTestId('reattach-hint')).toBeInTheDocument();
+
+    // The selection is cleared so the focus overlay cannot spring back onto
+    // the thread (issue #403); the drawer closes, its content stays mounted.
+    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
 describe('DocumentReviewPage on an older version', () => {
   it('shows the read-only banner with a jump to the latest version', () => {
     seedHappyPath();

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -366,12 +366,16 @@ export function DocumentReviewPage() {
     setActiveAnnotationId(null);
   };
 
-  // Arming (issue #457): mutually exclusive with drafting a new mark, and the
-  // focus overlay/drawer make way so the document is selectable.
+  // Arming (issue #457): mutually exclusive with drafting a new mark. Only the
+  // focus overlay/drawer make way so the document is selectable — in panel
+  // mode the thread stays selected while the user picks the new passage
+  // (issue #480), mirroring the success-path guard in stagePending.
   const armReattach = (annotation: AnnotationView) => {
     setPending(null);
-    setActiveAnnotationId(null);
-    setListOpen(false);
+    if (focusMode) {
+      setActiveAnnotationId(null);
+      setListOpen(false);
+    }
     setReattaching({
       annotationId: annotation.id,
       excerpt: annotation.anchor?.textQuote?.quote ?? null,

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -37,7 +37,8 @@ testdata/
 └── documents/                # review document payloads (issues #308, #370)
     ├── sample.pdf            # minimal valid single-page PDF, text "QNOP SMOKE TEST"
     ├── doc1/                 # multi-version dummy: test-dummy-v1..v5.pdf (1 page each)
-    └── doc2/                 # multi-version story: scifi-story-v1..v5.pdf (3 pages each)
+    ├── doc2/                 # multi-version story: scifi-story-v1..v5.pdf (3 pages each)
+    └── doc3/                 # placement lab: placement-lab-v1..v3.pdf (1 page each, issue #480)
 ```
 
 The `documents/sample.pdf` fixture backs the ingest smoke test: it is uploaded,
@@ -54,6 +55,14 @@ the smoke's multi-version/diff steps:
   Signal") with real word-level edits between versions; v1→v2 replaces
   *letzten* → *einsamen* in the Kalinda sentence, which the diff assertions
   pin down. Keep those anchor words stable when regenerating the fixtures.
+- **doc3** (`placement-lab-v1..v3.pdf`) — the placement lab for manually
+  exercising re-anchoring outcomes (issues #457/#480). Annotate the three
+  target sentences in v1 (sections 3–5: ALPHA, BRAVO, CHARLIE), then upload
+  v2: ALPHA keeps its wording but a section inserted before it shifts its
+  position → **MOVED**; the BRAVO and CHARLIE sentences vanish without a
+  near-duplicate → **ORPHANED**. v3 prepends a preamble that shifts the whole
+  document once more, so placed (and freshly re-attached) annotations go
+  MOVED again for a second round.
 
 The seed's role/state users (`admin`, `member`, `auditor`, …) are pinned by
 `SeededAdminUsersIT`/`SeededTeamIT` — keep their rows and the Alpha/Beta teams

--- a/testdata/documents/doc3/placement-lab-v1.pdf
+++ b/testdata/documents/doc3/placement-lab-v1.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20000101000000+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (Placement Lab - Version 1) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 770
+>>
+stream
+Gat=h:J^")&B4*cME/OggPs\[h-5E45jBs:7%CcscHpfUmDsHbqsDumd%l>te1+@l37=:A^GfX(JU<3&ZN\-U#sWkN+<cuq5b_ZijTNTbR6M45,lTnJL@%!HQUjJ7PC/a/Gm<@3cDQ7L>bJGXTedP$,AP,]"EFP)?RW\VA-q='2&Kq4X2^r8]iJs['cl(9s+KX4\/PAgs!\2:ic=P@;\$Q!dZl/!/,b"Bq?C63\'f"k/c@uM?UDEjkQ$>_:KuATjp%j[Xo[.Q))l6Eed,5IAZ7>_EBkhNQ0*)s%<#'^M>NRM("*TUVt8pEILlWJrcBlJi_:)7!F'>]DlVu6_70\G10<5\H[S[W8c4%I9[Y*QoHYt,TkNPq-*HW1L<9j(e?[g.C3J"2RQ"i'F=tZ`lK8ek>TPGe#m@,qQ*ib=)3TA>VP0I(2/R)I+1uVWF%-=P$0]$=p'dBn/O]hBXQ[YDKGN`R>@SJM9:dmh2R'2Y,B2sfSH(!38KZ0tJLTJ3/gf&:ib0l_4R-BqK.37XI\%L'6#7MdCYm:N9'L(PXrjkX,8kXTm"=M<knLW=i9&Q_Hf[^7^,:$7RNUpkM-;a&pVl1Kd:f7:fLIaHoMtS2i0kUs>qD<rhqP=$j;\:9V-sT;Q/'l,4dfJ1!\HGbqJ9$4W3/m_PplLgEf4-E=#\+sjE>o5Otb]^_J6(Sn(fcBp^=7[AbR9--b'M8^8o2_\e8n&jSW[QUTBZqPd;0mfVUObf9I8Iree.MDXTQ'[+d[4r<&=Bp?_~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000524 00000 n 
+0000000592 00000 n 
+0000000870 00000 n 
+0000000929 00000 n 
+trailer
+<<
+/ID 
+[<3053a91ef44cc7007341b54789a8c619><3053a91ef44cc7007341b54789a8c619>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1789
+%%EOF

--- a/testdata/documents/doc3/placement-lab-v2.pdf
+++ b/testdata/documents/doc3/placement-lab-v2.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20000101000000+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (Placement Lab - Version 2) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 900
+>>
+stream
+GatU19lJ`N&A@7.bd",Kp"IFDp-]On7\WnI=?5KKX9ZCtfsQ!i3rJl8QOc.Y%O=BH`7fP+c'pYu$j-8[rtJ+VlO:N+AACOQk.ou*%+u=AfnDX$JL1:Xm>('hgHl<9(a`sH1eL9"/`Fm$aTX:o3LK@To\^%8Q!-Iu$/&\,^@#DIU`MDWO,ftF=GqL+`Mrt+h;*O8qs!lfnpBpTlV5FO]r(tnn7WtNBJsOt+&TO;+=".8ar-bRr5#(5`]S!X_M0<V[]!=P/`^-dJ?NX>ZtR8j#[AhG\0j/dj%:$>8@<t?<`htJDje3G_iE-j?cKPc]c[U/kK?&J2jie8>[`_cgapg',lsqIE>.6ED)\i=X4&msa*GO#Yc:=?F-!Hmea6eTb+[rm'`M+?DnRQ0Ac$-7-&LX!^4b"&8&o6gK$[K>X#n'P/:#j8MAs8`]IJI2aIG([_+TjsOD8"7.F8iV<T_*?R]l*Mdg#'8jk.&-3mWL1f2*8s&>UP_5%)TBaGq)no80kg*9N7QSS2*jZRm((U3@Bt%GHDub8l5knl@8F:n#$oY%WDK_c#)\EV#Hh+ILV)7@h9<FfdR4i=!:"X#Ipn<X%Al<tnmkLeBdDRC9E[s+#I4kg7#!bf_mqj6?NGn_&rAC!_"hSatUd_$a_[.DSFSC2NO]ZX)'UH5-t.(4Xrifnp>O=TV=0L]4),EI;:1`am<rej_\MiI#"Lc5N4[+n5Y"l)1)]Kr0[j-!4TE%J$8CaaZjl_^1<>kuipsoZ_sh:%RV9"77-mV]8Q_[rFRgP@tXOH8>8[-W/;pCh&X>X@dS*e!8,PS;_0*Ak?:(nf=j%76q6#[!_5[2Po^Me.E-#lU[t7RgmjB<NtmS0?"=$a*!knYE\n,rN53%Dls7.%:/@?nK3F<:bi~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000524 00000 n 
+0000000592 00000 n 
+0000000870 00000 n 
+0000000929 00000 n 
+trailer
+<<
+/ID 
+[<016015860b6753a9979c0a46e67dcf1f><016015860b6753a9979c0a46e67dcf1f>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1919
+%%EOF

--- a/testdata/documents/doc3/placement-lab-v3.pdf
+++ b/testdata/documents/doc3/placement-lab-v3.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20000101000000+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (Placement Lab - Version 3) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1005
+>>
+stream
+GatU1?#SFN'RelB\<#B$=?_:P:MfF*8o-h2e>L"tkCUAN40hT0rqkM25gf]El%F`*TQ>NFmR[Zb]gDbE[fG<+q"u@i0S4Z]@5:S#?bgg`cC[T<:AfAqNk4h$%l'&O3m#CJ=Z1n[$h'E.j1%P>@)5ktJpT=TC'F,4aT"O)nH^(#k#$d$lo]#$G,SK2mi'R#c.*V40';&pIpN*"7uR2PdJXAlFI#H>3_VX!463QT?pL&a)J%T&M'/'Pj050en@3,hKL%_3&Vba8HpO8o2XP,<6<^;t6`cAbB*fBJ(7G_j4\O.Z,Aad(:LH%6p$@?2S!UJY1T!;;S6uhA7WTIq$=Y:r06[R#JADh=Nc@AJ9I]@26f$1?[e^RfYRQe24BTp$)P-.2''bHs7Me.90O2.JH)9:n++-DmV8ZKJNeo-^\Bq*]>KI4FWUR32iM;t4n:#h/3spQ^Hh]:LH&IN.J9N%S1E1FDklOET=E<Yn%B]-K`A)'ble@%!G#bMEiNX+]\K_M]"^1#un39pn<T6>GG.93i1d(FW,%'aXCBDR7;0d27SOq<*Ff(R8)oF-+oL0O;B?=<0C_%/fk8+9'd(>J3=4Z`k?5>-\mHDquEh78P51@BATf)L7ItKGkm#3VKT@brX?gGN@-!B_0U:!9;kiTp#Z2;)^c3d1-(Wu2,XK^2s6Z0Rn'EiJSUh&1`]L(5MbmiF7`Sm/YX9:UqQOBZK1eUa6<8,K,rc%Onj@k!A,[T>&R4jjjkJJ$m?52M%Rif'KrZYAp!?VKD[IMdjLtZFBJmM"iXBk3!6'`hD[X76<PU;umBu5P!\]*8n7hc0n&l3g2Ghn(l00n"XjoA*fdp''31_'#`Td8@?\(Ef]0(2u69O8DIB\H6h%aD=n9f\sGmc4-J9u?6rPP"l3$$sQKVlO^9&foDD'lpu7@@GIma[MrmW,=MF''-!=Cb)"'ol(u"1caYP+WfOq8V:/6Bi"H!jF<XHI@#&*;t?8tO6um(o^<:YrW-BUYqZ~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000524 00000 n 
+0000000592 00000 n 
+0000000870 00000 n 
+0000000929 00000 n 
+trailer
+<<
+/ID 
+[<09ae40c7e742b0722314d026a35db10a><09ae40c7e742b0722314d026a35db10a>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2025
+%%EOF


### PR DESCRIPTION
Closes #480.

## What was wrong

- **'Re-attach'** collapsed the thread: `armReattach` unconditionally cleared the selection and closed the list — needed only in focus mode, where the overlay/drawer must make way so the document is selectable. The deselect is now gated on `focusMode`, mirroring the success-path guard in `stagePending` (#403).
- **'Looks right'**: investigation showed the row toggle does **not** fire for the placement actions today — every nested control stops propagation, and MUI ButtonBase's synthesized activation only triggers for events on the row itself. The reported symptom most plausibly stems from the attention-filter dropout, now tracked separately as #548. To keep the toggle path safe without depending on every future control remembering `stopPropagation`, the row's `onClick` now ignores clicks originating on any interactive descendant (defense-in-depth).

## Tests

- Panel-level 'action click does not collapse' regression tests against the **real** ButtonBase row (the existing `AnnotationBadgeRow` test wraps a plain div and cannot catch this)
- Page-level arming tests for both modes: panel keeps the thread expanded (RED before the fix, GREEN after); focus still clears the selection for the overlay
- Full gate green: 972 tests / 141 files, lint, prettier, typecheck

## Also included

`testdata/documents/doc3/` — the **placement-lab** fixture family (v1–v3) for manually exercising re-anchoring outcomes: annotate the three target sentences in v1, upload v2 → one MOVED + two ORPHANED; v3 shifts everything again. Documented in `testdata/README.md`.

Follow-ups filed: #548 (attention-filter dropout), #549 (a11y: interactive-in-interactive nesting).

🤖 Co-Author: Claude (Fable 5) via Claude Code