### PR TITLE
feat(review): admin-controlled free re-attach of healthy placements

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -3301,10 +3301,15 @@ paths:
         document owner or the annotation's author picks a new passage on the
         LATEST version and the placement takes that anchor, flipping to
         PLACED — the discussion thread stays untouched. Allowed from ORPHANED,
-        FAILED and MOVED (a manual correction of a bad guess); a PLACED
-        placement answers 409 (`PLACEMENT_NOT_REATTACHABLE`) so nothing is
-        overwritten by accident. Older versions are a read-only record
-        (`VERSION_READ_ONLY`), closed reviews refuse (`REVIEW_CLOSED`).
+        FAILED and MOVED (a manual correction of a bad guess). A healthy
+        PLACED placement may additionally be re-positioned by an admin at any
+        time, and by the annotation's author when the operator enabled
+        `review.free_reattach_enabled` (issue #562) — for everyone else (and
+        with the setting off) PLACED answers 409
+        (`PLACEMENT_NOT_REATTACHABLE`) so nothing is overwritten by accident.
+        PENDING always refuses (re-anchoring is in flight). Older versions are
+        a read-only record (`VERSION_READ_ONLY`), closed reviews refuse
+        (`REVIEW_CLOSED`).
       operationId: reattachPlacement
       security:
         - bearerAuth: []
@@ -3882,6 +3887,20 @@ components:
       required:
         - oidcProviders
         - selfRegistrationEnabled
+    ServerConfigReview:
+      type: object
+      description: Public review-related configuration.
+      properties:
+        freeReattachEnabled:
+          type: boolean
+          description: |
+            Whether the operator lets annotation authors re-position their own
+            annotations even when the placement is healthy (issue #562). Admins
+            may always re-position regardless of this flag. The backend
+            enforces the gate independently; flipping this client-side cannot
+            bypass the service check.
+      required:
+        - freeReattachEnabled
     ServerConfigUpload:
       type: object
       description: Upload-related public configuration.
@@ -3911,6 +3930,8 @@ components:
           $ref: '#/components/schemas/ServerConfigGeneral'
         auth:
           $ref: '#/components/schemas/ServerConfigAuth'
+        review:
+          $ref: '#/components/schemas/ServerConfigReview'
         upload:
           $ref: '#/components/schemas/ServerConfigUpload'
         supportedFormats:
@@ -4659,7 +4680,8 @@ components:
           description: >-
             The audit event type, e.g. annotation.created, annotation.resolved,
             annotation.reopened, placement.confirmed, placement.reattached,
-            workflow.transition, document.due_date.changed, or the SYSTEM-scoped
+            placement.repositioned, workflow.transition,
+            document.due_date.changed, or the SYSTEM-scoped
             scheduler.job.enabled / scheduler.job.dry_run / scheduler.job.run_now.
         documentId:
           type: string

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -29,6 +29,7 @@ import io.qnop.api.v1.model.ServerConfigBranding;
 import io.qnop.api.v1.model.ServerConfigBrandingSlot;
 import io.qnop.api.v1.model.ServerConfigGeneral;
 import io.qnop.api.v1.model.ServerConfigResponse;
+import io.qnop.api.v1.model.ServerConfigReview;
 import io.qnop.api.v1.model.ServerConfigUpload;
 import io.qnop.api.v1.model.SupportedFormat;
 import io.qnop.service.ApplicationSettingKey;
@@ -97,6 +98,10 @@ public class ConfigController implements ServerConfigApi {
                     .oidcProviders(enabledOidcProviders())
                     .selfRegistrationEnabled(
                         settings.getBoolean(ApplicationSettingKey.AUTH_SELF_REGISTRATION_ENABLED)))
+            .review(
+                new ServerConfigReview()
+                    .freeReattachEnabled(
+                        settings.getBoolean(ApplicationSettingKey.REVIEW_FREE_REATTACH_ENABLED)))
             .upload(new ServerConfigUpload().maxDocumentSizeMb(DEFAULT_MAX_DOCUMENT_SIZE_MB))
             // Report only the formats whose extractor actually ships, so a client never offers an
             // upload the ingest pipeline would reject with 415 (magic-byte sniffing, issue #345).

--- a/qnop-app/src/test/java/io/qnop/review/PlacementReattachApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/PlacementReattachApiIT.java
@@ -20,6 +20,7 @@
  */
 package io.qnop.review;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -32,11 +33,16 @@ import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ReviewParticipant;
 import io.qnop.entity.WorkflowState;
 import io.qnop.repository.AnnotationPlacementRepository;
+import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
 import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +68,13 @@ class PlacementReattachApiIT extends SeededIntegrationTest {
   @Autowired private DocumentVersionRepository versions;
   @Autowired private ReviewParticipantRepository participants;
   @Autowired private AnnotationPlacementRepository placements;
+  @Autowired private ApplicationSettingsService settings;
+  @Autowired private AuditEventRepository auditEvents;
+
+  @AfterEach
+  void resetFreeReattach() {
+    setFreeReattach(false);
+  }
 
   private UUID documentId;
   private UUID versionId;
@@ -120,6 +133,29 @@ class PlacementReattachApiIT extends SeededIntegrationTest {
         .content(NEW_ANCHOR_BODY);
   }
 
+  /** Creates an anchored annotation as AUDITOR; its v1 placement is PLACED immediately. */
+  private String placedAnnotation() throws Exception {
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), AUDITOR_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        "{\"versionNumber\":1,\"anchor\":" + ANCHOR + ",\"comment\":\"check\"}"))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return JsonPath.read(json, "$.id");
+  }
+
+  private void setFreeReattach(boolean enabled) {
+    settings.update(
+        Map.of(
+            ApplicationSettingKey.REVIEW_FREE_REATTACH_ENABLED.getKey(), String.valueOf(enabled)),
+        null);
+  }
+
   @Test
   @DisplayName("the author re-attaches an orphan: new anchor, PLACED, thread untouched")
   void authorReattaches() throws Exception {
@@ -170,6 +206,92 @@ class PlacementReattachApiIT extends SeededIntegrationTest {
         .perform(reattach(annotationId, 1, AUDITOR_ID))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value("VERSION_READ_ONLY"));
+  }
+
+  // Free re-attach (issue #562): the operator switch opens PLACED for the
+  // author; admins bypass the switch; owners never get the PLACED path.
+
+  @Test
+  @DisplayName("setting on: the author re-positions a healthy placement; it is audited distinctly")
+  void freeReattachAuthorRepositions() throws Exception {
+    seedDocument();
+    String annotationId = placedAnnotation();
+    setFreeReattach(true);
+
+    mockMvc
+        .perform(reattach(annotationId, 1, AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.placementStatus").value("PLACED"))
+        .andExpect(jsonPath("$.anchor.textQuote.quote").value("the relocated clause"));
+
+    assertThat(auditEvents.findAll())
+        .anyMatch(event -> "placement.repositioned".equals(event.getEventType()));
+  }
+
+  @Test
+  @DisplayName("setting on: a non-author owner still gets 409 on a healthy placement")
+  void freeReattachOwnerStillRefused() throws Exception {
+    seedDocument();
+    String annotationId = placedAnnotation();
+    setFreeReattach(true);
+
+    mockMvc
+        .perform(reattach(annotationId, 1, MEMBER_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("PLACEMENT_NOT_REATTACHABLE"));
+  }
+
+  @Test
+  @DisplayName("an admin re-positions a healthy placement even with the setting off")
+  void adminBypassesTheSetting() throws Exception {
+    seedDocument();
+    String annotationId = placedAnnotation();
+
+    mockMvc
+        .perform(reattach(annotationId, 1, ADMIN_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.placementStatus").value("PLACED"))
+        .andExpect(jsonPath("$.anchor.textQuote.quote").value("the relocated clause"));
+
+    assertThat(auditEvents.findAll())
+        .anyMatch(event -> "placement.repositioned".equals(event.getEventType()));
+  }
+
+  @Test
+  @DisplayName("setting off: the author is refused on a healthy placement (regression)")
+  void settingOffKeepsPlacedRefusing() throws Exception {
+    seedDocument();
+    String annotationId = placedAnnotation();
+
+    mockMvc
+        .perform(reattach(annotationId, 1, AUDITOR_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("PLACEMENT_NOT_REATTACHABLE"));
+  }
+
+  @Test
+  @DisplayName("PENDING refuses for everyone, even admins with the setting on")
+  void pendingAlwaysRefuses() throws Exception {
+    seedDocument();
+    String annotationId = placedAnnotation();
+    setFreeReattach(true);
+    // PENDING has no mark method (it is the constructor state) — replace the
+    // placement with a freshly pending one, as the re-anchoring job would.
+    AnnotationPlacement placement =
+        placements
+            .findByAnnotationIdAndDocumentVersionId(UUID.fromString(annotationId), versionId)
+            .orElseThrow();
+    placements.delete(placement);
+    placements.save(new AnnotationPlacement(UUID.fromString(annotationId), versionId, ANCHOR));
+
+    mockMvc
+        .perform(reattach(annotationId, 1, ADMIN_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("PLACEMENT_NOT_REATTACHABLE"));
+    mockMvc
+        .perform(reattach(annotationId, 1, AUDITOR_ID))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("PLACEMENT_NOT_REATTACHABLE"));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
@@ -75,7 +75,7 @@ class AdminSettingsControllerIT extends AbstractIntegrationTest {
         .perform(get("/api/v1/admin/settings"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.settings").isArray())
-        .andExpect(jsonPath("$.settings.length()").value(21));
+        .andExpect(jsonPath("$.settings.length()").value(22));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
@@ -115,6 +115,17 @@ class ConfigControllerTest {
   }
 
   @Test
+  @DisplayName("review.freeReattachEnabled reflects the application setting (#562)")
+  void getConfig_reflectsFreeReattachSetting() throws Exception {
+    when(settings.getBoolean(ApplicationSettingKey.REVIEW_FREE_REATTACH_ENABLED)).thenReturn(true);
+
+    mockMvc
+        .perform(get("/api/v1/config"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.review.freeReattachEnabled").value(true));
+  }
+
+  @Test
   @DisplayName("enabled providers expose icon kind and account-switch affordances")
   void getConfig_mapsOidcLoginInfoFields() throws Exception {
     String googleLogin = "/oauth2/authorization/11111111-1111-1111-1111-111111111111";

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
@@ -130,7 +130,12 @@ public enum ApplicationSettingKey {
       "notifications.review_emails_enabled",
       SettingValueType.BOOLEAN,
       "true",
-      "Send email notifications for review activity (reviewer added, annotations, replies, status changes).");
+      "Send email notifications for review activity (reviewer added, annotations, replies, status changes)."),
+  REVIEW_FREE_REATTACH_ENABLED(
+      "review.free_reattach_enabled",
+      SettingValueType.BOOLEAN,
+      "false",
+      "Let authors re-position their own annotations even when the placement is healthy (admins always may).");
 
   private static final Map<String, ApplicationSettingKey> BY_KEY =
       Arrays.stream(values())

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationService.java
@@ -40,6 +40,8 @@ import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.CommentRepository;
 import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.document.DocumentValidationException;
 import java.time.Instant;
@@ -66,6 +68,7 @@ public class AnnotationService {
   static final String AUDIT_ANNOTATION_CLASSIFIED = "annotation.classified";
   static final String AUDIT_PLACEMENT_CONFIRMED = "placement.confirmed";
   static final String AUDIT_PLACEMENT_REATTACHED = "placement.reattached";
+  static final String AUDIT_PLACEMENT_REPOSITIONED = "placement.repositioned";
 
   /** Comments can be 20k chars; the view carries only what a card title needs (issue #393). */
   static final int FIRST_COMMENT_EXCERPT_CHARS = 300;
@@ -79,6 +82,7 @@ public class AnnotationService {
   private final ReviewWorkflowService workflow;
   private final ReviewIdentityResolver identity;
   private final ApplicationEventPublisher events;
+  private final ApplicationSettingsService settings;
   private final ReactionService reactions_;
 
   public AnnotationService(
@@ -91,7 +95,8 @@ public class AnnotationService {
       ReviewWorkflowService workflow,
       ReviewIdentityResolver identity,
       ReactionService reactions,
-      ApplicationEventPublisher events) {
+      ApplicationEventPublisher events,
+      ApplicationSettingsService settings) {
     this.annotations = annotations;
     this.placements = placements;
     this.comments = comments;
@@ -102,6 +107,7 @@ public class AnnotationService {
     this.identity = identity;
     this.reactions_ = reactions;
     this.events = events;
+    this.settings = settings;
   }
 
   /**
@@ -448,10 +454,13 @@ public class AnnotationService {
   }
 
   /**
-   * Re-attaches a lost placement by hand (ADR-0009, issue #457): the owner or the annotation's
-   * author picked a new passage on the LATEST version, so the placement takes that anchor and flips
-   * to PLACED — the thread stays untouched. Allowed from ORPHANED, FAILED and MOVED (a manual
-   * correction); PLACED refuses, so nothing is overwritten by accident.
+   * Re-attaches a placement by hand (ADR-0009, issue #457): the actor picked a new passage on the
+   * LATEST version, so the placement takes that anchor and flips to PLACED — the thread stays
+   * untouched. Allowed from ORPHANED, FAILED and MOVED (a manual correction). A healthy PLACED
+   * placement may additionally be re-positioned by an admin at any time, and by the annotation's
+   * author when the operator enabled {@code review.free_reattach_enabled} (issue #562) — audited as
+   * {@code placement.repositioned} to keep it distinguishable from a rescue. PENDING always refuses
+   * (re-anchoring is in flight); see {@link PlacementReattachPolicy}.
    */
   @Transactional
   public AnnotationView reattachPlacement(
@@ -496,17 +505,25 @@ public class AnnotationService {
                 () ->
                     DocumentValidationException.notFound(
                         "no placement on version " + versionNumber));
-    if (placement.getStatus() == PlacementStatus.PLACED
-        || placement.getStatus() == PlacementStatus.PENDING) {
+    PlacementStatus before = placement.getStatus();
+    if (!PlacementReattachPolicy.reattachEligible(
+        before,
+        annotation.getAuthorId().equals(actor),
+        admin,
+        settings.getBoolean(ApplicationSettingKey.REVIEW_FREE_REATTACH_ENABLED))) {
       throw new WorkflowTransitionException(
           WorkflowTransitionException.PLACEMENT_NOT_REATTACHABLE,
-          "placement is " + placement.getStatus() + "; re-attach rescues lost placements");
+          "placement is " + before + "; re-attach is not available here");
     }
     placement.markPlaced(anchorJson);
     auditEvents.save(
         new AuditEvent(
             annotation.getDocumentId(),
-            AUDIT_PLACEMENT_REATTACHED,
+            // A free re-position of a healthy placement reads differently in the
+            // trail than the rescue of a lost one (#562).
+            before == PlacementStatus.PLACED
+                ? AUDIT_PLACEMENT_REPOSITIONED
+                : AUDIT_PLACEMENT_REATTACHED,
             actor,
             "{\"annotationId\":\"%s\",\"versionNumber\":%d}"
                 .formatted(annotationId, versionNumber)));

--- a/qnop-core/src/main/java/io/qnop/service/review/PlacementReattachPolicy.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/PlacementReattachPolicy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.PlacementStatus;
+
+/**
+ * Decides whether a placement may be re-attached (ADR-0009, issues #457/#479/#562), given the
+ * actor's relation to the annotation and the operator's free-re-attach switch. Pure and DB-free so
+ * the full setting × status × actor matrix is unit-testable.
+ *
+ * <p>Rules: {@code PENDING} never (re-anchoring is in flight). The lost placements ({@code
+ * ORPHANED}/{@code FAILED}/{@code MOVED}) are always rescuable — by whoever passed the caller's
+ * outer authorization (owner, author or admin). A healthy {@code PLACED} placement may be
+ * re-positioned by an <em>admin</em> at any time, and by the annotation's <em>author</em> when the
+ * operator enabled {@code review.free_reattach_enabled} (#562); everyone else is refused so nothing
+ * is overwritten by accident.
+ */
+final class PlacementReattachPolicy {
+
+  private PlacementReattachPolicy() {}
+
+  static boolean reattachEligible(
+      PlacementStatus status, boolean actorIsAuthor, boolean actorIsAdmin, boolean freeReattach) {
+    return switch (status) {
+      case PENDING -> false;
+      case PLACED -> actorIsAdmin || (freeReattach && actorIsAuthor);
+      case ORPHANED, FAILED, MOVED -> true;
+    };
+  }
+}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -62,6 +62,9 @@ databaseChangeLog:
   - include:
       file: migrations/0017-scheduler-job-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0018-free-reattach-setting.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/migrations/0018-free-reattach-setting.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0018-free-reattach-setting.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2026-present devtank42 GmbH
+#
+# This file is part of qnop (Qualified Notes on Papers).
+#
+# qnop is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with qnop. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Seed row for the free-re-attach switch (issue #562). Additive changeset —
+# 1.0.0 installations have applied the original settings seed, so new keys land
+# in their own changeset from now on. The registry (ApplicationSettingKey)
+# stays authoritative per ADR-0025; this row mirrors its default.
+databaseChangeLog:
+  - changeSet:
+      id: 0018-free-reattach-setting
+      author: qnop
+      comment: Adds the review.free_reattach_enabled application setting (issue #562), default off.
+      changes:
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "review.free_reattach_enabled" }
+              - column: { name: setting_value, value: "false" }
+              - column: { name: setting_desc, value: "Let authors re-position their own annotations even when the placement is healthy (admins always may)." }
+              - column: { name: value_type, value: "BOOLEAN" }

--- a/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
  */
 class ApplicationSettingKeyTest {
 
-  /** The keys seeded by db/changelog/migrations/0002-settings-schema.yaml (issue #13). */
+  /** The keys seeded by the settings changesets (0002 + additive follow-ups, issue #13). */
   private static final Set<String> SEEDED_KEYS =
       Set.of(
           "general.application_name",
@@ -61,7 +61,8 @@ class ApplicationSettingKeyTest {
           "auth.self_registration_default_role",
           "auth.password_reset_enabled",
           "auth.password_reset_token_ttl_minutes",
-          "notifications.review_emails_enabled");
+          "notifications.review_emails_enabled",
+          "review.free_reattach_enabled");
 
   @Test
   void registryMatchesSeededKeys() {

--- a/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnnotationServiceTest.java
@@ -68,6 +68,8 @@ class AnnotationServiceTest {
   private final ReviewWorkflowService workflow = mock(ReviewWorkflowService.class);
   private final ReviewIdentityResolver identity = mock(ReviewIdentityResolver.class);
   private final ReactionService reactions = mock(ReactionService.class);
+  private final io.qnop.service.ApplicationSettingsService settings =
+      mock(io.qnop.service.ApplicationSettingsService.class);
 
   private final AnnotationService service =
       new AnnotationService(
@@ -80,7 +82,8 @@ class AnnotationServiceTest {
           workflow,
           identity,
           reactions,
-          mock(org.springframework.context.ApplicationEventPublisher.class));
+          mock(org.springframework.context.ApplicationEventPublisher.class),
+          settings);
 
   private final UUID documentId = UUID.randomUUID();
   private final UUID author = UUID.randomUUID();

--- a/qnop-core/src/test/java/io/qnop/service/review/PlacementReattachPolicyTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/PlacementReattachPolicyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.qnop.entity.PlacementStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * The full setting × status × actor matrix for re-attach eligibility (issues #457/#479/#562):
+ * PENDING never; lost placements always (outer authorization already ran); PLACED for admins
+ * unconditionally and for authors only under the free-re-attach switch.
+ */
+class PlacementReattachPolicyTest {
+
+  @ParameterizedTest(name = "{0} author={1} admin={2} free={3} -> {4}")
+  @CsvSource({
+    // PENDING: never, for anyone, in any setting state.
+    "PENDING, true,  true,  true,  false",
+    "PENDING, true,  false, true,  false",
+    "PENDING, false, true,  false, false",
+    // PLACED: admin always; author only when the switch is on; owner never.
+    "PLACED,  false, true,  false, true",
+    "PLACED,  false, true,  true,  true",
+    "PLACED,  true,  false, true,  true",
+    "PLACED,  true,  false, false, false",
+    "PLACED,  false, false, true,  false",
+    "PLACED,  false, false, false, false",
+    // Lost placements: always eligible regardless of actor flags and setting.
+    "ORPHANED, false, false, false, true",
+    "FAILED,   false, false, false, true",
+    "MOVED,    false, false, false, true",
+    "ORPHANED, true,  true,  true,  true",
+  })
+  void matrix(PlacementStatus status, boolean author, boolean admin, boolean free, boolean want) {
+    assertEquals(want, PlacementReattachPolicy.reattachEligible(status, author, admin, free));
+  }
+}

--- a/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
+++ b/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
@@ -31,7 +31,14 @@ import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { BarChart3, Lock, SlidersHorizontal, Upload, type LucideIcon } from 'lucide-react';
+import {
+  BarChart3,
+  FileText,
+  Lock,
+  SlidersHorizontal,
+  Upload,
+  type LucideIcon,
+} from 'lucide-react';
 import type { AdminSetting } from '../../../api/generated';
 import { useSettings, useUpdateSettings } from '../../../api/hooks/useSettings';
 import { TimezonePicker } from '../../TimezonePicker';
@@ -42,13 +49,14 @@ import { apiErrorMessage, apiFieldErrors } from '../../../utils/apiError';
 import { isHttpUrl, isInteger, isIntegerInRange } from '../../../utils/validation';
 
 /** Group prefixes in display order; unknown groups are appended alphabetically. */
-const GROUP_ORDER = ['general', 'upload', 'tracking', 'auth'] as const;
+const GROUP_ORDER = ['general', 'upload', 'tracking', 'auth', 'review'] as const;
 
 const GROUP_LABELS: Record<string, string> = {
   general: 'General',
   upload: 'Uploads',
   tracking: 'Usage tracking',
   auth: 'Authentication',
+  review: 'Review',
 };
 
 /** Brand-tint section icon per group, matching the Email / SMTP page's language. */
@@ -57,6 +65,7 @@ const GROUP_ICONS: Record<string, LucideIcon> = {
   upload: Upload,
   tracking: BarChart3,
   auth: Lock,
+  review: FileText,
 };
 
 const GROUP_DESCRIPTIONS: Record<string, string> = {
@@ -64,6 +73,7 @@ const GROUP_DESCRIPTIONS: Record<string, string> = {
   upload: 'Constraints applied to document uploads.',
   tracking: 'Anonymous, privacy-friendly usage analytics.',
   auth: 'Self-registration and password-reset behaviour.',
+  review: 'Behaviour of the document review workflow.',
 };
 
 /**

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.test.tsx
@@ -196,6 +196,23 @@ describe('FocusAnnotationCard', () => {
   });
 
   // Issue #412: the shared copy-link affordance rides the card header.
+  // Issue #562: the focus card also gates the free re-position — author under
+  // the operator switch (admins covered by the same predicate).
+  it('offers Re-position on a PLACED placement to the author under the switch (#562)', () => {
+    const onArmReattach = vi.fn();
+    renderCard({
+      annotation: { ...ANNOTATION, placementStatus: PlacementStatus.Placed },
+      versionNumber: 3,
+      onArmReattach,
+      freeReattachEnabled: true,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-position' }));
+    expect(onArmReattach).toHaveBeenCalledWith(
+      expect.objectContaining({ id: ANNOTATION.id, placementStatus: PlacementStatus.Placed }),
+    );
+  });
+
   // Issue #479: the focus card is the third gate — a MOVED placement offers
   // both accepting the guessed spot and re-attaching it manually.
   it('offers both placement actions on a MOVED placement and arms re-attach (#479)', () => {

--- a/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
+++ b/qnop-ui/src/components/reviews/focus/FocusAnnotationCard.tsx
@@ -66,6 +66,10 @@ interface FocusAnnotationCardProps {
   versionNumber?: number | null;
   /** Arms re-attaching a lost placement (issue #457) — the page closes the card and waits for the selection. */
   onArmReattach?: (annotation: AnnotationView) => void;
+  /** Operator switch: authors may re-position their own healthy placements (issue #562). */
+  freeReattachEnabled?: boolean;
+  /** Admins may re-position healthy placements regardless of the switch (issue #562). */
+  viewerIsAdmin?: boolean;
   /** True once the review is FINALIZED/CANCELLED (issue #394): no reopening. */
   reviewClosed?: boolean;
   /** Thread participation policy (issue #413) — READ_ONLY suppresses foreign composers. */
@@ -109,6 +113,8 @@ export function FocusAnnotationCard({
   readOnly = false,
   versionNumber = null,
   onArmReattach,
+  freeReattachEnabled = false,
+  viewerIsAdmin = false,
   reviewClosed = false,
   threadParticipation = 'OPEN',
   ownerId,
@@ -353,11 +359,17 @@ export function FocusAnnotationCard({
                         versionNumber != null &&
                         !readOnly &&
                         !reviewClosed &&
-                        (annotation.placementStatus === 'ORPHANED' ||
+                        (((annotation.placementStatus === 'ORPHANED' ||
                           annotation.placementStatus === 'FAILED' ||
                           // A second-guessed MOVED may be corrected manually (#479).
                           annotation.placementStatus === 'MOVED') &&
-                        (userId === ownerId || userId === annotation.authorId)
+                          (userId === ownerId || userId === annotation.authorId)) ||
+                          // A healthy placement may be re-positioned by an admin
+                          // at any time, or by the author under the operator
+                          // switch (#562).
+                          (annotation.placementStatus === 'PLACED' &&
+                            (viewerIsAdmin ||
+                              (freeReattachEnabled && userId === annotation.authorId))))
                           ? () => onArmReattach(annotation)
                           : undefined
                       }

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.test.tsx
@@ -78,12 +78,33 @@ describe('AnnotationBadgeRow placement affordances', () => {
     expect(screen.getByRole('button', { name: 'Re-attach' })).toBeInTheDocument();
   });
 
-  it('keeps both placement actions away from a settled (PLACED) placement', () => {
+  // Issue #562: a healthy placement offers the free re-position under a
+  // distinct label — the caller decides who gets the handler.
+  it('offers Re-position on a PLACED placement when the caller wires the handler (#562)', () => {
+    const onReattachPlacement = vi.fn();
     renderRow(annotation({ placementStatus: PlacementStatus.Placed }), {
+      onReattachPlacement,
+      onConfirmPlacement: vi.fn(),
+    });
+
+    expect(screen.queryByRole('button', { name: 'Re-attach' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Looks right' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Re-position' }));
+    expect(onReattachPlacement).toHaveBeenCalled();
+  });
+
+  it('keeps every placement action away from PLACED without a handler and from PENDING', () => {
+    renderRow(annotation({ placementStatus: PlacementStatus.Placed }), {
+      onConfirmPlacement: vi.fn(),
+    });
+    expect(screen.queryByRole('button', { name: 'Re-position' })).not.toBeInTheDocument();
+
+    renderRow(annotation({ placementStatus: PlacementStatus.Pending }), {
       onReattachPlacement: vi.fn(),
       onConfirmPlacement: vi.fn(),
     });
     expect(screen.queryByRole('button', { name: 'Re-attach' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Re-position' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Looks right' })).not.toBeInTheDocument();
   });
 

--- a/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationBadgeRow.tsx
@@ -142,6 +142,26 @@ export function AnnotationBadgeRow({
             </Button>
           </Tooltip>
         )}
+      {onReattachPlacement && annotation.placementStatus === PlacementStatus.Placed && (
+        // Free re-position of a healthy placement (#562) — the caller decides
+        // who gets the handler (admins always, authors under the switch); the
+        // distinct label separates it from the lost-placement rescue.
+        <Tooltip title="Re-position this annotation" describeChild>
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<Crosshair size={12} />}
+            onClick={(event) => {
+              // Sits inside clickable cards — arming must not toggle them.
+              event.stopPropagation();
+              onReattachPlacement();
+            }}
+            sx={{ py: 0, minHeight: 0, fontSize: 12 }}
+          >
+            Re-position
+          </Button>
+        </Tooltip>
+      )}
       <Stack
         direction="row"
         spacing={1}

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -238,6 +238,45 @@ describe('AnnotationPanel', () => {
     expect(props.onSelect).not.toHaveBeenCalled();
   });
 
+  // Issue #562: a healthy placement offers Re-position to the author under the
+  // operator switch, and to admins regardless of it.
+  it('offers Re-position on PLACED to the author when free re-attach is enabled (#562)', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const onArmReattach = vi.fn();
+    renderPanel({
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Placed })],
+      activeAnnotationId: 'a1',
+      versionNumber: 3,
+      onArmReattach,
+      freeReattachEnabled: true,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-position' }));
+    expect(onArmReattach).toHaveBeenCalledWith(expect.objectContaining({ id: 'a1' }));
+  });
+
+  it('hides Re-position from the author while the switch is off, but admins always see it (#562)', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    renderPanel({
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Placed })],
+      activeAnnotationId: 'a1',
+      versionNumber: 3,
+      onArmReattach: vi.fn(),
+    });
+    expect(screen.queryByRole('button', { name: 'Re-position' })).toBeNull();
+
+    cleanup();
+    useAuthStore.setState({ userId: 'someone-else' });
+    renderPanel({
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Placed })],
+      activeAnnotationId: 'a1',
+      versionNumber: 3,
+      onArmReattach: vi.fn(),
+      viewerIsAdmin: true,
+    });
+    expect(screen.getByRole('button', { name: 'Re-position' })).toBeInTheDocument();
+  });
+
   // Issue #479: MOVED offers Re-attach alongside Looks right; #480's
   // no-collapse guarantee must hold for it too.
   it('arms re-attach on a MOVED placement without collapsing the row (#479)', () => {

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -88,6 +88,10 @@ interface AnnotationPanelProps {
    * viewer, so it turns the next selection into the new anchor.
    */
   onArmReattach?: (annotation: AnnotationView) => void;
+  /** Operator switch: authors may re-position their own healthy placements (issue #562). */
+  freeReattachEnabled?: boolean;
+  /** Admins may re-position healthy placements regardless of the switch (issue #562). */
+  viewerIsAdmin?: boolean;
   /** True once the review is FINALIZED/CANCELLED (issue #394): no reopening. */
   reviewClosed?: boolean;
   /** Drops the section's outer card frame — the focus drawer brings its own edge. */
@@ -136,6 +140,8 @@ export function AnnotationPanel({
   readOnly = false,
   versionNumber = null,
   onArmReattach,
+  freeReattachEnabled = false,
+  viewerIsAdmin = false,
   reviewClosed = false,
   frameless = false,
   previousSeenAt = null,
@@ -232,11 +238,15 @@ export function AnnotationPanel({
             versionNumber != null &&
             !readOnly &&
             !reviewClosed &&
-            (annotation.placementStatus === 'ORPHANED' ||
+            (((annotation.placementStatus === 'ORPHANED' ||
               annotation.placementStatus === 'FAILED' ||
               // A second-guessed MOVED may be corrected manually (#479).
               annotation.placementStatus === 'MOVED') &&
-            (userId === ownerId || userId === annotation.authorId)
+              (userId === ownerId || userId === annotation.authorId)) ||
+              // A healthy placement may be re-positioned by an admin at any
+              // time, or by the author under the operator switch (#562).
+              (annotation.placementStatus === 'PLACED' &&
+                (viewerIsAdmin || (freeReattachEnabled && userId === annotation.authorId))))
               ? () => onArmReattach(annotation)
               : undefined
           }

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -74,6 +74,7 @@ import {
 } from '../../components/reviews/focus/spotlightModel';
 import { useAnchorElement } from '../../components/reviews/focus/useAnchorElement';
 import { useRecordVisit } from '../../api/hooks/useReviews';
+import { useConfig } from '../../api/hooks/useConfig';
 import { useViewMode, type ReviewViewMode } from '../../components/reviews/focus/useViewMode';
 import { columnOf } from '../../components/reviews/tasks/tasksModel';
 import { NewTaskDialog } from '../../components/reviews/tasks/NewTaskDialog';
@@ -94,7 +95,7 @@ import { ViewerToolbar } from '../../components/reviews/viewer/ViewerToolbar';
 import { ReattachHintBar } from '../../components/reviews/viewer/ReattachHintBar';
 import { isOpenWorkflowState } from '../../components/reviews/workflowMeta';
 import { recordRecentReview } from '../../components/dashboard/recentReviews';
-import { useAuthStore } from '../../stores/authStore';
+import { selectIsAdmin, useAuthStore } from '../../stores/authStore';
 import { apiErrorCode } from '../../utils/apiError';
 import { revealInScroller } from '../../utils/revealInScroller';
 import { pdfFetchVersion, resolveEffectiveVersion } from './resolveEffectiveVersion';
@@ -119,6 +120,10 @@ export function DocumentReviewPage() {
   const { toast, notify, clear } = useToast();
   const uploadAttachment = useCommentAttachmentUpload(documentId, notify);
   const userId = useAuthStore((s) => s.userId);
+  const viewerIsAdmin = useAuthStore(selectIsAdmin);
+  // The operator's free-re-attach switch (#562); the server enforces it
+  // independently, this only gates the affordance.
+  const freeReattachEnabled = useConfig().data?.review?.freeReattachEnabled ?? false;
 
   const documentQuery = useDocument(documentId);
   const latestVersion = documentQuery.data?.latestVersionNumber ?? 0;
@@ -691,6 +696,8 @@ export function DocumentReviewPage() {
                   readOnly={!isLatestVersion}
                   versionNumber={versionNumber}
                   onArmReattach={armReattach}
+                  freeReattachEnabled={freeReattachEnabled}
+                  viewerIsAdmin={viewerIsAdmin}
                   reviewClosed={!isOpenWorkflowState(document.workflowState)}
                   previousSeenAt={previousSeenAt}
                   buildPermalink={buildPermalink}
@@ -730,6 +737,8 @@ export function DocumentReviewPage() {
               readOnly={!isLatestVersion}
               versionNumber={versionNumber}
               onArmReattach={armReattach}
+              freeReattachEnabled={freeReattachEnabled}
+              viewerIsAdmin={viewerIsAdmin}
               reviewClosed={!isOpenWorkflowState(document.workflowState)}
               previousSeenAt={previousSeenAt}
               buildPermalink={buildPermalink}
@@ -752,6 +761,8 @@ export function DocumentReviewPage() {
           readOnly={!isLatestVersion}
           versionNumber={versionNumber}
           onArmReattach={armReattach}
+          freeReattachEnabled={freeReattachEnabled}
+          viewerIsAdmin={viewerIsAdmin}
           reviewClosed={!isOpenWorkflowState(document.workflowState)}
           threadParticipation={document.threadParticipation ?? 'OPEN'}
           ownerId={document.ownerId}

--- a/qnop-ui/src/utils/auditDetail.test.ts
+++ b/qnop-ui/src/utils/auditDetail.test.ts
@@ -40,6 +40,9 @@ describe('formatAuditDetail', () => {
     expect(
       formatAuditDetail('placement.reattached', '{"annotationId":"a1b2c3","versionNumber":2}'),
     ).toBe('On version 2');
+    expect(
+      formatAuditDetail('placement.repositioned', '{"annotationId":"a1b2c3","versionNumber":2}'),
+    ).toBe('On version 2');
   });
 
   it('renders a classification from its type and priority', () => {

--- a/qnop-ui/src/utils/auditDetail.ts
+++ b/qnop-ui/src/utils/auditDetail.ts
@@ -94,6 +94,7 @@ export function formatAuditDetail(
     }
     case 'placement.confirmed':
     case 'placement.reattached':
+    case 'placement.repositioned':
       return obj.versionNumber !== null && obj.versionNumber !== undefined
         ? `On version ${formatValue(obj.versionNumber)}`
         : EM_DASH;

--- a/qnop-ui/src/utils/auditEvents.test.ts
+++ b/qnop-ui/src/utils/auditEvents.test.ts
@@ -43,6 +43,7 @@ describe('auditEventMeta', () => {
         'annotation.created',
         'annotation.classified',
         'placement.reattached',
+        'placement.repositioned',
         'workflow.transition',
         'document.due_date.changed',
         'extraction.succeeded',

--- a/qnop-ui/src/utils/auditEvents.ts
+++ b/qnop-ui/src/utils/auditEvents.ts
@@ -75,6 +75,12 @@ export const AUDIT_EVENT_META: Record<string, AuditEventMeta> = {
       'An annotation was re-anchored to a new spot — e.g. after a new version shifted the text.',
     tone: 'amber',
   },
+  'placement.repositioned': {
+    label: 'Placement re-positioned',
+    description:
+      'A healthy annotation was deliberately moved to a different passage (free re-attach, issue #562).',
+    tone: 'amber',
+  },
   'workflow.transition': {
     label: 'Status changed',
     description: 'The review moved to a new workflow status (e.g. Draft → In review).',


### PR DESCRIPTION
Closes #562.

Re-attach was remediation-only: the service guard rejected PLACED, so a healthy annotation could never be re-positioned. This PR makes re-attach generally available, gated as decided in the issue discussion:

## Authorization matrix (the one behavioral change is the PLACED row)

| Setting | Status | Author | Owner (non-author) | Admin |
|---|---|---|---|---|
| off | PLACED | 409 | 409 | **allowed (bypass)** |
| **on** | **PLACED** | **allowed** | 409 | allowed |
| both | PENDING | 409 | 409 | 409 |
| both | ORPHANED/FAILED/MOVED | allowed | allowed | allowed |

## Changes

- **DB-free decision**: `PlacementReattachPolicy` (setting × status × actor) with a parameterized 13-case matrix test — the 403/409 boundary stays exactly as before (strangers 403 before any status check; non-authors on PLACED get 409, no state leak).
- **Runtime setting** `review.free_reattach_enabled` (default off) on the ADR-0025 machinery: registry entry, **additive seed changeset 0018** (post-1.0.0 rule — applied changesets are never amended), mirror test updated, runtime-effective via the cached snapshot, editable in a new **Review** group of the admin settings page.
- **Config exposure**: `review.freeReattachEnabled` on `GET /api/v1/config` (`ServerConfigReview`, same pattern as `auth.selfRegistrationEnabled`) — the server enforces the gate independently.
- **Distinct audit event** `placement.repositioned` for the free case (service constant, OpenAPI vocabulary, UI audit registry + detail renderer) — the trail separates a deliberate move from the rescue of a lost placement.
- **UI**: the three re-attach gates (badge row, panel, focus card) offer the affordance on PLACED under a distinct **Re-position** label/tooltip; `DocumentReviewPage` plumbs the config flag and the viewer's admin role down.

## Test plan
- [x] Policy matrix unit test (13 cases)
- [x] Five new ITs over the wire against real PostgreSQL: author re-positions with setting on (+ `placement.repositioned` audited), owner still 409, admin bypasses with setting off, author 409 with setting off (regression), PENDING refuses for everyone
- [x] ConfigController test for the new flag; settings-count IT updated
- [x] Frontend: Re-position gating tests (author×switch, admin bypass) in badge row, panel and focus card; audit vocabulary/detail tests
- [x] Gates: frontend 988 tests / lint / prettier / typecheck green; backend full build green except the known local-only `ConfigurationControllerIT` environment issue (green in CI, red locally even on unmodified main)

🤖 Co-Author: Claude (Fable 5) via Claude Code