### PR TITLE
feat(review): owner-or-admin workflow transitions with actor-scoped capability

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2106,15 +2106,17 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
     post:
       tags: [ReviewWorkflow]
-      summary: Request a workflow transition (owner-only)
+      summary: Request a workflow transition (owner or admin)
       description: |
         Moves the review to `targetState` through the state-machine choke-point
-        (ADR-0011). Rejected with `409` when the edge is not in the transition
-        table, when it belongs to the derived `IN_REVIEW ⇄ CHANGES_REQUESTED`
-        pair (issue #405 — that pair follows the open-annotation count and is
-        never set by hand), when a guard vetoes it — finalization requires zero
-        OPEN annotations and zero PENDING placements (re-anchoring complete) —
-        or when the current or target state is not managed by this edition.
+        (ADR-0011). Permitted for the document owner and for admins (issue
+        #568) — every transition is audited with the real actor. Rejected with
+        `409` when the edge is not in the transition table, when it belongs to
+        the derived `IN_REVIEW ⇄ CHANGES_REQUESTED` pair (issue #405 — that
+        pair follows the open-annotation count and is never set by hand), when
+        a guard vetoes it — finalization requires zero OPEN annotations and
+        zero PENDING placements (re-anchoring complete) — or when the current
+        or target state is not managed by this edition.
       operationId: transitionDocumentWorkflow
       security:
         - bearerAuth: []
@@ -2138,7 +2140,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '403':
-          description: The caller is not the document owner
+          description: The caller is neither the document owner nor an admin
           content:
             application/json:
               schema:
@@ -3744,22 +3746,60 @@ components:
       required:
         - state
         - allowedTransitions
+        - mayTransition
+        - transitions
       properties:
         state:
           type: string
           description: The current workflow state (Community values or an enterprise extension).
           example: IN_REVIEW
-        allowedTransitions:
+        mayTransition:
+          type: boolean
+          description: |
+            Whether the CALLER may request explicit transitions — the document
+            owner or an admin (issue #568). Drives the client affordance only;
+            the transition endpoint enforces authorization independently.
+        transitions:
           type: array
           description: |
-            Target states the owner may request explicitly from `state` (manual
-            transition table only; guards are evaluated on the transition
-            request, and the derived `IN_REVIEW ⇄ CHANGES_REQUESTED` pair is
-            excluded, issue #405). Empty for terminal states and for states
-            this edition does not manage.
+            The manual targets reachable from `state`, with the domain guards
+            pre-evaluated at read time so a client can explain a blocked
+            option (issue #568). Advisory — a guard's verdict can change at
+            any moment; the transition request re-checks authoritatively. The
+            derived `IN_REVIEW ⇄ CHANGES_REQUESTED` pair is excluded (issue
+            #405). Empty for terminal states.
+          items:
+            $ref: '#/components/schemas/WorkflowTransitionOption'
+        allowedTransitions:
+          type: array
+          deprecated: true
+          description: |
+            Deprecated — superseded by `transitions` (issue #568); kept
+            populated for one release. The manual target names without guard
+            evaluation.
           items:
             type: string
           example: [FINALIZED, CANCELLED]
+    WorkflowTransitionOption:
+      type: object
+      description: One manual workflow target with its read-time guard verdict (issue #568).
+      required:
+        - targetState
+        - available
+      properties:
+        targetState:
+          type: string
+          description: The target workflow state.
+          example: FINALIZED
+        available:
+          type: boolean
+          description: True when no domain guard vetoes the transition right now.
+        blockedReason:
+          type: string
+          description: |
+            Human-readable guard veto, present when `available` is false —
+            e.g. "cannot finalize: 3 open annotation(s) must be resolved
+            first".
     WorkflowTransitionRequest:
       type: object
       description: A request to move the review to `targetState` (issue #246, ADR-0011).

--- a/qnop-app/src/main/java/io/qnop/web/ReviewWorkflowController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ReviewWorkflowController.java
@@ -22,6 +22,7 @@ package io.qnop.web;
 
 import io.qnop.api.v1.endpoint.ReviewWorkflowApi;
 import io.qnop.api.v1.model.WorkflowStatus;
+import io.qnop.api.v1.model.WorkflowTransitionOption;
 import io.qnop.api.v1.model.WorkflowTransitionRequest;
 import io.qnop.service.review.ReviewWorkflowService;
 import java.util.UUID;
@@ -54,12 +55,24 @@ public class ReviewWorkflowController implements ReviewWorkflowApi {
       UUID documentId, WorkflowTransitionRequest request) {
     UUID actor = CurrentUser.requireUserId();
     return ResponseEntity.ok(
-        toDto(workflow.transition(documentId, request.getTargetState(), actor)));
+        toDto(
+            workflow.transition(
+                documentId, request.getTargetState(), actor, CurrentUser.isAdmin())));
   }
 
   private static WorkflowStatus toDto(ReviewWorkflowService.WorkflowStatus status) {
     return new WorkflowStatus()
         .state(status.state())
-        .allowedTransitions(status.allowedTransitions());
+        .allowedTransitions(status.allowedTransitions())
+        .mayTransition(status.mayTransition())
+        .transitions(
+            status.transitions().stream()
+                .map(
+                    option ->
+                        new WorkflowTransitionOption()
+                            .targetState(option.targetState())
+                            .available(option.available())
+                            .blockedReason(option.blockedReason()))
+                .toList());
   }
 }

--- a/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
@@ -172,6 +172,57 @@ class ReviewWorkflowControllerIT extends SeededIntegrationTest {
   // --- POST: refusals ---------------------------------------------------------------
 
   @Test
+  void adminMovesTheWorkflowAndIsAuditedAsThemselves() throws Exception {
+    // #568: admins may transition without being the owner.
+    Document document = draftOwnedByMember();
+
+    mockMvc
+        .perform(
+            post(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(ADMIN_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetState\":\"IN_REVIEW\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.state").value("IN_REVIEW"));
+
+    assertThat(auditEvents.findByDocumentIdOrderByCreatedAtDesc(document.getId()))
+        .anySatisfy(
+            event -> {
+              assertThat(event.getEventType()).isEqualTo("workflow.transition");
+              assertThat(event.getActorId()).isEqualTo(ADMIN_ID);
+            });
+  }
+
+  @Test
+  void statusScopesTheCapabilityToOwnerAndAdmin() throws Exception {
+    // #568: mayTransition drives the client affordance; reviewers get false.
+    Document document = draftOwnedByMember();
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
+
+    mockMvc
+        .perform(
+            get(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.mayTransition").value(true))
+        .andExpect(jsonPath("$.transitions[?(@.targetState=='IN_REVIEW')].available").value(true));
+
+    mockMvc
+        .perform(
+            get(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(MEMBER2_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.mayTransition").value(false));
+
+    mockMvc
+        .perform(
+            get(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(ADMIN_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.mayTransition").value(true));
+  }
+
+  @Test
   void nonOwnerIsRejectedWith403() throws Exception {
     Document document = draftOwnedByMember();
 

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowMachine.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowMachine.java
@@ -196,6 +196,30 @@ public class ReviewWorkflowMachine {
         .orElse(List.of());
   }
 
+  /** One manual target with its read-time guard verdict — empty reason means "available". */
+  public record TransitionOption(WorkflowState target, Optional<String> blockedReason) {}
+
+  /**
+   * The manual targets from {@code currentRaw} with the guards pre-evaluated against {@code
+   * context} (issue #568), so a client can explain a blocked option instead of silently omitting
+   * it. Advisory only — the verdict can change at any moment; {@link #manualTransition} re-checks
+   * authoritatively. Empty for terminal or unknown states.
+   */
+  public List<TransitionOption> transitionOptions(String currentRaw, TransitionContext context) {
+    return WorkflowState.fromString(currentRaw)
+        .map(
+            state ->
+                MANUAL_EDGES.get(state).stream()
+                    .map(
+                        target ->
+                            new TransitionOption(
+                                target,
+                                Optional.ofNullable(GUARDS.get(target))
+                                    .flatMap(guard -> guard.veto(context))))
+                    .toList())
+        .orElse(List.of());
+  }
+
   // --- annotation sub-machine (ADR-0011, amended by #405) ----------------------
 
   /** Whether an annotation in {@code current} may still be resolved: only {@code OPEN} may. */

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -100,7 +100,14 @@ public class ReviewWorkflowService {
    * their names (kept as strings so the web layer maps them without depending on the entity enum,
    * ADR-0004, issue #315).
    */
-  public record WorkflowStatus(String state, List<String> allowedTransitions) {}
+  public record WorkflowStatus(
+      String state,
+      List<String> allowedTransitions,
+      boolean mayTransition,
+      List<TransitionOptionView> transitions) {}
+
+  /** One manual target with its read-time guard verdict (issue #568); reason null = available. */
+  public record TransitionOptionView(String targetState, boolean available, String blockedReason) {}
 
   /**
    * The current workflow status of a document, readable by anyone who may see the document — its
@@ -114,19 +121,20 @@ public class ReviewWorkflowService {
     if (!documentAccess.isVisible(documentId, actorId, admin)) {
       throw new DocumentNotFoundException(documentId);
     }
-    return statusOf(document);
+    return statusOf(document, actorId, admin);
   }
 
   /**
-   * Requests an explicit transition to {@code targetRaw}, owner-only. A target this edition does
-   * not know, an illegal edge, the derived {@code IN_REVIEW ⇄ CHANGES_REQUESTED} pair (issue #405),
-   * or a vetoing guard (the FINALIZED invariant) is rejected with {@link
+   * Requests an explicit transition to {@code targetRaw} — permitted for the document owner and for
+   * admins (issue #568); the audit event carries the real actor either way. A target this edition
+   * does not know, an illegal edge, the derived {@code IN_REVIEW ⇄ CHANGES_REQUESTED} pair (issue
+   * #405), or a vetoing guard (the FINALIZED invariant) is rejected with {@link
    * WorkflowTransitionException} (HTTP 409).
    */
   @Transactional
-  public WorkflowStatus transition(UUID documentId, String targetRaw, UUID actorId) {
+  public WorkflowStatus transition(UUID documentId, String targetRaw, UUID actorId, boolean admin) {
     Document document = loadForUpdate(documentId);
-    requireOwner(document, actorId);
+    requireOwnerOrAdmin(document, actorId, admin);
     WorkflowState target =
         WorkflowState.fromString(targetRaw)
             .orElseThrow(
@@ -135,7 +143,7 @@ public class ReviewWorkflowService {
                         WorkflowTransitionException.INVALID_TRANSITION,
                         "unknown target state '" + targetRaw + "'"));
     applyTransition(document, target, actorId, true);
-    return statusOf(document);
+    return statusOf(document, actorId, admin);
   }
 
   /**
@@ -253,12 +261,7 @@ public class ReviewWorkflowService {
   private void applyTransition(
       Document document, WorkflowState target, UUID actorId, boolean manual) {
     String from = document.getWorkflowState();
-    TransitionContext context =
-        new TransitionContext(
-            annotations.countByDocumentIdAndStatus(document.getId(), AnnotationStatus.OPEN),
-            placements.countByDocumentIdAndStatus(document.getId(), PlacementStatus.PENDING),
-            versions.existsByDocumentIdAndExtractionStatus(
-                document.getId(), ExtractionStatus.READY));
+    TransitionContext context = contextOf(document);
     TransitionResult result =
         manual
             ? machine.manualTransition(from, target, context)
@@ -279,12 +282,35 @@ public class ReviewWorkflowService {
         new ReviewEvent.WorkflowChanged(document.getId(), actorId, from, target.name(), manual));
   }
 
-  private WorkflowStatus statusOf(Document document) {
+  private WorkflowStatus statusOf(Document document, UUID actorId, boolean admin) {
+    // The guard verdicts are advisory (they can change at any moment); the
+    // transition call re-checks authoritatively (issue #568).
+    List<TransitionOptionView> options =
+        machine.transitionOptions(document.getWorkflowState(), contextOf(document)).stream()
+            .map(
+                option ->
+                    new TransitionOptionView(
+                        option.target().name(),
+                        option.blockedReason().isEmpty(),
+                        option.blockedReason().orElse(null)))
+            .toList();
     return new WorkflowStatus(
         document.getWorkflowState(),
         machine.allowedTransitions(document.getWorkflowState()).stream()
             .map(WorkflowState::name)
-            .toList());
+            .toList(),
+        admin || document.getOwnerId().equals(actorId),
+        options);
+  }
+
+  /**
+   * The document-derived guard facts, loaded fresh (open annotations, pending placements, READY).
+   */
+  private TransitionContext contextOf(Document document) {
+    return new TransitionContext(
+        annotations.countByDocumentIdAndStatus(document.getId(), AnnotationStatus.OPEN),
+        placements.countByDocumentIdAndStatus(document.getId(), PlacementStatus.PENDING),
+        versions.existsByDocumentIdAndExtractionStatus(document.getId(), ExtractionStatus.READY));
   }
 
   private Document load(UUID documentId) {
@@ -305,8 +331,8 @@ public class ReviewWorkflowService {
         .orElseThrow(() -> new DocumentNotFoundException(documentId));
   }
 
-  private static void requireOwner(Document document, UUID actorId) {
-    if (!document.getOwnerId().equals(actorId)) {
+  private static void requireOwnerOrAdmin(Document document, UUID actorId, boolean admin) {
+    if (!admin && !document.getOwnerId().equals(actorId)) {
       throw new NotDocumentOwnerException();
     }
   }

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowMachineTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowMachineTest.java
@@ -113,6 +113,36 @@ class ReviewWorkflowMachineTest {
   }
 
   @Test
+  void transitionOptionsCarryReadTimeGuardVerdicts() {
+    // Blocked FINALIZED explains itself; CANCELLED is unguarded (#568).
+    var blocked =
+        machine.transitionOptions(
+            WorkflowState.IN_REVIEW.name(), new TransitionContext(3, 0, true));
+    assertThat(blocked)
+        .anySatisfy(
+            option -> {
+              assertThat(option.target()).isEqualTo(WorkflowState.FINALIZED);
+              assertThat(option.blockedReason())
+                  .hasValueSatisfying(reason -> assertThat(reason).contains("3 open annotation"));
+            })
+        .anySatisfy(
+            option -> {
+              assertThat(option.target()).isEqualTo(WorkflowState.CANCELLED);
+              assertThat(option.blockedReason()).isEmpty();
+            });
+
+    var clear =
+        machine.transitionOptions(
+            WorkflowState.IN_REVIEW.name(), new TransitionContext(0, 0, true));
+    assertThat(clear).allSatisfy(option -> assertThat(option.blockedReason()).isEmpty());
+
+    assertThat(
+            machine.transitionOptions(
+                WorkflowState.FINALIZED.name(), new TransitionContext(0, 0, true)))
+        .isEmpty();
+  }
+
+  @Test
   void finalizedAndCancelledAreTerminal() {
     for (WorkflowState terminal : EnumSet.of(WorkflowState.FINALIZED, WorkflowState.CANCELLED)) {
       assertThat(machine.allowedTransitions(terminal.name())).isEmpty();

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceLockTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceLockTest.java
@@ -81,7 +81,7 @@ class ReviewWorkflowServiceLockTest {
     Document document = new Document(owner, "Locked review"); // DRAFT, owned by the actor
     when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(document));
 
-    service.transition(documentId, WorkflowState.CANCELLED.name(), owner);
+    service.transition(documentId, WorkflowState.CANCELLED.name(), owner, false);
 
     verify(documents).findByIdForUpdate(documentId);
     verify(documents, never()).findById(any());
@@ -137,7 +137,8 @@ class ReviewWorkflowServiceLockTest {
     when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(inReview));
     when(annotations.countByDocumentIdAndStatus(any(), any())).thenReturn(1L); // an open annotation
 
-    assertThatThrownBy(() -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner))
+    assertThatThrownBy(
+            () -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner, false))
         .isInstanceOf(WorkflowTransitionException.class)
         .hasMessageContaining("open");
     verify(documents).findByIdForUpdate(documentId);

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
@@ -23,6 +23,8 @@ package io.qnop.service.review;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -124,10 +126,50 @@ class ReviewWorkflowServiceTest {
     when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(draft));
 
     assertThatThrownBy(
-            () -> service.transition(documentId, WorkflowState.IN_REVIEW.name(), stranger))
+            () -> service.transition(documentId, WorkflowState.IN_REVIEW.name(), stranger, false))
         .isInstanceOf(NotDocumentOwnerException.class);
     assertThat(draft.getWorkflowState()).isEqualTo(WorkflowState.DRAFT.name());
     verify(auditEvents, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("an admin may transition without being the owner, audited as themselves (#568)")
+  void adminMayTransition() {
+    Document draft = document(WorkflowState.DRAFT);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(draft));
+
+    service.transition(documentId, WorkflowState.IN_REVIEW.name(), stranger, true);
+
+    assertThat(draft.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
+    assertThat(captureAudits().getValue().getActorId()).isEqualTo(stranger);
+  }
+
+  @Test
+  @DisplayName("status scopes the capability to owner/admin and pre-evaluates guards (#568)")
+  void statusCarriesCapabilityAndGuardVerdicts() {
+    when(documents.findById(documentId)).thenReturn(Optional.of(document(WorkflowState.IN_REVIEW)));
+    when(documentAccess.isVisible(eq(documentId), any(), anyBoolean())).thenReturn(true);
+    when(annotations.countByDocumentIdAndStatus(any(), any())).thenReturn(3L);
+    when(versions.existsByDocumentIdAndExtractionStatus(any(), any())).thenReturn(true);
+
+    ReviewWorkflowService.WorkflowStatus ownerView = service.status(documentId, owner, false);
+    assertThat(ownerView.mayTransition()).isTrue();
+    assertThat(ownerView.transitions())
+        .anySatisfy(
+            option -> {
+              assertThat(option.targetState()).isEqualTo(WorkflowState.FINALIZED.name());
+              assertThat(option.available()).isFalse();
+              assertThat(option.blockedReason()).contains("3 open annotation");
+            })
+        .anySatisfy(
+            option -> {
+              assertThat(option.targetState()).isEqualTo(WorkflowState.CANCELLED.name());
+              assertThat(option.available()).isTrue();
+              assertThat(option.blockedReason()).isNull();
+            });
+
+    assertThat(service.status(documentId, stranger, false).mayTransition()).isFalse();
+    assertThat(service.status(documentId, stranger, true).mayTransition()).isTrue();
   }
 
   @Test
@@ -136,7 +178,7 @@ class ReviewWorkflowServiceTest {
     when(documents.findByIdForUpdate(documentId))
         .thenReturn(Optional.of(document(WorkflowState.DRAFT)));
 
-    assertThatThrownBy(() -> service.transition(documentId, "NONSENSE", owner))
+    assertThatThrownBy(() -> service.transition(documentId, "NONSENSE", owner, false))
         .isInstanceOfSatisfying(
             WorkflowTransitionException.class,
             e -> assertThat(e.getCode()).isEqualTo(WorkflowTransitionException.INVALID_TRANSITION));
@@ -148,7 +190,7 @@ class ReviewWorkflowServiceTest {
     Document draft = document(WorkflowState.DRAFT);
     when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(draft));
 
-    service.transition(documentId, WorkflowState.IN_REVIEW.name(), owner);
+    service.transition(documentId, WorkflowState.IN_REVIEW.name(), owner, false);
 
     assertThat(draft.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
     AuditEvent audit = captureAudits().getValue();
@@ -167,7 +209,7 @@ class ReviewWorkflowServiceTest {
     // open annotations = 0 (default), pending placements = 0 (default), a READY version exists.
     when(versions.existsByDocumentIdAndExtractionStatus(any(), any())).thenReturn(true);
 
-    service.transition(documentId, WorkflowState.FINALIZED.name(), owner);
+    service.transition(documentId, WorkflowState.FINALIZED.name(), owner, false);
 
     assertThat(inReview.getWorkflowState()).isEqualTo(WorkflowState.FINALIZED.name());
     verify(auditEvents).save(any());
@@ -181,7 +223,8 @@ class ReviewWorkflowServiceTest {
     when(placements.countByDocumentIdAndStatus(any(), any())).thenReturn(1L);
     when(versions.existsByDocumentIdAndExtractionStatus(any(), any())).thenReturn(true);
 
-    assertThatThrownBy(() -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner))
+    assertThatThrownBy(
+            () -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner, false))
         .isInstanceOf(WorkflowTransitionException.class);
     assertThat(inReview.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
     verify(auditEvents, never()).save(any());
@@ -194,7 +237,8 @@ class ReviewWorkflowServiceTest {
     when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(inReview));
     // no counts stubbed: 0 open, 0 pending, but existsBy...READY defaults to false.
 
-    assertThatThrownBy(() -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner))
+    assertThatThrownBy(
+            () -> service.transition(documentId, WorkflowState.FINALIZED.name(), owner, false))
         .isInstanceOf(WorkflowTransitionException.class);
     assertThat(inReview.getWorkflowState()).isEqualTo(WorkflowState.IN_REVIEW.name());
   }

--- a/qnop-ui/src/api/hooks/useReviews.test.tsx
+++ b/qnop-ui/src/api/hooks/useReviews.test.tsx
@@ -148,8 +148,18 @@ describe('usePrincipalSearch', () => {
 
 describe('useWorkflow / useTransitionWorkflow', () => {
   it('reads the state and posts a transition', async () => {
-    const draft: WorkflowStatus = { state: 'DRAFT', allowedTransitions: ['IN_REVIEW'] };
-    const inReview: WorkflowStatus = { state: 'IN_REVIEW', allowedTransitions: [] };
+    const draft: WorkflowStatus = {
+      state: 'DRAFT',
+      allowedTransitions: ['IN_REVIEW'],
+      mayTransition: true,
+      transitions: [],
+    };
+    const inReview: WorkflowStatus = {
+      state: 'IN_REVIEW',
+      allowedTransitions: [],
+      mayTransition: true,
+      transitions: [],
+    };
     vi.mocked(reviewWorkflowApi.getDocumentWorkflow).mockResolvedValue({ data: draft } as Awaited<
       ReturnType<typeof reviewWorkflowApi.getDocumentWorkflow>
     >);

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
@@ -134,7 +134,15 @@ beforeEach(() => {
   vi.mocked(documentsApi.listParticipants).mockResolvedValue({
     data: PARTICIPANTS,
   } as Awaited<ReturnType<typeof documentsApi.listParticipants>>);
-  mockWorkflow({ state: 'IN_REVIEW', allowedTransitions: ['FINALIZED', 'CANCELLED'] });
+  mockWorkflow({
+    state: 'IN_REVIEW',
+    allowedTransitions: ['FINALIZED', 'CANCELLED'],
+    mayTransition: true,
+    transitions: [
+      { targetState: 'FINALIZED', available: true },
+      { targetState: 'CANCELLED', available: true },
+    ],
+  });
 });
 
 describe('ReviewHubHead — owner', () => {
@@ -174,7 +182,12 @@ describe('ReviewHubHead — progress & participants', () => {
 
 describe('ReviewHubHead — workflow transitions', () => {
   it('confirms and executes a transition from the allowed set', async () => {
-    const finalized: WorkflowStatus = { state: 'FINALIZED', allowedTransitions: [] };
+    const finalized: WorkflowStatus = {
+      state: 'FINALIZED',
+      allowedTransitions: [],
+      mayTransition: true,
+      transitions: [],
+    };
     vi.mocked(reviewWorkflowApi.transitionDocumentWorkflow).mockResolvedValue({
       data: finalized,
     } as Awaited<ReturnType<typeof reviewWorkflowApi.transitionDocumentWorkflow>>);
@@ -191,6 +204,49 @@ describe('ReviewHubHead — workflow transitions', () => {
       }),
     );
     await waitFor(() => expect(notify).toHaveBeenCalledWith('Review moved to Finalized.'));
+  });
+
+  // Issue #568: the capability is actor-scoped, and blocked targets explain
+  // themselves instead of silently disappearing.
+  it('hides the status button entirely from a caller without the capability', async () => {
+    mockWorkflow({
+      state: 'IN_REVIEW',
+      allowedTransitions: ['FINALIZED', 'CANCELLED'],
+      mayTransition: false,
+      transitions: [
+        { targetState: 'FINALIZED', available: true },
+        { targetState: 'CANCELLED', available: true },
+      ],
+    });
+    renderHub();
+
+    await screen.findByTestId('participants-button');
+    expect(screen.queryByRole('button', { name: /Change status/ })).not.toBeInTheDocument();
+  });
+
+  it('renders a blocked target disabled with its guard reason (#568)', async () => {
+    mockWorkflow({
+      state: 'IN_REVIEW',
+      allowedTransitions: ['FINALIZED', 'CANCELLED'],
+      mayTransition: true,
+      transitions: [
+        {
+          targetState: 'FINALIZED',
+          available: false,
+          blockedReason: 'cannot finalize: 3 open annotation(s) must be resolved first',
+        },
+        { targetState: 'CANCELLED', available: true },
+      ],
+    });
+    renderHub();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Change status/ }));
+
+    const finalize = await screen.findByText('Move to Finalized');
+    expect(finalize.closest('li')).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText('Move to Cancelled').closest('li')).not.toHaveAttribute(
+      'aria-disabled',
+    );
   });
 
   it('surfaces a guard veto (409 INVALID_TRANSITION) as a mapped error toast', async () => {
@@ -215,7 +271,12 @@ describe('ReviewHubHead — workflow transitions', () => {
   });
 
   it('hides the status button when no transitions are offered', async () => {
-    mockWorkflow({ state: 'FINALIZED', allowedTransitions: [] });
+    mockWorkflow({
+      state: 'FINALIZED',
+      allowedTransitions: [],
+      mayTransition: true,
+      transitions: [],
+    });
     renderHub();
 
     await screen.findByTestId('participants-button');

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -126,7 +126,10 @@ export function ReviewHubHead({
   // size-capped principal directory, which drops users in big workspaces.
   const ownerName =
     ownerId === ownUserId ? (ownDisplayName ?? 'You') : (ownerDisplayName ?? 'Owner');
-  const transitions = workflowQuery.data?.allowedTransitions ?? [];
+  // Actor-scoped capability + guard-evaluated options (issue #568): reviewers
+  // never see the affordance; blocked targets explain themselves.
+  const mayTransition = workflowQuery.data?.mayTransition ?? false;
+  const transitionOptions = workflowQuery.data?.transitions ?? [];
   const maxSizeMb = config?.upload.maxDocumentSizeMb ?? FALLBACK_MAX_SIZE_MB;
 
   const total = annotations.length;
@@ -332,7 +335,7 @@ export function ReviewHubHead({
         </ButtonBase>
       </Tooltip>
 
-      {transitions.length > 0 && (
+      {mayTransition && transitionOptions.length > 0 && (
         <>
           <Button
             size="small"
@@ -349,16 +352,26 @@ export function ReviewHubHead({
             anchorEl={workflowMenuAnchor}
             onClose={() => setWorkflowMenuAnchor(null)}
           >
-            {transitions.map((target) => (
-              <MenuItem
-                key={target}
-                onClick={() => {
-                  setWorkflowMenuAnchor(null);
-                  setConfirmTarget(target);
-                }}
+            {transitionOptions.map((option) => (
+              // A blocked target stays visible and explains itself (issue
+              // #568) — a silently missing FINALIZED read as a bug.
+              <Tooltip
+                key={option.targetState}
+                title={option.available ? '' : (option.blockedReason ?? '')}
+                placement="left"
               >
-                Move to {workflowLabel(target)}
-              </MenuItem>
+                <span>
+                  <MenuItem
+                    disabled={!option.available}
+                    onClick={() => {
+                      setWorkflowMenuAnchor(null);
+                      setConfirmTarget(option.targetState);
+                    }}
+                  >
+                    Move to {workflowLabel(option.targetState)}
+                  </MenuItem>
+                </span>
+              </Tooltip>
             ))}
           </Menu>
         </>

--- a/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
@@ -98,7 +98,12 @@ beforeEach(() => {
   vi.mocked(documentsApi.addParticipant).mockResolvedValue({ data: { id: 'p1' } } as Awaited<
     ReturnType<typeof documentsApi.addParticipant>
   >);
-  const started: WorkflowStatus = { state: 'IN_REVIEW', allowedTransitions: [] };
+  const started: WorkflowStatus = {
+    state: 'IN_REVIEW',
+    allowedTransitions: [],
+    mayTransition: true,
+    transitions: [],
+  };
   vi.mocked(reviewWorkflowApi.transitionDocumentWorkflow).mockResolvedValue({
     data: started,
   } as Awaited<ReturnType<typeof reviewWorkflowApi.transitionDocumentWorkflow>>);


### PR DESCRIPTION
Part 1 of #568 (authorization + capability + guard reasons). Terminal-transition auto-close (+ setting) and the gamified workflow display follow as separate PRs.

## What was broken

The 'Change status' affordance failed on both ends: the server was **owner-only with no admin bypass**, while the UI rendered the dropdown for **every participant** (`transitions.length > 0`, no owner gate) — a reviewer could pick *Cancel*, confirm, and only then get a 403.

## Changes

- **Authorization**: `transition()` permits the document owner **and admins** (#563 moderation direction); the audit event carries the real actor either way. Reviewers keep the 403.
- **Contract** (OpenAPI-first): `WorkflowStatus` gains
  - `mayTransition` — actor-scoped capability (owner or admin) driving the client affordance; the endpoint enforces independently.
  - `transitions[]` (`WorkflowTransitionOption {targetState, available, blockedReason}`) — manual targets with the domain guards **pre-evaluated at read time**, so a blocked FINALIZED explains itself ('cannot finalize: 3 open annotation(s) must be resolved first'). Advisory only; the POST re-checks authoritatively.
  - `allowedTransitions` stays populated but **deprecated** for one release (no hard break).
- **State machine**: new DB-free `transitionOptions(state, context)` reusing the existing guards.
- **UI**: the hub head renders 'Change status' on `mayTransition` only; blocked targets render as disabled menu items with the guard reason as tooltip (a silently missing FINALIZED read as a bug).

## Test plan
- [x] Machine: guard verdicts per option (blocked FINALIZED with reason, unguarded CANCELLED, terminal states empty)
- [x] Service: admin may transition (audited as themselves); capability scoping owner/reviewer/admin; guard verdicts in status
- [x] IT over the wire: admin POST 200 + audit actor; `mayTransition` true/false/true for owner/reviewer/admin; existing owner/403/409 suites green
- [x] Hub head: no button without capability; blocked option disabled with reason; existing transition/veto tests green
- [x] Gates: frontend 990 tests / lint / prettier / typecheck; backend full build green except the known local-only `ConfigurationControllerIT` environment issue (green in CI)

Refs #568

🤖 Co-Author: Claude (Fable 5) via Claude Code