### PR TITLE
feat(review): workflow milestone path replaces the flat status pill

### DIFF
--- a/qnop-ui/src/components/reviews/WorkflowMilestones.test.tsx
+++ b/qnop-ui/src/components/reviews/WorkflowMilestones.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { WorkflowMilestones } from './WorkflowMilestones';
+import { milestoneIndex } from './workflowMeta';
+
+function renderStrip(
+  props: Parameters<typeof WorkflowMilestones>[0],
+  mode: 'light' | 'dark' = 'light',
+) {
+  return render(
+    <ThemeProvider theme={buildTheme(mode)}>
+      <WorkflowMilestones {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('milestoneIndex', () => {
+  it('charts the Community states and rejects unknown ones', () => {
+    expect(milestoneIndex('DRAFT')).toBe(0);
+    expect(milestoneIndex('IN_REVIEW')).toBe(1);
+    expect(milestoneIndex('CHANGES_REQUESTED')).toBe(1);
+    expect(milestoneIndex('FINALIZED')).toBe(2);
+    expect(milestoneIndex('CANCELLED')).toBe('cancelled');
+    expect(milestoneIndex('ENTERPRISE_GATE')).toBeNull();
+  });
+});
+
+describe('WorkflowMilestones', () => {
+  it('renders the live stage with progress for an in-review document', () => {
+    renderStrip({ state: 'IN_REVIEW', total: 5, resolved: 2 });
+
+    const strip = screen.getByTestId('workflow-milestones');
+    expect(strip).toHaveAccessibleName('In review — 2 of 5 annotations resolved, 3 to go');
+    expect(strip).toHaveTextContent('In review');
+    expect(strip).toHaveTextContent('2/5');
+  });
+
+  it('ping-pongs the derived pair as one stage — changes requested stays mid-path', () => {
+    renderStrip({ state: 'CHANGES_REQUESTED', total: 3, resolved: 3 });
+
+    const strip = screen.getByTestId('workflow-milestones');
+    expect(strip).toHaveTextContent('Changes requested');
+    expect(strip).toHaveAccessibleName(/ready to finalize/);
+  });
+
+  it('celebrates the finalized arrival', () => {
+    renderStrip({ state: 'FINALIZED' });
+
+    const strip = screen.getByTestId('workflow-milestones');
+    expect(strip).toHaveTextContent('Finalized');
+    expect(strip).toHaveAccessibleName('Review finalized — every concern settled');
+  });
+
+  it('renders the cancelled side exit with the auto-close hint', () => {
+    renderStrip({ state: 'CANCELLED', total: 4, resolved: 1 });
+
+    const strip = screen.getByTestId('workflow-milestones');
+    expect(strip).toHaveTextContent('Cancelled');
+    expect(strip).toHaveAccessibleName(
+      'Review cancelled — 3 annotations were closed automatically',
+    );
+  });
+
+  it('announces a draft as not yet in review, in both themes', () => {
+    renderStrip({ state: 'DRAFT' });
+    expect(screen.getByTestId('workflow-milestones')).toHaveAccessibleName(
+      'Draft — not yet in review',
+    );
+
+    renderStrip({ state: 'DRAFT' }, 'dark');
+    expect(screen.getAllByTestId('workflow-milestones')[1]).toHaveAccessibleName(
+      'Draft — not yet in review',
+    );
+  });
+
+  it('falls back to the flat badge for an unknown (enterprise) state', () => {
+    renderStrip({ state: 'LEGAL_HOLD' });
+
+    expect(screen.queryByTestId('workflow-milestones')).toBeNull();
+    expect(screen.getByText('Legal hold')).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/reviews/WorkflowMilestones.tsx
+++ b/qnop-ui/src/components/reviews/WorkflowMilestones.tsx
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { Ban, CircleCheckBig } from 'lucide-react';
+import { WorkflowBadge } from './WorkflowBadge';
+import { milestoneIndex, workflowLabel } from './workflowMeta';
+
+interface WorkflowMilestonesProps {
+  /** The current workflow state (open set — unknown states fall back to the flat badge). */
+  state: string;
+  /** Annotation counts feeding the live stage's progress; omit when unknown. */
+  total?: number;
+  resolved?: number;
+}
+
+const DOT = 9;
+
+/**
+ * The review's position on its milestone path (issue #568), replacing the flat
+ * status pill: Draft → In review → Finalized as a compact track, the derived
+ * `IN_REVIEW ⇄ CHANGES_REQUESTED` pair (#405) rendered as ONE live stage whose
+ * tone and label ping-pong with the open-annotation count. CANCELLED is the
+ * side exit (a terminated track), FINALIZED the celebratory arrival. Purely
+ * informational — reviewers and owners read the same path. The pulse on the
+ * live stage is compositor-only and stops under prefers-reduced-motion;
+ * unknown (enterprise) states render the plain badge instead of guessing.
+ */
+export function WorkflowMilestones({ state, total = 0, resolved = 0 }: WorkflowMilestonesProps) {
+  const theme = useTheme();
+  const position = milestoneIndex(state);
+  if (position === null) {
+    return <WorkflowBadge state={state} />;
+  }
+
+  const open = Math.max(0, total - resolved);
+  const label = workflowLabel(state);
+  const cancelled = position === 'cancelled';
+  const finalized = position === 2;
+  const activeIndex = cancelled ? -1 : position;
+  const activeTone =
+    state === 'CHANGES_REQUESTED'
+      ? theme.qnop.badge.amber
+      : { bg: theme.qnop.surface2, fg: theme.qnop.brand.blue, border: theme.palette.divider };
+
+  const summary = cancelled
+    ? `Review cancelled${open > 0 ? ` — ${open} annotation${open === 1 ? '' : 's'} were closed automatically` : ''}`
+    : finalized
+      ? 'Review finalized — every concern settled'
+      : position === 0
+        ? 'Draft — not yet in review'
+        : total > 0
+          ? `${label} — ${resolved} of ${total} annotation${total === 1 ? '' : 's'} resolved${open > 0 ? `, ${open} to go` : ', ready to finalize'}`
+          : `${label} — no annotations yet`;
+
+  const dot = (index: number) => {
+    const done = finalized || index < activeIndex;
+    const active = !finalized && index === activeIndex;
+    return (
+      <Box
+        key={index}
+        aria-hidden
+        sx={{
+          width: DOT,
+          height: DOT,
+          borderRadius: '50%',
+          flexShrink: 0,
+          boxSizing: 'border-box',
+          ...(done && { bgcolor: theme.palette.success.main }),
+          ...(active && {
+            bgcolor: activeTone.fg,
+            // The one deliberate motion moment: the live stage breathes.
+            // Compositor-only (transform/opacity) and off under reduced motion.
+            animation: 'qnop-milestone-pulse 2.4s ease-in-out infinite',
+            '@keyframes qnop-milestone-pulse': {
+              '0%, 100%': { transform: 'scale(1)', opacity: 1 },
+              '50%': { transform: 'scale(1.35)', opacity: 0.65 },
+            },
+            '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+          }),
+          ...(!done &&
+            !active && {
+              bgcolor: 'transparent',
+              border: `1.5px solid ${cancelled ? theme.palette.text.disabled : theme.palette.divider}`,
+            }),
+        }}
+      />
+    );
+  };
+
+  const connector = (index: number) => {
+    const filled = finalized || index < activeIndex;
+    return (
+      <Box
+        key={`c${index}`}
+        aria-hidden
+        sx={{
+          width: 14,
+          height: 2,
+          borderRadius: 1,
+          flexShrink: 0,
+          bgcolor: filled ? theme.palette.success.main : theme.palette.divider,
+          ...(cancelled && { bgcolor: theme.palette.text.disabled, opacity: 0.4 }),
+        }}
+      />
+    );
+  };
+
+  return (
+    <Tooltip title={summary} describeChild>
+      <Box
+        role="img"
+        aria-label={summary}
+        data-testid="workflow-milestones"
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.75,
+          height: 26,
+          px: 1.25,
+          borderRadius: 99,
+          border: '1px solid',
+          borderColor: cancelled ? theme.qnop.badge.red.border : theme.palette.divider,
+          bgcolor: cancelled ? theme.qnop.badge.red.bg : theme.qnop.surface2,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {cancelled ? (
+          <Ban size={13} aria-hidden style={{ color: theme.qnop.badge.red.fg, flexShrink: 0 }} />
+        ) : (
+          dot(0)
+        )}
+        {connector(0)}
+        {!cancelled && dot(1)}
+        {cancelled && (
+          <Typography
+            component="span"
+            sx={{ fontSize: 12, fontWeight: 600, color: theme.qnop.badge.red.fg }}
+          >
+            {label}
+          </Typography>
+        )}
+        {!cancelled && !finalized && (
+          <Typography
+            component="span"
+            sx={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: position === 1 ? activeTone.fg : theme.palette.text.secondary,
+            }}
+          >
+            {position === 0 ? 'Draft' : label}
+            {position === 1 && total > 0 && (
+              <Box component="span" sx={{ fontWeight: 400, color: 'text.secondary', ml: 0.5 }}>
+                {resolved}/{total}
+              </Box>
+            )}
+          </Typography>
+        )}
+        {connector(1)}
+        {finalized ? (
+          <>
+            <CircleCheckBig
+              size={14}
+              aria-hidden
+              style={{ color: theme.palette.success.main, flexShrink: 0 }}
+            />
+            <Typography
+              component="span"
+              sx={{ fontSize: 12, fontWeight: 600, color: theme.palette.success.main }}
+            >
+              Finalized
+            </Typography>
+          </>
+        ) : (
+          dot(2)
+        )}
+      </Box>
+    </Tooltip>
+  );
+}

--- a/qnop-ui/src/components/reviews/workflowMeta.ts
+++ b/qnop-ui/src/components/reviews/workflowMeta.ts
@@ -48,3 +48,31 @@ export function workflowLabel(state: string): string {
 export function isOpenWorkflowState(state: string): boolean {
   return !CLOSED_STATES.has(state);
 }
+
+/**
+ * The review's milestone path (issue #568): Draft → In review → Finalized.
+ * The derived `IN_REVIEW ⇄ CHANGES_REQUESTED` pair (#405) is ONE live stage —
+ * it ping-pongs with the open-annotation count and never advances the path.
+ */
+export const WORKFLOW_MILESTONES = ['DRAFT', 'IN_REVIEW', 'FINALIZED'] as const;
+
+/**
+ * Where a state sits on the milestone path: the stage index, `'cancelled'` for
+ * the side exit, or `null` for a state this edition does not chart (an
+ * enterprise extension) — callers fall back to the flat badge then.
+ */
+export function milestoneIndex(state: string): number | 'cancelled' | null {
+  switch (state) {
+    case 'DRAFT':
+      return 0;
+    case 'IN_REVIEW':
+    case 'CHANGES_REQUESTED':
+      return 1;
+    case 'FINALIZED':
+      return 2;
+    case 'CANCELLED':
+      return 'cancelled';
+    default:
+      return null;
+  }
+}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -33,7 +33,7 @@ import Popper from '@mui/material/Popper';
 import Stack from '@mui/material/Stack';
 import { Copy, NotebookPen } from 'lucide-react';
 import type { Anchor, AnnotationView, NormalizedBox } from '../../api/generated';
-import { ExtractionStatus } from '../../api/generated';
+import { AnnotationStatus, ExtractionStatus } from '../../api/generated';
 import type { AnnotationPriority, AnnotationType } from '../../api/generated';
 import {
   useAnnotations,
@@ -80,7 +80,7 @@ import { columnOf } from '../../components/reviews/tasks/tasksModel';
 import { NewTaskDialog } from '../../components/reviews/tasks/NewTaskDialog';
 import { Composer } from '../../components/reviews/panel/Composer';
 import { useCommentAttachmentUpload } from '../../components/reviews/markdown/useCommentAttachmentUpload';
-import { WorkflowBadge } from '../../components/reviews/WorkflowBadge';
+import { WorkflowMilestones } from '../../components/reviews/WorkflowMilestones';
 import { AnonymousBadge } from '../../components/reviews/AnonymousBadge';
 import type {
   ScreenPosition,
@@ -479,7 +479,11 @@ export function DocumentReviewPage() {
         title={document.title}
         titleAdornment={
           <>
-            <WorkflowBadge state={document.workflowState} />
+            <WorkflowMilestones
+              state={document.workflowState}
+              total={annotations.length}
+              resolved={annotations.filter((a) => a.status !== AnnotationStatus.Open).length}
+            />
             {document.anonymous && <AnonymousBadge />}
           </>
         }


### PR DESCRIPTION
Part 3 of #568 — closes #568 (parts 1 and 2 were #569 and #570).

The review's status becomes a **position on its path**: a compact milestone strip in the page header charts Draft → In review → Finalized, replacing the flat status pill.

## Design

- The derived `IN_REVIEW ⇄ CHANGES_REQUESTED` pair (#405) renders as **one live stage** whose tone (blue/amber), label and `resolved/total` count ping-pong with the open annotations — the state machine's most confusing property becomes visible instead.
- **One deliberate motion moment**: the live stage breathes (compositor-only `transform`/`opacity` pulse, disabled via `prefers-reduced-motion` media query).
- **CANCELLED** is the side exit — a red terminated track whose accessible name carries the auto-close hint from #570 ('3 annotations were closed automatically'). **FINALIZED** is the celebratory arrival (full green path + check glyph).
- Both themes ride the existing qnop tone tokens; the strip is purely informational and identical for owners and reviewers; the full story lives in the accessible name (`role="img"`) and tooltip.
- **Unknown (enterprise) states fall back to the flat `WorkflowBadge`** instead of guessing a position — the state set stays open (ADR-0011). The badge itself remains in use on the reviews list.

New `milestoneIndex`/`WORKFLOW_MILESTONES` helpers in `workflowMeta`; `WorkflowMilestones` component wired into `DocumentReviewPage`'s header with the annotation counts it already has.

## Test plan
- [x] 7 component tests: all five states incl. accessible names, ping-pong stage, cancelled auto-close hint, both themes, enterprise fallback; `milestoneIndex` mapping pinned
- [x] Full gate green: 1000 tests / 143 files, eslint, prettier, typecheck
- [ ] Visual check on the running app (both themes) — no Playwright screenshot infra exists in the repo yet; noted as possible follow-up rather than building it here

Follow-up filed: #571 (uniform header across the Document/Tasks/Compare tabs, building on this component).

🤖 Co-Author: Claude (Fable 5) via Claude Code