### PR TITLE
chore(deps): unblock the pnpm-audit gate — brace-expansion override + react-router v8 (#605)

### DIFF
--- a/docs/adr/0039-enterprise-packaging-and-runtime-extensions.md
+++ b/docs/adr/0039-enterprise-packaging-and-runtime-extensions.md
@@ -31,7 +31,7 @@ An enterprise feature ships as a single JAR carrying everything it needs:
 There is exactly **one** frontend build — the AGPL `qnop-ui` in this repository. Enterprise UI is loaded at runtime:
 
 - `qnop-ui` defines **slots** (examples: review panel tabs, admin navigation sections, dashboard cards, whole routes with nav entries) and publishes a small versioned npm package **`qnop-ui-spi`** — the frontend analogue of `qnop-spi`: TypeScript types for slots + the extension registry contract, nothing else.
-- The host app exposes its singletons (`react`, `react-dom`, `react-router-dom`, MUI core, the `qnop-ui-spi` runtime) through an **import map** in `index.html` — browser-standard ESM, no module-federation tooling.
+- The host app exposes its singletons (`react`, `react-dom`, `react-router`, MUI core, the `qnop-ui-spi` runtime) through an **import map** in `index.html` — browser-standard ESM, no module-federation tooling.
 - An enterprise JAR serves its UI as a prebuilt, hash-versioned **ESM bundle** (built in `qnop-enterprise` against `qnop-ui-spi`, with the shared singletons declared external) under `/enterprise/ui/…`.
 - `/config` advertises edition, entitlements ([ADR-0012](0012-edition-vs-entitlements.md)) and the list of extension entry URLs **plus the `qnop-ui-spi` contract version** they were built against. The host dynamically `import()`s compatible entries and mounts what they register into the slots; on a major-version mismatch the extension is skipped and reported instead of breaking the app.
 - Entitlement checks in the UI are convenience only — the server remains the authority on every enterprise endpoint.

--- a/qnop-ui/package.json
+++ b/qnop-ui/package.json
@@ -42,7 +42,7 @@
     "react-easy-crop": "6.2.2",
     "react-image-crop": "11.1.2",
     "react-markdown": "10.1.0",
-    "react-router-dom": "7.18.1",
+    "react-router": "8.3.0",
     "rehype-highlight": "7.0.2",
     "rehype-sanitize": "6.0.0",
     "remark": "15.0.1",

--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -5,8 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  brace-expansion@<5.0.8: 5.0.8
   shell-quote@<=1.8.4: 1.10.0
 
 importers:
@@ -82,9 +81,9 @@ importers:
       react-markdown:
         specifier: 10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)(supports-color@10.2.2)
-      react-router-dom:
-        specifier: 7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router:
+        specifier: 8.3.0
+        version: 8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rehype-highlight:
         specifier: 7.0.2
         version: 7.0.2
@@ -1277,9 +1276,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1296,12 +1292,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1398,9 +1391,6 @@ packages:
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   concurrently@10.0.3:
     resolution: {integrity: sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==}
     engines: {node: '>=22'}
@@ -1419,9 +1409,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   core-js-pure@3.49.0:
     resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
@@ -2667,19 +2656,12 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -2788,9 +2770,6 @@ packages:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4534,8 +4513,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.37: {}
@@ -4546,12 +4523,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4644,8 +4616,6 @@ snapshots:
 
   compare-versions@6.1.1: {}
 
-  concat-map@0.0.1: {}
-
   concurrently@10.0.3:
     dependencies:
       chalk: 5.6.2
@@ -4665,7 +4635,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   core-js-pure@3.49.0: {}
 
@@ -5990,11 +5960,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 
@@ -6229,17 +6199,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
-  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.7
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
 
@@ -6411,8 +6374,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.4: {}
-
-  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/qnop-ui/pnpm-workspace.yaml
+++ b/qnop-ui/pnpm-workspace.yaml
@@ -8,12 +8,16 @@ allowBuilds:
   core-js-pure: false
 
 # Force patched releases of transitive DEV dependencies onto vulnerable version
-# lines flagged by `pnpm audit --audit-level high` (issue #557): brace-expansion
-# GHSA-3jxr-9vmj-r5cp (two version lines) and shell-quote GHSA-395f-4hp3-45gv —
-# all reachable only via dev tooling (eslint, openapi-generator-cli,
-# concurrently). Drop each override once the upstream trees ship the patched
-# versions on their own (Renovate will bump).
+# lines flagged by `pnpm audit --audit-level high` (issues #557, #605):
+# brace-expansion GHSA-3jxr-9vmj-r5cp and GHSA-mh99-v99m-4gvg, and shell-quote
+# GHSA-395f-4hp3-45gv — all reachable only via dev tooling (eslint,
+# openapi-generator-cli, concurrently). Drop each override once the upstream
+# trees ship the patched versions on their own (Renovate will bump).
+#
+# GHSA-mh99-v99m-4gvg marks every brace-expansion <= 5.0.7 vulnerable and
+# patches only the 5.0.x line, so the two former per-line pins (1.1.16 and
+# 5.0.7) collapse into a single override onto 5.0.8. That is safe for the CJS
+# consumers in the tree: 5.0.8 still publishes a `require` export condition.
 overrides:
-  'brace-expansion@<1.1.16': 1.1.16
-  'brace-expansion@>=3.0.0 <5.0.7': 5.0.7
+  'brace-expansion@<5.0.8': 5.0.8
   'shell-quote@<=1.8.4': 1.10.0

--- a/qnop-ui/src/components/admin/storage/MissingBinariesTable.tsx
+++ b/qnop-ui/src/components/admin/storage/MissingBinariesTable.tsx
@@ -26,7 +26,7 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import type { MissingBinary } from '../../../api/generated';
 import { reviewPath } from '../../dashboard/dashboardModel';
 import { ToneBadge } from '../ToneBadge';

--- a/qnop-ui/src/components/audit/AuditTable.tsx
+++ b/qnop-ui/src/components/audit/AuditTable.tsx
@@ -30,7 +30,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { Check, Copy, ListFilter } from 'lucide-react';
 import type { AuditEvent } from '../../api/generated';
 import { useFormatters } from '../../hooks/useFormatters';

--- a/qnop-ui/src/components/auth/AdminRoute.test.tsx
+++ b/qnop-ui/src/components/auth/AdminRoute.test.tsx
@@ -21,7 +21,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { AdminRoute } from './AdminRoute';
 import { useAuthStore } from '../../stores/authStore';
 

--- a/qnop-ui/src/components/auth/AdminRoute.tsx
+++ b/qnop-ui/src/components/auth/AdminRoute.tsx
@@ -20,7 +20,7 @@
  */
 
 import type { ReactNode } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { selectIsAdmin, useAuthStore } from '../../stores/authStore';
 import { ProtectedRoute } from './ProtectedRoute';
 

--- a/qnop-ui/src/components/auth/AuthModeSwitch.tsx
+++ b/qnop-ui/src/components/auth/AuthModeSwitch.tsx
@@ -20,7 +20,7 @@
  */
 
 import Box from '@mui/material/Box';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 
 type Mode = 'login' | 'register';
 

--- a/qnop-ui/src/components/auth/ProtectedRoute.test.tsx
+++ b/qnop-ui/src/components/auth/ProtectedRoute.test.tsx
@@ -21,7 +21,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ProtectedRoute } from './ProtectedRoute';
 import { useAuthStore } from '../../stores/authStore';
 

--- a/qnop-ui/src/components/auth/ProtectedRoute.tsx
+++ b/qnop-ui/src/components/auth/ProtectedRoute.tsx
@@ -20,7 +20,7 @@
  */
 
 import type { ReactNode } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 import { useAuthStore } from '../../stores/authStore';
 
 interface ProtectedRouteProps {

--- a/qnop-ui/src/components/auth/RoleRoute.test.tsx
+++ b/qnop-ui/src/components/auth/RoleRoute.test.tsx
@@ -21,7 +21,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { RoleRoute } from './RoleRoute';
 import { useAuthStore } from '../../stores/authStore';
 

--- a/qnop-ui/src/components/auth/RoleRoute.tsx
+++ b/qnop-ui/src/components/auth/RoleRoute.tsx
@@ -20,7 +20,7 @@
  */
 
 import type { ReactNode } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import type { UserRole } from '../../api/generated';
 import { useAuthStore } from '../../stores/authStore';
 import { ProtectedRoute } from './ProtectedRoute';

--- a/qnop-ui/src/components/dashboard/ActivityCard.tsx
+++ b/qnop-ui/src/components/dashboard/ActivityCard.tsx
@@ -33,7 +33,7 @@ import {
   Workflow,
   type LucideIcon,
 } from 'lucide-react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import Link from '@mui/material/Link';
 import type { DashboardActivity } from '../../api/generated';
 import { useFormatters } from '../../hooks/useFormatters';

--- a/qnop-ui/src/components/dashboard/DeadlinesCard.tsx
+++ b/qnop-ui/src/components/dashboard/DeadlinesCard.tsx
@@ -25,7 +25,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { CalendarClock, Hourglass } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { DocumentSummary } from '../../api/generated';
 import { SectionCard } from '../admin/layout/SectionCard';
 import { CardEmptyState } from './CardEmptyState';

--- a/qnop-ui/src/components/dashboard/EmptyDashboard.tsx
+++ b/qnop-ui/src/components/dashboard/EmptyDashboard.tsx
@@ -36,7 +36,7 @@ import {
   UserCheck,
   Users,
 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 /** The quest path — the three moves from empty workspace to running review. */
 const STEPS: { icon: LucideIcon; title: string; hint: string }[] = [

--- a/qnop-ui/src/components/dashboard/PersonLink.test.tsx
+++ b/qnop-ui/src/components/dashboard/PersonLink.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';

--- a/qnop-ui/src/components/dashboard/PersonLink.tsx
+++ b/qnop-ui/src/components/dashboard/PersonLink.tsx
@@ -22,7 +22,7 @@
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { useAuthStore } from '../../stores/authStore';
 import { UserHoverCard } from '../people/UserHoverCard';
 import { UserAvatar } from '../shell/UserAvatar';

--- a/qnop-ui/src/components/dashboard/PlayerCard.tsx
+++ b/qnop-ui/src/components/dashboard/PlayerCard.tsx
@@ -25,7 +25,7 @@ import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { Medal } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useUserProfile } from '../../api/hooks/useUsers';
 import { AchievementRow } from '../profile/AchievementRow';
 import { publicProfileAchievements } from '../profile/profileModel';

--- a/qnop-ui/src/components/dashboard/RepliesCard.tsx
+++ b/qnop-ui/src/components/dashboard/RepliesCard.tsx
@@ -25,7 +25,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { MessageCircleDashed, MessagesSquare } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { DashboardReply } from '../../api/generated';
 import { useFormatters } from '../../hooks/useFormatters';
 import { SectionCard } from '../admin/layout/SectionCard';

--- a/qnop-ui/src/components/dashboard/ReviewListCard.tsx
+++ b/qnop-ui/src/components/dashboard/ReviewListCard.tsx
@@ -25,7 +25,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { CircleCheck, Inbox, PartyPopper, type LucideIcon } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { DocumentSummary } from '../../api/generated';
 import { ToneBadge } from '../admin/ToneBadge';
 import { SectionCard } from '../admin/layout/SectionCard';

--- a/qnop-ui/src/components/people/UserHoverCard.test.tsx
+++ b/qnop-ui/src/components/people/UserHoverCard.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AxiosResponse } from 'axios';

--- a/qnop-ui/src/components/people/UserHoverCard.tsx
+++ b/qnop-ui/src/components/people/UserHoverCard.tsx
@@ -30,7 +30,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { alpha, useTheme } from '@mui/material/styles';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { CalendarDays, Crown, Users } from 'lucide-react';
 import type { PublicUserProfile } from '../../api/generated';
 import { useUserProfile } from '../../api/hooks/useUsers';

--- a/qnop-ui/src/components/profile/ProfileMissionList.tsx
+++ b/qnop-ui/src/components/profile/ProfileMissionList.tsx
@@ -25,7 +25,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { Crown, Telescope, UserCheck } from 'lucide-react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import type { DocumentSummary } from '../../api/generated';
 import { reviewPath } from '../dashboard/dashboardModel';
 import { ToneBadge } from '../admin/ToneBadge';

--- a/qnop-ui/src/components/profile/ProfileMovesCard.tsx
+++ b/qnop-ui/src/components/profile/ProfileMovesCard.tsx
@@ -34,7 +34,7 @@ import {
   Sparkles,
   Workflow,
 } from 'lucide-react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import type { DashboardActivity } from '../../api/generated';
 import { activityPhrase, reviewPath } from '../dashboard/dashboardModel';
 import { useFormatters } from '../../hooks/useFormatters';

--- a/qnop-ui/src/components/reviews/ReviewParamGate.test.tsx
+++ b/qnop-ui/src/components/reviews/ReviewParamGate.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { useDocumentBySlug } from '../../api/hooks/useDocuments';
 import { ReviewParamGate } from './ReviewParamGate';
 import { useReviewDocumentId } from './reviewDocumentId';

--- a/qnop-ui/src/components/reviews/ReviewParamGate.tsx
+++ b/qnop-ui/src/components/reviews/ReviewParamGate.tsx
@@ -24,7 +24,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { Link as RouterLink, useParams } from 'react-router-dom';
+import { Link as RouterLink, useParams } from 'react-router';
 import { useDocumentBySlug } from '../../api/hooks/useDocuments';
 import { ReviewDocumentIdContext } from './reviewDocumentId';
 

--- a/qnop-ui/src/components/reviews/hub/ParticipantsDialog.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ParticipantsDialog.test.tsx
@@ -22,7 +22,7 @@
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import { AxiosError, type AxiosResponse } from 'axios';

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
@@ -22,7 +22,7 @@
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import { AxiosError, type AxiosResponse } from 'axios';

--- a/qnop-ui/src/components/reviews/hub/ReviewViewTabs.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewViewTabs.test.tsx
@@ -21,7 +21,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../../theme/theme';
 import { ReviewViewTabs } from './ReviewViewTabs';

--- a/qnop-ui/src/components/reviews/hub/ReviewViewTabs.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewViewTabs.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Stack from '@mui/material/Stack';

--- a/qnop-ui/src/components/reviews/list/ReviewListParts.test.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewListParts.test.tsx
@@ -23,7 +23,7 @@ import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ParticipantView } from '../../../api/generated';
 import { ParticipantKind } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';

--- a/qnop-ui/src/components/reviews/markdown/Markdown.test.tsx
+++ b/qnop-ui/src/components/reviews/markdown/Markdown.test.tsx
@@ -21,7 +21,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../../theme/theme';

--- a/qnop-ui/src/components/reviews/markdown/MentionLink.tsx
+++ b/qnop-ui/src/components/reviews/markdown/MentionLink.tsx
@@ -22,7 +22,7 @@
 import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { useUserProfile } from '../../../api/hooks/useUsers';
 import { UserHoverCard } from '../../people/UserHoverCard';
 import { UserAvatar } from '../../shell/UserAvatar';

--- a/qnop-ui/src/components/reviews/reviewDocumentId.ts
+++ b/qnop-ui/src/components/reviews/reviewDocumentId.ts
@@ -20,7 +20,7 @@
  */
 
 import { createContext, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 /** Provided by {@code ReviewParamGate} once a slug URL resolved (issue #411). */
 export const ReviewDocumentIdContext = createContext<string | null>(null);

--- a/qnop-ui/src/components/reviews/useReviewPermalink.test.tsx
+++ b/qnop-ui/src/components/reviews/useReviewPermalink.test.tsx
@@ -22,7 +22,7 @@
 import type { ReactNode } from 'react';
 import { describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { useReviewPermalink, type PermalinkView } from './useReviewPermalink';
 
 function wrapperFor(entry: string) {

--- a/qnop-ui/src/components/reviews/useReviewPermalink.ts
+++ b/qnop-ui/src/components/reviews/useReviewPermalink.ts
@@ -20,7 +20,7 @@
  */
 
 import { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 /** The document view a permalink should reopen in (issue #412). */
 export type PermalinkView = 'panel' | 'focus';

--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -25,7 +25,7 @@ import Container from '@mui/material/Container';
 import Drawer from '@mui/material/Drawer';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
-import { Outlet, useMatch } from 'react-router-dom';
+import { Outlet, useMatch } from 'react-router';
 import { SidebarContent } from './SidebarContent';
 import { TopBar } from './TopBar';
 

--- a/qnop-ui/src/components/shell/Breadcrumbs.tsx
+++ b/qnop-ui/src/components/shell/Breadcrumbs.tsx
@@ -24,7 +24,7 @@ import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { ChevronRight } from 'lucide-react';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router';
 import { useTeam } from '../../api/hooks/useTeams';
 import { useMyTeam } from '../../api/hooks/useMyTeams';
 import { TeamAvatar } from './TeamAvatar';

--- a/qnop-ui/src/components/shell/SidebarContent.tsx
+++ b/qnop-ui/src/components/shell/SidebarContent.tsx
@@ -29,7 +29,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme, type SxProps, type Theme } from '@mui/material/styles';
 import { ShieldCheck } from 'lucide-react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import { useConfig } from '../../api/hooks/useConfig';
 import { useAuthStore } from '../../stores/authStore';
 import { BrandLogo } from '../branding/BrandLogo';

--- a/qnop-ui/src/components/shell/TopBar.test.tsx
+++ b/qnop-ui/src/components/shell/TopBar.test.tsx
@@ -22,7 +22,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../theme/theme';
 import { TopBar } from './TopBar';

--- a/qnop-ui/src/components/shell/UserFooter.tsx
+++ b/qnop-ui/src/components/shell/UserFooter.tsx
@@ -27,7 +27,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import { KeyRound, LogOut, UserRound } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useAuthStore } from '../../stores/authStore';
 import { UserAvatar } from './UserAvatar';
 

--- a/qnop-ui/src/components/shell/search/GlobalSearch.test.tsx
+++ b/qnop-ui/src/components/shell/search/GlobalSearch.test.tsx
@@ -22,7 +22,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import type { GlobalSearchResponse } from '../../../api/generated';
 import { buildTheme } from '../../../theme/theme';
 import { useAuthStore } from '../../../stores/authStore';

--- a/qnop-ui/src/components/shell/search/GlobalSearch.tsx
+++ b/qnop-ui/src/components/shell/search/GlobalSearch.tsx
@@ -30,7 +30,7 @@ import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { Search } from 'lucide-react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { SEARCH_MIN_LENGTH, useSearchQuick } from '../../../api/hooks/useSearch';
 import { useAuthStore } from '../../../stores/authStore';
 import { SearchDropdownResults } from './SearchDropdownResults';

--- a/qnop-ui/src/components/shell/search/SearchDropdownResults.tsx
+++ b/qnop-ui/src/components/shell/search/SearchDropdownResults.tsx
@@ -37,7 +37,7 @@ import {
   Users,
   UsersRound,
 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { GlobalSearchResponse } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { useAuthStore } from '../../../stores/authStore';

--- a/qnop-ui/src/main.tsx
+++ b/qnop-ui/src/main.tsx
@@ -24,7 +24,7 @@ import { createRoot } from 'react-dom/client';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router/dom';
 import '@fontsource/outfit/300.css';
 import '@fontsource/outfit/400.css';
 import '@fontsource/outfit/500.css';

--- a/qnop-ui/src/pages/HomePage.test.tsx
+++ b/qnop-ui/src/pages/HomePage.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import type { DashboardResponse, DocumentSummary } from '../api/generated';
 import { useDashboard } from '../api/hooks/useDashboard';

--- a/qnop-ui/src/pages/HomePage.tsx
+++ b/qnop-ui/src/pages/HomePage.tsx
@@ -35,7 +35,7 @@ import {
   Trophy,
   UserCheck,
 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useDashboard } from '../api/hooks/useDashboard';
 import { useReviews } from '../api/hooks/useReviews';
 import { PageHeader } from '../components/admin/layout/PageHeader';

--- a/qnop-ui/src/pages/UserProfilePage.test.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AxiosResponse } from 'axios';

--- a/qnop-ui/src/pages/UserProfilePage.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.tsx
@@ -40,7 +40,7 @@ import {
   Users,
 } from 'lucide-react';
 import { useEffect } from 'react';
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import type { PublicUserProfile } from '../api/generated';
 import { useDashboard } from '../api/hooks/useDashboard';

--- a/qnop-ui/src/pages/admin/EmailLayout.test.tsx
+++ b/qnop-ui/src/pages/admin/EmailLayout.test.tsx
@@ -22,7 +22,7 @@
 import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { buildTheme } from '../../theme/theme';
 import { EmailLayout } from './EmailLayout';
 

--- a/qnop-ui/src/pages/admin/EmailLayout.tsx
+++ b/qnop-ui/src/pages/admin/EmailLayout.tsx
@@ -22,7 +22,7 @@
 import Stack from '@mui/material/Stack';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-import { Link as RouterLink, Outlet, useLocation } from 'react-router-dom';
+import { Link as RouterLink, Outlet, useLocation } from 'react-router';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 
 const EMAIL_TABS = [

--- a/qnop-ui/src/pages/admin/MailTemplateEditPage.test.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplateEditPage.test.tsx
@@ -22,7 +22,7 @@
 import { forwardRef, useImperativeHandle, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { MailTemplateResponse } from '../../api/generated';
@@ -60,8 +60,8 @@ vi.mock('../../api/hooks/useMailTemplatePreview', () => ({
   useMailTemplatePreview: () => ({ status: 'idle', data: null, error: null, refresh: vi.fn() }),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('react-router-dom')>()),
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router')>()),
   useParams: () => ({ key: 'auth.password_reset' }),
 }));
 

--- a/qnop-ui/src/pages/admin/MailTemplateEditPage.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplateEditPage.tsx
@@ -34,7 +34,7 @@ import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { Send, Eye, RotateCcw, Variable } from 'lucide-react';
-import { Link as RouterLink, useParams } from 'react-router-dom';
+import { Link as RouterLink, useParams } from 'react-router';
 import type { MailTemplateResponse } from '../../api/generated';
 import {
   useMailTemplate,

--- a/qnop-ui/src/pages/admin/MailTemplatesKeyRedirect.test.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplatesKeyRedirect.test.tsx
@@ -21,7 +21,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router';
 import { MailTemplatesKeyRedirect } from './MailTemplatesKeyRedirect';
 
 /** Echoes the key the target route received, so the tests can assert it survived the redirect. */

--- a/qnop-ui/src/pages/admin/MailTemplatesKeyRedirect.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplatesKeyRedirect.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router';
 
 /**
  * Legacy redirect for pre-#525 bookmarks: `/admin/mail-templates/:key` →

--- a/qnop-ui/src/pages/admin/MailTemplatesListPage.test.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplatesListPage.test.tsx
@@ -67,8 +67,8 @@ vi.mock('../../api/hooks/useMailTemplates', () => ({
   useSendTestEmail: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('react-router-dom')>()),
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router')>()),
   useNavigate: () => navigateMock,
 }));
 

--- a/qnop-ui/src/pages/admin/MailTemplatesListPage.tsx
+++ b/qnop-ui/src/pages/admin/MailTemplatesListPage.tsx
@@ -32,7 +32,7 @@ import TableRow from '@mui/material/TableRow';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { ChevronRight } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { MailTemplateResponse } from '../../api/generated';
 import { useMailTemplates } from '../../api/hooks/useMailTemplates';
 import { ToneBadge } from '../../components/admin/ToneBadge';

--- a/qnop-ui/src/pages/admin/TeamDetailPage.test.tsx
+++ b/qnop-ui/src/pages/admin/TeamDetailPage.test.tsx
@@ -23,7 +23,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import type { AdminTeamDetail, AdminTeamMember } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { TeamDetailPage } from './TeamDetailPage';

--- a/qnop-ui/src/pages/admin/TeamDetailPage.tsx
+++ b/qnop-ui/src/pages/admin/TeamDetailPage.tsx
@@ -37,7 +37,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import { ArrowLeftRight, MoreVertical, SquarePen, UserMinus, UserPlus } from 'lucide-react';
-import { Link as RouterLink, useParams } from 'react-router-dom';
+import { Link as RouterLink, useParams } from 'react-router';
 import type { AdminTeamMember } from '../../api/generated';
 import { useRemoveTeamMember, useSetTeamMemberRole, useTeam } from '../../api/hooks/useTeams';
 import { AddMemberDialog } from '../../components/admin/teams/AddMemberDialog';

--- a/qnop-ui/src/pages/admin/TeamsPage.test.tsx
+++ b/qnop-ui/src/pages/admin/TeamsPage.test.tsx
@@ -24,7 +24,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { AdminTeamListResponse, AdminTeamSummary } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { TeamsPage } from './TeamsPage';
@@ -81,8 +81,8 @@ vi.mock('../../api/hooks/useTeams', () => ({
   useDeleteTeam: () => ({ mutateAsync: deleteMutate, isPending: false }),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('react-router-dom')>()),
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router')>()),
   useNavigate: () => navigateSpy,
 }));
 

--- a/qnop-ui/src/pages/admin/TeamsPage.tsx
+++ b/qnop-ui/src/pages/admin/TeamsPage.tsx
@@ -41,7 +41,7 @@ import Typography from '@mui/material/Typography';
 import { MoreVertical, SquarePen, Trash2, UsersRound } from 'lucide-react';
 import { ClearableSearchField } from '../../components/ClearableSearchField';
 import { TeamAvatar } from '../../components/shell/TeamAvatar';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { AdminTeamSummary } from '../../api/generated';
 import { useDeleteTeam, useTeams } from '../../api/hooks/useTeams';
 import { TeamFormDialog } from '../../components/admin/teams/TeamFormDialog';

--- a/qnop-ui/src/pages/auth/ChangePasswordPage.test.tsx
+++ b/qnop-ui/src/pages/auth/ChangePasswordPage.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { axe } from 'vitest-axe';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import { changePassword } from '../../api/auth';

--- a/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ChangePasswordPage.tsx
@@ -28,7 +28,7 @@ import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { Link as RouterLink, Navigate } from 'react-router-dom';
+import { Link as RouterLink, Navigate } from 'react-router';
 import { Check, Copy, Sparkles } from 'lucide-react';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { PasswordField } from '../../components/auth/PasswordField';

--- a/qnop-ui/src/pages/auth/ForgotPasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ForgotPasswordPage.tsx
@@ -28,7 +28,7 @@ import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import { Mail } from 'lucide-react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { forgotPassword } from '../../api/auth';
 import { apiErrorMessage } from '../../utils/apiError';

--- a/qnop-ui/src/pages/auth/LoginPage.test.tsx
+++ b/qnop-ui/src/pages/auth/LoginPage.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';

--- a/qnop-ui/src/pages/auth/LoginPage.tsx
+++ b/qnop-ui/src/pages/auth/LoginPage.tsx
@@ -29,7 +29,7 @@ import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import { ArrowRight, AtSign } from 'lucide-react';
-import { Link as RouterLink, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink, useNavigate, useSearchParams } from 'react-router';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { AuthModeSwitch } from '../../components/auth/AuthModeSwitch';
 import { OidcButtons } from '../../components/auth/OidcButtons';

--- a/qnop-ui/src/pages/auth/RegisterPage.test.tsx
+++ b/qnop-ui/src/pages/auth/RegisterPage.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { AxiosError, type AxiosResponse } from 'axios';
 import { axe } from 'vitest-axe';
 import { renderWithProviders } from '../../test/renderWithProviders';

--- a/qnop-ui/src/pages/auth/RegisterPage.tsx
+++ b/qnop-ui/src/pages/auth/RegisterPage.tsx
@@ -32,7 +32,7 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { ArrowRight, AtSign, Mail, User } from 'lucide-react';
-import { Link as RouterLink, Navigate } from 'react-router-dom';
+import { Link as RouterLink, Navigate } from 'react-router';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { AuthModeSwitch } from '../../components/auth/AuthModeSwitch';
 import { OidcButtons } from '../../components/auth/OidcButtons';

--- a/qnop-ui/src/pages/auth/ResetPasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ResetPasswordPage.tsx
@@ -25,7 +25,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
-import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink, useSearchParams } from 'react-router';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { PasswordField } from '../../components/auth/PasswordField';
 import { PasswordStrengthMeter } from '../../components/auth/PasswordStrengthMeter';

--- a/qnop-ui/src/pages/auth/VerifyEmailPage.tsx
+++ b/qnop-ui/src/pages/auth/VerifyEmailPage.tsx
@@ -24,7 +24,7 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Link from '@mui/material/Link';
-import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink, useSearchParams } from 'react-router';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { verifyEmail } from '../../api/auth';
 

--- a/qnop-ui/src/pages/errors/ErrorState.tsx
+++ b/qnop-ui/src/pages/errors/ErrorState.tsx
@@ -23,7 +23,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 
 interface ErrorStateProps {
   code: string;

--- a/qnop-ui/src/pages/my-teams/MyTeamDetailPage.test.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamDetailPage.test.tsx
@@ -23,7 +23,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import type { TeamDetail, TeamMember } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';

--- a/qnop-ui/src/pages/my-teams/MyTeamDetailPage.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamDetailPage.tsx
@@ -37,7 +37,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import { ArrowLeftRight, MoreVertical, Pencil, UserMinus, UserPlus } from 'lucide-react';
-import { Link as RouterLink, useParams } from 'react-router-dom';
+import { Link as RouterLink, useParams } from 'react-router';
 import type { TeamMember, TeamRole } from '../../api/generated';
 import {
   useMyTeam,

--- a/qnop-ui/src/pages/my-teams/MyTeamsPage.test.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamsPage.test.tsx
@@ -22,7 +22,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { MyTeamListResponse } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { MyTeamsPage } from './MyTeamsPage';

--- a/qnop-ui/src/pages/my-teams/MyTeamsPage.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamsPage.tsx
@@ -29,7 +29,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { keyframes } from '@mui/material/styles';
 import { ArrowRight, Crown, Eye, Lock, Trophy, UsersRound } from 'lucide-react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import type { MyTeam } from '../../api/generated';
 import { useMyTeams } from '../../api/hooks/useMyTeams';
 import { TeamRoleBadge } from '../../components/admin/teams/TeamRoleBadge';

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -22,7 +22,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView, RenderedSurface } from '../../api/generated';
 import { AnnotationStatus, ExtractionStatus, PlacementStatus } from '../../api/generated';

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';

--- a/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import type { PrincipalListResponse, WorkflowStatus } from '../../api/generated';

--- a/qnop-ui/src/pages/reviews/NewReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/NewReviewPage.tsx
@@ -28,7 +28,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight, Rocket } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { PrincipalView } from '../../api/generated';
 import { ParticipantKind, ThreadParticipation } from '../../api/generated';
 import { documentsApi, reviewWorkflowApi } from '../../api/config';

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -22,7 +22,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import type { AnnotationView } from '../../api/generated';
 import {

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -21,7 +21,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import type { DocumentSummary } from '../../api/generated';
 import { ParticipantKind } from '../../api/generated';

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -33,7 +33,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import { LayoutGrid, Plus, Rows3 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { DocumentSummary } from '../../api/generated';
 import { useReviews } from '../../api/hooks/useReviews';
 import { ClearableSearchField } from '../../components/ClearableSearchField';

--- a/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
@@ -21,7 +21,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import type { DiffChange, DocumentVersionSummary } from '../../api/generated';
 import { DiffChangeType, ExtractionStatus } from '../../api/generated';

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';

--- a/qnop-ui/src/pages/search/SearchPage.test.tsx
+++ b/qnop-ui/src/pages/search/SearchPage.test.tsx
@@ -22,7 +22,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { buildTheme } from '../../theme/theme';
 import { SearchPage } from './SearchPage';
 

--- a/qnop-ui/src/pages/search/SearchPage.tsx
+++ b/qnop-ui/src/pages/search/SearchPage.tsx
@@ -37,7 +37,7 @@ import {
   Users,
   UsersRound,
 } from 'lucide-react';
-import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink, useSearchParams } from 'react-router';
 import {
   SEARCH_MIN_LENGTH,
   useSearchAnnotations,

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -20,7 +20,7 @@
  */
 
 import { lazy } from 'react';
-import { Navigate, createBrowserRouter } from 'react-router-dom';
+import { Navigate, createBrowserRouter } from 'react-router';
 import { AppShell } from '../components/shell/AppShell';
 import { LazyBoundary } from '../components/errors/LazyBoundary';
 import { AdminRoute } from '../components/auth/AdminRoute';

--- a/qnop-ui/src/test/renderWithProviders.tsx
+++ b/qnop-ui/src/test/renderWithProviders.tsx
@@ -23,7 +23,7 @@ import type { ReactNode } from 'react';
 import { render, type RenderResult } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { buildTheme } from '../theme/theme';
 
 interface RenderOptions {


### PR DESCRIPTION
Closes #605.

## Summary

Unblocks the `pnpm audit --audit-level high` gate in the Frontend CI job, which is currently red on `main` and therefore blocks every open PR by proxy — including the docs-only #603/#604.

**1. `brace-expansion` — one override instead of two.** [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (DoS via unbounded expansion) marks every version ≤ 5.0.7 vulnerable and ships the patch only on the 5.0.x line, so #557's two per-line pins (`1.1.16` and `5.0.7`) no longer satisfy the gate and collapse into a single `brace-expansion@<5.0.8: 5.0.8` override. The package is purely transitive (41 paths via `eslint`/`minimatch` and `openapi-generator-cli`/`glob`), and 5.0.8 still publishes a `require` export condition, so the CJS consumers in the tree keep resolving.

**2. `react-router` — migrated to v8.** [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) patches in 8.3.0, and there is no `react-router-dom@8`: v8 completes the package merge, so the fix means dropping `react-router-dom` entirely.

- 88 files migrated: everything imports from `react-router`; only `RouterProvider` moved to the `react-router/dom` entry point.
- No routing behaviour change. Route definitions, guards and navigation semantics are untouched, and every API in use (`createBrowserRouter`, `Routes`/`Route`, `Navigate`, `NavLink`, `Link`, `Outlet`, `MemoryRouter`, `useLocation`, `useMatch`, `useNavigate`, `useParams`, `useSearchParams`) exists unchanged in v8.
- Prerequisites already satisfied: React 19.2.7 (v8 requires `>= 19.2.7`), Node 24 in CI, ESM-only package.
- The advisory itself is an RSC-mode CSRF bypass and is not exploitable in a Vite SPA with no RSC and no server actions — but the audit gate is severity-based, and taking the real fix keeps the gate honest rather than adding a suppression.

ADR-0039's import-map singleton list is updated to name the merged package (`react-router-dom` → `react-router`); it was the only remaining reference in the repo.

The lockfile change is tightly scoped: `react-router@8.3.0` (whose deps swap `cookie`/`set-cookie-parser` for `cookie-es`) and `brace-expansion@5.0.8` replacing both former lines.

## Test plan

Run locally in a clean worktree:

- [x] `pnpm audit --audit-level high` → **No known vulnerabilities found** (exit 0)
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `tsc -b --noEmit`
- [x] `vite build`
- [x] `vitest run` → 1069/1071. The two failures (`TimezoneSetting`, `ApplicationSettingsForm` timezone-list tests) are load-induced 5 s timeouts in the full parallel run — both pass when run isolated, and neither touches routing.
- [x] No `react-router-dom` import remains in `qnop-ui/src`

## Follow-up

Once this lands, PR #604 (#603, ADR-0049) needs its branch updated so the Frontend check re-runs; it is otherwise green and mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 5) via Claude Code
