### PR TITLE
feat(review): poll re-anchoring placements live and refresh settled threads

### DIFF
--- a/qnop-ui/src/api/hooks/useAnnotations.test.tsx
+++ b/qnop-ui/src/api/hooks/useAnnotations.test.tsx
@@ -23,13 +23,17 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { AnnotationListResponse } from '../generated';
+import type { AnnotationListResponse, AnnotationView } from '../generated';
+import { AnnotationStatus, PlacementStatus } from '../generated';
 import {
   annotationKeys,
+  hasPendingPlacement,
+  settledSince,
   useAnnotations,
   useCreateAnnotation,
   useResolveAnnotation,
 } from './useAnnotations';
+import { commentKeys } from './useComments';
 import { annotationsApi } from '../config';
 
 vi.mock('../config', () => ({
@@ -75,6 +79,95 @@ describe('useAnnotations', () => {
 
     expect(result.current.fetchStatus).toBe('idle');
     expect(annotationsApi.listAnnotations).not.toHaveBeenCalled();
+  });
+
+  // Live re-anchoring (issue #553): when the polled list shows a placement
+  // settling, the annotation's comment thread is refreshed alongside.
+  it('invalidates the comment thread of a placement that settled', async () => {
+    const pending: AnnotationListResponse = {
+      annotations: [
+        placement('a1', PlacementStatus.Pending),
+        placement('a2', PlacementStatus.Placed),
+      ],
+    };
+    const settled: AnnotationListResponse = {
+      annotations: [
+        placement('a1', PlacementStatus.Moved),
+        placement('a2', PlacementStatus.Placed),
+      ],
+    };
+    vi.mocked(annotationsApi.listAnnotations)
+      .mockResolvedValueOnce({ data: pending } as Awaited<
+        ReturnType<typeof annotationsApi.listAnnotations>
+      >)
+      .mockResolvedValueOnce({ data: settled } as Awaited<
+        ReturnType<typeof annotationsApi.listAnnotations>
+      >);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    const localWrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useAnnotations(DOC_ID, 2), { wrapper: localWrapper });
+    await waitFor(() =>
+      expect(result.current.data?.annotations[0].placementStatus).toBe(PlacementStatus.Pending),
+    );
+
+    // A poll observes the settle — simulate it by refetching the query.
+    await result.current.refetch();
+    await waitFor(() =>
+      expect(result.current.data?.annotations[0].placementStatus).toBe(PlacementStatus.Moved),
+    );
+
+    await waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: commentKeys.list('a1') }),
+    );
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: commentKeys.list('a2') });
+  });
+});
+
+function placement(id: string, placementStatus: PlacementStatus): AnnotationView {
+  return {
+    id,
+    documentId: DOC_ID,
+    authorId: 'u1',
+    status: AnnotationStatus.Open,
+    placementStatus,
+    commentCount: 0,
+    reactions: [],
+    createdAt: '2026-07-01T10:00:00Z',
+    updatedAt: '2026-07-01T10:00:00Z',
+  };
+}
+
+describe('hasPendingPlacement', () => {
+  it('is true only while some placement is PENDING', () => {
+    expect(hasPendingPlacement(undefined)).toBe(false);
+    expect(hasPendingPlacement([placement('a1', PlacementStatus.Placed)])).toBe(false);
+    expect(
+      hasPendingPlacement([
+        placement('a1', PlacementStatus.Placed),
+        placement('a2', PlacementStatus.Pending),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('settledSince', () => {
+  it('names exactly the previously pending placements that are no longer pending', () => {
+    const previous = new Set(['a1', 'a2']);
+    const now = [
+      placement('a1', PlacementStatus.Moved),
+      placement('a2', PlacementStatus.Pending),
+      placement('a3', PlacementStatus.Orphaned),
+    ];
+    expect(settledSince(previous, now)).toEqual(['a1']);
+  });
+
+  it('treats a vanished annotation as settled', () => {
+    expect(settledSince(new Set(['gone']), [])).toEqual(['gone']);
   });
 });
 

--- a/qnop-ui/src/api/hooks/useAnnotations.ts
+++ b/qnop-ui/src/api/hooks/useAnnotations.ts
@@ -19,8 +19,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useEffect, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { Anchor, AnnotationCreateRequest, AnnotationListResponse } from '../generated';
+import type {
+  Anchor,
+  AnnotationCreateRequest,
+  AnnotationListResponse,
+  AnnotationView,
+} from '../generated';
+import { PlacementStatus } from '../generated';
 import { annotationsApi } from '../config';
 import type { Notify } from '../../components/admin/layout/useToast';
 import { commentKeys } from './useComments';
@@ -32,20 +39,66 @@ export const annotationKeys = {
     [...annotationKeys.all, 'list', documentId, version] as const,
 };
 
+/** Poll cadence while the server is still re-anchoring placements (issue #553). */
+const REANCHOR_POLL_MS = 2500;
+
+/** Whether any placement on the viewed version is still being matched. */
+export function hasPendingPlacement(annotations: AnnotationView[] | undefined): boolean {
+  return (annotations ?? []).some((a) => a.placementStatus === PlacementStatus.Pending);
+}
+
+/** The ids of the previously pending placements that the current list shows settled. */
+export function settledSince(
+  previousPending: ReadonlySet<string>,
+  annotations: AnnotationView[] | undefined,
+): string[] {
+  const stillPending = new Set(
+    (annotations ?? [])
+      .filter((a) => a.placementStatus === PlacementStatus.Pending)
+      .map((a) => a.id),
+  );
+  return [...previousPending].filter((id) => !stillPending.has(id));
+}
+
 /**
  * The document's annotations with each placement (anchor + placement status)
  * resolved against the given 1-based version (ADR-0009: identity is
  * version-independent, physical location is per version).
+ *
+ * While any placement is PENDING after a version upload, the list polls
+ * (issue #553, mirroring the extraction polling of #300) — this one query
+ * feeds the panel chips and the document marks, so both settle live. When a
+ * poll observes a placement settling, that annotation's comment thread is
+ * invalidated too, so an open thread reflects activity that arrived while
+ * re-anchoring ran.
  */
 export function useAnnotations(documentId: string, version: number | undefined) {
-  return useQuery<AnnotationListResponse>({
+  const queryClient = useQueryClient();
+  const query = useQuery<AnnotationListResponse>({
     queryKey: annotationKeys.list(documentId, version),
     queryFn: async () => {
       const response = await annotationsApi.listAnnotations({ documentId, version });
       return response.data;
     },
     enabled: version !== undefined && version >= 1,
+    refetchInterval: (q) =>
+      hasPendingPlacement(q.state.data?.annotations) ? REANCHOR_POLL_MS : false,
   });
+
+  const pendingIds = useRef<ReadonlySet<string>>(new Set());
+  const annotations = query.data?.annotations;
+  useEffect(() => {
+    for (const id of settledSince(pendingIds.current, annotations)) {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(id) });
+    }
+    pendingIds.current = new Set(
+      (annotations ?? [])
+        .filter((a) => a.placementStatus === PlacementStatus.Pending)
+        .map((a) => a.id),
+    );
+  }, [annotations, queryClient]);
+
+  return query;
 }
 
 /**


### PR DESCRIPTION
Closes #553.

After a version upload the PENDING 'Re-anchoring…' chips only updated on a manual refetch. Now the annotations list polls while re-anchoring runs, and the UI settles by itself:

- `useAnnotations` gains a conditional `refetchInterval`: while any placement on the viewed version is PENDING, poll every 2.5 s (mirroring the extraction polling of #300); stop as soon as none is.
- The one shared query feeds the panel chips **and** the document marks — each poll updates both, so the highlight visibly moves to its re-anchored position without user action. Together with #555's spinner this completes the live re-anchoring experience.
- When a poll observes a placement settling (PENDING → anything), exactly that annotation's comment thread is invalidated, so an open thread reflects activity that arrived while re-anchoring ran; unaffected threads stay untouched.

The settle logic is extracted into pure helpers (`hasPendingPlacement`, `settledSince`) for direct unit testing.

## Test plan
- [x] Unit tests for the helpers (incl. 'vanished annotation counts as settled')
- [x] Hook test driving PENDING → MOVED: exactly the settled annotation's comment thread is invalidated
- [x] Full gate green: 972 tests / 141 files, lint, prettier, typecheck

🤖 Co-Author: Claude (Fable 5) via Claude Code