### PR TITLE
ci: wire the dependency-license scanner promised by ADR-0007 (#498)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,26 @@ jobs:
           fi
           ./gradlew dependencyCheckAggregate --stacktrace
 
+  license-scan:
+    name: Backend dependency licenses (ADR-0007)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+      # ADR-0007 / issue #498: the dependency-license gate promised once real
+      # dependencies landed. `checkLicense` fails on any shipped (runtimeClasspath)
+      # dependency whose license is outside the permissive allowlist in
+      # config/allowed-licenses.json (Apache-2.0/MIT/BSD/MPL-2.0 + reviewed per-module
+      # exceptions). The jk1 plugin resolves cross-module configurations at execution
+      # time, which is incompatible with the repo's configuration cache and parallel
+      # execution — so both are disabled for this task only; other jobs are unaffected.
+      - name: Check dependency licenses
+        run: ./gradlew checkLicense --no-configuration-cache --no-parallel --stacktrace
+
   qnop-ui:
     name: Frontend (lint + format + test + build)
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,10 @@
 //   - openapi-generator (ADR-0021): applied without a version by qnop-api-model
 //     and qnop-api-endpoint.
 
+import com.github.jk1.license.filter.LicenseBundleNormalizer
+import com.github.jk1.license.render.InventoryHtmlReportRenderer
+import com.github.jk1.license.render.JsonReportRenderer
+
 plugins {
     alias(libs.plugins.spring.boot) apply false
     alias(libs.plugins.openapi.generator) apply false
@@ -21,6 +25,11 @@ plugins {
     // job invokes it only when an NVD API key secret is present (otherwise the NVD
     // feed is heavily rate-limited).
     alias(libs.plugins.dependency.check)
+    // Dependency-license scanner (issue #498, ADR-0007): applied at the root so
+    // `checkLicense` aggregates every module's shipped dependencies and fails on any
+    // license outside the permissive allowlist. Like the OWASP gate above it is NOT
+    // wired into `check`/`build`; the CI `license-scan` job invokes it explicitly.
+    alias(libs.plugins.license.report)
 }
 
 dependencyCheck {
@@ -32,6 +41,21 @@ dependencyCheck {
     (findProperty("nvdApiKey") as String? ?: System.getenv("NVD_API_KEY"))
         ?.takeIf { it.isNotBlank() }
         ?.let { nvd.apiKey = it }
+}
+
+// Dependency-license policy (issue #498, ADR-0007). Scans only what we ship —
+// each module's `runtimeClasspath` — so test/compile-only licenses (e.g. JUnit's
+// EPL) never gate the product. The bundle normalizer collapses the many spellings
+// of each license to a canonical name before the allowlist in config/
+// allowed-licenses.json is applied by `checkLicense`.
+licenseReport {
+    configurations = arrayOf("runtimeClasspath")
+    filters = arrayOf(LicenseBundleNormalizer())
+    renderers = arrayOf(
+        InventoryHtmlReportRenderer("index.html", "qnop dependency licenses"),
+        JsonReportRenderer("licenses.json", false),
+    )
+    allowedLicensesFile = file("config/allowed-licenses.json")
 }
 
 tasks.register("buildAll") {

--- a/config/allowed-licenses.json
+++ b/config/allowed-licenses.json
@@ -1,0 +1,33 @@
+{
+  "_comment": [
+    "Dependency-license allowlist for `checkLicense` (issue #498, ADR-0007). jk1 marks a",
+    "dependency compliant when AT LEAST ONE of its declared licenses is allowed here; a",
+    "dependency whose every license is absent fails the CI `license-scan` job. License",
+    "names are the canonical strings produced by the bundle normalizer (see build.gradle.kts).",
+    "",
+    "Tier 1 — permissive licenses allowed for ANY module (ADR-0007's allowlist:",
+    "Apache-2.0 / MIT / BSD / MPL-2.0, plus their exact spellings here). EDL-1.0 (the",
+    "Eclipse Distribution License) is verbatim BSD-3-Clause, so it belongs with BSD.",
+    "",
+    "Tier 2 — per-module exceptions: dependencies whose only licenses are copyleft but",
+    "which are safe to ship in an AGPL/commercial-add-on split, each justified inline.",
+    "Scoping every exception to one module keeps the gate strict — a NEW copyleft",
+    "dependency that is not listed here fails CI and forces a conscious review."
+  ],
+  "allowedLicenses": [
+    { "moduleLicense": "Apache License, Version 2.0" },
+    { "moduleLicense": "MIT License" },
+    { "moduleLicense": "MIT-0" },
+    { "moduleLicense": "The 2-Clause BSD License" },
+    { "moduleLicense": "The 3-Clause BSD License" },
+    { "moduleLicense": "Mozilla Public License, Version 2.0" },
+    { "moduleLicense": "Eclipse Distribution License - v 1.0", "_comment": "EDL-1.0 is verbatim BSD-3-Clause (permissive)." },
+
+    { "moduleName": "jakarta.annotation:jakarta.annotation-api", "moduleLicense": "Eclipse Public License - v 2.0", "_comment": "Jakarta spec API; EPL-2.0 / GPL-2.0-with-Classpath-Exception — the classpath exception makes linking license-neutral." },
+    { "moduleName": "jakarta.transaction:jakarta.transaction-api", "moduleLicense": "Eclipse Public License - v 2.0", "_comment": "Jakarta spec API; EPL-2.0 / GPL-2.0-with-Classpath-Exception (linking-safe spec)." },
+    { "moduleName": "ch.qos.logback:logback-classic", "moduleLicense": "Eclipse Public License - v 2.0", "_comment": "Logging library, dual EPL-1.0 / LGPL-2.1; used unmodified as a dynamically-linked runtime dependency." },
+    { "moduleName": "ch.qos.logback:logback-core", "moduleLicense": "Eclipse Public License - v 2.0", "_comment": "Logging library, dual EPL-1.0 / LGPL-2.1; used unmodified as a dynamically-linked runtime dependency." },
+    { "moduleName": "org.aspectj:aspectjweaver", "moduleLicense": "Eclipse Public License - v 2.0", "_comment": "AspectJ weaver (EPL-2.0), used unmodified as a library; no AspectJ source is modified or shipped." },
+    { "moduleName": "org.liquibase:liquibase-core", "moduleLicense": "FSL-1.1-ALv2", "_comment": "Liquibase 5.x is Functional Source License 1.1 (source-available, converts to Apache-2.0 after two years). qnop uses it unmodified as a schema-migration tool and is not a competing product, which the FSL permits. Reviewed acceptance — revisit on major Liquibase upgrades." }
+  ]
+}

--- a/docs/adr/0007-spdx-dco-license-scanning.md
+++ b/docs/adr/0007-spdx-dco-license-scanning.md
@@ -27,3 +27,16 @@ An open-core business under AGPL-3.0 depends on (a) being able to prove which co
 ## Amendment (2026-07-16, license scanner still pending)
 
 The full dependency-license scanner promised "once real dependencies land" (e.g. ScanCode/ORT or a Gradle license plugin) is still not wired into CI — the check in place remains the SPDX-header job. Tracked in issue #498.
+
+## Amendment (2026-07-22, license scanner wired — issue #498)
+
+The dependency-license scanner is now in CI. The [jk1 `dependency-license-report`](https://github.com/jk1/Gradle-License-Report) Gradle plugin is applied at the root (like the OWASP gate, and likewise **not** wired into `check`/`build`); the CI `license-scan` job runs `checkLicense`, which fails on any dependency on a module's **`runtimeClasspath`** (i.e. what actually ships — test/compile-only licenses such as JUnit's EPL never gate the product) whose license falls outside the allowlist in `config/allowed-licenses.json`.
+
+**Policy encoded in the allowlist:**
+
+- **Tier 1 — permissive, allowed for any module:** Apache-2.0, MIT (incl. MIT-0), BSD-2/3-Clause, MPL-2.0, and EDL-1.0 (the Eclipse Distribution License, which is verbatim BSD-3-Clause). This is ADR-0007's allowlist above.
+- **Tier 2 — reviewed per-module exceptions:** dependencies whose only licenses are copyleft but which are safe to ship under the AGPL/commercial split, each scoped to a single module and justified inline: the Jakarta spec APIs `jakarta.annotation-api` / `jakarta.transaction-api` (EPL-2.0 / GPL-2.0-**with-Classpath-Exception** — linking-neutral), `ch.qos.logback:logback-core`/`-classic` (dual EPL/LGPL logging library, used unmodified), `org.aspectj:aspectjweaver` (EPL-2.0, used unmodified), and `org.liquibase:liquibase-core` (FSL-1.1-ALv2 — source-available, converts to Apache-2.0; qnop uses it unmodified as a migration tool and is not a competing product, which the FSL permits).
+
+Because jk1 treats a dependency as compliant when **at least one** of its licenses is allowed, scoping every non-permissive license to a single module keeps the gate strict: a new copyleft dependency that is not explicitly listed fails CI and forces a conscious review. The jk1 task is run with `--no-configuration-cache --no-parallel` (it resolves cross-module configurations at execution time, incompatible with the repo's config cache / parallel execution); this affects only the `license-scan` job.
+
+Deeper provenance/SBOM tooling (ScanCode/ORT) remains a future option if a full SBOM or license-text audit is required; the CI gate here covers the contamination concern this ADR set out to address.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,11 @@ spotless = "8.7.0"
 # root; the CI job runs dependencyCheckAggregate only when an NVD API key secret
 # is present.
 dependencyCheck = "12.1.0"
+# Dependency-license scanner (issue #498, ADR-0007). Applied at the root; the CI
+# `license-scan` job runs `checkLicense`, which fails on any runtime dependency
+# whose license is outside the permissive allowlist (Apache-2.0/MIT/BSD/MPL-2.0).
+# Not wired into `check`/`build`, mirroring the OWASP gate.
+licenseReport = "2.9"
 # Spring Boot plugin + BOM. The BOM (spring-boot-dependencies) manages the
 # versions of the Spring stack, JPA/Hibernate, the PostgreSQL driver, Liquibase
 # and Testcontainers — so those artifacts are declared below WITHOUT versions.
@@ -147,3 +152,4 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapiGenerator" }
 dependency-check = { id = "org.owasp.dependencycheck", version.ref = "dependencyCheck" }
+license-report = { id = "com.github.jk1.dependency-license-report", version.ref = "licenseReport" }


### PR DESCRIPTION
## Summary

Wires the dependency-license scanner that ADR-0007 promised "once real dependencies land" — the check in place had remained the SPDX-header job. Closes #498.

The [jk1 `dependency-license-report`](https://github.com/jk1/Gradle-License-Report) plugin is applied at the root (like the OWASP gate, and likewise **not** wired into `check`/`build`), plus a CI **`license-scan`** job running `checkLicense`. It scans only each module's **`runtimeClasspath`** — what actually ships, so test/compile-only licenses (e.g. JUnit's EPL) never gate the product — and fails on any dependency whose license is outside `config/allowed-licenses.json`.

## Policy encoded in the allowlist

The current tree is 193 runtime dependencies (175 Apache-2.0). ADR-0007's allowlist is strictly Apache-2.0/MIT/BSD/MPL-2.0, but the tree contains unavoidable, safe copyleft artifacts. The allowlist is therefore two-tier (ADR-0007 amended to match):

**Tier 1 — permissive, any module:** Apache-2.0, MIT (incl. MIT-0), BSD-2/3-Clause, MPL-2.0, and **EDL-1.0** (the Eclipse Distribution License = verbatim BSD-3-Clause).

**Tier 2 — reviewed per-module exceptions** (copyleft but safe to ship under the AGPL/commercial split, each scoped to one module + justified inline):

| Dependency | License | Why safe |
|---|---|---|
| `jakarta.annotation-api`, `jakarta.transaction-api` | EPL-2.0 / GPL-2.0-**with-Classpath-Exception** | Spec APIs; the classpath exception makes linking license-neutral |
| `ch.qos.logback:logback-core`, `-classic` | dual EPL-1.0 / LGPL-2.1 | Logging library, used unmodified as a dynamically-linked runtime dep |
| `org.aspectj:aspectjweaver` | EPL-2.0 | Used unmodified as a library |
| `org.liquibase:liquibase-core` | FSL-1.1-ALv2 | Source-available, converts to Apache-2.0 after two years; used unmodified as a migration tool, non-competing (which the FSL permits) — **conscious acceptance** |

Because jk1 clears a dependency when **at least one** of its licenses is allowed, scoping every non-permissive license to a single module keeps the gate strict: a new, unlisted copyleft dependency fails CI and forces a conscious review.

## Notable finding

**Liquibase 5.x is under FSL-1.1** (Functional Source License), not Apache-2.0. It's source-available and converts to Apache-2.0 after two years; qnop uses it unmodified as a schema-migration tool and is not a competing product, which the FSL permits — accepted as a documented exception. Flagging it for a conscious maintainer decision; the alternative is pinning Liquibase to its last Apache-2.0 release.

## Implementation notes

- The jk1 task runs with `--no-configuration-cache --no-parallel` — it resolves cross-module configurations at execution time, which is incompatible with the repo's config cache / parallel execution. Only the `license-scan` job is affected; the local gate and all other jobs are unchanged.
- The allowlist entries carry inline `_comment` justifications (ignored by jk1).

## Test plan

- [x] `checkLicense` passes locally on the current tree (0 violations).
- [x] Verified the gate **fails** on a non-allowlisted license (a permissive-only allowlist flags every EPL/GPL-CPE/LGPL/FSL dependency).
- [x] `spotlessCheck` and a config-cache-enabled `help`/normal configuration still pass — the plugin doesn't affect the standard build.
- [ ] CI `license-scan` job green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
