### PR TITLE
fix(review): keep the active annotation visible when it leaves the filter (#548)

### DIFF
--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -110,14 +110,20 @@ function renderPanel(props: Partial<Parameters<typeof AnnotationPanel>[0]> = {})
     notify: vi.fn(),
   };
   const merged = { ...defaults, ...props };
-  render(
+  const wrap = (current: Parameters<typeof AnnotationPanel>[0]) => (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={buildTheme('light')}>
-        <AnnotationPanel {...merged} />
+        <AnnotationPanel {...current} />
       </ThemeProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
-  return merged;
+  const { rerender } = render(wrap(merged));
+  return {
+    ...merged,
+    /** Re-renders the same panel with patched props — the panel keeps its own state. */
+    update: (patch: Partial<Parameters<typeof AnnotationPanel>[0]>) =>
+      rerender(wrap({ ...merged, ...patch })),
+  };
 }
 
 describe('AnnotationPanel', () => {
@@ -239,6 +245,88 @@ describe('AnnotationPanel', () => {
       versionNumber: 3,
     });
     expect(props.onSelect).not.toHaveBeenCalled();
+  });
+
+  // Issue #548: reaching an annotation through the banner narrows the list to
+  // "needs attention" — confirming the placement then settles it out of that
+  // facet, and the expanded card the reviewer is reading must not vanish.
+  it('keeps the active annotation listed after "Looks right" settles it out of the attention facet (#548)', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const panel = renderPanel({
+      annotations: [
+        annotation('a1', { placementStatus: PlacementStatus.Moved }),
+        annotation('a2', { placementStatus: PlacementStatus.Orphaned }),
+      ],
+      activeAnnotationId: null,
+      versionNumber: 3,
+    });
+
+    // The banner's "Review" action sets the placement facet.
+    fireEvent.click(
+      within(screen.getByTestId('reanchor-banner')).getByRole('button', {
+        name: 'Review',
+      }),
+    );
+    expect(screen.getByTestId('annotation-item-a1')).toBeInTheDocument();
+
+    // The reviewer opens the moved annotation and confirms its placement; the
+    // refetch flips it MOVED → PLACED, which no longer matches "attention".
+    panel.update({ activeAnnotationId: 'a1' });
+    fireEvent.click(screen.getByRole('button', { name: 'Looks right' }));
+    panel.update({
+      activeAnnotationId: 'a1',
+      annotations: [
+        annotation('a1', { placementStatus: PlacementStatus.Placed }),
+        annotation('a2', { placementStatus: PlacementStatus.Orphaned }),
+      ],
+    });
+
+    // Still listed, still expanded — and the untouched orphan still matches.
+    expect(screen.getByTestId('annotation-item-a1')).toBeInTheDocument();
+    expect(screen.getByTestId('thread-a1')).toBeInTheDocument();
+    expect(screen.getByTestId('annotation-item-a2')).toBeInTheDocument();
+  });
+
+  it('explains the empty list when the pinned annotation is all that is left (#548)', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const panel = renderPanel({
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Moved })],
+      activeAnnotationId: null,
+      versionNumber: 3,
+    });
+
+    // Filter first, then open the annotation — the order the banner produces.
+    fireEvent.click(
+      within(screen.getByTestId('reanchor-banner')).getByRole('button', { name: 'Review' }),
+    );
+    panel.update({
+      activeAnnotationId: 'a1',
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Moved })],
+    });
+    panel.update({
+      activeAnnotationId: 'a1',
+      annotations: [annotation('a1', { placementStatus: PlacementStatus.Placed })],
+    });
+
+    expect(screen.getByTestId('annotation-item-a1')).toBeInTheDocument();
+    expect(screen.getByText(/the one you have open stays until you select another/)).toBeVisible();
+  });
+
+  it('still drops the active annotation when the reviewer re-filters themselves (#548)', () => {
+    renderPanel({
+      annotations: [
+        annotation('a1', { placementStatus: PlacementStatus.Placed }),
+        annotation('a2', { placementStatus: PlacementStatus.Orphaned }),
+      ],
+      activeAnnotationId: 'a1',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter annotations' }));
+    fireEvent.mouseDown(screen.getByLabelText('Placement'));
+    fireEvent.click(screen.getByRole('option', { name: 'Needs attention' }));
+
+    expect(screen.queryByTestId('annotation-item-a1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('annotation-item-a2')).toBeInTheDocument();
   });
 
   // Issue #562: a healthy placement offers Re-position to the author under the

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -160,6 +160,23 @@ export function AnnotationPanel({
   onNewDocumentNote,
 }: AnnotationPanelProps) {
   const [filters, setFilters] = useState<AnnotationFilters>(EMPTY_FILTERS);
+  // The card the reviewer has open must never be yanked out of the list by an
+  // action taken ON it (issue #548): confirming a moved placement flips the
+  // annotation out of the `attention` facet, resolving flips it out of `open` —
+  // and the expanded card being read would vanish once the mutation settles.
+  // So the active annotation is pinned into the visible list. Re-narrowing the
+  // list is still the reviewer's call: touching a facet or the search field
+  // drops the pin, because that IS an explicit request to re-filter.
+  const [pinnedId, setPinnedId] = useState<string | null>(activeAnnotationId);
+  const [pinnedFor, setPinnedFor] = useState<string | null>(activeAnnotationId);
+  if (activeAnnotationId !== pinnedFor) {
+    setPinnedFor(activeAnnotationId);
+    setPinnedId(activeAnnotationId);
+  }
+  const changeFilters = (next: AnnotationFilters) => {
+    setFilters(next);
+    setPinnedId(null);
+  };
   const userId = useAuthStore((state) => state.userId);
 
   // A newly selected annotation must be in view (issue #491) — in a long list
@@ -201,18 +218,28 @@ export function AnnotationPanel({
   // Sort + status-filter once per (annotations, filter) change, not on every
   // render (e.g. a hover or selection): the list can be large and the sort is
   // O(n log n) (issue #334).
-  const { visible, hiddenByFilter } = useMemo(() => {
+  const { visible, hiddenByFilter, pinnedOut } = useMemo(() => {
     const matches = (annotation: AnnotationView) =>
       matchesFilters(annotation, filters, authorNameOf(annotation), resolveMentions);
     // ONE flat list (issue #481): document-scoped remarks lead, then anchored
     // ones by document position — each card carries its own scope marker.
-    const items = [...annotations].sort(comparePanelOrder).filter(matches);
+    const items = [...annotations].sort(comparePanelOrder);
+    const matching = items.filter(matches);
+    // The pinned card keeps its place in the order (issue #548) — it must not
+    // jump to the top just because it stopped matching.
+    const matched = new Set(matching.map((annotation) => annotation.id));
+    const pinnedDropped = pinnedId != null && !matched.has(pinnedId);
     return {
-      visible: items,
-      hiddenByFilter: annotations.length > 0 && items.length === 0,
+      visible: pinnedDropped
+        ? items.filter((annotation) => matched.has(annotation.id) || annotation.id === pinnedId)
+        : matching,
+      // The facet counts stay honest: "nothing matches" is about the filter,
+      // not about what the pin keeps on screen.
+      hiddenByFilter: annotations.length > 0 && matching.length === 0,
+      pinnedOut: pinnedDropped,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- authorNameOf derives from the inputs below
-  }, [annotations, filters, userId, displayName, resolveMentions]);
+  }, [annotations, filters, pinnedId, userId, displayName, resolveMentions]);
   const newCount = visible.filter((a) => isUnseen(a, previousSeenAt, userId)).length;
 
   // Under a non-OPEN policy (issue #413) only the annotation's author and the
@@ -349,13 +376,13 @@ export function AnnotationPanel({
           <ReanchorBanner
             annotations={annotations}
             versionNumber={versionNumber}
-            onReview={() => setFilters((current) => ({ ...current, placement: 'attention' }))}
+            onReview={() => changeFilters({ ...filters, placement: 'attention' })}
           />
         )}
         {annotations.length > 0 && (
           <PanelFilterBar
             filters={filters}
-            onChange={setFilters}
+            onChange={changeFilters}
             authors={authors}
             authorFacet={!anonymous}
           />
@@ -378,7 +405,11 @@ export function AnnotationPanel({
         )}
         {hiddenByFilter && (
           <Typography variant="body2" color="text.secondary">
-            No annotations match this filter.
+            {pinnedOut
+              ? // The one card left on screen is the one being read (issue #548) —
+                // say so, or the filter would look broken.
+                'No annotations match this filter — the one you have open stays until you select another.'
+              : 'No annotations match this filter.'}
           </Typography>
         )}
         {visible.map(renderItem)}


### PR DESCRIPTION
Closes #548. Follow-up to #480 (phase 3 of its plan).

## The bug

Reaching a moved annotation through the ReanchorBanner's **Review** action narrows the panel to the `attention` facet. Confirming with **Looks right** flips the annotation `MOVED → PLACED`, it stops matching that facet on the refetch, and the expanded card the reviewer was reading vanishes — delayed, once the mutation settles.

## The fix

The issue's recommended option, not the "clear the facet after a confirm" alternative:

- **The active annotation is pinned into the visible list** even when it no longer matches the filter — an action taken *on* the open card must never yank it off screen. The same pin covers the sibling case where resolving an annotation drops it out of the `open` facet.
- **It keeps its position in the panel order**, so the card does not jump to the top the moment it stops matching.
- **Re-narrowing stays the reviewer's call:** any touch of a facet or the search field drops the pin, because that is an explicit request to re-filter. Both `PanelFilterBar.onChange` and the banner's `onReview` route through one local `changeFilters`.

Counters stay consistent with what is on screen, as the issue asks: `hiddenByFilter` still reflects the filter alone, and the empty state now reads *"No annotations match this filter — the one you have open stays until you select another."* so a list holding exactly one pinned card does not look broken. The `n new` badge counts `visible`, i.e. what is actually rendered.

Frontend-only — no API, schema, or ADR change.

## Test plan

Three regression tests in `AnnotationPanel.test.tsx` (the render helper now returns an `update()` so a panel can be re-rendered with new props while keeping its own filter state):

- [x] The active annotation stays listed **and expanded** after "Looks right" settles it out of `attention`; the untouched orphan still matches.
- [x] The empty-state copy explains the list when the pinned card is all that is left.
- [x] Counter-test: filtering **manually** still drops the active annotation — the pin is not a permanent override.

Gates:

- [x] `pnpm vitest run AnnotationPanel.test.tsx` — 34/34
- [x] `pnpm test:run` — 1073/1074; the single failure is `TimezoneSetting > saves the picked zone` (5 s timeout under parallel load), green in isolation and unrelated to this change
- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck`
- [ ] **Not done:** step 1 of the issue — confirming the symptom at runtime. This fix rests on the code-path analysis in the issue plus the regression tests, not on an observed reproduction. Worth a manual pass on the review UI before merge.

🤖 Co-Author: Claude (Opus 5) via Claude Code
