### PR TITLE
fix(ui): override vulnerable transitive dev deps to unblock pnpm audit

### DIFF
--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  shell-quote@<=1.8.4: 1.10.0
+
 importers:
 
   .:
@@ -1291,11 +1296,11 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -2807,8 +2812,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -4541,12 +4546,12 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4645,7 +4650,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -5981,11 +5986,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.16
 
   minipass@7.1.3: {}
 
@@ -6433,7 +6438,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.1:
     dependencies:

--- a/qnop-ui/pnpm-workspace.yaml
+++ b/qnop-ui/pnpm-workspace.yaml
@@ -6,3 +6,14 @@ allowBuilds:
   '@openapitools/openapi-generator-cli': true
   # core-js-pure's only "build" is a funding postinstall; it needs no compilation.
   core-js-pure: false
+
+# Force patched releases of transitive DEV dependencies onto vulnerable version
+# lines flagged by `pnpm audit --audit-level high` (issue #557): brace-expansion
+# GHSA-3jxr-9vmj-r5cp (two version lines) and shell-quote GHSA-395f-4hp3-45gv —
+# all reachable only via dev tooling (eslint, openapi-generator-cli,
+# concurrently). Drop each override once the upstream trees ship the patched
+# versions on their own (Renovate will bump).
+overrides:
+  'brace-expansion@<1.1.16': 1.1.16
+  'brace-expansion@>=3.0.0 <5.0.7': 5.0.7
+  'shell-quote@<=1.8.4': 1.10.0


### PR DESCRIPTION
Closes #557. **Unblocks CI for every open PR** (#554, #555, #556 currently fail on this).

Three fresh HIGH advisories against transitive **dev** dependencies fail the frontend gate (`pnpm audit --audit-level high`):

| Package | Vulnerable | Patched | Advisory | Reached via |
|---|---|---|---|---|
| `brace-expansion` | <1.1.16 | 1.1.16 | GHSA-3jxr-9vmj-r5cp (DoS) | eslint/minimatch |
| `brace-expansion` | >=3.0.0 <5.0.7 | 5.0.7 | GHSA-3jxr-9vmj-r5cp (DoS) | eslint + openapi-generator (~40 paths) |
| `shell-quote` | <=1.8.4 | 1.10.0¹ | GHSA-395f-4hp3-45gv (DoS) | openapi-generator>concurrently |

¹ the advisory names 1.8.5 as patched, but no 1.8.x release beyond 1.8.4 exists — 1.10.0 is the next published version.

Range-scoped `overrides` in `pnpm-workspace.yaml` (pnpm 11 no longer reads the `pnpm` field in package.json) force the patched releases onto the vulnerable lines only; each override is annotated and can be dropped once the upstream trees catch up via Renovate. No runtime exposure — all paths are dev tooling.

## Test plan
- [x] `pnpm audit --audit-level high` → 'No known vulnerabilities found'
- [x] Full gate green locally: eslint, prettier, 968 tests, production build
- [x] Peer warning (jsx-a11y vs eslint 10) pre-exists on main — unrelated

🤖 Co-Author: Claude (Fable 5) via Claude Code