### PR TITLE
feat(dashboard): designed empty states + dark-mode fix for tinted surfaces

### DIFF
--- a/qnop-ui/src/components/dashboard/ActivityCard.tsx
+++ b/qnop-ui/src/components/dashboard/ActivityCard.tsx
@@ -29,6 +29,7 @@ import {
   CircleCheck,
   MessageSquarePlus,
   RotateCcw,
+  Sparkles,
   Workflow,
   type LucideIcon,
 } from 'lucide-react';
@@ -37,6 +38,7 @@ import Link from '@mui/material/Link';
 import type { DashboardActivity } from '../../api/generated';
 import { useFormatters } from '../../hooks/useFormatters';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { CardEmptyState } from './CardEmptyState';
 import { CardScroller } from './CardScroller';
 import { CountPill } from './CountPill';
 import { UserHoverCard } from '../people/UserHoverCard';
@@ -71,9 +73,12 @@ export function ActivityCard({ activity }: ActivityCardProps) {
       action={<CountPill value={activity.length} />}
     >
       {activity.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          Nothing new — you are all caught up.
-        </Typography>
+        <CardEmptyState
+          icon={Sparkles}
+          tone="amber"
+          title="All quiet"
+          text="When teammates act on your reviews, it shows up here."
+        />
       ) : (
         <CardScroller>
           <Stack spacing={1.25}>

--- a/qnop-ui/src/components/dashboard/CardEmptyState.tsx
+++ b/qnop-ui/src/components/dashboard/CardEmptyState.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
+import type { LucideIcon } from 'lucide-react';
+
+/**
+ * The shared "designed emptiness" anatomy of the dashboard boxes (issue #588):
+ * a tinted icon medallion, a bold one-liner, a quiet explanation. Emptiness is
+ * a state with its own meaning per box — green celebrates finished work, blue
+ * stays calm or invites the next step, amber marks the pleasant quiet.
+ */
+export function CardEmptyState({
+  icon: Icon,
+  title,
+  text,
+  tone = 'blue',
+}: {
+  icon: LucideIcon;
+  title: string;
+  text: string;
+  tone?: 'green' | 'blue' | 'amber';
+}) {
+  const theme = useTheme();
+  const color =
+    tone === 'green'
+      ? theme.palette.success.main
+      : tone === 'amber'
+        ? theme.palette.warning.main
+        : theme.qnop.brand.blue;
+  return (
+    <Stack spacing={1} sx={{ alignItems: 'center', py: 2, textAlign: 'center' }}>
+      <Box
+        aria-hidden
+        sx={{
+          width: 44,
+          height: 44,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color,
+          bgcolor: alpha(color, 0.12),
+        }}
+      >
+        <Icon size={20} />
+      </Box>
+      <Typography sx={{ fontWeight: 700 }}>{title}</Typography>
+      <Typography variant="body2" color="text.secondary">
+        {text}
+      </Typography>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/dashboard/DeadlinesCard.tsx
+++ b/qnop-ui/src/components/dashboard/DeadlinesCard.tsx
@@ -24,10 +24,11 @@ import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
-import { CalendarClock } from 'lucide-react';
+import { CalendarClock, Hourglass } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { DocumentSummary } from '../../api/generated';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { CardEmptyState } from './CardEmptyState';
 import { CardScroller } from './CardScroller';
 import { CountPill } from './CountPill';
 import { dueUrgency, reviewPath } from './dashboardModel';
@@ -62,9 +63,11 @@ export function DeadlinesCard({ reviews }: DeadlinesCardProps) {
       action={<CountPill value={reviews.length} />}
     >
       {reviews.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          No deadlines — nothing is due.
-        </Typography>
+        <CardEmptyState
+          icon={Hourglass}
+          title="Nothing on the clock"
+          text="Due dates from your open reviews land here."
+        />
       ) : (
         <CardScroller>
           <Stack spacing={0.5}>

--- a/qnop-ui/src/components/dashboard/RepliesCard.tsx
+++ b/qnop-ui/src/components/dashboard/RepliesCard.tsx
@@ -24,11 +24,12 @@ import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
-import { MessagesSquare } from 'lucide-react';
+import { MessageCircleDashed, MessagesSquare } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { DashboardReply } from '../../api/generated';
 import { useFormatters } from '../../hooks/useFormatters';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { CardEmptyState } from './CardEmptyState';
 import { CardScroller } from './CardScroller';
 import { CountPill } from './CountPill';
 import { PersonLink } from './PersonLink';
@@ -56,9 +57,11 @@ export function RepliesCard({ replies }: RepliesCardProps) {
       action={<CountPill value={replies.length} />}
     >
       {replies.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          No new replies — your threads are quiet.
-        </Typography>
+        <CardEmptyState
+          icon={MessageCircleDashed}
+          title="No replies yet"
+          text="Answers in discussions you started or joined land here."
+        />
       ) : (
         <CardScroller>
           <Stack spacing={0.5}>

--- a/qnop-ui/src/components/dashboard/ReviewListCard.tsx
+++ b/qnop-ui/src/components/dashboard/ReviewListCard.tsx
@@ -24,11 +24,12 @@ import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
-import { CircleCheck, PartyPopper, type LucideIcon } from 'lucide-react';
+import { CircleCheck, Inbox, PartyPopper, type LucideIcon } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { DocumentSummary } from '../../api/generated';
 import { ToneBadge } from '../admin/ToneBadge';
 import { SectionCard } from '../admin/layout/SectionCard';
+import { CardEmptyState } from './CardEmptyState';
 import { CardScroller } from './CardScroller';
 import { CountPill } from './CountPill';
 import { DueDateLabel } from '../reviews/DueDateLabel';
@@ -43,6 +44,10 @@ interface ReviewListCardProps {
   description: string;
   reviews: DocumentSummary[];
   emptyText: string;
+  /** Headline over `emptyText` in the designed empty state (issue #588). */
+  emptyTitle?: string;
+  /** Medallion glyph of the designed empty state (issue #588). */
+  emptyIcon?: LucideIcon;
   /** Shows the owner's "Ready to finalize" cue on settled reviews. */
   ownerCues?: boolean;
   /** Turns the empty state into a small celebration — earned quiet, not absence. */
@@ -60,6 +65,8 @@ export function ReviewListCard({
   description,
   reviews,
   emptyText,
+  emptyTitle = 'Nothing here yet',
+  emptyIcon = Inbox,
   ownerCues = false,
   celebrateEmpty = false,
 }: ReviewListCardProps) {
@@ -76,31 +83,9 @@ export function ReviewListCard({
     >
       {visible.length === 0 ? (
         celebrateEmpty ? (
-          <Stack spacing={1} sx={{ alignItems: 'center', py: 2 }}>
-            <Box
-              aria-hidden
-              sx={{
-                width: 44,
-                height: 44,
-                borderRadius: '50%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                color: theme.palette.success.main,
-                bgcolor: alpha(theme.palette.success.main, 0.12),
-              }}
-            >
-              <PartyPopper size={20} />
-            </Box>
-            <Typography sx={{ fontWeight: 700 }}>All caught up!</Typography>
-            <Typography variant="body2" color="text.secondary">
-              {emptyText}
-            </Typography>
-          </Stack>
+          <CardEmptyState icon={PartyPopper} tone="green" title="All caught up!" text={emptyText} />
         ) : (
-          <Typography variant="body2" color="text.secondary">
-            {emptyText}
-          </Typography>
+          <CardEmptyState icon={emptyIcon} title={emptyTitle} text={emptyText} />
         )
       ) : (
         <CardScroller>

--- a/qnop-ui/src/pages/HomePage.test.tsx
+++ b/qnop-ui/src/pages/HomePage.test.tsx
@@ -146,6 +146,19 @@ describe('HomePage dashboard (issue #454)', () => {
     expect(screen.getByText('Ready to finalize')).toBeInTheDocument();
   });
 
+  it('treats emptiness as a designed state in every box (#588)', () => {
+    // One closed foreign review: the dashboard renders (not the brand-new
+    // empty page), yet every box is empty.
+    mockData([review({ workflowState: 'FINALIZED', ownerId: 'someone-else' })]);
+    renderPage();
+
+    expect(screen.getByText('All caught up!')).toBeInTheDocument();
+    expect(screen.getByText('Nothing on the clock')).toBeInTheDocument();
+    expect(screen.getByText('No reviews yet')).toBeInTheDocument();
+    expect(screen.getByText('All quiet')).toBeInTheDocument();
+    expect(screen.getByText('No replies yet')).toBeInTheDocument();
+  });
+
   it('leads each review row with the typed document icon', () => {
     mockData([review({ id: 'w1', title: 'A pdf review', contentType: 'application/pdf' })]);
     renderPage();

--- a/qnop-ui/src/pages/HomePage.tsx
+++ b/qnop-ui/src/pages/HomePage.tsx
@@ -25,7 +25,16 @@ import Chip from '@mui/material/Chip';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { CalendarClock, FileText, History, Inbox, Plus, Trophy, UserCheck } from 'lucide-react';
+import {
+  CalendarClock,
+  FileText,
+  History,
+  Inbox,
+  Plus,
+  Rocket,
+  Trophy,
+  UserCheck,
+} from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useDashboard } from '../api/hooks/useDashboard';
 import { useReviews } from '../api/hooks/useReviews';
@@ -188,7 +197,9 @@ export function HomePage() {
               title="My reviews"
               description="Reviews you own, running ones first."
               reviews={owned}
-              emptyText="You own no reviews yet."
+              emptyTitle="No reviews yet"
+              emptyText="Start your first one with “New review”."
+              emptyIcon={Rocket}
               ownerCues
             />
             <ActivityCard activity={dashboardQuery.data?.activity ?? []} />

--- a/qnop-ui/src/theme/theme.test.ts
+++ b/qnop-ui/src/theme/theme.test.ts
@@ -43,6 +43,13 @@ describe('buildTheme', () => {
     expect(theme.palette.text.primary).toBe(tokens.dark.fg);
   });
 
+  it('tints primary.light translucently so it composites in both modes (#589)', () => {
+    // A solid blue50 stayed light in dark mode and drowned the text on the
+    // wizard pills and toggle rows — the tint must be translucent brand blue.
+    expect(buildTheme('light').palette.primary.light).toBe(tokens.badge.blue.bg);
+    expect(buildTheme('dark').palette.primary.light).toBe(tokens.badge.blue.bg);
+  });
+
   it('maps the semantic colours (AA-strong tones for white-on-colour buttons)', () => {
     const theme = buildTheme('light');
     expect(theme.palette.success.main).toBe(tokens.semantic.successStrong);

--- a/qnop-ui/src/theme/theme.ts
+++ b/qnop-ui/src/theme/theme.ts
@@ -92,7 +92,12 @@ export function buildTheme(mode: PaletteMode): Theme {
       primary: {
         main: tokens.brand.bluePress,
         dark: tokens.brand.blueDeep,
-        light: tokens.brand.blue50,
+        // Translucent, not blue50: `primary.light` tints surfaces (wizard
+        // pills, drop zone, active nav), and only a translucent brand tint
+        // composites correctly over light AND dark surfaces (issue #589 —
+        // the solid blue50 stayed light in dark mode and drowned the text).
+        // Over white it renders within ±1/channel of blue50.
+        light: tokens.badge.blue.bg,
         contrastText: '#FFFFFF',
       },
       secondary: { main: tokens.brand.navy, contrastText: '#FFFFFF' },


### PR DESCRIPTION
## Summary

First round of the dashboard/wizard UI polish session — two independent fixes:

### Designed empty states for every dashboard box (closes #588)

The Deadlines, My reviews, Recent activity and Replies boxes announced emptiness with a plain gray sentence, which read unfinished next to the celebration state of "Waiting on you". The celebration anatomy (tinted icon medallion, bold headline, quiet line) moves into a shared `CardEmptyState` component, and every box gets its own designed emptiness:

- **Waiting on you** — unchanged party (green PartyPopper), now via the shared component.
- **Deadlines** — calm hourglass: "Nothing on the clock".
- **My reviews** — rocket inviting the first review: "No reviews yet".
- **Recent activity** — amber sparkles: "All quiet".
- **Replies to you** — dashed bubble: "No replies yet".

Tone system: green stays reserved for the "all done" celebration, blue is calm/inviting, amber the pleasant quiet — all from the existing tokens.

### Dark mode: readable `primary.light` surfaces (fixes #589)

`palette.primary.light` was the solid light-mode tint `blue50` in **both** modes, so every surface tinted with it — the create-review wizard's selected-reviewer pills (step 2), the "Start review immediately" / anonymity rows (step 3), the document drop zone, the active sidebar item, the My Teams tiles — rendered as a bright light box with light text in dark mode. The tint is now the translucent brand blue already used by the badge tones, which composites correctly over light **and** dark surfaces; over white it renders within one channel step of `blue50`, so light mode is visually unchanged.

## Test plan

- [x] `HomePage.test.tsx`: one closed foreign review → the dashboard renders all five empty-state headlines.
- [x] `theme.test.ts`: `primary.light` is the translucent badge tint in both modes.
- [x] Full gates green: 1048 vitest tests, tsc, ESLint, Prettier.
- [x] Visually verified in the running dev stack: dashboard empty states (light + dark), wizard steps 1–3 in dark mode (pills, toggle rows, drop zone) and the step-3 row in light mode (unchanged).

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
