### PR TITLE
fix(reviews): a team-only roster no longer 500s the participants list

### DIFF
--- a/qnop-app/src/test/java/io/qnop/review/TeamOnlyRosterIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/TeamOnlyRosterIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.entity.Document;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+/**
+ * Regression for issue #584: a roster whose ONLY reviewer is a team 500'd the participants list
+ * (and could 500 the reviews overview) — {@code Map.of().get(null)} throws, and the team row's null
+ * user id hit exactly that on the slug lookup. The visible UI fallout: an empty reviewer list, the
+ * picker still offering the team, and a baffling "already a reviewer" 409 on re-add.
+ */
+class TeamOnlyRosterIT extends SeededIntegrationTest {
+
+  @Autowired DocumentRepository documents;
+
+  @Test
+  void teamOnlyRosterListsAndTheOverviewSurvives() throws Exception {
+    Document document = documents.save(new Document(MEMBER_ID, "Team-only review"));
+    UUID documentId = document.getId();
+
+    // Add ONLY a team (seeded Alpha) — no user participant, so the slug map is empty.
+    mockMvc
+        .perform(
+            post("/api/v1/documents/{id}/participants", documentId)
+                .header("Authorization", "Bearer " + token(MEMBER_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamId\":\"" + TEAM_ALPHA_ID + "\"}"))
+        .andExpect(status().isCreated());
+
+    // The list answers 200 with the TEAM row (was: 500, issue #584).
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}/participants", documentId)
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.participants.length()").value(1))
+        .andExpect(jsonPath("$.participants[0].kind").value("TEAM"))
+        .andExpect(jsonPath("$.participants[0].principalId").value(TEAM_ALPHA_ID.toString()))
+        .andExpect(jsonPath("$.participants[0].displayName").value("Alpha"));
+
+    // The reviews overview shares the mapping — it must survive the team-only roster too.
+    mockMvc
+        .perform(get("/api/v1/documents").header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[?(@.title=='Team-only review')]").exists());
+
+    // Re-adding stays the honest duplicate answer.
+    mockMvc
+        .perform(
+            post("/api/v1/documents/{id}/participants", documentId)
+                .header("Authorization", "Bearer " + token(MEMBER_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"teamId\":\"" + TEAM_ALPHA_ID + "\"}"))
+        .andExpect(status().isConflict());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
@@ -172,7 +172,7 @@ public class DocumentOverviewService {
   private List<ParticipantView> rosterFor(
       Document document, UUID actor, List<ParticipantProjection> rows, Map<UUID, String> slugById) {
     if (!document.isAnonymous() || document.getOwnerId().equals(actor)) {
-      return rows.stream().map(row -> ParticipantView.of(row, slugById.get(row.userId()))).toList();
+      return rows.stream().map(row -> ParticipantView.of(row, slugById)).toList();
     }
     return ReviewParticipantService.anonymiseRoster(
         document.getId(), rows, identity.forDocument(document.getId(), actor));

--- a/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
@@ -101,7 +101,7 @@ public class ReviewParticipantService {
     if (!anonymise) {
       Map<UUID, String> slugById =
           userSlugs(rows.stream().map(ParticipantProjection::userId).toList());
-      return rows.stream().map(row -> ParticipantView.of(row, slugById.get(row.userId()))).toList();
+      return rows.stream().map(row -> ParticipantView.of(row, slugById)).toList();
     }
 
     return anonymiseRoster(documentId, rows, identity.forDocument(documentId, actor));
@@ -236,13 +236,18 @@ public class ReviewParticipantService {
   public record ParticipantView(
       UUID id, UUID principalId, boolean team, String slug, String displayName, Instant createdAt) {
 
-    static ParticipantView of(ParticipantProjection projection, String slug) {
+    /**
+     * Builds the view, looking the slug up itself so the null-guard lives in ONE place (issue
+     * #584): a team row has no user id, and the slug map degenerates to the JDK's immutable {@code
+     * Map.of()} on a team-only roster — whose {@code get(null)} throws, 500ing the whole list.
+     */
+    static ParticipantView of(ParticipantProjection projection, Map<UUID, String> slugById) {
       boolean team = projection.teamId() != null;
       return new ParticipantView(
           projection.id(),
           team ? projection.teamId() : projection.userId(),
           team,
-          team ? null : slug,
+          team ? null : slugById.get(projection.userId()),
           projection.displayName(),
           projection.createdAt());
     }


### PR DESCRIPTION
Closes #584.

## Symptom

Create a review whose only reviewer is a **team**: the reviewer roster renders empty, the "Add reviewer" picker still offers that team, and picking it fails with a baffling "already a reviewer…" (409).

## Root cause (reproduced over the wire)

`GET /documents/{id}/participants` answered **500** for a team-only roster: team rows carry no user id, and with no user participants the slug map degenerates to the JDK's immutable **`Map.of()` — whose `get(null)` throws NPE**. With at least one user participant the map is a `Collectors.toMap` HashMap (null-tolerant), which is why mixed rosters never showed it. All three UI symptoms follow from the failed query: empty roster fallback, nothing for the picker to filter against, honest 409 from the (correct) server-side duplicate check.

The reviews overview (`DocumentOverviewService.rosterFor`) shared the exact pattern and could 500 for a caller whose only visible review has a team-only roster.

## Fix

The slug lookup moves into `ParticipantView.of`, which short-circuits team rows before touching the map — one guard covering both consumers. No contract change.

## Test plan

- [x] Regression IT `TeamOnlyRosterIT` over the wire: add ONLY a team → participants list answers 200 with the TEAM row; the reviews overview survives; re-adding stays 409. **Verified red without the fix, green with it.**
- [x] `./gradlew build` — full gate incl. Spotless, ArchUnit and all Testcontainers ITs

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)