### PR TITLE
fix(storage): verify-and-heal COMMITTED dedup hits against out-of-band loss (#575)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/storage/StorageServiceIT.java
+++ b/qnop-app/src/test/java/io/qnop/storage/StorageServiceIT.java
@@ -111,6 +111,33 @@ class StorageServiceIT extends AbstractIntegrationTest {
   }
 
   @Test
+  void reStagingHealsACommittedRowWhoseObjectVanishedOutOfBand() {
+    // Reproduce the #575 loss: a COMMITTED row (the object was durable once) whose object was
+    // removed out of band — bucket wiped / restored without the object store. Delete only the
+    // object via the provider; the registry row survives and stays COMMITTED.
+    byte[] data = uniqueContent();
+    StagedObject staged = stage(data, "application/pdf");
+    storage.commit(staged.key());
+    provider.delete(staged.key());
+    assertThat(provider.exists(staged.key())).isFalse();
+    assertThat(repository.findByObjectKey(staged.key()))
+        .hasValueSatisfying(
+            row -> assertThat(row.getStatus()).isEqualTo(StorageObjectStatus.COMMITTED));
+
+    // Re-staging identical content must verify the vanished object and re-upload it, instead of
+    // trusting the COMMITTED row and returning a key that points at nothing.
+    StagedObject restaged = stage(data, "application/pdf");
+
+    assertThat(restaged.key()).isEqualTo(staged.key());
+    assertThat(provider.exists(staged.key())).isTrue();
+    // Healing never demotes the row — it is still, correctly, COMMITTED.
+    assertThat(repository.findByObjectKey(staged.key()))
+        .hasValueSatisfying(
+            row -> assertThat(row.getStatus()).isEqualTo(StorageObjectStatus.COMMITTED));
+    storage.delete(staged.key());
+  }
+
+  @Test
   void identicalContentDeduplicates() {
     byte[] data = uniqueContent();
 

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
@@ -82,12 +82,16 @@ public class StorageService {
    * Buffers the content (to compute its hash and length), records a {@code PENDING} registry row,
    * and uploads it under a content-addressed key.
    *
-   * <p><strong>Dedup is authoritative only for {@code COMMITTED} rows</strong> (issue #289): a
-   * {@code PENDING} row can be <em>poisoned</em> — it is persisted before {@code put}, so a failed
-   * upload leaves a row with no object behind it. On a {@code PENDING} hit (or a lost concurrent
-   * insert race), the object's real existence is checked and it is (re-)uploaded when missing;
-   * {@code put} is idempotent for a content-addressed key + identical bytes, so this self-heals a
-   * failed earlier upload without ever returning a key that points at nothing.
+   * <p><strong>A registry hit is a dedup hint, never blind trust</strong> — the object's real
+   * existence is verified before the upload is skipped, and it is (re-)uploaded from the buffered
+   * bytes whenever it is actually absent. {@code put} is idempotent for a content-addressed key +
+   * identical bytes, so this self-heals without ever returning a key that points at nothing. Two
+   * ways the row can outlive its object: a {@code PENDING} row can be <em>poisoned</em> — it is
+   * persisted before {@code put}, so a failed upload leaves a row with no object (issue #289); and
+   * a {@code COMMITTED} row can be orphaned by <em>out-of-band</em> object loss — the bucket is
+   * wiped or an environment is restored without the object store, leaving the row pointing at
+   * nothing (issue #575). Both are healed here because {@code stage} demonstrably holds the full
+   * bytes.
    */
   public StagedObject stage(InputStream content, String contentType) {
     return stage(content, contentType, Long.MAX_VALUE);
@@ -109,7 +113,19 @@ public class StorageService {
 
       Optional<StorageObject> existing = repository.findByObjectKey(key);
       if (existing.map(o -> o.getStatus() == StorageObjectStatus.COMMITTED).orElse(false)) {
-        return new StagedObject(key, hash, size); // authoritative dedup: the object is durable
+        // Fast path: a COMMITTED row means the object was durable once. But it can still vanish
+        // out of band (bucket wiped, environment restored without the object store), and the row
+        // survives — so verify it, and re-materialize from the bytes we already buffered when it
+        // is gone, rather than returning a key that points at nothing (issue #575). One HEAD per
+        // dedup hit is negligible against an upload; the row stays COMMITTED (it still is).
+        if (!provider.exists(key)) {
+          log.warn(
+              "Committed storage object {} was missing from the provider — re-uploaded from "
+                  + "buffered content (out-of-band object loss)",
+              key);
+          uploadBuffered(buffer, key, size, contentType);
+        }
+        return new StagedObject(key, hash, size);
       }
       // Persist the PENDING row (in Spring Data's own transaction) BEFORE the upload, so a crash
       // between the two always leaves a row the reaper can reclaim. A concurrent stage of identical

--- a/qnop-core/src/test/java/io/qnop/service/storage/StorageServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/storage/StorageServiceTest.java
@@ -44,9 +44,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
 
 /**
- * DB-free unit tests for {@link StorageService#stage} dedup correctness (issue #289): only {@code
- * COMMITTED} rows are authoritative, and a {@code PENDING} row is (re-)uploaded when the object is
- * actually missing — so a failed earlier {@code put} can never poison the key.
+ * DB-free unit tests for {@link StorageService#stage} dedup correctness. A registry hit is only a
+ * dedup hint: the object's real existence is verified before the upload is skipped, and it is
+ * (re-)uploaded from the buffered bytes whenever it is missing — whether the row is a poisoned
+ * {@code PENDING} one (issue #289) or a {@code COMMITTED} one whose object vanished out of band
+ * (issue #575) — so a stale row can never leave a key pointing at nothing.
  */
 class StorageServiceTest {
 
@@ -94,14 +96,31 @@ class StorageServiceTest {
   }
 
   @Test
-  @DisplayName("a COMMITTED hit dedups without uploading or a HEAD check")
-  void committedRowIsAuthoritativeDedup() {
+  @DisplayName("a COMMITTED hit whose object exists dedups without uploading")
+  void committedRowWithExistingObjectDedups() {
     when(repository.findByObjectKey(anyString())).thenReturn(Optional.of(committedRow()));
+    when(provider.exists(anyString())).thenReturn(true);
 
     storage.stage(content(), "application/pdf");
 
+    // The object is verified present, then the upload is skipped and the row left untouched.
+    verify(provider).exists(anyString());
     verify(provider, never()).put(anyString(), any(), anyLong(), anyString());
-    verify(provider, never()).exists(anyString());
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("a COMMITTED hit whose object vanished out of band re-uploads — the #575 fix")
+  void committedRowWithMissingObjectIsReuploaded() {
+    when(repository.findByObjectKey(anyString())).thenReturn(Optional.of(committedRow()));
+    when(provider.exists(anyString())).thenReturn(false);
+
+    storage.stage(content(), "application/pdf");
+
+    // The COMMITTED row is no longer trusted blindly: the absent object is re-materialized from
+    // the buffered bytes, and the row is not re-inserted (it already exists and stays COMMITTED).
+    verify(provider).exists(anyString());
+    verify(provider).put(anyString(), any(), anyLong(), eq("application/pdf"));
     verify(repository, never()).save(any());
   }
 


### PR DESCRIPTION
## Summary

`StorageService.stage(...)` trusted a `COMMITTED` registry row unconditionally — the dedup fast path returned without ever asking the provider whether the object still exists. When the object store changes out of band (bucket emptied, bucket re-created, environment restored without the object store), the DB row survives but the object does not: a new review deduplicates to that key, no upload happens, extraction then can't find the object, and the reviewer sees an empty document. Closes #575.

## Fix

Extend the #289 `PENDING` verify-and-heal to `COMMITTED` hits: on a `COMMITTED` dedup hit, HEAD the object (`provider.exists`), and when it's absent re-upload from the bytes `stage` already buffered (`put` is idempotent for a content-addressed key + identical content) and log a warning. `stage` demonstrably holds the full bytes, so healing is free and total; the row stays `COMMITTED`.

- **Cost:** one HEAD per dedup hit — negligible against an upload — turning silent data-loss propagation into a self-healing path.
- Comment attachments share `stage`, so they heal too.

## Scope

Prevention that **complements #523** (admin storage-consistency scan): #523 *detects* DB↔storage drift for already-ingested versions after the fact; this *prevents* new uploads from re-referencing vanished objects. Neither replaces the other — versions whose objects vanished still need #523-style detection/remediation.

## Test plan

- [x] DB-free unit tests (`StorageServiceTest`): a `COMMITTED` hit whose object exists dedups without uploading; a `COMMITTED` hit whose object vanished re-uploads and does not re-insert the row.
- [x] Spotless + ArchUnit + unit tests green locally.
- [ ] IT (`StorageServiceIT`, MinIO/Testcontainers, CI-only): stage → `commit` → delete the object out of band via the provider (row stays `COMMITTED`) → re-stage identical content → assert the object exists again and the row is still `COMMITTED`.

## Notes

Updated the `stage` javadoc and the poisoned-row comment to reflect the widened skepticism (a registry hit is a dedup hint, never blind trust). No ADR needed — behavioural hardening within ADR-0005/0036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
