### PR TITLE
fix(teams): never leave a team with members but no lead (#542)

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1569,9 +1569,10 @@ paths:
         A LEAD of the team (or an ADMIN) promotes a member to LEAD or demotes a
         LEAD to MEMBER (issue #470). Demoting the team's last remaining LEAD is
         rejected with 409 `LAST_LEAD`, which also prevents a sole lead from locking
-        themselves out. A lead may not change their OWN role (409
-        `SELF_ROLE_CHANGE`) — demoting a lead is another lead's or an admin's
-        call; admins are exempt. Any non-lead caller gets 403.
+        themselves out. Nobody changes their OWN role through this surface (409
+        `SELF_ROLE_CHANGE`, mirroring `SELF_REMOVAL`) — demoting a lead is
+        another lead's or an admin's call, and the admin console is the path
+        for one's own role. Any non-lead caller gets 403.
       operationId: setMyTeamMemberRole
       security:
         - bearerAuth: []
@@ -1599,8 +1600,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: >-
-            The change would leave the team without a lead (`LAST_LEAD`), or a
-            non-admin caller is changing their own role (`SELF_ROLE_CHANGE`)
+            The change would leave the team without a lead (`LAST_LEAD`), or
+            the caller is changing their own role (`SELF_ROLE_CHANGE`)
           content:
             application/json:
               schema:

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -1569,7 +1569,9 @@ paths:
         A LEAD of the team (or an ADMIN) promotes a member to LEAD or demotes a
         LEAD to MEMBER (issue #470). Demoting the team's last remaining LEAD is
         rejected with 409 `LAST_LEAD`, which also prevents a sole lead from locking
-        themselves out. Any non-lead caller gets 403.
+        themselves out. A lead may not change their OWN role (409
+        `SELF_ROLE_CHANGE`) — demoting a lead is another lead's or an admin's
+        call; admins are exempt. Any non-lead caller gets 403.
       operationId: setMyTeamMemberRole
       security:
         - bearerAuth: []
@@ -1596,7 +1598,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '409':
-          description: The change would leave the team without a lead (`LAST_LEAD`)
+          description: >-
+            The change would leave the team without a lead (`LAST_LEAD`), or a
+            non-admin caller is changing their own role (`SELF_ROLE_CHANGE`)
           content:
             application/json:
               schema:

--- a/qnop-app/src/test/java/io/qnop/web/MyTeamsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/MyTeamsControllerIT.java
@@ -261,8 +261,13 @@ class MyTeamsControllerIT extends AbstractIntegrationTest {
   void lastLeadCannotBeDemotedOrRemoved() throws Exception {
     String admin = token(createUser("root", UserRole.ADMIN));
     User lead = createUser("lead", UserRole.MEMBER);
+    User member = createUser("member", UserRole.MEMBER);
     String teamId = createTeam(admin, "Core");
     addMember(admin, teamId, lead, "LEAD");
+    // A plain member remains, so removing/demoting the lead would strip the team's last
+    // lead while members remain — the guarded case (removing the *sole* member instead
+    // empties the team, which is allowed; issue #542).
+    addMember(admin, teamId, member, "MEMBER");
 
     String leadToken = token("lead");
 

--- a/qnop-app/src/test/java/io/qnop/web/MyTeamsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/MyTeamsControllerIT.java
@@ -269,13 +269,12 @@ class MyTeamsControllerIT extends AbstractIntegrationTest {
     // empties the team, which is allowed; issue #542).
     addMember(admin, teamId, member, "MEMBER");
 
-    String leadToken = token("lead");
-
-    // The sole lead cannot demote themselves (self-lockout) ...
+    // The sole lead cannot be demoted — exercised via the admin, since a lead's
+    // self-demotion is already refused earlier as SELF_ROLE_CHANGE (#542 follow-up) ...
     mockMvc
         .perform(
             patch("/api/v1/teams/{id}/members/{uid}", teamId, lead.getId())
-                .header("Authorization", bearer(leadToken))
+                .header("Authorization", bearer(admin))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"teamRole\":\"MEMBER\"}"))
         .andExpect(status().isConflict())
@@ -288,6 +287,37 @@ class MyTeamsControllerIT extends AbstractIntegrationTest {
                 .header("Authorization", bearer(admin)))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value("LAST_LEAD"));
+  }
+
+  @Test
+  void leadCannotChangeTheirOwnRoleButAnotherLeadMay() throws Exception {
+    String admin = token(createUser("root", UserRole.ADMIN));
+    User lead = createUser("lead", UserRole.MEMBER);
+    User coLead = createUser("colead", UserRole.MEMBER);
+    String teamId = createTeam(admin, "Core");
+    addMember(admin, teamId, lead, "LEAD");
+    addMember(admin, teamId, coLead, "LEAD");
+
+    // A co-lead remains, so the last-lead guard would allow it — but demoting a
+    // lead is another lead's or an admin's call, never their own (#542 follow-up).
+    mockMvc
+        .perform(
+            patch("/api/v1/teams/{id}/members/{uid}", teamId, lead.getId())
+                .header("Authorization", bearer(token("lead")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamRole\":\"MEMBER\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("SELF_ROLE_CHANGE"));
+
+    // The other lead may demote them.
+    mockMvc
+        .perform(
+            patch("/api/v1/teams/{id}/members/{uid}", teamId, lead.getId())
+                .header("Authorization", bearer(token("colead")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamRole\":\"MEMBER\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.teamRole").value("MEMBER"));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/TeamControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/TeamControllerIT.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -121,6 +122,7 @@ class TeamControllerIT extends AbstractIntegrationTest {
   void manageMembers() throws Exception {
     createUser("root", UserRole.ADMIN);
     User alice = createUser("alice", UserRole.MEMBER);
+    User bob = createUser("bob", UserRole.MEMBER);
     String token = token("root");
     String teamId = createTeam(token, "Core", null);
 
@@ -151,7 +153,16 @@ class TeamControllerIT extends AbstractIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.members[0].teamRole").value("LEAD"));
 
-    // Change the role.
+    // Add a second lead so demoting alice does not strip the team's last lead (#542).
+    mockMvc
+        .perform(
+            post("/api/v1/admin/teams/{id}/members", teamId)
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"%s\",\"teamRole\":\"LEAD\"}".formatted(bob.getId())))
+        .andExpect(status().isCreated());
+
+    // Change the role (allowed now that bob remains a lead).
     mockMvc
         .perform(
             patch("/api/v1/admin/teams/{id}/members/{uid}", teamId, alice.getId())
@@ -162,6 +173,59 @@ class TeamControllerIT extends AbstractIntegrationTest {
         .andExpect(jsonPath("$.teamRole").value("MEMBER"));
 
     // Remove the member.
+    mockMvc
+        .perform(
+            delete("/api/v1/admin/teams/{id}/members/{uid}", teamId, alice.getId())
+                .header("Authorization", bearer(token)))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("the last lead cannot be demoted or removed while other members remain (#542)")
+  void lastLeadIsProtected() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User alice = createUser("alice", UserRole.MEMBER); // the sole lead
+    User bob = createUser("bob", UserRole.MEMBER); // a plain member
+    String token = token("root");
+    String teamId = createTeam(token, "Core", null);
+    addMember(token, teamId, alice.getId(), "LEAD");
+    addMember(token, teamId, bob.getId(), "MEMBER");
+
+    // Demoting the sole lead → 409 LAST_LEAD, unchanged.
+    mockMvc
+        .perform(
+            patch("/api/v1/admin/teams/{id}/members/{uid}", teamId, alice.getId())
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamRole\":\"MEMBER\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("LAST_LEAD"));
+
+    // Removing the sole lead → 409 LAST_LEAD, unchanged.
+    mockMvc
+        .perform(
+            delete("/api/v1/admin/teams/{id}/members/{uid}", teamId, alice.getId())
+                .header("Authorization", bearer(token)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("LAST_LEAD"));
+
+    // Alice is still a LEAD.
+    mockMvc
+        .perform(get("/api/v1/admin/teams/{id}", teamId).header("Authorization", bearer(token)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.members[?(@.displayName == 'alice')].teamRole").value("LEAD"));
+  }
+
+  @Test
+  @DisplayName("removing the sole member (the last lead) empties the team and is allowed (#542)")
+  void soleMemberCanBeRemoved() throws Exception {
+    createUser("root", UserRole.ADMIN);
+    User alice = createUser("alice", UserRole.MEMBER);
+    String token = token("root");
+    String teamId = createTeam(token, "Core", null);
+    addMember(token, teamId, alice.getId(), "LEAD");
+
+    // No other members remain, so removing the sole lead empties the team — allowed.
     mockMvc
         .perform(
             delete("/api/v1/admin/teams/{id}/members/{uid}", teamId, alice.getId())
@@ -236,6 +300,16 @@ class TeamControllerIT extends AbstractIntegrationTest {
     Matcher matcher = ID_FIELD.matcher(result.getResponse().getContentAsString());
     assertThat(matcher.find()).isTrue();
     return matcher.group(1);
+  }
+
+  private void addMember(String token, String teamId, UUID userId, String role) throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/admin/teams/{id}/members", teamId)
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"%s\",\"teamRole\":\"%s\"}".formatted(userId, role)))
+        .andExpect(status().isCreated());
   }
 
   private static String bearer(String token) {

--- a/qnop-core/src/main/java/io/qnop/repository/TeamMembershipRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/TeamMembershipRepository.java
@@ -43,6 +43,12 @@ public interface TeamMembershipRepository extends JpaRepository<TeamMembership, 
   /** How many members hold the given role in the team — the last-lead guardrail (#470). */
   long countByTeamIdAndTeamRole(UUID teamId, TeamRole teamRole);
 
+  /**
+   * Total members of a team, regardless of role — lets the last-lead guard allow emptying a team
+   * (removing its sole member) while still blocking a lead-less team with members (issue #542).
+   */
+  long countByTeamId(UUID teamId);
+
   /** The members of a team joined with their user identity, ordered by display name. */
   @Query(
       "SELECT new io.qnop.repository.TeamMemberProjection("

--- a/qnop-core/src/main/java/io/qnop/service/TeamService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TeamService.java
@@ -306,16 +306,17 @@ public class TeamService {
 
   /**
    * Change a member's role as a lead (or admin); refuses to demote the last lead (issue #470). A
-   * non-admin lead may never change their OWN role here (issue #542 follow-up): demoting a lead is
-   * another lead's or an admin's call — otherwise a lead could quietly slip out of their
-   * responsibility (and self-promotion is meaningless, since only leads reach this path). Admins
-   * are exempt, in line with the admin-may-do-everything direction.
+   * caller may never change their OWN role through this self-management surface (issue #542
+   * follow-up): demoting a lead is a hand-over decision made by another lead or an admin —
+   * otherwise a lead could quietly slip out of their responsibility. This mirrors the {@code
+   * SELF_REMOVAL} rule exactly, admins included — the admin console ({@code /admin/teams}) is the
+   * path for changing one's own role.
    */
   @Transactional
   public TeamMemberView setMemberRoleAsLead(
       UUID teamId, UUID actorId, boolean admin, UUID userId, String teamRole) {
     requireLeadOrAdmin(teamId, actorId, admin);
-    if (!admin && actorId.equals(userId)) {
+    if (actorId.equals(userId)) {
       throw new TeamConflictException(
           "SELF_ROLE_CHANGE",
           "You cannot change your own role — ask another lead or an administrator.");

--- a/qnop-core/src/main/java/io/qnop/service/TeamService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TeamService.java
@@ -304,11 +304,22 @@ public class TeamService {
     return addMember(teamId, userId, teamRole);
   }
 
-  /** Change a member's role as a lead (or admin); refuses to demote the last lead (issue #470). */
+  /**
+   * Change a member's role as a lead (or admin); refuses to demote the last lead (issue #470). A
+   * non-admin lead may never change their OWN role here (issue #542 follow-up): demoting a lead is
+   * another lead's or an admin's call — otherwise a lead could quietly slip out of their
+   * responsibility (and self-promotion is meaningless, since only leads reach this path). Admins
+   * are exempt, in line with the admin-may-do-everything direction.
+   */
   @Transactional
   public TeamMemberView setMemberRoleAsLead(
       UUID teamId, UUID actorId, boolean admin, UUID userId, String teamRole) {
     requireLeadOrAdmin(teamId, actorId, admin);
+    if (!admin && actorId.equals(userId)) {
+      throw new TeamConflictException(
+          "SELF_ROLE_CHANGE",
+          "You cannot change your own role — ask another lead or an administrator.");
+    }
     // The last-lead guard and the team lock live in the base setMemberRole (issue #542),
     // so this self-service path is covered by the same invariant as the admin path.
     return setMemberRole(teamId, userId, teamRole);

--- a/qnop-core/src/main/java/io/qnop/service/TeamService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TeamService.java
@@ -177,21 +177,31 @@ public class TeamService {
 
   @Transactional
   public TeamMemberView setMemberRole(UUID teamId, UUID userId, String teamRole) {
+    TeamRole target = requireTeamRole(teamRole);
+    lockTeam(teamId);
     TeamMembership membership =
         memberships
             .findByTeamIdAndUserId(teamId, userId)
             .orElseThrow(() -> TeamNotFoundException.membership(teamId, userId));
-    membership.setTeamRole(requireTeamRole(teamRole));
+    if (target == TeamRole.MEMBER) {
+      // Demoting the team's last lead would leave the team with members and no lead.
+      guardKeepsALead(teamId, userId, false);
+    }
+    membership.setTeamRole(target);
     User user = users.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
     return toMemberView(user, membership);
   }
 
   @Transactional
   public void removeMember(UUID teamId, UUID userId) {
+    lockTeam(teamId);
     TeamMembership membership =
         memberships
             .findByTeamIdAndUserId(teamId, userId)
             .orElseThrow(() -> TeamNotFoundException.membership(teamId, userId));
+    // Removing the last lead is refused only while other members remain; removing the
+    // sole member (who is that lead) empties the team, which is allowed (issue #542).
+    guardKeepsALead(teamId, userId, true);
     memberships.delete(membership);
   }
 
@@ -299,10 +309,8 @@ public class TeamService {
   public TeamMemberView setMemberRoleAsLead(
       UUID teamId, UUID actorId, boolean admin, UUID userId, String teamRole) {
     requireLeadOrAdmin(teamId, actorId, admin);
-    if (requireTeamRole(teamRole) == TeamRole.MEMBER) {
-      lockTeam(teamId);
-      guardNotLastLead(teamId, userId);
-    }
+    // The last-lead guard and the team lock live in the base setMemberRole (issue #542),
+    // so this self-service path is covered by the same invariant as the admin path.
     return setMemberRole(teamId, userId, teamRole);
   }
 
@@ -319,8 +327,7 @@ public class TeamService {
       throw new TeamConflictException(
           "SELF_REMOVAL", "You cannot remove yourself from a team; ask an administrator.");
     }
-    lockTeam(teamId);
-    guardNotLastLead(teamId, userId);
+    // The last-lead guard and the team lock live in the base removeMember (issue #542).
     removeMember(teamId, userId);
   }
 
@@ -344,16 +351,26 @@ public class TeamService {
   }
 
   /**
-   * Blocks an operation that would strip the team's last remaining lead. Only fires when {@code
-   * userId} is currently a LEAD and no other lead remains — removing/demoting a MEMBER, or a LEAD
-   * with co-leads, is unaffected. This is the single place the "never zero leads" invariant lives
-   * for the self-management surface, and it is what prevents a sole lead's self-lockout.
+   * Blocks an operation that would leave the team with members but no lead — the "never zero leads"
+   * invariant (issue #542), enforced here so every entry point (admin and the #470 self-management
+   * surface) is covered, and a sole lead can never lock themselves (or everyone) out. Fires only
+   * when {@code userId} is currently the team's <em>last</em> LEAD and the operation would still
+   * leave at least one member behind: a demotion (which keeps the member) always would, a removal
+   * only when other members remain. Removing/demoting a plain MEMBER, or a LEAD with a co-lead, is
+   * unaffected; removing the sole member (who is the last lead) empties the team, which is allowed
+   * — the legitimate just-created state (delete the team to be rid of it entirely).
    */
-  private void guardNotLastLead(UUID teamId, UUID userId) {
+  private void guardKeepsALead(UUID teamId, UUID userId, boolean removal) {
     boolean targetIsLead =
         memberships.existsByTeamIdAndUserIdAndTeamRole(teamId, userId, TeamRole.LEAD);
-    if (targetIsLead && memberships.countByTeamIdAndTeamRole(teamId, TeamRole.LEAD) <= 1) {
-      throw new TeamConflictException("LAST_LEAD", "A team must keep at least one lead.");
+    if (!targetIsLead || memberships.countByTeamIdAndTeamRole(teamId, TeamRole.LEAD) > 1) {
+      return;
+    }
+    long membersAfter = memberships.countByTeamId(teamId) - (removal ? 1 : 0);
+    if (membersAfter >= 1) {
+      throw new TeamConflictException(
+          "LAST_LEAD",
+          "A team must keep at least one lead — promote another member to lead first.");
     }
   }
 

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -71,6 +71,9 @@ databaseChangeLog:
   - include:
       file: migrations/0020-annotation-dismissed-status.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0021-team-slug-backfill.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/migrations/0021-team-slug-backfill.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0021-team-slug-backfill.yaml
@@ -1,0 +1,63 @@
+# Copyright (c) 2026-present devtank42 GmbH
+#
+# This file is part of qnop (Qualified Notes on Papers).
+#
+# qnop is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with qnop. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Backfills slugs for pre-slug teams (issue #542 follow-up): teams created
+# before TeamSlugService existed (#470) carry slug = NULL forever, so their
+# My Teams URLs fall back to the raw UUID. This one-time pass mirrors the
+# TeamSlugs derivation (lowercase, non-alphanumerics to hyphens, edge-trim,
+# 'team' fallback, no UUID-shaped slugs — those would be unreachable, since
+# the resolver parses UUID-shaped refs as ids) and the base-n collision rule,
+# honouring ck_team_slug and ux_team_slug_lower. Additive (post-1.0.0 rule);
+# a no-op on databases where every team already has a slug.
+databaseChangeLog:
+  - changeSet:
+      id: 0021-team-slug-backfill
+      author: qnop
+      comment: Backfills slugs for pre-slug teams (issue #542 follow-up).
+      changes:
+        - sql:
+            splitStatements: false
+            sql: |
+              DO $$
+              DECLARE
+                r RECORD;
+                base TEXT;
+                candidate TEXT;
+                n INT;
+              BEGIN
+                FOR r IN SELECT id, name FROM team WHERE slug IS NULL ORDER BY created_at, id LOOP
+                  base := trim(both '-' from regexp_replace(lower(r.name), '[^a-z0-9]+', '-', 'g'));
+                  IF base = '' THEN
+                    base := 'team';
+                  END IF;
+                  IF length(base) < 3
+                     OR base ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+                    base := base || '-team';
+                  END IF;
+                  base := trim(both '-' from substr(base, 1, 64));
+                  candidate := base;
+                  n := 1;
+                  WHILE EXISTS (SELECT 1 FROM team WHERE lower(slug) = lower(candidate)) LOOP
+                    n := n + 1;
+                    candidate :=
+                      trim(both '-' from substr(base, 1, 64 - length('-' || n::text))) || '-' || n;
+                  END LOOP;
+                  UPDATE team SET slug = candidate WHERE id = r.id;
+                END LOOP;
+              END $$;

--- a/qnop-core/src/test/java/io/qnop/service/TeamServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TeamServiceTest.java
@@ -330,8 +330,9 @@ class TeamServiceTest {
         .thenReturn(Optional.of(TeamMembership.of(teamId, lead, TeamRole.LEAD)));
     when(memberships.countByTeamId(teamId)).thenReturn(2L); // another member remains
 
-    // The sole lead cannot self-demote (last-lead) ...
-    assertThatThrownBy(() -> service.setMemberRoleAsLead(teamId, lead, false, lead, "MEMBER"))
+    // Even an admin cannot demote the sole lead (the admin actor also skips the
+    // self-role-change check, so this exercises the last-lead guard in isolation) ...
+    assertThatThrownBy(() -> service.setMemberRoleAsLead(teamId, admin, true, lead, "MEMBER"))
         .isInstanceOf(TeamConflictException.class)
         .extracting("code")
         .isEqualTo("LAST_LEAD");
@@ -342,6 +343,36 @@ class TeamServiceTest {
         .extracting("code")
         .isEqualTo("LAST_LEAD");
     verify(memberships, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("a lead cannot change their own role — another lead or an admin must (#542)")
+  void leadCannotChangeOwnRole() {
+    UUID teamId = UUID.randomUUID();
+    UUID lead = UUID.randomUUID();
+    when(memberships.existsByTeamIdAndUserIdAndTeamRole(teamId, lead, TeamRole.LEAD))
+        .thenReturn(true);
+
+    assertThatThrownBy(() -> service.setMemberRoleAsLead(teamId, lead, false, lead, "MEMBER"))
+        .isInstanceOf(TeamConflictException.class)
+        .extracting("code")
+        .isEqualTo("SELF_ROLE_CHANGE");
+    // The self-check fires before the membership is ever resolved, so it blocks
+    // self-demotion even when co-leads remain.
+    verify(memberships, never()).findByTeamIdAndUserId(any(), any());
+
+    // An admin changing their own role is exempt (admin-may-do-everything); the
+    // last-lead guard still applies and passes here because a co-lead remains.
+    UUID admin = UUID.randomUUID();
+    when(memberships.existsByTeamIdAndUserIdAndTeamRole(teamId, admin, TeamRole.LEAD))
+        .thenReturn(true);
+    when(memberships.countByTeamIdAndTeamRole(teamId, TeamRole.LEAD)).thenReturn(2L);
+    when(memberships.findByTeamIdAndUserId(teamId, admin))
+        .thenReturn(Optional.of(TeamMembership.of(teamId, admin, TeamRole.LEAD)));
+    when(users.findById(admin))
+        .thenReturn(Optional.of(User.internal("Ad", "ad@example.com", "ad", "h")));
+    assertThat(service.setMemberRoleAsLead(teamId, admin, true, admin, "MEMBER").teamRole())
+        .isEqualTo("MEMBER");
   }
 
   @Test

--- a/qnop-core/src/test/java/io/qnop/service/TeamServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TeamServiceTest.java
@@ -324,6 +324,11 @@ class TeamServiceTest {
     when(memberships.existsByTeamIdAndUserIdAndTeamRole(teamId, lead, TeamRole.LEAD))
         .thenReturn(true);
     when(memberships.countByTeamIdAndTeamRole(teamId, TeamRole.LEAD)).thenReturn(1L);
+    // The guard now lives in the base methods (issue #542), which resolve the membership
+    // and count the remaining members before deciding.
+    when(memberships.findByTeamIdAndUserId(teamId, lead))
+        .thenReturn(Optional.of(TeamMembership.of(teamId, lead, TeamRole.LEAD)));
+    when(memberships.countByTeamId(teamId)).thenReturn(2L); // another member remains
 
     // The sole lead cannot self-demote (last-lead) ...
     assertThatThrownBy(() -> service.setMemberRoleAsLead(teamId, lead, false, lead, "MEMBER"))
@@ -388,6 +393,48 @@ class TeamServiceTest {
         .thenReturn(Optional.of(memberMembership));
     service.removeMemberAsLead(teamId, actor, false, member);
     verify(memberships).delete(memberMembership);
+  }
+
+  @Test
+  @DisplayName(
+      "admin path: demoting or removing the last lead is rejected while members remain (#542)")
+  void adminPathLastLeadGuard() {
+    UUID teamId = UUID.randomUUID();
+    UUID lead = UUID.randomUUID();
+    when(memberships.existsByTeamIdAndUserIdAndTeamRole(teamId, lead, TeamRole.LEAD))
+        .thenReturn(true);
+    when(memberships.countByTeamIdAndTeamRole(teamId, TeamRole.LEAD)).thenReturn(1L);
+    when(memberships.findByTeamIdAndUserId(teamId, lead))
+        .thenReturn(Optional.of(TeamMembership.of(teamId, lead, TeamRole.LEAD)));
+    when(memberships.countByTeamId(teamId)).thenReturn(2L); // a second member remains
+
+    // The admin endpoints call the base methods directly — the guard must fire there too.
+    assertThatThrownBy(() -> service.setMemberRole(teamId, lead, "MEMBER"))
+        .isInstanceOf(TeamConflictException.class)
+        .extracting("code")
+        .isEqualTo("LAST_LEAD");
+    assertThatThrownBy(() -> service.removeMember(teamId, lead))
+        .isInstanceOf(TeamConflictException.class)
+        .extracting("code")
+        .isEqualTo("LAST_LEAD");
+    verify(memberships, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName(
+      "admin path: removing the sole member (the last lead) empties the team and is allowed (#542)")
+  void adminPathEmptyTeamAllowed() {
+    UUID teamId = UUID.randomUUID();
+    UUID lead = UUID.randomUUID();
+    when(memberships.existsByTeamIdAndUserIdAndTeamRole(teamId, lead, TeamRole.LEAD))
+        .thenReturn(true);
+    when(memberships.countByTeamIdAndTeamRole(teamId, TeamRole.LEAD)).thenReturn(1L);
+    TeamMembership sole = TeamMembership.of(teamId, lead, TeamRole.LEAD);
+    when(memberships.findByTeamIdAndUserId(teamId, lead)).thenReturn(Optional.of(sole));
+    when(memberships.countByTeamId(teamId)).thenReturn(1L); // the sole member
+
+    service.removeMember(teamId, lead); // empties the team — allowed
+    verify(memberships).delete(sole);
   }
 
   private static Team teamWithId(UUID id, String name) {

--- a/qnop-core/src/test/java/io/qnop/service/TeamServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TeamServiceTest.java
@@ -346,7 +346,7 @@ class TeamServiceTest {
   }
 
   @Test
-  @DisplayName("a lead cannot change their own role — another lead or an admin must (#542)")
+  @DisplayName("nobody changes their own role through the self-management surface (#542)")
   void leadCannotChangeOwnRole() {
     UUID teamId = UUID.randomUUID();
     UUID lead = UUID.randomUUID();
@@ -357,22 +357,17 @@ class TeamServiceTest {
         .isInstanceOf(TeamConflictException.class)
         .extracting("code")
         .isEqualTo("SELF_ROLE_CHANGE");
+
+    // Admins included — mirroring SELF_REMOVAL: one's own role changes via the
+    // admin console, never through this surface.
+    UUID admin = UUID.randomUUID();
+    assertThatThrownBy(() -> service.setMemberRoleAsLead(teamId, admin, true, admin, "MEMBER"))
+        .isInstanceOf(TeamConflictException.class)
+        .extracting("code")
+        .isEqualTo("SELF_ROLE_CHANGE");
     // The self-check fires before the membership is ever resolved, so it blocks
     // self-demotion even when co-leads remain.
     verify(memberships, never()).findByTeamIdAndUserId(any(), any());
-
-    // An admin changing their own role is exempt (admin-may-do-everything); the
-    // last-lead guard still applies and passes here because a co-lead remains.
-    UUID admin = UUID.randomUUID();
-    when(memberships.existsByTeamIdAndUserIdAndTeamRole(teamId, admin, TeamRole.LEAD))
-        .thenReturn(true);
-    when(memberships.countByTeamIdAndTeamRole(teamId, TeamRole.LEAD)).thenReturn(2L);
-    when(memberships.findByTeamIdAndUserId(teamId, admin))
-        .thenReturn(Optional.of(TeamMembership.of(teamId, admin, TeamRole.LEAD)));
-    when(users.findById(admin))
-        .thenReturn(Optional.of(User.internal("Ad", "ad@example.com", "ad", "h")));
-    assertThat(service.setMemberRoleAsLead(teamId, admin, true, admin, "MEMBER").teamRole())
-        .isEqualTo("MEMBER");
   }
 
   @Test

--- a/qnop-ui/src/pages/my-teams/MyTeamDetailPage.test.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamDetailPage.test.tsx
@@ -169,7 +169,7 @@ describe('MyTeamDetailPage', () => {
     expect(removeMemberMutate.mock.calls[0][0]).toEqual({ teamId: 't1', userId: 'u1' });
   });
 
-  it('offers no actions at all on a non-admin lead’s own row (#542 follow-up)', () => {
+  it('offers no actions at all on the caller’s own row (#542 follow-up)', () => {
     useAuthStore.setState({ userId: 'u1' }); // the caller is the lead Ada (u1)
     renderPage();
 
@@ -180,14 +180,12 @@ describe('MyTeamDetailPage', () => {
     expect(screen.getByRole('button', { name: 'Actions for Alan Turing' })).toBeTruthy();
   });
 
-  it('keeps the role change on an admin’s own row, but never self-removal', async () => {
+  it('hides the own-row actions for admins too — one’s own role changes in the admin console', () => {
     useAuthStore.setState({ userId: 'u1', role: 'ADMIN' });
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Actions for Ada Lovelace' }));
-
-    expect(await screen.findByText('Make member')).toBeTruthy();
-    expect(screen.queryByText('Remove from team')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Actions for Ada Lovelace' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Actions for Alan Turing' })).toBeTruthy();
   });
 
   it('surfaces an error toast when a removal is rejected (last-lead guard)', async () => {

--- a/qnop-ui/src/pages/my-teams/MyTeamDetailPage.test.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamDetailPage.test.tsx
@@ -102,7 +102,7 @@ beforeEach(() => {
   teamState.data = makeTeam();
   teamState.isLoading = false;
   teamState.isError = false;
-  useAuthStore.setState({ userId: null });
+  useAuthStore.setState({ userId: null, role: null });
 });
 
 function renderPage() {
@@ -169,8 +169,19 @@ describe('MyTeamDetailPage', () => {
     expect(removeMemberMutate.mock.calls[0][0]).toEqual({ teamId: 't1', userId: 'u1' });
   });
 
-  it('never offers self-removal on the caller’s own row, but keeps the hand-over demote', async () => {
+  it('offers no actions at all on a non-admin lead’s own row (#542 follow-up)', () => {
     useAuthStore.setState({ userId: 'u1' }); // the caller is the lead Ada (u1)
+    renderPage();
+
+    // Demoting yourself is another lead's or an admin's call, and self-removal
+    // was already off the table — so the own row carries no actions menu at all.
+    expect(screen.queryByRole('button', { name: 'Actions for Ada Lovelace' })).toBeNull();
+    // Other rows keep their menu.
+    expect(screen.getByRole('button', { name: 'Actions for Alan Turing' })).toBeTruthy();
+  });
+
+  it('keeps the role change on an admin’s own row, but never self-removal', async () => {
+    useAuthStore.setState({ userId: 'u1', role: 'ADMIN' });
     renderPage();
 
     fireEvent.click(screen.getByRole('button', { name: 'Actions for Ada Lovelace' }));

--- a/qnop-ui/src/pages/my-teams/MyTeamDetailPage.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamDetailPage.tsx
@@ -52,7 +52,7 @@ import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { useToast } from '../../components/admin/layout/useToast';
 import { PersonLink } from '../../components/dashboard/PersonLink';
 import { useFormatters } from '../../hooks/useFormatters';
-import { useAuthStore } from '../../stores/authStore';
+import { selectIsAdmin, useAuthStore } from '../../stores/authStore';
 import { apiErrorMessage } from '../../utils/apiError';
 
 /**
@@ -61,8 +61,10 @@ import { apiErrorMessage } from '../../utils/apiError';
  * (or an admin) gets member management — add, promote/demote, remove — while a
  * plain member gets a read-only roster. Members render as {@link PersonLink}
  * everywhere (avatar, profile hover-card, click-through to the profile), like the
- * rest of the app. A lead is never offered "Remove from team" on their own row;
- * the server rejects self-removal too. The last-lead guardrail surfaces as a toast.
+ * rest of the app. A lead is never offered "Remove from team" or a role change
+ * on their own row (issue #542 follow-up: demoting a lead is another lead's or
+ * an admin's call — admins keep the affordance); the server rejects self-removal
+ * and self-role-change too. The last-lead guardrail surfaces as a toast.
  */
 export function MyTeamDetailPage() {
   const { id = '' } = useParams();
@@ -70,6 +72,7 @@ export function MyTeamDetailPage() {
   const setRole = useSetMyTeamMemberRole();
   const removeMember = useRemoveMyTeamMember();
   const currentUserId = useAuthStore((s) => s.userId);
+  const viewerIsAdmin = useAuthStore(selectIsAdmin);
   const { formatDateTime } = useFormatters();
   const { toast, notify, clear } = useToast();
 
@@ -172,13 +175,17 @@ export function MyTeamDetailPage() {
                 </TableCell>
                 {canManage && (
                   <TableCell align="right">
-                    <IconButton
-                      size="small"
-                      aria-label={`Actions for ${member.displayName}`}
-                      onClick={(e) => openMenu(e, member)}
-                    >
-                      <MoreVertical size={18} />
-                    </IconButton>
+                    {/* A non-admin lead has no actions on their own row: no
+                        self-removal, no self-role-change (#542 follow-up). */}
+                    {(member.userId !== currentUserId || viewerIsAdmin) && (
+                      <IconButton
+                        size="small"
+                        aria-label={`Actions for ${member.displayName}`}
+                        onClick={(e) => openMenu(e, member)}
+                      >
+                        <MoreVertical size={18} />
+                      </IconButton>
+                    )}
                   </TableCell>
                 )}
               </TableRow>
@@ -190,19 +197,21 @@ export function MyTeamDetailPage() {
       {canManage && (
         <>
           <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
-            <MenuItem
-              onClick={() => {
-                setAnchorEl(null);
-                if (active) toggleRole(active);
-              }}
-            >
-              <ListItemIcon>
-                <ArrowLeftRight size={16} />
-              </ListItemIcon>
-              <ListItemText>
-                {active?.teamRole === 'LEAD' ? 'Make member' : 'Make lead'}
-              </ListItemText>
-            </MenuItem>
+            {(active?.userId !== currentUserId || viewerIsAdmin) && (
+              <MenuItem
+                onClick={() => {
+                  setAnchorEl(null);
+                  if (active) toggleRole(active);
+                }}
+              >
+                <ListItemIcon>
+                  <ArrowLeftRight size={16} />
+                </ListItemIcon>
+                <ListItemText>
+                  {active?.teamRole === 'LEAD' ? 'Make member' : 'Make lead'}
+                </ListItemText>
+              </MenuItem>
+            )}
             {active?.userId !== currentUserId && (
               <MenuItem
                 onClick={() => {

--- a/qnop-ui/src/pages/my-teams/MyTeamDetailPage.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamDetailPage.tsx
@@ -52,7 +52,7 @@ import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { useToast } from '../../components/admin/layout/useToast';
 import { PersonLink } from '../../components/dashboard/PersonLink';
 import { useFormatters } from '../../hooks/useFormatters';
-import { selectIsAdmin, useAuthStore } from '../../stores/authStore';
+import { useAuthStore } from '../../stores/authStore';
 import { apiErrorMessage } from '../../utils/apiError';
 
 /**
@@ -61,10 +61,12 @@ import { apiErrorMessage } from '../../utils/apiError';
  * (or an admin) gets member management — add, promote/demote, remove — while a
  * plain member gets a read-only roster. Members render as {@link PersonLink}
  * everywhere (avatar, profile hover-card, click-through to the profile), like the
- * rest of the app. A lead is never offered "Remove from team" or a role change
- * on their own row (issue #542 follow-up: demoting a lead is another lead's or
- * an admin's call — admins keep the affordance); the server rejects self-removal
- * and self-role-change too. The last-lead guardrail surfaces as a toast.
+ * rest of the app. Nobody manages their own membership here (issue #542
+ * follow-up, mirroring SELF_REMOVAL): the caller's own row carries no actions
+ * menu at all — no self-removal, no self-role-change; demoting a lead is
+ * another lead's or an admin's call, and one's own role changes via the admin
+ * console. The server rejects both anyway; the last-lead guardrail surfaces
+ * as a toast.
  */
 export function MyTeamDetailPage() {
   const { id = '' } = useParams();
@@ -72,7 +74,6 @@ export function MyTeamDetailPage() {
   const setRole = useSetMyTeamMemberRole();
   const removeMember = useRemoveMyTeamMember();
   const currentUserId = useAuthStore((s) => s.userId);
-  const viewerIsAdmin = useAuthStore(selectIsAdmin);
   const { formatDateTime } = useFormatters();
   const { toast, notify, clear } = useToast();
 
@@ -175,9 +176,10 @@ export function MyTeamDetailPage() {
                 </TableCell>
                 {canManage && (
                   <TableCell align="right">
-                    {/* A non-admin lead has no actions on their own row: no
-                        self-removal, no self-role-change (#542 follow-up). */}
-                    {(member.userId !== currentUserId || viewerIsAdmin) && (
+                    {/* Nobody manages their own membership here: no self-removal,
+                        no self-role-change (#542 follow-up) — so the own row
+                        carries no actions menu at all. */}
+                    {member.userId !== currentUserId && (
                       <IconButton
                         size="small"
                         aria-label={`Actions for ${member.displayName}`}
@@ -197,34 +199,30 @@ export function MyTeamDetailPage() {
       {canManage && (
         <>
           <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
-            {(active?.userId !== currentUserId || viewerIsAdmin) && (
-              <MenuItem
-                onClick={() => {
-                  setAnchorEl(null);
-                  if (active) toggleRole(active);
-                }}
-              >
-                <ListItemIcon>
-                  <ArrowLeftRight size={16} />
-                </ListItemIcon>
-                <ListItemText>
-                  {active?.teamRole === 'LEAD' ? 'Make member' : 'Make lead'}
-                </ListItemText>
-              </MenuItem>
-            )}
-            {active?.userId !== currentUserId && (
-              <MenuItem
-                onClick={() => {
-                  setAnchorEl(null);
-                  setRemoveTarget(active);
-                }}
-              >
-                <ListItemIcon>
-                  <UserMinus size={16} />
-                </ListItemIcon>
-                <ListItemText>Remove from team</ListItemText>
-              </MenuItem>
-            )}
+            <MenuItem
+              onClick={() => {
+                setAnchorEl(null);
+                if (active) toggleRole(active);
+              }}
+            >
+              <ListItemIcon>
+                <ArrowLeftRight size={16} />
+              </ListItemIcon>
+              <ListItemText>
+                {active?.teamRole === 'LEAD' ? 'Make member' : 'Make lead'}
+              </ListItemText>
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                setAnchorEl(null);
+                setRemoveTarget(active);
+              }}
+            >
+              <ListItemIcon>
+                <UserMinus size={16} />
+              </ListItemIcon>
+              <ListItemText>Remove from team</ListItemText>
+            </MenuItem>
           </Menu>
 
           <AddMyTeamMemberDialog


### PR DESCRIPTION
## Summary

Fixes a team being left with **members but no lead** (issue #542). An admin could remove or demote a team's *last* `LEAD` and strip the team of leadership.

## Root cause

The `LAST_LEAD` invariant was already enforced — but **only on the #470 self-service surface** (`removeMemberAsLead` / `setMemberRoleAsLead`). The **admin path** (`TeamController` → the base `TeamService.removeMember` / `setMemberRole`) bypassed the guard entirely.

## Fix

- **One guard, every door.** Move the pessimistic team lock + last-lead guard down into the base `removeMember` / `setMemberRole`, so the admin path **and** the #470 self-service path are covered by a single guard. The `*AsLead` wrappers keep only their authz (`requireLeadOrAdmin`) and the `SELF_REMOVAL` rule.
- **The real invariant — "never ≥1 member with 0 leads":** demoting the last lead is always rejected; removing the last lead is rejected **only while other members remain**. Removing the *sole* member (who is the last lead) empties the team, which is **allowed** — the legitimate just-created state (delete the team to be rid of it entirely). Added `TeamMembershipRepository.countByTeamId` for the members-remain check.
- Rejections surface as the existing `TeamConflictException("LAST_LEAD", …)` → **409** via `TeamController.onConflict`. No controller, exception, or schema change.

## Acceptance criteria

- [x] Removing the last `LEAD` while other members remain → 409 `LAST_LEAD`; membership unchanged.
- [x] Demoting the last `LEAD` to `MEMBER` while members remain → 409 `LAST_LEAD`.
- [x] Removing/demoting a lead is allowed when another lead remains.
- [x] The #470 self-service path cannot bypass the guard (it now calls the guarded base methods).
- [x] Empty-team edge case (remove sole member = last lead) is **allowed** and covered by a test.

## Tests

- **Unit** (`TeamServiceTest`): admin-path last-lead demote/remove rejected; empty-team removal allowed; existing `lastLeadGuard` updated for the relocated guard.
- **Integration** (`TeamControllerIT`): admin demote/remove of the last lead → 409 `LAST_LEAD`; sole-member removal → 204; `manageMembers` now adds a co-lead before demoting (respecting the invariant).

Verified locally: `spotlessCheck`, ArchUnit, `TeamServiceTest` green; ITs compile and run in CI (Docker).


## Follow-ups in this PR (review feedback)

- **A lead may not change their own role** — `setMemberRoleAsLead` now refuses the caller changing their OWN role with 409 `SELF_ROLE_CHANGE`, mirroring `SELF_REMOVAL` exactly, **admins included**: demoting a lead is a hand-over decision made by another lead or an admin, and one's own role changes in the admin console (`/admin/teams`, unchanged). The My Teams roster hides the actions menu on the caller's own row entirely.
- **Slug backfill for pre-slug teams** — teams created before `TeamSlugService` (#470) carry `slug = NULL`, so their `/my-teams` links degrade to the raw UUID. Additive changeset `0021-team-slug-backfill` derives a slug once for every NULL-slug team, mirroring the `TeamSlugs` rules in SQL (kebab-case, `team` fallback, no UUID-shaped slugs — the resolver parses those as ids, base-n collision suffix) within `ck_team_slug` and `ux_team_slug_lower`; a no-op wherever slugs already exist. The plpgsql pass was verified against edge cases (collisions, short/empty/accented/UUID-shaped names, 64-char truncation) on a scratch Postgres.
- Contract: the `setMyTeamMemberRole` description + 409 documentation now cover `SELF_ROLE_CHANGE`.
- Tests: service matrix (lead **and** admin blocked from self role change), wire tests (lead self-demote → 409, the co-lead's demote → 200), UI tests (own row has no actions menu — admins too).

Closes #542

🤖 Co-Author: Claude (Opus 4.x) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

