### PR TITLE
feat(review): offer manual re-attach on MOVED placements

### DIFF
--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -196,6 +196,23 @@ describe('FocusAnnotationCard', () => {
   });
 
   // Issue #412: the shared copy-link affordance rides the card header.
+  // Issue #479: the focus card is the third gate — a MOVED placement offers
+  // both accepting the guessed spot and re-attaching it manually.
+  it('offers both placement actions on a MOVED placement and arms re-attach (#479)', () => {
+    const onArmReattach = vi.fn();
+    renderCard({
+      annotation: { ...ANNOTATION, placementStatus: PlacementStatus.Moved },
+      versionNumber: 3,
+      onArmReattach,
+    });
+
+    expect(screen.getByRole('button', { name: 'Looks right' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
+    expect(onArmReattach).toHaveBeenCalledWith(
+      expect.objectContaining({ id: ANNOTATION.id, placementStatus: PlacementStatus.Moved }),
+    );
+  });
+
   it('offers a copy-link affordance in the header when a permalink builder is wired', () => {
     renderCard({ buildPermalink: (id) => `https://qnop.example/reviews/d?annotation=${id}` });
     expect(screen.getByRole('button', { name: 'Copy link to annotation' })).toBeInTheDocument();

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -354,7 +354,9 @@ export function FocusAnnotationCard({
                         !readOnly &&
                         !reviewClosed &&
                         (annotation.placementStatus === 'ORPHANED' ||
-                          annotation.placementStatus === 'FAILED') &&
+                          annotation.placementStatus === 'FAILED' ||
+                          // A second-guessed MOVED may be corrected manually (#479).
+                          annotation.placementStatus === 'MOVED') &&
                         (userId === ownerId || userId === annotation.authorId)
                           ? () => onArmReattach(annotation)
                           : undefined

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.test.tsx
@@ -78,13 +78,29 @@ describe('AnnotationBadgeRow placement affordances', () => {
     expect(screen.getByRole('button', { name: 'Re-attach' })).toBeInTheDocument();
   });
 
-  it('keeps Re-attach away from settled placements and Looks right on MOVED only', () => {
+  it('keeps both placement actions away from a settled (PLACED) placement', () => {
     renderRow(annotation({ placementStatus: PlacementStatus.Placed }), {
       onReattachPlacement: vi.fn(),
       onConfirmPlacement: vi.fn(),
     });
     expect(screen.queryByRole('button', { name: 'Re-attach' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Looks right' })).not.toBeInTheDocument();
+  });
+
+  // Issue #479: a MOVED placement offers accepting the guessed spot AND fixing
+  // it manually — the same re-attach the lost placements already have.
+  it('offers both Looks right and Re-attach for a MOVED placement (#479)', () => {
+    const onConfirmPlacement = vi.fn();
+    const onReattachPlacement = vi.fn();
+    renderRow(annotation({ placementStatus: PlacementStatus.Moved }), {
+      onConfirmPlacement,
+      onReattachPlacement,
+    });
+
+    expect(screen.getByRole('button', { name: 'Looks right' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
+    expect(onReattachPlacement).toHaveBeenCalled();
+    expect(onConfirmPlacement).not.toHaveBeenCalled();
   });
 
   it('hides Re-attach without a handler — read-only viewers see only the chip', () => {

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
@@ -101,36 +101,46 @@ export function AnnotationBadgeRow({
       )}
       <PlacementStatusChip status={annotation.placementStatus} />
       {onConfirmPlacement && annotation.placementStatus === PlacementStatus.Moved && (
-        <Button
-          size="small"
-          variant="text"
-          startIcon={<Check size={12} />}
-          onClick={(event) => {
-            // Sits inside clickable cards — confirming must not toggle them.
-            event.stopPropagation();
-            onConfirmPlacement();
-          }}
-          sx={{ py: 0, minHeight: 0, fontSize: 12 }}
+        <Tooltip
+          // describeChild: the title is a description — the visible text stays the accessible name.
+          title="Accept the relocated highlight"
+          describeChild
         >
-          Looks right
-        </Button>
-      )}
-      {onReattachPlacement &&
-        (annotation.placementStatus === PlacementStatus.Orphaned ||
-          annotation.placementStatus === PlacementStatus.Failed) && (
           <Button
             size="small"
             variant="text"
-            startIcon={<Crosshair size={12} />}
+            startIcon={<Check size={12} />}
             onClick={(event) => {
-              // Sits inside clickable cards — arming must not toggle them.
+              // Sits inside clickable cards — confirming must not toggle them.
               event.stopPropagation();
-              onReattachPlacement();
+              onConfirmPlacement();
             }}
             sx={{ py: 0, minHeight: 0, fontSize: 12 }}
           >
-            Re-attach
+            Looks right
           </Button>
+        </Tooltip>
+      )}
+      {onReattachPlacement &&
+        // MOVED offers the manual correction alongside "Looks right" (#479).
+        (annotation.placementStatus === PlacementStatus.Orphaned ||
+          annotation.placementStatus === PlacementStatus.Failed ||
+          annotation.placementStatus === PlacementStatus.Moved) && (
+          <Tooltip title="Pick the correct passage yourself" describeChild>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<Crosshair size={12} />}
+              onClick={(event) => {
+                // Sits inside clickable cards — arming must not toggle them.
+                event.stopPropagation();
+                onReattachPlacement();
+              }}
+              sx={{ py: 0, minHeight: 0, fontSize: 12 }}
+            >
+              Re-attach
+            </Button>
+          </Tooltip>
         )}
       <Stack
         direction="row"

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -238,6 +238,25 @@ describe('AnnotationPanel', () => {
     expect(props.onSelect).not.toHaveBeenCalled();
   });
 
+  // Issue #479: MOVED offers Re-attach alongside Looks right; #480's
+  // no-collapse guarantee must hold for it too.
+  it('arms re-attach on a MOVED placement without collapsing the row (#479)', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const onArmReattach = vi.fn();
+    const props = renderPanel({
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Moved })],
+      activeAnnotationId: 'a1',
+      versionNumber: 3,
+      onArmReattach,
+    });
+
+    expect(screen.getByRole('button', { name: 'Looks right' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
+
+    expect(onArmReattach).toHaveBeenCalledWith(expect.objectContaining({ id: 'a1' }));
+    expect(props.onSelect).not.toHaveBeenCalled();
+  });
+
   it('keeps the row expanded when "Re-attach" arms re-attach mode (#480)', () => {
     useAuthStore.setState({ userId: 'u1' });
     const onArmReattach = vi.fn();

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -233,7 +233,9 @@ export function AnnotationPanel({
             !readOnly &&
             !reviewClosed &&
             (annotation.placementStatus === 'ORPHANED' ||
-              annotation.placementStatus === 'FAILED') &&
+              annotation.placementStatus === 'FAILED' ||
+              // A second-guessed MOVED may be corrected manually (#479).
+              annotation.placementStatus === 'MOVED') &&
             (userId === ownerId || userId === annotation.authorId)
               ? () => onArmReattach(annotation)
               : undefined


### PR DESCRIPTION
Closes #479.

A MOVED placement (re-anchoring succeeded but the highlight shifted) only offered **'Looks right'**. Reviewers can now also correct a bad guess manually: **'Re-attach'** appears alongside, running the existing status-agnostic arm-and-pick flow.

## Changes

- **Three frontend status gates opened** (the backend has always permitted re-attach from MOVED — verified against `AnnotationService` and the OpenAPI contract): the badge-row button render, the panel wiring, and the **focus-card wiring the issue had not spotted** (without it, re-attach would never appear in focus mode). An exhaustive search confirmed no fourth gate.
- **Tooltips** on both actions (`describeChild`, so the visible text stays the accessible name): *Accept the relocated highlight* vs. *Pick the correct passage yourself*.
- Semantics unchanged elsewhere: ORPHANED/FAILED keep re-attach, PLACED/PENDING offer neither, confirm stays MOVED-only. The #480 no-collapse guard is status-agnostic and covers the new button automatically.

## Test plan
- [x] TDD: three new tests RED before the gates opened, GREEN after — MOVED shows both actions in badge row, panel and focus card (the focus card's first placement-action coverage)
- [x] #480 no-collapse regression pinned for MOVED re-attach (arming keeps the row expanded)
- [x] Accessible names asserted as 'Looks right'/'Re-attach' (the tooltip's aria-label pitfall was caught by existing tests and fixed via `describeChild`)
- [x] Full gate green: 984 tests / 142 files, eslint, prettier, typecheck

Known, out of scope: re-attaching under the 'attention' filter flips MOVED → PLACED and can drop the card from the filtered list — same class as #548.

🤖 Co-Author: Claude (Fable 5) via Claude Code