### PR TITLE
feat(identity): enforce cross-namespace slug uniqueness (#595)

### DIFF
--- a/docs/adr/0048-cross-namespace-slug-uniqueness.md
+++ b/docs/adr/0048-cross-namespace-slug-uniqueness.md
@@ -1,0 +1,35 @@
+# ADR-0048: Cross-namespace slug uniqueness (users and teams)
+
+- **Status:** Accepted
+- **Date:** 2026-07-24
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+Users carry immutable, human-readable profile slugs (issue #486), teams carry immutable URL slugs (issue #470). Each namespace is unique on its own: `UserSlugService` and `TeamSlugService` are mirrored twins that derive a kebab-case base from the display name, probe `base-n` candidates against **their own table** (`existsBySlugIgnoreCase`), and rely on the per-table case-insensitive unique indexes (`ux_qnop_user_slug_lower`, `ux_team_slug_lower`) to backstop the check-then-save race.
+
+@-mentions (issue #462) turned user slugs into **reference tokens inside stored Markdown**: `@anna-krause` in a comment body is resolved — on the server for notifications, on the client for rendering — purely by its slug. Team mentions (issue #596) want the same token shape for teams. With two independent namespaces, `@design` could name both a user and a team, forcing a documented precedence rule into every resolver (server notification path, client pill renderer, excerpt resolver, search) — and a subtle identity trap for users ("I mentioned the designer, qnop pinged the whole team").
+
+The trap to avoid: ambiguity handled by convention in four places drifts; ambiguity removed at the source cannot.
+
+## Decision
+
+**1. One flat slug namespace.** A slug identifies exactly one principal — user *or* team. Cross-namespace collisions are prevented at allocation time; mention resolution becomes a simple "look up user, else team" with no precedence semantics.
+
+**2. Allocation checks both tables.** Both slug services probe candidates through a shared `SlugNamespace` helper that consults `qnop_user` *and* `team` case-insensitively. One helper, two callers — the mirrored services cannot drift apart.
+
+**3. The cross-table race closes with a Postgres advisory lock.** Per-table unique indexes cannot guard a collision *across* tables (simultaneous creation of user "Design" and team "Design"). Allocation therefore takes a transaction-scoped `pg_advisory_xact_lock(hashtext(lower(slug)))` before probing; the lock releases with the transaction. Postgres-only is set by ADR-0020.
+
+   *Considered and rejected:* a `slug_registry` table with a real cross-kind unique constraint. It is the only guard that also catches direct DB edits, but it adds a second write on every user/team creation and a cleanup obligation on every deletion path — a standing drift risk for a race the advisory lock already closes for all application paths. Documented here so a future principal kind (e.g. service accounts) re-evaluates deliberately.
+
+**4. Existing collisions: teams yield.** A one-time additive Liquibase changeset (post-1.0 rule) re-allocates any team slug that collides case-insensitively with a user slug to its next free `base-n` candidate. User slugs are **external identity** — they live in profile links, mails, and as mention tokens inside stored Markdown bodies that nobody rewrites; team slugs are internal `/my-teams/…` links. Expected collision count in real data: approximately zero. A re-slugged team's saved links 404 (slugs are non-enumerable by design); accepted.
+
+**5. Future principal kinds join the namespace.** Anything that becomes mention-addressable by slug allocates through the shared helper. The namespace is flat by definition, not by accident.
+
+## Consequences
+
+- Mention resolution (issue #596) needs no precedence rule anywhere: server (`CommentMentionService`), pill renderer (`MentionLink`), excerpt resolver (`useMentionNames`) and search all do "user, else team" and get the same answer by construction.
+- Slug allocation acquires a Postgres-specific primitive (advisory lock). This is the second such dependency after ADR-0033's job queue (`FOR UPDATE SKIP LOCKED`); the project is deliberately Postgres-native (ADR-0020).
+- Direct DB edits can still create collisions past the application guard. The per-table indexes keep each namespace internally consistent; cross-namespace consistency relies on writes going through the services — same trust level as every other service-enforced invariant.
+- A user slug can now be "taken" by a team name and vice versa; the `base-n` fallback makes this invisible to the person creating either.
+- Re-slugged teams (migration, expected ~0) break saved `/my-teams/…` links with a 404.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,6 +63,8 @@ Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-reco
 | [0044](0044-storage-consistency-scan-and-remediation.md) | Storage-consistency scan & remediation, and the StorageProvider.list SPI extension | Accepted |
 | [0045](0045-scheduler-jobs-dashboard.md) | Scheduler-jobs dashboard: an operator gate in front of the maintenance sweeps | Accepted |
 | [0046](0046-publish-spi-and-api-to-github-packages.md) | Publish qnop-spi & qnop-api to GitHub Packages (maven-publish convention) | Accepted |
+| [0047](0047-federated-global-search.md) | Federated global search behind a SearchService port | Accepted |
+| [0048](0048-cross-namespace-slug-uniqueness.md) | Cross-namespace slug uniqueness (users and teams) | Accepted |
 
 ## Template
 

--- a/qnop-app/src/test/java/io/qnop/identity/CrossNamespaceSlugIT.java
+++ b/qnop-app/src/test/java/io/qnop/identity/CrossNamespaceSlugIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.bootstrap.AbstractIntegrationTest;
+import io.qnop.entity.Team;
+import io.qnop.entity.User;
+import io.qnop.repository.TeamRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.service.TeamSlugService;
+import io.qnop.service.UserSlugService;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.FileCopyUtils;
+
+/**
+ * Cross-namespace slug uniqueness (issue #595, ADR-0048) against a real PostgreSQL: allocation
+ * yields to the OTHER namespace's slugs, the advisory lock serializes concurrent cross-namespace
+ * allocations, and the 0024 migration re-slugs pre-existing collisions (teams yield). Tests manage
+ * their transactions explicitly ({@link TransactionTemplate}) because the lock protocol is
+ * transaction-scoped; committed leftovers are wiped in {@link #cleanUp()}.
+ */
+class CrossNamespaceSlugIT extends AbstractIntegrationTest {
+
+  private static final String MIGRATION_SQL =
+      "db/changelog/migrations/0024-cross-namespace-slug-collisions.sql";
+
+  @Autowired UserSlugService userSlugs;
+  @Autowired TeamSlugService teamSlugs;
+  @Autowired UserRepository users;
+  @Autowired TeamRepository teams;
+  @Autowired JdbcTemplate jdbc;
+  @Autowired PlatformTransactionManager txManager;
+
+  @AfterEach
+  void cleanUp() {
+    jdbc.update("DELETE FROM team WHERE slug LIKE 'clash-co%' OR slug LIKE 'collide%'");
+    jdbc.update("DELETE FROM qnop_user WHERE slug LIKE 'clash-co%' OR slug LIKE 'collide%'");
+  }
+
+  @Test
+  @DisplayName("a user allocation yields to an existing team slug")
+  void userAllocationYieldsToTeamSlug() {
+    TransactionTemplate tx = new TransactionTemplate(txManager);
+    String allocated =
+        tx.execute(
+            status -> {
+              Team team = Team.create("Design Crew", null);
+              team.setSlug(teamSlugs.allocate("Design Crew"));
+              teams.saveAndFlush(team);
+              assertThat(team.getSlug()).isEqualTo("design-crew");
+
+              String slug = userSlugs.allocate("Design Crew");
+              status.setRollbackOnly();
+              return slug;
+            });
+
+    assertThat(allocated).isEqualTo("design-crew-2");
+  }
+
+  @Test
+  @DisplayName("a team allocation yields to an existing user slug")
+  void teamAllocationYieldsToUserSlug() {
+    TransactionTemplate tx = new TransactionTemplate(txManager);
+    String allocated =
+        tx.execute(
+            status -> {
+              User user = User.external("Design Crew", "design-crew@example.com");
+              user.setSlug(userSlugs.allocate("Design Crew"));
+              users.saveAndFlush(user);
+              assertThat(user.getSlug()).isEqualTo("design-crew");
+
+              String slug = teamSlugs.allocate("Design Crew");
+              status.setRollbackOnly();
+              return slug;
+            });
+
+    assertThat(allocated).isEqualTo("design-crew-2");
+  }
+
+  @Test
+  @DisplayName("concurrent cross-namespace allocations of the same name never duplicate")
+  void concurrentCrossNamespaceAllocationsNeverDuplicate() throws Exception {
+    TransactionTemplate tx = new TransactionTemplate(txManager);
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      CountDownLatch teamAllocated = new CountDownLatch(1);
+      CountDownLatch userStarted = new CountDownLatch(1);
+
+      // A allocates the team slug and then HOLDS its transaction open — the advisory lock on
+      // "clash-co" stays held, so B must queue behind it instead of racing the uncommitted row.
+      Future<String> teamSlug =
+          pool.submit(
+              () ->
+                  tx.execute(
+                      status -> {
+                        Team team = Team.create("Clash Co", null);
+                        team.setSlug(teamSlugs.allocate("Clash Co"));
+                        teams.saveAndFlush(team);
+                        teamAllocated.countDown();
+                        try {
+                          userStarted.await(5, TimeUnit.SECONDS);
+                          // Give B time to reach the advisory lock. Correctness does NOT depend
+                          // on this window: if B arrives later it simply sees the committed row.
+                          Thread.sleep(300);
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                        }
+                        return team.getSlug();
+                      }));
+
+      assertThat(teamAllocated.await(10, TimeUnit.SECONDS)).isTrue();
+
+      Future<String> userSlug =
+          pool.submit(
+              () ->
+                  tx.execute(
+                      status -> {
+                        userStarted.countDown();
+                        String slug = userSlugs.allocate("Clash Co");
+                        status.setRollbackOnly();
+                        return slug;
+                      }));
+
+      assertThat(teamSlug.get(10, TimeUnit.SECONDS)).isEqualTo("clash-co");
+      assertThat(userSlug.get(10, TimeUnit.SECONDS)).isEqualTo("clash-co-2");
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @Test
+  @DisplayName("the 0024 migration re-slugs a colliding team and leaves the user untouched")
+  void migrationReslugsCollidingTeam() throws IOException {
+    // Manufacture the pre-rule state the migration exists for: identical slugs in both tables.
+    jdbc.update(
+        "INSERT INTO qnop_user (id, display_name, slug, email, source, enabled,"
+            + " password_change_required, role, created_at, updated_at, version)"
+            + " VALUES (?, 'Collide', 'collide', 'collide@example.com', 'EXTERNAL', true, false,"
+            + " 'MEMBER', now(), now(), 0)",
+        UUID.randomUUID());
+    jdbc.update(
+        "INSERT INTO team (id, name, slug, enabled, created_at, updated_at, version)"
+            + " VALUES (?, 'Collide', 'collide', true, now(), now(), 0)",
+        UUID.randomUUID());
+
+    jdbc.execute(migrationSql());
+
+    assertThat(jdbc.queryForObject("SELECT slug FROM team WHERE name = 'Collide'", String.class))
+        .isEqualTo("collide-2");
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT slug FROM qnop_user WHERE display_name = 'Collide'", String.class))
+        .isEqualTo("collide");
+  }
+
+  /** The exact statement the 0024 changeset runs — loaded from the shared sqlFile resource. */
+  private static String migrationSql() throws IOException {
+    return FileCopyUtils.copyToString(
+        new InputStreamReader(
+            new ClassPathResource(MIGRATION_SQL).getInputStream(), StandardCharsets.UTF_8));
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/UserRepository.java
@@ -65,6 +65,20 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   boolean existsBySlugIgnoreCase(String slug);
 
   /**
+   * Serializes slug allocation across the flat user⟷team namespace (issue #595, ADR-0048): a
+   * transaction-scoped Postgres advisory lock on the lowercased candidate. The per-table unique
+   * indexes cannot guard a collision ACROSS tables, so concurrent allocations of the same candidate
+   * queue here; the lock releases with the transaction. A {@code hashtext} collision between two
+   * different slugs merely serializes two unrelated allocations, never corrupts one. The subselect
+   * exists so the statement yields an integer — {@code pg_advisory_xact_lock} itself returns the
+   * SQL {@code void} type, which JDBC cannot map.
+   */
+  @Query(
+      value = "SELECT 1 FROM (SELECT pg_advisory_xact_lock(hashtext(:slugLower))) AS lock_taken",
+      nativeQuery = true)
+  Long acquireSlugAllocationLock(@Param("slugLower") String slugLower);
+
+  /**
    * Paginated admin search (issues #104/#124): an optional case-insensitive match on display name,
    * email or username, plus optional role and enabled-status filters. {@code q} must be passed
    * pre-lowercased and {@code LIKE}-wrapped (e.g. {@code %alice%}); a {@code null} {@code q}/{@code

--- a/qnop-core/src/main/java/io/qnop/service/SlugNamespace.java
+++ b/qnop-core/src/main/java/io/qnop/service/SlugNamespace.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import io.qnop.repository.TeamRepository;
+import io.qnop.repository.UserRepository;
+import java.util.Locale;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The flat user⟷team slug namespace (issue #595, ADR-0048): a slug identifies exactly one principal
+ * — user OR team — so an {@code @slug} mention token (issues #462/#596) can never be ambiguous.
+ * Both slug services probe their candidates through this one helper; derivation stays in {@code
+ * UserSlugs}/{@code TeamSlugs}, the namespace rule lives here and the two allocation paths cannot
+ * drift apart.
+ *
+ * <p>The per-table unique indexes ({@code ux_qnop_user_slug_lower}, {@code ux_team_slug_lower})
+ * backstop the check-then-save race only <em>within</em> a namespace; no index can guard the
+ * cross-table window. {@link #lockAndCheckFree} therefore serializes on a transaction-scoped
+ * advisory lock keyed by the lowercased candidate before probing, so two concurrent allocations of
+ * the same slug — user vs. team included — cannot both succeed.
+ */
+@Service
+public class SlugNamespace {
+
+  private final UserRepository users;
+  private final TeamRepository teams;
+
+  public SlugNamespace(UserRepository users, TeamRepository teams) {
+    this.users = users;
+    this.teams = teams;
+  }
+
+  /**
+   * Locks the candidate for the calling transaction and reports whether it is free in BOTH
+   * namespaces, case-insensitively. {@code MANDATORY}: an advisory xact lock outside a transaction
+   * would be released immediately and guard nothing — a non-transactional caller is a bug and must
+   * fail loudly rather than allocate unguarded.
+   */
+  @Transactional(propagation = Propagation.MANDATORY)
+  public boolean lockAndCheckFree(String candidate) {
+    users.acquireSlugAllocationLock(candidate.toLowerCase(Locale.ROOT));
+    return !users.existsBySlugIgnoreCase(candidate) && !teams.existsBySlugIgnoreCase(candidate);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/TeamSlugService.java
+++ b/qnop-core/src/main/java/io/qnop/service/TeamSlugService.java
@@ -20,22 +20,23 @@
  */
 package io.qnop.service;
 
-import io.qnop.repository.TeamRepository;
 import org.springframework.stereotype.Service;
 
 /**
  * Allocates a free team slug at team creation (issue #470): the {@link TeamSlugs}-derived base, or
- * the first free {@code base-n} candidate on collision. Mirrors {@link UserSlugService}. The
- * check-then-save window is racy in theory; {@code ux_team_slug_lower} backstops it, so two
- * simultaneous creates of the same name can fail one request but never produce a duplicate slug.
+ * the first free {@code base-n} candidate on collision. Mirrors {@link UserSlugService}.
+ *
+ * <p>Candidates are probed through the flat {@link SlugNamespace} (issue #595, ADR-0048): a slug
+ * must be free among teams AND users, and the namespace's advisory lock closes the check-then-save
+ * race that the per-table unique indexes cannot guard across tables.
  */
 @Service
 public class TeamSlugService {
 
-  private final TeamRepository teams;
+  private final SlugNamespace namespace;
 
-  public TeamSlugService(TeamRepository teams) {
-    this.teams = teams;
+  public TeamSlugService(SlugNamespace namespace) {
+    this.namespace = namespace;
   }
 
   /** The first free slug for a team name (participates in the caller's transaction). */
@@ -43,7 +44,7 @@ public class TeamSlugService {
     String base = TeamSlugs.derive(name);
     for (int attempt = 1; ; attempt++) {
       String candidate = TeamSlugs.candidate(base, attempt);
-      if (!teams.existsBySlugIgnoreCase(candidate)) {
+      if (namespace.lockAndCheckFree(candidate)) {
         return candidate;
       }
     }

--- a/qnop-core/src/main/java/io/qnop/service/UserSlugService.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSlugService.java
@@ -20,7 +20,6 @@
  */
 package io.qnop.service;
 
-import io.qnop.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
 /**
@@ -29,17 +28,17 @@ import org.springframework.stereotype.Service;
  * (self-registration, OIDC provisioning, bootstrap admin, admin create) allocates through here so
  * derivation and collision handling never drift apart.
  *
- * <p>The check-then-save window is racy in theory; {@code ux_qnop_user_slug_lower} backstops it, so
- * two simultaneous registrations of the same display name can fail one request but never produce a
- * duplicate slug.
+ * <p>Candidates are probed through the flat {@link SlugNamespace} (issue #595, ADR-0048): a slug
+ * must be free among users AND teams, and the namespace's advisory lock closes the check-then-save
+ * race that the per-table unique indexes cannot guard across tables.
  */
 @Service
 public class UserSlugService {
 
-  private final UserRepository users;
+  private final SlugNamespace namespace;
 
-  public UserSlugService(UserRepository users) {
-    this.users = users;
+  public UserSlugService(SlugNamespace namespace) {
+    this.namespace = namespace;
   }
 
   /** The first free slug for a display name (participates in the caller's transaction). */
@@ -47,7 +46,7 @@ public class UserSlugService {
     String base = UserSlugs.derive(displayName);
     for (int attempt = 1; ; attempt++) {
       String candidate = UserSlugs.candidate(base, attempt);
-      if (!users.existsBySlugIgnoreCase(candidate)) {
+      if (namespace.lockAndCheckFree(candidate)) {
         return candidate;
       }
     }

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -80,6 +80,9 @@ databaseChangeLog:
   - include:
       file: migrations/0023-comment-mention-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0024-cross-namespace-slug-collisions.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/migrations/0024-cross-namespace-slug-collisions.sql
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0024-cross-namespace-slug-collisions.sql
@@ -1,0 +1,51 @@
+-- Copyright (c) 2026-present devtank42 GmbH
+--
+-- This file is part of qnop (Qualified Notes on Papers).
+--
+-- qnop is free software: you can redistribute it and/or modify it under the
+-- terms of the GNU Affero General Public License as published by the Free
+-- Software Foundation, either version 3 of the License, or (at your option)
+-- any later version.
+--
+-- qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+-- WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+-- details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with qnop. If not, see <https://www.gnu.org/licenses/>.
+--
+-- SPDX-License-Identifier: AGPL-3.0-only
+
+-- One-time cross-namespace collision resolution (issue #595, ADR-0048): a team
+-- whose slug collides case-insensitively with a USER slug is re-allocated to
+-- its next free base-n candidate, probing BOTH tables. Teams yield because
+-- user slugs are external identity (profile links, @mention tokens inside
+-- stored Markdown bodies); team slugs are internal /my-teams/… links. Expected
+-- to be a no-op on real data; idempotent, so re-running it is safe.
+DO $$
+DECLARE
+  r RECORD;
+  base TEXT;
+  candidate TEXT;
+  n INT;
+BEGIN
+  FOR r IN
+    SELECT t.id, t.slug
+    FROM team t
+    WHERE t.slug IS NOT NULL
+      AND EXISTS (SELECT 1 FROM qnop_user u WHERE lower(u.slug) = lower(t.slug))
+    ORDER BY t.created_at, t.id
+  LOOP
+    base := r.slug;
+    candidate := base;
+    n := 1;
+    WHILE EXISTS (SELECT 1 FROM qnop_user WHERE lower(slug) = lower(candidate))
+          OR EXISTS (SELECT 1 FROM team WHERE lower(slug) = lower(candidate) AND id <> r.id)
+    LOOP
+      n := n + 1;
+      candidate := trim(both '-' from substr(base, 1, 64 - length('-' || n::text))) || '-' || n;
+    END LOOP;
+    UPDATE team SET slug = candidate WHERE id = r.id;
+  END LOOP;
+END $$;

--- a/qnop-core/src/main/resources/db/changelog/migrations/0024-cross-namespace-slug-collisions.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0024-cross-namespace-slug-collisions.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2026-present devtank42 GmbH
+#
+# This file is part of qnop (Qualified Notes on Papers).
+#
+# qnop is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with qnop. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Cross-namespace slug uniqueness (issue #595, ADR-0048): from now on a slug
+# identifies exactly one principal — user OR team — so @mention tokens (#462,
+# #596) resolve unambiguously. Allocation enforces this going forward
+# (SlugNamespace); this one-time pass resolves collisions that predate the
+# rule. Teams yield (see the .sql for the rationale). Additive (post-1.0.0
+# rule); a no-op on databases without cross-namespace collisions. The body
+# lives in a sqlFile so the migration integration test executes the exact
+# same statement against a manufactured collision.
+databaseChangeLog:
+  - changeSet:
+      id: 0024-cross-namespace-slug-collisions
+      author: qnop
+      comment: Re-slugs teams colliding case-insensitively with a user slug (issue #595).
+      changes:
+        - sqlFile:
+            path: 0024-cross-namespace-slug-collisions.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/AdminUserServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import io.qnop.entity.User;
 import io.qnop.entity.UserRole;
 import io.qnop.repository.OidcIdentityRepository;
+import io.qnop.repository.TeamRepository;
 import io.qnop.repository.UserRepository;
 import io.qnop.service.AdminUserService.AdminUserPage;
 import io.qnop.service.AdminUserService.AdminUserView;
@@ -60,7 +61,8 @@ class AdminUserServiceTest {
   private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
   private final PasswordResetFlowService passwordResetFlow = mock(PasswordResetFlowService.class);
   private final RefreshTokenService refreshTokens = mock(RefreshTokenService.class);
-  // The mocked repository reports every slug candidate free, so the base slug wins (issue #486).
+  // The mocked repositories report every slug candidate free in both namespaces (issue #595), so
+  // the base slug wins (issue #486).
   private final AdminUserService service =
       new AdminUserService(
           users,
@@ -68,7 +70,7 @@ class AdminUserServiceTest {
           passwordEncoder,
           passwordResetFlow,
           refreshTokens,
-          new UserSlugService(users));
+          new UserSlugService(new SlugNamespace(users, mock(TeamRepository.class))));
 
   private void noClash() {
     when(users.existsByEmailIgnoreCaseAndSource(any(), any())).thenReturn(false);

--- a/qnop-core/src/test/java/io/qnop/service/SlugNamespaceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/SlugNamespaceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+import io.qnop.repository.TeamRepository;
+import io.qnop.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** The flat user⟷team slug namespace (issue #595, ADR-0048). */
+@ExtendWith(MockitoExtension.class)
+class SlugNamespaceTest {
+
+  @Mock private UserRepository users;
+  @Mock private TeamRepository teams;
+
+  @Test
+  @DisplayName("a candidate is free only when neither a user nor a team claims it")
+  void freeOnlyWhenBothNamespacesAreFree() {
+    SlugNamespace namespace = new SlugNamespace(users, teams);
+    when(users.existsBySlugIgnoreCase("design")).thenReturn(false);
+    when(teams.existsBySlugIgnoreCase("design")).thenReturn(false);
+
+    assertThat(namespace.lockAndCheckFree("design")).isTrue();
+  }
+
+  @Test
+  @DisplayName("a user slug blocks the candidate")
+  void userSlugBlocks() {
+    SlugNamespace namespace = new SlugNamespace(users, teams);
+    when(users.existsBySlugIgnoreCase("design")).thenReturn(true);
+
+    assertThat(namespace.lockAndCheckFree("design")).isFalse();
+  }
+
+  @Test
+  @DisplayName("a team slug blocks the candidate")
+  void teamSlugBlocks() {
+    SlugNamespace namespace = new SlugNamespace(users, teams);
+    when(users.existsBySlugIgnoreCase("design")).thenReturn(false);
+    when(teams.existsBySlugIgnoreCase("design")).thenReturn(true);
+
+    assertThat(namespace.lockAndCheckFree("design")).isFalse();
+  }
+
+  @Test
+  @DisplayName("takes the advisory lock on the lowercased candidate BEFORE probing")
+  void locksBeforeProbing() {
+    SlugNamespace namespace = new SlugNamespace(users, teams);
+    when(users.existsBySlugIgnoreCase("Design")).thenReturn(false);
+    when(teams.existsBySlugIgnoreCase("Design")).thenReturn(false);
+
+    namespace.lockAndCheckFree("Design");
+
+    // Probing before locking would re-open the race the lock exists to close.
+    InOrder order = inOrder(users, teams);
+    order.verify(users).acquireSlugAllocationLock("design");
+    order.verify(users).existsBySlugIgnoreCase("Design");
+    order.verify(teams).existsBySlugIgnoreCase("Design");
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/TeamSlugServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/TeamSlugServiceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Team-slug allocation probes the flat namespace (issues #470, #595). */
+@ExtendWith(MockitoExtension.class)
+class TeamSlugServiceTest {
+
+  @Mock private SlugNamespace namespace;
+
+  @Test
+  @DisplayName("allocates the derived base when the namespace is free")
+  void allocatesBase() {
+    when(namespace.lockAndCheckFree("procurement")).thenReturn(true);
+
+    assertThat(new TeamSlugService(namespace).allocate("Procurement")).isEqualTo("procurement");
+  }
+
+  @Test
+  @DisplayName("skips to base-n when the candidate is taken — by a team OR a user")
+  void skipsTakenCandidates() {
+    when(namespace.lockAndCheckFree("design")).thenReturn(false);
+    when(namespace.lockAndCheckFree("design-2")).thenReturn(true);
+
+    assertThat(new TeamSlugService(namespace).allocate("Design")).isEqualTo("design-2");
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/UserServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/UserServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import io.qnop.entity.User;
 import io.qnop.entity.UserRole;
 import io.qnop.entity.UserSource;
+import io.qnop.repository.TeamRepository;
 import io.qnop.repository.UserRepository;
 import io.qnop.service.UserService.UserProfileView;
 import java.util.Optional;
@@ -42,9 +43,13 @@ class UserServiceTest {
 
   private final UserRepository users = mock(UserRepository.class);
   private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
-  // The mocked repository reports every slug candidate free, so the base slug wins (issue #486).
+  // The mocked repositories report every slug candidate free in both namespaces (issue #595), so
+  // the base slug wins (issue #486).
   private final UserService service =
-      new UserService(users, passwordEncoder, new UserSlugService(users));
+      new UserService(
+          users,
+          passwordEncoder,
+          new UserSlugService(new SlugNamespace(users, mock(TeamRepository.class))));
 
   @Test
   @DisplayName("getProfile returns an entity-free view with role and source as names")

--- a/qnop-core/src/test/java/io/qnop/service/UserSlugServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/UserSlugServiceTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Profile-slug allocation probes the flat namespace (issues #486, #595). */
+@ExtendWith(MockitoExtension.class)
+class UserSlugServiceTest {
+
+  @Mock private SlugNamespace namespace;
+
+  @Test
+  @DisplayName("allocates the derived base when the namespace is free")
+  void allocatesBase() {
+    when(namespace.lockAndCheckFree("anna-krause")).thenReturn(true);
+
+    assertThat(new UserSlugService(namespace).allocate("Anna Krause")).isEqualTo("anna-krause");
+  }
+
+  @Test
+  @DisplayName("skips to base-n when the candidate is taken — by a user OR a team")
+  void skipsTakenCandidates() {
+    when(namespace.lockAndCheckFree("anna-krause")).thenReturn(false);
+    when(namespace.lockAndCheckFree("anna-krause-2")).thenReturn(false);
+    when(namespace.lockAndCheckFree("anna-krause-3")).thenReturn(true);
+
+    assertThat(new UserSlugService(namespace).allocate("Anna Krause")).isEqualTo("anna-krause-3");
+  }
+}


### PR DESCRIPTION
Closes qnophq/qnop#595. Prerequisite for team mentions (#596).

## Summary

A slug now identifies exactly one principal — user **or** team — so an `@slug` mention token (#462, qnophq/qnop-ee#1) can never be ambiguous.

- **`SlugNamespace`** (new, `io.qnop.service`): both `UserSlugService` and `TeamSlugService` probe their `base-n` candidates through this one helper, which checks `qnop_user` **and** `team` case-insensitively. One helper, two callers — the mirrored allocation paths cannot drift apart.
- **Advisory-lock backstop:** the per-table unique indexes cannot guard a collision *across* tables, so allocation takes a transaction-scoped `pg_advisory_xact_lock(hashtext(lower(candidate)))` before probing (Postgres-only per ADR-0020). The lock method is `MANDATORY`-transactional — a non-transactional caller fails loudly instead of allocating unguarded. All five creation paths (self-registration, OIDC provisioning, bootstrap admin, admin create, team create) were verified transactional.
- **Migration `0024`** (additive, post-1.0 rule): re-slugs teams whose slug collides case-insensitively with a user slug to the next free `base-n` candidate, probing both tables. Teams yield — user slugs are external identity (profile links, mention tokens inside stored Markdown), team slugs are internal `/my-teams/…` links. Expected no-op on real data; the body lives in a `sqlFile` so the migration IT executes the exact same statement.
- **ADR-0048** records the decision, including the rejected `slug_registry` alternative and the rule that future mention-addressable principal kinds join the flat namespace. The ADR index also gains the previously missing 0047 row.

## Test plan

- [x] Unit: `SlugNamespaceTest` (free only when both namespaces free; lock taken on the lowercased candidate BEFORE probing), `UserSlugServiceTest` / `TeamSlugServiceTest` (skip to `base-n` on cross-namespace collision)
- [x] IT (`CrossNamespaceSlugIT`, Testcontainers): user allocation yields to a team slug and vice versa; two concurrent cross-namespace allocations of the same name never duplicate (thread B queues behind A's advisory lock and allocates `clash-co-2`); the 0024 migration re-slugs a manufactured collision and leaves the user untouched
- [x] `./gradlew build` (Spotless + ArchUnit + full test suite) green
- [x] Seed data verified collision-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
