### PR TITLE
build: publish qnop-spi and qnop-api to GitHub Packages (#497)

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Publish -SNAPSHOT artifacts of the published contracts — qnop-spi and qnop-api
+# (models + endpoints) — to GitHub Packages on every push to main (issue #497,
+# ADR-0046), so the private qnop-enterprise repo can build against the latest
+# development contract without waiting for a tagged release. Tagged releases are
+# published by release.yml; this workflow only ever publishes SNAPSHOTs (it
+# skips itself on the brief non-SNAPSHOT commit prepare-release.yml creates).
+#
+# Tests are not run here — ci.yml already gates every commit on main; this only
+# re-publishes the artifacts ci.yml just proved.
+
+name: Publish snapshot
+
+on:
+  push:
+    branches:
+      - main
+    # Only the paths that can change the published jars — the contract sources,
+    # the OpenAPI spec, the build plumbing and the version.
+    paths:
+      - 'qnop-spi/**'
+      - 'qnop-api/**'
+      - 'build-logic/**'
+      - 'gradle/**'
+      - 'VERSION'
+      - 'settings.gradle.kts'
+      - 'build.gradle.kts'
+      - '.github/workflows/publish-snapshot.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+# One publish at a time; a newer main supersedes an in-flight run (latest
+# SNAPSHOT wins anyway).
+concurrency:
+  group: publish-snapshot
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish snapshot to GitHub Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Guard — only publish SNAPSHOT versions
+        id: guard
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Publishing snapshot ${VERSION}"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::VERSION ${VERSION} is a release, not a SNAPSHOT — release.yml publishes tagged releases; skipping."
+          fi
+
+      - name: Set up JDK 21
+        if: steps.guard.outputs.publish == 'true'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        if: steps.guard.outputs.publish == 'true'
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Publish qnop-spi and qnop-api snapshots to GitHub Packages
+        if: steps.guard.outputs.publish == 'true'
+        run: ./gradlew --no-daemon -x test publish
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,20 @@ jobs:
             || { echo "::error::SPA bundle missing from the boot jar"; exit 1; }
           ls -lh deploy/context/app.jar
 
+      # Publish the Spring-free published contracts — qnop-spi and qnop-api
+      # (models + endpoints) — to GitHub Packages so the private qnop-enterprise
+      # repo can depend on this release (issue #497, ADR-0046). Only those three
+      # modules define a publication; -x test mirrors the release philosophy
+      # (ci.yml already gated the commit this tag points at). SIGNING_* is
+      # optional: the publication is signed only when the secret is configured.
+      - name: Publish qnop-spi and qnop-api to GitHub Packages
+        run: ./gradlew --no-daemon -x test publish
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 

--- a/build-logic/src/main/kotlin/qnop.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/qnop.publish-conventions.gradle.kts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026-present devtank42 GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Publishing conventions (issue #497, ADR-0046): publish the two Spring-free
+// PUBLISHED contracts — qnop-spi (the plugin boundary, ADR-0003) and qnop-api
+// (the REST contract, ADR-0015/0021) — to GitHub Packages so the private
+// qnop-enterprise repository can depend on them (ADR-0002). Applied via
+// `plugins { id("qnop.publish-conventions") }` ON TOP of `qnop.java-conventions`
+// (which sets group/version and already adds the sources jar).
+//
+// It adds: full POM metadata (AGPL-3.0-only licence, SCM, organisation), a
+// javadoc jar, the GitHub Packages Maven repository, and OPT-IN PGP signing —
+// signing runs only when a key is present in the environment, so a normal build
+// and a SNAPSHOT publish never require GPG.
+
+plugins {
+    `java-library`
+    `maven-publish`
+    signing
+}
+
+java {
+    // qnop.java-conventions already adds `withSourcesJar()`; a javadoc jar
+    // completes the source/javadoc pair consumers expect.
+    withJavadocJar()
+}
+
+// Generated modules (qnop-api-*) feed javadoc plain POJOs/interfaces; disable
+// doclint so a missing @param on generated code never fails the jar, and keep
+// it quiet so the build log stays readable.
+tasks.withType<Javadoc>().configureEach {
+    (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+            // group/version come from qnop.java-conventions (the root VERSION file);
+            // artifactId is the module name (e.g. qnop-spi, qnop-api-model).
+            pom {
+                name.set(provider { "${project.group}:${project.name}" })
+                description.set(provider { project.description ?: project.name })
+                url.set("https://github.com/qnophq/qnop")
+                licenses {
+                    license {
+                        name.set("GNU Affero General Public License v3.0 only")
+                        url.set("https://www.gnu.org/licenses/agpl-3.0-standalone.html")
+                        distribution.set("repo")
+                    }
+                }
+                organization {
+                    name.set("devtank42 GmbH")
+                    url.set("https://github.com/qnophq")
+                }
+                developers {
+                    developer {
+                        id.set("devtank42")
+                        name.set("devtank42 GmbH")
+                        url.set("https://github.com/qnophq")
+                    }
+                }
+                scm {
+                    url.set("https://github.com/qnophq/qnop")
+                    connection.set("scm:git:https://github.com/qnophq/qnop.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/qnophq/qnop.git")
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/qnophq/qnop")
+            // Local publishes read `gpr.user`/`gpr.key` from ~/.gradle/gradle.properties;
+            // CI falls back to the Actions-provided GITHUB_ACTOR / GITHUB_TOKEN.
+            credentials {
+                username =
+                    providers.gradleProperty("gpr.user")
+                        .orElse(providers.environmentVariable("GITHUB_ACTOR"))
+                        .orNull
+                password =
+                    providers.gradleProperty("gpr.key")
+                        .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+                        .orNull
+            }
+        }
+    }
+}
+
+// Opt-in, in-memory PGP signing: only when an ASCII-armoured key is supplied via
+// SIGNING_KEY (release CI, or a local publish with the secret). Without it,
+// signing is not required and no signature tasks are wired — GitHub Packages
+// does not mandate signatures, so an unsigned SNAPSHOT publish stays frictionless.
+signing {
+    val signingKey = providers.environmentVariable("SIGNING_KEY").orNull
+    val signingPassword = providers.environmentVariable("SIGNING_PASSWORD").orNull
+    isRequired = signingKey != null
+    if (signingKey != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications["maven"])
+    }
+}

--- a/docs/adr/0046-publish-spi-and-api-to-github-packages.md
+++ b/docs/adr/0046-publish-spi-and-api-to-github-packages.md
@@ -1,0 +1,36 @@
+# ADR-0046: Publish `qnop-spi` and `qnop-api` to GitHub Packages
+
+- **Status:** Accepted
+- **Date:** 2026-07-22
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+The open-core split (ADR-0002) keeps the commercial add-ons in a separate, private `qnop-enterprise` repository that builds against the **published** `qnop-spi` artifact and plugs in via Spring auto-configuration (ADR-0003). The REST contract is likewise a published, versioned surface (`qnop-api`, ADR-0015/0021). But no `maven-publish` configuration existed anywhere in the build, so neither artifact could actually be consumed outside this repo — `qnop-enterprise` had nothing to depend on.
+
+We need to publish the Spring-free published contracts to a Maven repository the enterprise repo can resolve, without standing up new infrastructure and without loosening the AGPL boundary.
+
+## Decision
+
+**1. Publish to GitHub Packages, via a `qnop.publish-conventions` convention plugin.** A new precompiled plugin in `build-logic/` (alongside `qnop.java-conventions`, ADR-0006) applies `maven-publish` + `signing` and configures a single `MavenPublication` from the `java` component, the GitHub Packages Maven repository (`https://maven.pkg.github.com/qnophq/qnop`), full POM metadata (name, description, `url`, the **AGPL-3.0-only** licence, organisation, developer, SCM) and a javadoc jar (the sources jar already comes from `qnop.java-conventions`). GitHub Packages is chosen over Maven Central because the consumer (`qnop-enterprise`) is a private GitHub repo already authenticated to the same org — no Sonatype account, namespace verification, or mandatory-signing hurdle, and access control comes for free. Ported from plugwerk's publish convention.
+
+**2. Apply it only to the three Spring-free published modules:** `qnop-spi`, `qnop-api-model` and `qnop-api-endpoint`. `qnop-core`/`qnop-app` are the AGPL server and are **not** published (they are consumed as a running application/image, ADR-0040, not as a library); the `qnop-api` container project builds nothing and carries no publication.
+
+**3. Credentials resolve from Gradle properties first, then the CI environment.** `gpr.user`/`gpr.key` (from `~/.gradle/gradle.properties`) let a maintainer publish locally; CI falls back to the Actions-provided `GITHUB_ACTOR` / `GITHUB_TOKEN`. No secret is ever hard-coded.
+
+**4. Signing is opt-in and in-memory.** The `signing` block signs the publication **only** when an ASCII-armoured `SIGNING_KEY` is present in the environment (`isRequired = signingKey != null`); otherwise no signature task is wired. GitHub Packages does not mandate signatures, so a normal `build` and a SNAPSHOT publish stay frictionless, while a tagged release can attach signatures once a key is configured as a secret.
+
+**5. Wire publishing into the tag-triggered release (ADR-0040) first.** `release.yml` gains a `./gradlew publish` step (it already holds `packages: write`), so a `vX.Y.Z` tag publishes the matching release artifacts next to the container image. A **snapshot-publish workflow on `main`** — so `qnop-enterprise` can build against the latest `-SNAPSHOT` during development — is a deliberate follow-up, kept out of this change to keep it reviewable.
+
+## Consequences
+
+- **Easier:** `qnop-enterprise` can finally declare `io.qnop:qnop-spi` / `io.qnop:qnop-api-endpoint` dependencies and resolve them from GitHub Packages; the publication carries a correct, licence-bearing POM.
+- **Harder / accepted:** consumers must authenticate to GitHub Packages even for these AGPL artifacts (a GitHub-Packages limitation — anonymous read is not supported); a future mirror to Maven Central would remove that friction if broader public consumption is wanted.
+- **Deferred:** the `main` snapshot-publish workflow; signing is inert until a `SIGNING_KEY` secret is added; a Maven Central mirror.
+
+## Alternatives considered
+
+- **Maven Central (Sonatype OSSRH).** Rejected for now: namespace verification, mandatory PGP signing, and a separate account — heavyweight for an artifact whose only consumer today is a sibling private repo. Revisit if public library consumption becomes a goal.
+- **A private Maven repo (Nexus/Artifactory/S3).** Rejected: new infrastructure to run and secure, when GitHub Packages is already available and access-controlled by the existing org membership.
+- **Committing the artifacts / a Git submodule of `qnop-spi`.** Rejected: no versioned dependency resolution, no transitive POM, and it couples the two repos' histories — the opposite of the clean published-contract boundary ADR-0003 wants.
+- **Publishing `qnop-core` too.** Rejected: it is the AGPL application core, consumed as an image (ADR-0040), not a library; publishing it would invite linking that the open-core boundary (ADR-0002/0003) deliberately routes through the SPI.

--- a/docs/adr/0046-publish-spi-and-api-to-github-packages.md
+++ b/docs/adr/0046-publish-spi-and-api-to-github-packages.md
@@ -20,13 +20,13 @@ We need to publish the Spring-free published contracts to a Maven repository the
 
 **4. Signing is opt-in and in-memory.** The `signing` block signs the publication **only** when an ASCII-armoured `SIGNING_KEY` is present in the environment (`isRequired = signingKey != null`); otherwise no signature task is wired. GitHub Packages does not mandate signatures, so a normal `build` and a SNAPSHOT publish stay frictionless, while a tagged release can attach signatures once a key is configured as a secret.
 
-**5. Wire publishing into the tag-triggered release (ADR-0040) first.** `release.yml` gains a `./gradlew publish` step (it already holds `packages: write`), so a `vX.Y.Z` tag publishes the matching release artifacts next to the container image. A **snapshot-publish workflow on `main`** — so `qnop-enterprise` can build against the latest `-SNAPSHOT` during development — is a deliberate follow-up, kept out of this change to keep it reviewable.
+**5. Publish on both a tagged release and every `main` push.** `release.yml` gains a `./gradlew publish` step (it already holds `packages: write`), so a `vX.Y.Z` tag publishes the matching release artifacts next to the container image. A separate `publish-snapshot.yml` publishes the `-SNAPSHOT` artifacts on every push to `main` (guarded so it skips the brief non-SNAPSHOT commit `prepare-release.yml` creates, and path-filtered to the contract sources / spec / build plumbing), so `qnop-enterprise` can build against the latest development contract without waiting for a release. Neither workflow runs tests — `ci.yml` already gates every commit on `main`.
 
 ## Consequences
 
 - **Easier:** `qnop-enterprise` can finally declare `io.qnop:qnop-spi` / `io.qnop:qnop-api-endpoint` dependencies and resolve them from GitHub Packages; the publication carries a correct, licence-bearing POM.
 - **Harder / accepted:** consumers must authenticate to GitHub Packages even for these AGPL artifacts (a GitHub-Packages limitation — anonymous read is not supported); a future mirror to Maven Central would remove that friction if broader public consumption is wanted.
-- **Deferred:** the `main` snapshot-publish workflow; signing is inert until a `SIGNING_KEY` secret is added; a Maven Central mirror.
+- **Deferred:** signing is inert until a `SIGNING_KEY` secret is added; a Maven Central mirror.
 
 ## Alternatives considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,6 +62,7 @@ Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-reco
 | [0043](0043-system-audit-stream.md) | System-audit stream: generalising the audit trail beyond documents | Accepted |
 | [0044](0044-storage-consistency-scan-and-remediation.md) | Storage-consistency scan & remediation, and the StorageProvider.list SPI extension | Accepted |
 | [0045](0045-scheduler-jobs-dashboard.md) | Scheduler-jobs dashboard: an operator gate in front of the maintenance sweeps | Accepted |
+| [0046](0046-publish-spi-and-api-to-github-packages.md) | Publish qnop-spi & qnop-api to GitHub Packages (maven-publish convention) | Accepted |
 
 ## Template
 

--- a/qnop-api/qnop-api-endpoint/build.gradle.kts
+++ b/qnop-api/qnop-api-endpoint/build.gradle.kts
@@ -11,6 +11,8 @@
 plugins {
     id("qnop.java-conventions")
     id("org.openapi.generator")
+    // Published to GitHub Packages for the qnop-enterprise repo (issue #497, ADR-0046).
+    id("qnop.publish-conventions")
 }
 
 description = "qnop-api-endpoint — generated Spring MVC interfaces for the qnop REST contract (ADR-0021)"
@@ -70,5 +72,11 @@ tasks.named("compileJava") {
 }
 
 tasks.named("sourcesJar") {
+    dependsOn(tasks.openApiGenerate)
+}
+
+// The javadoc jar (added by qnop.publish-conventions) documents the generated
+// sources, so they must exist first.
+tasks.named("javadoc") {
     dependsOn(tasks.openApiGenerate)
 }

--- a/qnop-api/qnop-api-model/build.gradle.kts
+++ b/qnop-api/qnop-api-model/build.gradle.kts
@@ -18,6 +18,8 @@ plugins {
     // Version comes from the root `plugins {}` block (apply false there) so the
     // generator loads once in the shared root classloader scope.
     id("org.openapi.generator")
+    // Published to GitHub Packages for the qnop-enterprise repo (issue #497, ADR-0046).
+    id("qnop.publish-conventions")
 }
 
 description = "qnop-api-model — generated, Spring-free REST DTOs (ADR-0021)"
@@ -83,5 +85,11 @@ tasks.named("compileJava") {
 }
 
 tasks.named("sourcesJar") {
+    dependsOn(tasks.openApiGenerate)
+}
+
+// The javadoc jar (added by qnop.publish-conventions) documents the generated
+// sources, so they must exist first.
+tasks.named("javadoc") {
     dependsOn(tasks.openApiGenerate)
 }

--- a/qnop-spi/build.gradle.kts
+++ b/qnop-spi/build.gradle.kts
@@ -8,7 +8,11 @@
 
 plugins {
     id("qnop.java-conventions")
+    // Published to GitHub Packages for the qnop-enterprise repo (issue #497, ADR-0046).
+    id("qnop.publish-conventions")
 }
+
+description = "qnop-spi — the Spring-free extension-point contract for qnop add-ons (ADR-0003)"
 
 dependencies {
     testImplementation(platform(libs.junit.bom))


### PR DESCRIPTION
## Summary

Closes #497. The open-core split (ADR-0002/0003) has the private `qnop-enterprise` repo build against the **published** `qnop-spi` (plugin boundary) and `qnop-api` (REST contract) artifacts — but no `maven-publish` configuration existed anywhere, so there was nothing to depend on. This ports plugwerk's publish convention into `build-logic/` and wires publishing into the release.

## What changed

**New convention plugin — `build-logic/src/main/kotlin/qnop.publish-conventions.gradle.kts`** (`maven-publish` + `signing`; both are core Gradle plugins, so no new `build-logic` dependency):
- A `MavenPublication` from the `java` component with full POM metadata: name, description, `url`, the **AGPL-3.0-only** licence, organisation, developer, SCM.
- A **javadoc jar** (the sources jar already comes from `qnop.java-conventions`); `Xdoclint:none -quiet` so the generated `qnop-api-*` sources never fail the javadoc jar.
- The **GitHub Packages** repository (`https://maven.pkg.github.com/qnophq/qnop`); credentials resolve from `gpr.user`/`gpr.key` (local `~/.gradle/gradle.properties`) then fall back to the Actions-provided `GITHUB_ACTOR`/`GITHUB_TOKEN`.
- **Opt-in in-memory PGP signing**: the publication is signed only when `SIGNING_KEY` is present (`isRequired = signingKey != null`), so a normal build and a SNAPSHOT publish never require GPG.

**Applied to the three Spring-free published modules only** — `qnop-spi`, `qnop-api-model`, `qnop-api-endpoint` (each gains the plugin + a `description`; the two generated api modules also get `javadoc dependsOn openApiGenerate`). `qnop-core`/`qnop-app` are the AGPL application (shipped as an image, ADR-0040) and are **not** published; the `qnop-api` container project has no publication.

**Two publish triggers:**
- **Release** — `release.yml` gains a `./gradlew --no-daemon -x test publish` step after the boot-jar build (it already holds `packages: write`); `SIGNING_*` pass through as optional secrets.
- **Snapshot** — a new `publish-snapshot.yml` publishes the `-SNAPSHOT` artifacts on every push to `main`, so `qnop-enterprise` can build against the latest development contract without waiting for a release. Guarded to publish only when `VERSION` is a `-SNAPSHOT` (skips the brief release-prep commit) and path-filtered to the contract sources / spec / build plumbing.

**ADR-0046** records the decision (GitHub Packages over Maven Central, and why).

## Verification (local)

- [x] `spotlessCheck` — green
- [x] `publishToMavenLocal` for all three modules — green; POMs inspected: correct GAV, AGPL licence, SCM, and dependency scopes (`qnop-api-endpoint` carries `io.qnop:qnop-api-model` + the Spring Boot BOM import); each module emits main + sources + javadoc jars
- [x] `./gradlew publish --dry-run` — resolves to exactly the three `…GitHubPackagesRepository` publish tasks, nothing else
- [x] `ArchitectureRulesTest` — green
- [ ] A real publish needs GitHub Packages credentials + network, so it runs only in the release workflow (CI), not locally

## Note on the snapshot workflow

The issue lists the `main` snapshot-publish workflow as a "later" item, but SNAPSHOTs are needed for day-to-day `qnop-enterprise` development, so it's included here rather than deferred (ADR-0046 §5 updated accordingly).

## Deferred

- Opt-in signing stays inert until a `SIGNING_KEY` secret is configured.
- A Maven Central mirror (only if broad public consumption becomes a goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
