### PR TITLE
ci: Trivy security scanning + CycloneDX SBOM gate; drop OWASP (#496)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,29 +28,11 @@ jobs:
       # conformance tests via the `check` task.
       - run: ./gradlew build --stacktrace
 
-  backend-audit:
-    name: Backend dependency audit (OWASP)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
-        with:
-          distribution: temurin
-          java-version: '21'
-      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
-      # Per-PR backend CVE gate (#195): OWASP Dependency-Check fails on CVSS >= 7.
-      # It needs a (free) NVD API key to hit the NVD feed without heavy rate-limiting,
-      # so the step is a no-op until the NVD_API_KEY repository secret is set — then it
-      # becomes an active gate. NVD_API_KEY is read from the env (never the CLI).
-      - name: OWASP Dependency-Check (aggregate)
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: |
-          if [ -z "$NVD_API_KEY" ]; then
-            echo "::notice::NVD_API_KEY secret not set — skipping the OWASP backend audit. Request a free key at https://nvd.nist.gov/developers/request-an-api-key and add it as the NVD_API_KEY secret to enable the per-PR backend CVE gate."
-            exit 0
-          fi
-          ./gradlew dependencyCheckAggregate --stacktrace
+  # The backend CVE gate is now the Trivy SBOM scan in security.yml (issue #496):
+  # it scans a CycloneDX SBOM of qnop-app's runtime classpath with Trivy's own
+  # maintained vulnerability DB, so it needs no NVD API key and is always active —
+  # unlike the former OWASP Dependency-Check job here, which was a no-op until an
+  # NVD_API_KEY secret was set (issue #195, ADR-0007 amendment).
 
   license-scan:
     name: Backend dependency licenses (ADR-0007)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+name: Security
+
+# Security scanning (issue #496), split from ci.yml so it owns the
+# `security-events: write` permission the SARIF upload needs and can run on a
+# weekly schedule to catch newly-disclosed CVEs against unchanged code.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly (Mon 05:27 UTC): re-scan main so a CVE disclosed after the last
+    # push still surfaces, without waiting for the next change.
+    - cron: '27 5 * * 1'
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-fs:
+    name: Trivy filesystem scan (vuln + secret)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Upload SARIF to the code-scanning (Security) tab.
+      security-events: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      # A repository-wide vulnerability + secret sweep. Reporting only — findings
+      # land in the Security tab (exit-code 0); the active CVE gate is the SBOM
+      # scan below. Trivy's own maintained DB needs no NVD API key.
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret
+          format: sarif
+          output: trivy-fs.sarif
+          severity: MEDIUM,HIGH,CRITICAL
+          exit-code: '0'
+          hide-progress: 'true'
+      - name: Upload filesystem SARIF
+        # A fork PR carries a read-only token, so the upload would 403 — skip it
+        # there (the scan itself still ran); same-repo PRs and pushes upload.
+        if: >-
+          ${{ !cancelled()
+          && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  trivy-sbom:
+    name: Trivy SBOM scan (backend runtime deps)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+      # Trivy's filesystem scan cannot parse the Gradle Kotlin DSL to enumerate
+      # Java dependencies, so scan a CycloneDX SBOM of the *resolved* runtime
+      # classpath instead (issue #496). Test-only configurations are excluded in
+      # the build script, so a CVE in a test tool never gates a shipped artifact.
+      - name: Generate CycloneDX SBOM (qnop-app runtime classpath)
+        run: ./gradlew :qnop-app:cyclonedxBom --stacktrace
+      # Report HIGH + CRITICAL advisories to the job log (HIGH warns, does not
+      # fail) so a reviewer sees them inline.
+      - name: SBOM vulnerability report (HIGH + CRITICAL)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: sbom
+          scan-ref: qnop-app/build/reports/bom.json
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          hide-progress: 'true'
+      - name: SBOM SARIF
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: sbom
+          scan-ref: qnop-app/build/reports/bom.json
+          format: sarif
+          output: trivy-sbom.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '0'
+          hide-progress: 'true'
+      - name: Upload SBOM SARIF
+        if: >-
+          ${{ !cancelled()
+          && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        with:
+          sarif_file: trivy-sbom.sarif
+          category: trivy-sbom
+      # The gate: a CRITICAL advisory in a shipped runtime dependency fails the
+      # build. Replaces the OWASP Dependency-Check job, which was a no-op without
+      # an NVD API key (issue #195, ADR-0007 amendment).
+      - name: Fail on a CRITICAL advisory
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: sbom
+          scan-ref: qnop-app/build/reports/bom.json
+          format: table
+          severity: CRITICAL
+          exit-code: '1'
+          hide-progress: 'true'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,28 +19,18 @@ import com.github.jk1.license.render.JsonReportRenderer
 plugins {
     alias(libs.plugins.spring.boot) apply false
     alias(libs.plugins.openapi.generator) apply false
-    // OWASP Dependency-Check (issue #195): applied at the root so
-    // `dependencyCheckAggregate` scans every module against the NVD. It is NOT wired
-    // into `check`/`build`, so the local gate is unaffected; the CI `backend-audit`
-    // job invokes it only when an NVD API key secret is present (otherwise the NVD
-    // feed is heavily rate-limited).
-    alias(libs.plugins.dependency.check)
     // Dependency-license scanner (issue #498, ADR-0007): applied at the root so
     // `checkLicense` aggregates every module's shipped dependencies and fails on any
-    // license outside the permissive allowlist. Like the OWASP gate above it is NOT
-    // wired into `check`/`build`; the CI `license-scan` job invokes it explicitly.
+    // license outside the permissive allowlist. NOT wired into `check`/`build`; the
+    // CI `license-scan` job invokes it explicitly.
     alias(libs.plugins.license.report)
-}
-
-dependencyCheck {
-    // Fail on a high/critical advisory (CVSS >= 7.0) in any module's runtime deps.
-    failBuildOnCVSS = 7.0f
-    formats = listOf("HTML", "SARIF")
-    // NVD API key from the NVD_API_KEY env var (CI secret) or a -PnvdApiKey property;
-    // kept off the command line so it does not leak into build logs.
-    (findProperty("nvdApiKey") as String? ?: System.getenv("NVD_API_KEY"))
-        ?.takeIf { it.isNotBlank() }
-        ?.let { nvd.apiKey = it }
+    // CycloneDX SBOM generation (issue #496): declared here so the plugin loads
+    // once in the shared root classloader scope; qnop-app applies it (without a
+    // version) to emit a CycloneDX SBOM of its runtime classpath. The CI Trivy
+    // SBOM scan gates on that SBOM (CRITICAL fails, HIGH warns), replacing the
+    // OWASP Dependency-Check job that was a no-op without an NVD API key (issue
+    // #195, ADR-0007 amendment).
+    alias(libs.plugins.cyclonedx.bom) apply false
 }
 
 // Dependency-license policy (issue #498, ADR-0007). Scans only what we ship —

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,4 +80,4 @@ A Vite + React + TypeScript + MaterialUI SPA (`qnop-ui/`) talking to the Spring 
 | Persistence | PostgreSQL + Liquibase; S3/MinIO object storage |
 | Frontend | Vite, React 19, TypeScript, MaterialUI |
 | Build/quality | Convention plugins, Spotless (google-java-format), ArchUnit, JUnit 5 |
-| CI | GitHub Actions (`.github/workflows/ci.yml`): backend build (ArchUnit + Spotless), OWASP dependency audit, frontend lint/format/test/build + audit, docker-compose smoke deploy (incl. OIDC login), SPDX scan |
+| CI | GitHub Actions (`.github/workflows/ci.yml`): backend build (ArchUnit + Spotless), frontend lint/format/test/build + audit, docker-compose smoke deploy (incl. OIDC login), SPDX scan. Security scanning (`security.yml`): Trivy filesystem scan (vuln + secret → Security tab) and a Trivy CycloneDX-SBOM scan of qnop-app's runtime classpath (CRITICAL fails, HIGH warns) — the backend CVE gate (issue #496, ADR-0007) |

--- a/docs/adr/0007-spdx-dco-license-scanning.md
+++ b/docs/adr/0007-spdx-dco-license-scanning.md
@@ -30,7 +30,7 @@ The full dependency-license scanner promised "once real dependencies land" (e.g.
 
 ## Amendment (2026-07-22, license scanner wired — issue #498)
 
-The dependency-license scanner is now in CI. The [jk1 `dependency-license-report`](https://github.com/jk1/Gradle-License-Report) Gradle plugin is applied at the root (like the OWASP gate, and likewise **not** wired into `check`/`build`); the CI `license-scan` job runs `checkLicense`, which fails on any dependency on a module's **`runtimeClasspath`** (i.e. what actually ships — test/compile-only licenses such as JUnit's EPL never gate the product) whose license falls outside the allowlist in `config/allowed-licenses.json`.
+The dependency-license scanner is now in CI. The [jk1 `dependency-license-report`](https://github.com/jk1/Gradle-License-Report) Gradle plugin is applied at the root (**not** wired into `check`/`build`); the CI `license-scan` job runs `checkLicense`, which fails on any dependency on a module's **`runtimeClasspath`** (i.e. what actually ships — test/compile-only licenses such as JUnit's EPL never gate the product) whose license falls outside the allowlist in `config/allowed-licenses.json`.
 
 **Policy encoded in the allowlist:**
 
@@ -40,3 +40,14 @@ The dependency-license scanner is now in CI. The [jk1 `dependency-license-report
 Because jk1 treats a dependency as compliant when **at least one** of its licenses is allowed, scoping every non-permissive license to a single module keeps the gate strict: a new copyleft dependency that is not explicitly listed fails CI and forces a conscious review. The jk1 task is run with `--no-configuration-cache --no-parallel` (it resolves cross-module configurations at execution time, incompatible with the repo's config cache / parallel execution); this affects only the `license-scan` job.
 
 Deeper provenance/SBOM tooling (ScanCode/ORT) remains a future option if a full SBOM or license-text audit is required; the CI gate here covers the contamination concern this ADR set out to address.
+
+## Amendment (2026-07-22, vulnerability scanning: Trivy SBOM replaces OWASP; issue #496)
+
+The **vulnerability** side of dependency scanning (distinct from the license side above) is now a dedicated `security.yml` workflow with two Trivy scans:
+
+- **Trivy filesystem scan** (`fs`, scanners `vuln,secret`) over the whole repo, reporting to the code-scanning (Security) tab via SARIF. Reporting only — it does not fail the build.
+- **Trivy CycloneDX-SBOM scan** — the active **backend CVE gate**. Trivy's filesystem scan cannot parse the Gradle Kotlin DSL to enumerate Java dependencies, so the build emits a CycloneDX SBOM of **qnop-app's resolved `runtimeClasspath`** (the `org.cyclonedx.bom` Gradle plugin, test configurations excluded so a test-tool CVE never gates a shipped artifact), which Trivy then scans: **a CRITICAL advisory fails the build; HIGH warns** (reported to the log and the Security tab).
+
+**NVD_API_KEY decision.** The former OWASP Dependency-Check CI job (`backend-audit`, issue #195) required a (free) NVD API key to hit the NVD feed without crippling rate-limiting; without the `NVD_API_KEY` secret it exited early, so the only active dependency gate was the frontend `pnpm audit`. Rather than take on the operational burden of provisioning and rotating an NVD key, we **drop OWASP Dependency-Check entirely** (job, Gradle plugin, and version-catalog entry) in favour of Trivy, whose self-maintained vulnerability DB needs **no API key** and is therefore always active. The frontend `pnpm audit` gate is unchanged.
+
+**Consequences.** The backend now has an always-on CVE gate with no secret to manage; newly-disclosed CVEs against unchanged code surface via a weekly scheduled run. Trivy's DB and OWASP's NVD-derived data can differ at the margins, and CVSS-7.0-but-not-CRITICAL advisories no longer hard-fail (they warn as HIGH) — an intentional trade to keep the gate actionable. Dependency-**license** scanning (the amendment above, issue #498) is a separate CI gate and is unaffected.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,15 +8,18 @@ archunit = "1.4.2"
 # NOTE: keep `spotless` in sync with build-logic/build.gradle.kts (precompiled
 # script plugins cannot read this catalog at plugin-resolution time).
 spotless = "8.7.0"
-# OWASP Dependency-Check — backend per-PR CVE gate (issue #195). Applied at the
-# root; the CI job runs dependencyCheckAggregate only when an NVD API key secret
-# is present.
-dependencyCheck = "12.1.0"
 # Dependency-license scanner (issue #498, ADR-0007). Applied at the root; the CI
 # `license-scan` job runs `checkLicense`, which fails on any runtime dependency
 # whose license is outside the permissive allowlist (Apache-2.0/MIT/BSD/MPL-2.0).
-# Not wired into `check`/`build`, mirroring the OWASP gate.
+# Not wired into `check`/`build`; the CI job invokes it explicitly.
 licenseReport = "2.9"
+# CycloneDX SBOM generation (issue #496). The `cyclonedxBom` task emits a
+# CycloneDX SBOM of qnop-app's resolved runtime classpath, which the CI Trivy
+# SBOM scan gates on (CRITICAL fails, HIGH warns) — closing the blind spot that
+# Trivy's filesystem scan cannot parse the Gradle Kotlin DSL to enumerate Java
+# dependencies. Replaces the OWASP Dependency-Check gate, which needed an NVD
+# API key to be effective and was a no-op without it (see ADR-0007 amendment).
+cyclonedx = "2.3.1"
 # Spring Boot plugin + BOM. The BOM (spring-boot-dependencies) manages the
 # versions of the Spring stack, JPA/Hibernate, the PostgreSQL driver, Liquibase
 # and Testcontainers — so those artifacts are declared below WITHOUT versions.
@@ -151,5 +154,5 @@ testcontainers-minio = { module = "org.testcontainers:testcontainers-minio" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGenerator" }
-dependency-check = { id = "org.owasp.dependencycheck", version.ref = "dependencyCheck" }
 license-report = { id = "com.github.jk1.dependency-license-report", version.ref = "licenseReport" }
+cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -15,11 +15,26 @@ plugins {
     // Version comes from the root `plugins {}` block (declared there `apply false`
     // to keep a single shared plugin classloader — see the root build script).
     id("org.springframework.boot")
+    // CycloneDX SBOM of this module's runtime classpath (issue #496) — the input
+    // to the CI Trivy SBOM scan (the backend CVE gate).
+    id("org.cyclonedx.bom")
 }
 
 // Stamp build-info.properties into the jar so /api/v1/config reports the real
 // version (BuildProperties in ConfigController, issue #495).
 springBoot { buildInfo() }
+
+// CycloneDX SBOM (issue #496): emit build/reports/bom.json for exactly the
+// runtime classpath — the deps that actually ship. Test-only configurations
+// (JUnit, Testcontainers, ArchUnit, …) are excluded so a CVE in a test tool
+// never gates a shipped artifact. This SBOM is the input to the CI Trivy scan.
+tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
+    setIncludeConfigs(listOf("runtimeClasspath"))
+    setOutputFormat("json")
+    setOutputName("bom")
+    setProjectType("application")
+    setIncludeLicenseText(false)
+}
 
 // SPA embedding (ADR-0040): with -PembedUi the boot jar carries the built
 // qnop-ui bundle under static/. Opt-in so developer builds and the test suite


### PR DESCRIPTION
## Summary

Adopts a dedicated **`security.yml`** security-scanning workflow and resolves the NVD_API_KEY question (issue #496).

### Trivy filesystem scan (report → Security tab)
A repo-wide `vuln` + `secret` sweep, uploaded as SARIF to the code-scanning **Security tab**. Reporting only (non-blocking); it uses Trivy's own maintained DB, so no NVD API key.

### Trivy CycloneDX-SBOM scan (the backend CVE gate)
Trivy's filesystem scan can't parse the Gradle Kotlin DSL to enumerate Java dependencies, so the build now emits a **CycloneDX SBOM of qnop-app's resolved `runtimeClasspath`** (the `org.cyclonedx.bom` plugin; **test configurations excluded** so a CVE in a test tool never gates a shipped artifact), which Trivy scans:

- **CRITICAL** advisory → **fails** the build.
- **HIGH** → **warns** (logged + surfaced in the Security tab).

A weekly `schedule` re-scans `main` so newly-disclosed CVEs surface against unchanged code.

### NVD_API_KEY decision — drop OWASP Dependency-Check
The former `backend-audit` job needed a (free) NVD API key to hit the NVD feed without crippling rate-limiting; without the `NVD_API_KEY` secret it exited early, leaving `pnpm audit` as the only active dependency gate. Rather than provision/rotate an NVD key, we **remove OWASP Dependency-Check entirely** — CI job, Gradle plugin, and version-catalog entry — in favour of Trivy, whose self-maintained DB needs no key and is always active. Documented as an **ADR-0007 amendment**.

## Changes

- **`.github/workflows/security.yml`** (new): `trivy-fs` + `trivy-sbom` jobs (SHA-pinned actions; `security-events: write`; SARIF upload skipped on fork PRs where the token is read-only).
- **`.github/workflows/ci.yml`**: removed the OWASP `backend-audit` job.
- **`build.gradle.kts` / `qnop-app/build.gradle.kts` / `libs.versions.toml`**: replaced the `org.owasp.dependencycheck` plugin with `org.cyclonedx.bom` (2.3.1); `cyclonedxBom` restricted to `runtimeClasspath`, JSON output.
- **`docs/adr/0007-*.md`**, **`docs/ARCHITECTURE.md`**: recorded the decision.

## Test plan

- [x] `./gradlew :qnop-app:cyclonedxBom` produces `bom.json` — **198 runtime components, 0 test deps** (verified JUnit/Testcontainers/ArchUnit excluded).
- [x] `./gradlew spotlessCheck` clean; both workflow YAMLs parse; action SHAs match current `main`.
- [ ] CI: Trivy fs + SBOM scans run green on this PR (first live run).

## Follow-ups for a maintainer (repo settings — not code)

- Update branch protection: drop the required check `Backend dependency audit (OWASP)`, add `Trivy SBOM scan (backend runtime deps)` (and optionally `Trivy filesystem scan …`).
- The `NVD_API_KEY` secret, if set, is now unused and can be deleted.

Closes #496

🤖 Co-Author: Claude (Opus 4.x) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
