### PR TITLE
feat(ui): spinner on the 'Re-anchoring…' placement chip

### DIFF
--- a/qnop-ui/src/components/reviews/panel/PlacementStatusChip.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/PlacementStatusChip.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import type { ReactNode } from 'react';
+import { PlacementStatus } from '../../../api/generated';
+import { buildTheme } from '../../../theme/theme';
+import { PlacementStatusChip } from './PlacementStatusChip';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>;
+}
+
+describe('PlacementStatusChip', () => {
+  it('shows a spinner while re-anchoring is pending (#552)', () => {
+    render(<PlacementStatusChip status={PlacementStatus.Pending} />, { wrapper });
+
+    expect(screen.getByText('Re-anchoring…')).toBeTruthy();
+    expect(screen.getByTestId('placement-pending-spinner')).toBeTruthy();
+  });
+
+  it.each([PlacementStatus.Moved, PlacementStatus.Orphaned, PlacementStatus.Failed] as const)(
+    'renders %s without a spinner',
+    (status) => {
+      render(<PlacementStatusChip status={status} />, { wrapper });
+
+      expect(screen.queryByTestId('placement-pending-spinner')).toBeNull();
+    },
+  );
+
+  it('renders nothing for PLACED — the expected state needs no badge', () => {
+    const { container } = render(<PlacementStatusChip status={PlacementStatus.Placed} />, {
+      wrapper,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/qnop-ui/src/components/reviews/panel/PlacementStatusChip.tsx
+++ b/qnop-ui/src/components/reviews/panel/PlacementStatusChip.tsx
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import CircularProgress from '@mui/material/CircularProgress';
 import Tooltip from '@mui/material/Tooltip';
 import { PlacementStatus } from '../../../api/generated';
 import type { BadgeTone } from '../../admin/ToneBadge';
@@ -59,7 +60,24 @@ export function PlacementStatusChip({ status }: { status?: PlacementStatus }) {
   return (
     <Tooltip title={cue.hint}>
       <span>
-        <ToneBadge tone={cue.tone} label={cue.label} />
+        <ToneBadge
+          tone={cue.tone}
+          label={cue.label}
+          icon={
+            // Re-anchoring is actively running (issue #552) — a spinner in the
+            // badge's own foreground colour signals work-in-progress. The
+            // label carries the meaning, so the glyph is decorative.
+            status === PlacementStatus.Pending ? (
+              <CircularProgress
+                size={10}
+                thickness={5}
+                color="inherit"
+                aria-hidden
+                data-testid="placement-pending-spinner"
+              />
+            ) : undefined
+          }
+        />
       </span>
     </Tooltip>
   );


### PR DESCRIPTION
Closes #552.

While a new version is being matched, annotations carry the neutral PENDING 'Re-anchoring…' chip — a static label that undersells that work is actively running. A 10px `CircularProgress` now sits in `ToneBadge`'s existing icon slot:

- `color="inherit"` — the spinner picks up the badge's foreground tone; no new colors, works in light and dark
- No layout shift (the icon slot is part of the pill's flex layout)
- Decorative and `aria-hidden` — the label + tooltip carry the meaning
- Only the PENDING cue gets it; Moved/Orphaned/Failed stay static

Appears everywhere the chip renders: panel badge row, focus card, drawer.

## Test plan
- [x] New `PlacementStatusChip` tests: spinner for PENDING, none for Moved/Orphaned/Failed, nothing rendered for PLACED
- [x] Full gate green: 973 tests / 142 files, lint, prettier, typecheck

🤖 Co-Author: Claude (Fable 5) via Claude Code