### PR TITLE
refactor(ui): migrate the audit and reviews search fields to ClearableSearchField

### DIFF
--- a/qnop-ui/src/pages/audit/AuditPage.tsx
+++ b/qnop-ui/src/pages/audit/AuditPage.tsx
@@ -26,16 +26,15 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Collapse from '@mui/material/Collapse';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
 import LinearProgress from '@mui/material/LinearProgress';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import TablePagination from '@mui/material/TablePagination';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { ChevronDown, HelpCircle, X } from 'lucide-react';
+import { ChevronDown, HelpCircle } from 'lucide-react';
 import { useAuditLog } from '../../api/hooks/useAuditLog';
+import { ClearableSearchField } from '../../components/ClearableSearchField';
 import { AuditTable } from '../../components/audit/AuditTable';
 import { AuditEventBadge } from '../../components/audit/AuditEventBadge';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
@@ -198,35 +197,21 @@ export function AuditPage() {
             <TextField {...params} label="Event type" placeholder="All events" />
           )}
         />
-        <TextField
+        <ClearableSearchField
           label="Search details"
           value={detailSearch}
-          onChange={(e) => setDetailSearch(e.target.value)}
-          placeholder="e.g. a storage key or workflow state"
-          size="small"
-          sx={{ minWidth: 240, flexGrow: 1, maxWidth: 360 }}
-          slotProps={{
-            htmlInput: { maxLength: 256 },
-            input: {
-              endAdornment: detailSearch ? (
-                <InputAdornment position="end">
-                  <IconButton
-                    size="small"
-                    edge="end"
-                    aria-label="Clear the details search"
-                    onClick={() => {
-                      // Skip the debounce on reset — the filter drops immediately.
-                      setDetailSearch('');
-                      setDebouncedDetail('');
-                      setPage(0);
-                    }}
-                  >
-                    <X size={16} />
-                  </IconButton>
-                </InputAdornment>
-              ) : undefined,
-            },
+          onValueChange={setDetailSearch}
+          onClear={() => {
+            // Skip the debounce on reset — the filter drops immediately.
+            setDetailSearch('');
+            setDebouncedDetail('');
+            setPage(0);
           }}
+          clearLabel="Clear the details search"
+          hideSearchIcon
+          maxLength={256}
+          placeholder="e.g. a storage key or workflow state"
+          sx={{ minWidth: 240, flexGrow: 1, maxWidth: 360 }}
         />
         <TextField
           type="datetime-local"

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -24,8 +24,6 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
@@ -34,10 +32,11 @@ import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
-import { LayoutGrid, Plus, Rows3, Search, X } from 'lucide-react';
+import { LayoutGrid, Plus, Rows3 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { DocumentSummary } from '../../api/generated';
 import { useReviews } from '../../api/hooks/useReviews';
+import { ClearableSearchField } from '../../components/ClearableSearchField';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { isOpenWorkflowState } from '../../components/reviews/workflowMeta';
 import { roleOf } from '../../components/reviews/list/reviewListModel';
@@ -240,33 +239,11 @@ export function ReviewsPage() {
             spacing={2}
             sx={{ alignItems: { md: 'center' } }}
           >
-            <TextField
-              size="small"
+            <ClearableSearchField
               placeholder="Search reviews…"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onValueChange={setSearch}
               sx={{ width: { xs: '100%', md: 280 } }}
-              slotProps={{
-                input: {
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <Search size={16} />
-                    </InputAdornment>
-                  ),
-                  endAdornment: search ? (
-                    <InputAdornment position="end">
-                      <IconButton
-                        aria-label="Clear search"
-                        size="small"
-                        edge="end"
-                        onClick={() => setSearch('')}
-                      >
-                        <X size={16} />
-                      </IconButton>
-                    </InputAdornment>
-                  ) : undefined,
-                },
-              }}
             />
             <Box sx={{ flex: 1 }} />
             <TextField


### PR DESCRIPTION
Closes #559. Completes the consolidation started in #546.

The audit details search (#536) and the reviews list search (#539) landed on parallel branches with hand-rolled clear buttons while #546 extracted the shared `ClearableSearchField`. Both now use the component (net −38 lines):

- **Audit trail** ('Search details'): `onClear` override (clearing skips the debounce and resets paging immediately), `hideSearchIcon` (the field carries a label instead), `maxLength={256}`, unchanged `clearLabel`
- **Reviews list**: plain drop-in

Behavior and aria-labels are unchanged — the existing page tests pass without modification. All six search/filter fields in the app now share one implementation.

## Test plan
- [x] Full gate green: 981 tests / 142 files, typecheck, eslint, prettier

🤖 Co-Author: Claude (Fable 5) via Claude Code