### PR TITLE
refactor(review): one uniform header across the Document, Tasks and Compare tabs

### DIFF
--- a/qnop-ui/src/components/reviews/hub/ReviewPageHeader.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewPageHeader.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { AnnotationView, DocumentResponse } from '../../../api/generated';
+import { AnnotationStatus } from '../../../api/generated';
+import { PageHeader } from '../../admin/layout/PageHeader';
+import type { Notify } from '../../admin/layout/useToast';
+import { useAuthStore } from '../../../stores/authStore';
+import { AnonymousBadge } from '../AnonymousBadge';
+import { WorkflowMilestones } from '../WorkflowMilestones';
+import { useReviewDocumentId } from '../reviewDocumentId';
+import { ReviewHubHead } from './ReviewHubHead';
+
+interface ReviewPageHeaderProps {
+  /** The review's document detail — carries every header-relevant field. */
+  document: DocumentResponse;
+  /** The page's annotation set, feeding the milestone counts and the hub head. */
+  annotations: AnnotationView[];
+  /** The page's toast seam. */
+  notify: Notify;
+  /** Where to go after a successful new-version upload — the page decides. */
+  onVersionUploaded: (versionNumber: number) => void;
+}
+
+/**
+ * THE review page header (issue #571): title, the workflow milestone path
+ * (#568) with the anonymity badge, and the full hub head — identical on the
+ * Document, Tasks and Compare tabs, so switching tabs never makes the top of
+ * the page jump. The canonical document id and the viewer's identity are read
+ * here (not props) so `isOwner` cannot drift between tabs; tab identity is the
+ * tab bar's job, so this header deliberately has no per-tab slot.
+ */
+export function ReviewPageHeader({
+  document,
+  annotations,
+  notify,
+  onVersionUploaded,
+}: ReviewPageHeaderProps) {
+  const documentId = useReviewDocumentId();
+  const userId = useAuthStore((s) => s.userId);
+
+  return (
+    <PageHeader
+      title={document.title}
+      titleAdornment={
+        <>
+          <WorkflowMilestones
+            state={document.workflowState}
+            total={annotations.length}
+            resolved={annotations.filter((a) => a.status !== AnnotationStatus.Open).length}
+          />
+          {document.anonymous && <AnonymousBadge />}
+        </>
+      }
+      action={
+        <ReviewHubHead
+          documentId={documentId}
+          ownerId={document.ownerId}
+          ownerSlug={document.ownerSlug}
+          ownerDisplayName={document.ownerDisplayName}
+          isOwner={document.ownerId === userId}
+          ownUserId={userId}
+          anonymous={document.anonymous ?? false}
+          annotations={annotations}
+          dueAt={document.dueAt ?? null}
+          workflowState={document.workflowState}
+          notify={notify}
+          onVersionUploaded={onVersionUploaded}
+        />
+      }
+    />
+  );
+}

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -33,7 +33,7 @@ import Popper from '@mui/material/Popper';
 import Stack from '@mui/material/Stack';
 import { Copy, NotebookPen } from 'lucide-react';
 import type { Anchor, AnnotationView, NormalizedBox } from '../../api/generated';
-import { AnnotationStatus, ExtractionStatus } from '../../api/generated';
+import { ExtractionStatus } from '../../api/generated';
 import type { AnnotationPriority, AnnotationType } from '../../api/generated';
 import {
   useAnnotations,
@@ -48,11 +48,10 @@ import {
 } from '../../api/hooks/useDocuments';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { copyToClipboard } from '../../utils/clipboard';
-import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { useToast } from '../../components/admin/layout/useToast';
 import { BoundaryFallback } from '../../components/errors/BoundaryFallback';
 import { ErrorBoundary } from '../../components/errors/ErrorBoundary';
-import { ReviewHubHead } from '../../components/reviews/hub/ReviewHubHead';
+import { ReviewPageHeader } from '../../components/reviews/hub/ReviewPageHeader';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
 import { useReviewPermalink } from '../../components/reviews/useReviewPermalink';
@@ -80,8 +79,6 @@ import { columnOf } from '../../components/reviews/tasks/tasksModel';
 import { NewTaskDialog } from '../../components/reviews/tasks/NewTaskDialog';
 import { Composer } from '../../components/reviews/panel/Composer';
 import { useCommentAttachmentUpload } from '../../components/reviews/markdown/useCommentAttachmentUpload';
-import { WorkflowMilestones } from '../../components/reviews/WorkflowMilestones';
-import { AnonymousBadge } from '../../components/reviews/AnonymousBadge';
 import type {
   ScreenPosition,
   TextSelectionOffsets,
@@ -475,34 +472,11 @@ export function DocumentReviewPage() {
     >
       {/* No description line: the version lives in the toolbar dropdown, and
           every saved pixel goes to the document and its annotations. */}
-      <PageHeader
-        title={document.title}
-        titleAdornment={
-          <>
-            <WorkflowMilestones
-              state={document.workflowState}
-              total={annotations.length}
-              resolved={annotations.filter((a) => a.status !== AnnotationStatus.Open).length}
-            />
-            {document.anonymous && <AnonymousBadge />}
-          </>
-        }
-        action={
-          <ReviewHubHead
-            documentId={documentId}
-            ownerId={document.ownerId}
-            ownerSlug={document.ownerSlug}
-            ownerDisplayName={document.ownerDisplayName}
-            isOwner={document.ownerId === userId}
-            ownUserId={userId}
-            anonymous={document.anonymous ?? false}
-            annotations={annotations}
-            dueAt={document.dueAt ?? null}
-            workflowState={document.workflowState}
-            notify={notify}
-            onVersionUploaded={handleVersionChange}
-          />
-        }
+      <ReviewPageHeader
+        document={document}
+        annotations={annotations}
+        notify={notify}
+        onVersionUploaded={handleVersionChange}
       />
       <ReviewViewTabs
         documentId={routeSegment}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -42,6 +42,11 @@ import { ReviewTasksPage } from './ReviewTasksPage';
 // hooks above stay mocked, so a bare client per file is all the tests need.
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
+vi.mock('../../components/reviews/hub/ReviewHubHead', () => ({
+  ReviewHubHead: ({ isOwner }: { isOwner: boolean }) => (
+    <div data-testid="review-hub-head" data-is-owner={String(isOwner)} />
+  ),
+}));
 vi.mock('../../api/hooks/useDocuments', () => ({
   useDocument: vi.fn(),
   useDocumentVersions: vi.fn(),
@@ -90,7 +95,13 @@ function mockData() {
   vi.mocked(useDocument).mockReturnValue({
     isPending: false,
     isError: false,
-    data: { id: 'd1', title: 'Supply Contract', ownerId: 'owner-1', latestVersionNumber: 2 },
+    data: {
+      id: 'd1',
+      title: 'Supply Contract',
+      ownerId: 'owner-1',
+      latestVersionNumber: 2,
+      workflowState: 'IN_REVIEW',
+    },
   } as never);
   vi.mocked(useDocumentVersions).mockReturnValue({
     data: { versions: [{ versionNumber: 1 }, { versionNumber: 2 }] },
@@ -212,6 +223,7 @@ describe('ReviewTasksPage', () => {
         ownerId: 'owner-1',
         latestVersionNumber: 2,
         anonymous: true,
+        workflowState: 'IN_REVIEW',
       },
     } as never);
     renderPage();

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -34,6 +34,7 @@ import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useRecordVisit } from '../../api/hooks/useReviews';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { ReviewPageHeader } from '../../components/reviews/hub/ReviewPageHeader';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
 import { useReviewPermalink } from '../../components/reviews/useReviewPermalink';
@@ -125,6 +126,10 @@ export function ReviewTasksPage() {
   const [openTaskId, setOpenTaskId] = useState<string | null>(null);
   const [newTaskOpen, setNewTaskOpen] = useState(false);
 
+  // A new version uploaded from this tab lands on its Document view (issue #571).
+  const goToNewVersion = (versionNumber: number) =>
+    navigate(`/reviews/${routeSegment}?version=${versionNumber}`);
+
   const { resolveWith } = useResolveWithFeedback(notify);
 
   const setParam = (key: string, value: string | null) => {
@@ -206,33 +211,16 @@ export function ReviewTasksPage() {
     );
   }
   if (documentQuery.isError || !document) {
-    return (
-      <PageHeader
-        title="This review is not available"
-        titleAdornment={<Chip size="small" variant="outlined" label="Tasks" />}
-      />
-    );
+    return <PageHeader title="This review is not available" />;
   }
 
   return (
     <Stack spacing={2.5} sx={{ height: { md: '100%' }, minHeight: { md: 480 } }}>
-      <PageHeader
-        title={document.title}
-        titleAdornment={<Chip size="small" variant="outlined" label="Tasks" />}
-        action={
-          // A document-scoped task (issue #395) needs no selection — offered while the review is
-          // open and has a version to author against; the server refuses a closed review anyway.
-          isOpenWorkflowState(document.workflowState) && latestVersion >= 1 ? (
-            <Button
-              variant="contained"
-              size="small"
-              startIcon={<Plus size={16} />}
-              onClick={() => setNewTaskOpen(true)}
-            >
-              Global annotation
-            </Button>
-          ) : undefined
-        }
+      <ReviewPageHeader
+        document={document}
+        annotations={annotations}
+        notify={notify}
+        onVersionUploaded={goToNewVersion}
       />
       <ReviewViewTabs
         documentId={routeSegment}
@@ -284,6 +272,18 @@ export function ReviewTasksPage() {
             searchLabel="Search tasks"
           />
         </Box>
+        {/* A document-scoped task (issue #395) needs no selection — offered while the review is
+            open and has a version to author against; the server refuses a closed review anyway. */}
+        {isOpenWorkflowState(document.workflowState) && latestVersion >= 1 && (
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<Plus size={16} />}
+            onClick={() => setNewTaskOpen(true)}
+          >
+            Global annotation
+          </Button>
+        )}
       </Stack>
 
       {annotationsQuery.isPending ? (

--- a/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
@@ -37,6 +37,11 @@ import { useParticipants } from '../../api/hooks/useReviews';
 import { useVersionDiff } from '../../api/hooks/useVersionDiff';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 
+vi.mock('../../components/reviews/hub/ReviewHubHead', () => ({
+  ReviewHubHead: ({ isOwner }: { isOwner: boolean }) => (
+    <div data-testid="review-hub-head" data-is-owner={String(isOwner)} />
+  ),
+}));
 vi.mock('../../api/hooks/useDocuments', () => ({
   useDocument: vi.fn(),
   useDocumentVersions: vi.fn(),

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -37,7 +37,9 @@ import { useRenderedDocument } from '../../api/hooks/useDocuments';
 import { useParticipants } from '../../api/hooks/useReviews';
 import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useVersionDiff, versionDiffErrorCode } from '../../api/hooks/useVersionDiff';
-import { PageHeader } from '../../components/admin/layout/PageHeader';
+import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { useToast } from '../../components/admin/layout/useToast';
+import { ReviewPageHeader } from '../../components/reviews/hub/ReviewPageHeader';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
 import { ChangeSummaryPanel } from '../../components/reviews/diff/ChangeSummaryPanel';
@@ -60,6 +62,8 @@ export function VersionComparePage() {
   // The raw segment may be a slug (issue #411) — sibling links keep it, while
   // all data access below uses the canonical id resolved by the route gate.
   const { documentId: routeSegment = '' } = useParams();
+  const navigate = useNavigate();
+  const { toast, notify, clear } = useToast();
   const documentId = useReviewDocumentId();
   const [searchParams, setSearchParams] = useSearchParams();
   const { formatDateTime } = useFormatters();
@@ -100,9 +104,8 @@ export function VersionComparePage() {
   const diffQuery = useVersionDiff(documentId, from, to);
   // The tasks pill on the view tabs (issue #398) — cached alongside the other pages.
   const annotationsQuery = useAnnotations(documentId, readyNumbers.at(-1));
-  const openTaskCount = (annotationsQuery.data?.annotations ?? []).filter(
-    (annotation) => columnOf(annotation) !== 'done',
-  ).length;
+  const annotations = annotationsQuery.data?.annotations ?? [];
+  const openTaskCount = annotations.filter((annotation) => columnOf(annotation) !== 'done').length;
 
   const [activeChange, setActiveChange] = useState<number | null>(null);
   const [syncScroll, setSyncScroll] = useState(true);
@@ -159,9 +162,14 @@ export function VersionComparePage() {
 
   return (
     <Stack spacing={2.5} sx={{ height: { md: '100%' }, minHeight: { md: 480 } }}>
-      <PageHeader
-        title={document_.title}
-        titleAdornment={<Chip size="small" variant="outlined" label="Compare versions" />}
+      <ReviewPageHeader
+        document={document_}
+        annotations={annotations}
+        notify={notify}
+        onVersionUploaded={(versionNumber) =>
+          // A new version uploaded from this tab lands on its Document view (issue #571).
+          navigate(`/reviews/${routeSegment}?version=${versionNumber}`)
+        }
       />
       <ReviewViewTabs
         documentId={routeSegment}
@@ -302,6 +310,7 @@ export function VersionComparePage() {
           </Box>
         </>
       )}
+      <AdminToast toast={toast} onClose={clear} />
     </Stack>
   );
 }


### PR DESCRIPTION
Closes #571. Builds on #572's `WorkflowMilestones`.

## Problem

The three review tabs rendered three hand-rolled headers — Document had the milestone path, anonymity badge and full hub head; Tasks only an identity chip + a button; Compare only a chip. Switching tabs made the top of the page jump and lose the workflow position, progress, due date, participants and the status/version controls.

## Changes

- **New shared `ReviewPageHeader`** owns the composition; the pages call it with four props (`document`, `annotations`, `notify`, `onVersionUploaded`). The canonical document id and viewer identity are read inside the component, so `isOwner` cannot drift between tabs. `ReviewHubHead` already self-fetches workflow/participants/config, so no page needed new data loading beyond Compare's gaps.
- **Identity chips dropped** ('Tasks', 'Compare versions') — the tab bar already communicates the tab. The header deliberately has **no per-tab slot** (an optional extra action would reintroduce divergence).
- **Tasks**: 'Global annotation' relocates into the sub-toolbar next to the search (same open-review + version gate, same dialog wiring).
- **Uploads from Tasks/Compare** land on the new version's Document view (`/reviews/:segment?version=N`, slug-preserving); Document keeps its in-page version switch. Compare gains the toast seam (`useToast`/`AdminToast`) and `useNavigate` it never had.

## Test plan
- [x] All three page suites green with the shared header (Tasks/Compare mock `ReviewHubHead` with the same stub the Document test uses)
- [x] The plan-predicted `workflowState: undefined` fixture crash surfaced exactly as expected in two tasks fixtures and was fixed there (the API contract marks the field required — production unaffected)
- [x] 'Global annotation' assertions keep passing against the relocated button; the closed-review gate test still covers it
- [x] Full gate green: 1000 tests / 143 files, eslint, prettier, typecheck

🤖 Co-Author: Claude (Fable 5) via Claude Code