### PR TITLE
feat(ui): branded, gamified error pages with illustrations (#611)

### DIFF
--- a/qnop-ui/src/components/reviews/ReviewParamGate.test.tsx
+++ b/qnop-ui/src/components/reviews/ReviewParamGate.test.tsx
@@ -22,6 +22,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
 import { useDocumentBySlug } from '../../api/hooks/useDocuments';
 import { ReviewParamGate } from './ReviewParamGate';
 import { useReviewDocumentId } from './reviewDocumentId';
@@ -38,18 +40,20 @@ function Probe() {
 
 function renderGate(segment: string) {
   render(
-    <MemoryRouter initialEntries={[`/reviews/${segment}`]}>
-      <Routes>
-        <Route
-          path="/reviews/:documentId"
-          element={
-            <ReviewParamGate>
-              <Probe />
-            </ReviewParamGate>
-          }
-        />
-      </Routes>
-    </MemoryRouter>,
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter initialEntries={[`/reviews/${segment}`]}>
+        <Routes>
+          <Route
+            path="/reviews/:documentId"
+            element={
+              <ReviewParamGate>
+                <Probe />
+              </ReviewParamGate>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
   );
 }
 
@@ -93,7 +97,11 @@ describe('ReviewParamGate', () => {
       data: undefined,
     } as never);
     renderGate('no-such-review');
-    expect(screen.getByText('Review not found')).toBeInTheDocument();
+    expect(screen.getByText(/folded itself into a paper plane/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to reviews' })).toHaveAttribute(
+      'href',
+      '/reviews',
+    );
     expect(screen.getByRole('link', { name: 'Back to reviews' })).toHaveAttribute(
       'href',
       '/reviews',

--- a/qnop-ui/src/components/reviews/ReviewParamGate.tsx
+++ b/qnop-ui/src/components/reviews/ReviewParamGate.tsx
@@ -20,12 +20,12 @@
  */
 
 import type { ReactNode } from 'react';
-import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
-import { Link as RouterLink, useParams } from 'react-router';
+import { useParams } from 'react-router';
 import { useDocumentBySlug } from '../../api/hooks/useDocuments';
+import { ErrorState } from '../../pages/errors/ErrorState';
+import { NotFoundIllustration } from '../../pages/errors/illustrations';
 import { ReviewDocumentIdContext } from './reviewDocumentId';
 
 const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -52,16 +52,19 @@ export function ReviewParamGate({ children }: { children: ReactNode }) {
   }
 
   if (bySlug.isError || !bySlug.data?.id) {
+    // The branded not-found shell (issue #611): same voice as the full-page
+    // 404 - playful about the page, never the user, always a way onward.
+    // Anti-enumeration: an unknown slug and one the caller may not see read
+    // identically here, exactly like the server's 404 (issue #411).
     return (
-      <Stack spacing={1} sx={{ alignItems: 'center', py: 10 }}>
-        <Typography variant="h6">Review not found</Typography>
-        <Typography variant="body2" color="text.secondary">
-          No review answers to “{segment}”. The link may be outdated.
-        </Typography>
-        <Button component={RouterLink} to="/reviews" sx={{ mt: 1 }}>
-          Back to reviews
-        </Button>
-      </Stack>
+      <ErrorState
+        code="404"
+        title="This review folded itself into a paper plane"
+        message={`No review answers to “${segment}” — the link may be outdated, or the review moved on. Your other quests are waiting.`}
+        illustration={<NotFoundIllustration />}
+        primaryAction={{ label: 'Back to reviews', to: '/reviews' }}
+        secondaryAction={{ label: 'Back to dashboard', to: '/' }}
+      />
     );
   }
 

--- a/qnop-ui/src/pages/TeamProfilePage.test.tsx
+++ b/qnop-ui/src/pages/TeamProfilePage.test.tsx
@@ -144,6 +144,7 @@ describe('TeamProfilePage (#586)', () => {
     );
     renderPage('/teams/ghost-team');
 
-    expect(await screen.findByText('This team does not exist.')).toBeInTheDocument();
+    expect(await screen.findByText('This team packed up its crest')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to dashboard' })).toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/pages/TeamProfilePage.tsx
+++ b/qnop-ui/src/pages/TeamProfilePage.tsx
@@ -19,7 +19,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Paper from '@mui/material/Paper';
@@ -47,6 +46,8 @@ import { TeamAvatar } from '../components/shell/TeamAvatar';
 import { UserAvatar } from '../components/shell/UserAvatar';
 import { avatarSrc } from '../utils/avatarUrl';
 import { useFormatters } from '../hooks/useFormatters';
+import { ErrorState } from './errors/ErrorState';
+import { NotFoundIllustration } from './errors/illustrations';
 
 const SINCE_FORMAT = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
 
@@ -122,7 +123,18 @@ export function TeamProfilePage() {
     );
   }
   if (profileQuery.isError || !profileQuery.data) {
-    return <Alert severity="error">This team does not exist.</Alert>;
+    // The branded not-found shell (issue #611); unknown and disabled teams
+    // read identically (anti-enumeration, mirroring the server's 404).
+    return (
+      <ErrorState
+        code="404"
+        title="This team packed up its crest"
+        message="No team answers to this address — the link may be outdated, or the team moved on. The guild hall is back on the dashboard."
+        illustration={<NotFoundIllustration />}
+        primaryAction={{ label: 'Back to dashboard', to: '/' }}
+        secondaryAction={{ label: 'My teams', to: '/my-teams' }}
+      />
+    );
   }
 
   const profile = profileQuery.data;

--- a/qnop-ui/src/pages/UserProfilePage.test.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.test.tsx
@@ -158,4 +158,15 @@ describe('UserProfilePage slug URLs (issue #486)', () => {
     expect(usersApi.getUserProfile).not.toHaveBeenCalled();
     expect(usersApi.getUserProfileBySlug).not.toHaveBeenCalled();
   });
+
+  it('shows the branded not-found shell for an unknown slug (#611)', async () => {
+    vi.mocked(usersApi.getUserProfileBySlug).mockReturnValue(
+      Promise.reject(new Error('404')) as never,
+    );
+    renderPage('ghost-user');
+
+    expect(await screen.findByText('This player card went for a walk')).toBeInTheDocument();
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to dashboard' })).toHaveAttribute('href', '/');
+  });
 });

--- a/qnop-ui/src/pages/UserProfilePage.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.tsx
@@ -19,7 +19,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Paper from '@mui/material/Paper';
@@ -56,6 +55,8 @@ import {
   sharedReviewsWith,
 } from '../components/profile/profileModel';
 import { UserAvatar } from '../components/shell/UserAvatar';
+import { ErrorState } from './errors/ErrorState';
+import { NotFoundIllustration } from './errors/illustrations';
 
 const SINCE_FORMAT = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' });
 
@@ -137,7 +138,17 @@ export function UserProfilePage() {
     );
   }
   if (profileQuery.isError || !profileQuery.data) {
-    return <Alert severity="error">This user does not exist.</Alert>;
+    // The branded not-found shell (issue #611); unknown and inaccessible
+    // slugs read identically (anti-enumeration, as on the server).
+    return (
+      <ErrorState
+        code="404"
+        title="This player card went for a walk"
+        message="No profile answers to this address — the link may be outdated. The rest of the roster is right where you left it."
+        illustration={<NotFoundIllustration />}
+        primaryAction={{ label: 'Back to dashboard', to: '/' }}
+      />
+    );
   }
 
   const profile = profileQuery.data;

--- a/qnop-ui/src/pages/errors/ConflictPage.tsx
+++ b/qnop-ui/src/pages/errors/ConflictPage.tsx
@@ -19,19 +19,26 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useNavigate } from 'react-router';
 import { ErrorState } from './ErrorState';
-import { NotFoundIllustration } from './illustrations';
+import { ConflictIllustration } from './illustrations';
 
-/** 404 - the page went for a walk; the user did nothing wrong (issue #611). */
-export function NotFoundPage() {
+/**
+ * 409, full-page variant only (issue #611): the navigation target changed
+ * under the user (e.g. an optimistic-concurrency clash, ADR-0030). Routine
+ * in-page conflicts stay inline where they are handled today.
+ */
+export function ConflictPage() {
+  const navigate = useNavigate();
   return (
     <ErrorState
-      code="404"
-      title="This page folded itself into a paper plane"
-      message="Wherever it landed, it isn't at this address. Head back to the dashboard and pick up your quest from there."
-      illustration={<NotFoundIllustration />}
-      primaryAction={{ label: 'Back to dashboard', to: '/' }}
-      secondaryAction={{ label: 'My reviews', to: '/reviews' }}
+      code="409"
+      title="Two pins landed on the same line"
+      message="Someone changed this while you were on your way to it. Reload to see the current state - nothing of yours was lost."
+      illustration={<ConflictIllustration />}
+      tone="alert"
+      primaryAction={{ label: 'Reload this page', onClick: () => navigate(0) }}
+      secondaryAction={{ label: 'Back to dashboard', to: '/' }}
     />
   );
 }

--- a/qnop-ui/src/pages/errors/ErrorPages.test.tsx
+++ b/qnop-ui/src/pages/errors/ErrorPages.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { ErrorState } from './ErrorState';
+import { NotFoundIllustration } from './illustrations';
+import { NotFoundPage } from './NotFoundPage';
+import { ForbiddenPage } from './ForbiddenPage';
+import { ConflictPage } from './ConflictPage';
+import { ServerErrorPage } from './ServerErrorPage';
+import { MaintenancePage } from './MaintenancePage';
+import { RateLimitPage } from './RateLimitPage';
+import { OfflinePage } from './OfflinePage';
+
+function renderAt(element: React.ReactElement) {
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <MemoryRouter initialEntries={['/errors-under-test']}>
+        <Routes>
+          <Route path="/errors-under-test" element={element} />
+          <Route path="/" element={<div data-testid="home" />} />
+          <Route path="/reviews" element={<div data-testid="reviews" />} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('ErrorState shell (#611)', () => {
+  it('renders code chip, headline, decorative illustration and a working way onward', () => {
+    renderAt(
+      <ErrorState
+        code="404"
+        title="Headline"
+        message="Body copy."
+        illustration={<NotFoundIllustration />}
+      />,
+    );
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Headline');
+    // The illustration is decorative - hidden from assistive tech.
+    const illustration = screen.getByTestId('error-state').querySelector('[aria-hidden="true"]');
+    expect(illustration?.querySelector('svg')).toBeInTheDocument();
+    // Never a dead end: the default action really navigates.
+    fireEvent.click(screen.getByRole('link', { name: 'Back to dashboard' }));
+    expect(screen.getByTestId('home')).toBeInTheDocument();
+  });
+
+  it('announces interrupting states via role=alert, but not route states', () => {
+    renderAt(
+      <ErrorState
+        title="Interrupted"
+        message="m"
+        tone="alert"
+        illustration={<NotFoundIllustration />}
+      />,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});
+
+describe('error pages (#611)', () => {
+  it('404 is playful about the page, never the user, and links onward twice', () => {
+    renderAt(<NotFoundPage />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText(/paper plane/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('link', { name: 'My reviews' }));
+    expect(screen.getByTestId('reviews')).toBeInTheDocument();
+  });
+
+  it('403 frames a boundary without accusing', () => {
+    renderAt(<ForbiddenPage />);
+    expect(screen.getByText('403')).toBeInTheDocument();
+    expect(screen.getByText(/binder is locked/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to dashboard' })).toBeInTheDocument();
+  });
+
+  it('409 offers a reload and reassures nothing was lost', () => {
+    renderAt(<ConflictPage />);
+    expect(screen.getByText('409')).toBeInTheDocument();
+    expect(screen.getByText(/nothing of yours was lost/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload this page' })).toBeInTheDocument();
+  });
+
+  it('500 takes the blame itself and retries', () => {
+    renderAt(<ServerErrorPage />);
+    expect(screen.getByText('500')).toBeInTheDocument();
+    expect(screen.getByText(/not your doing/i)).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+  });
+
+  it('503 reassures and retries', () => {
+    renderAt(<MaintenancePage />);
+    expect(screen.getByText('503')).toBeInTheDocument();
+    expect(screen.getByText(/back shortly/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('429 stays light and offers the way back', () => {
+    renderAt(<RateLimitPage />);
+    expect(screen.getByText('429')).toBeInTheDocument();
+    expect(screen.getByText(/stamp champion/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to dashboard' })).toBeInTheDocument();
+  });
+
+  it('offline is calm, has no code chip, and offers a retry', () => {
+    renderAt(<OfflinePage />);
+    expect(screen.getByText(/paper cups/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^\d{3}$/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry connection' })).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/pages/errors/ErrorState.tsx
+++ b/qnop-ui/src/pages/errors/ErrorState.tsx
@@ -19,33 +19,125 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { alpha, useTheme } from '@mui/material/styles';
 import { Link as RouterLink } from 'react-router';
+import { tokens } from '../../theme/tokens';
 
-interface ErrorStateProps {
-  code: string;
-  title: string;
-  message: string;
+const fadeUp = {
+  '@keyframes errorStateFadeUp': {
+    from: { opacity: 0, transform: 'translateY(10px)' },
+    to: { opacity: 1, transform: 'translateY(0)' },
+  },
+};
+
+export interface ErrorAction {
+  label: string;
+  /** Router target; mutually exclusive with onClick. */
+  to?: string;
+  onClick?: () => void;
 }
 
-/** Shared, centered empty/error state used by the error pages. */
-export function ErrorState({ code, title, message }: ErrorStateProps) {
+interface ErrorStateProps {
+  /** The HTTP-ish code chip; omit for stateful pages like offline. */
+  code?: string;
+  title: string;
+  message: string;
+  /** The motif from {@code illustrations.tsx} - decorative, hidden from AT. */
+  illustration: ReactNode;
+  primaryAction?: ErrorAction;
+  secondaryAction?: ErrorAction;
+  /**
+   * 'route' (default) for destinations you can navigate to (404, 403) -
+   * plain content; 'alert' for states that interrupted the user (500, 503,
+   * 429, offline), announced via role="alert".
+   */
+  tone?: 'route' | 'alert';
+}
+
+function ActionButton({ action, primary }: { action: ErrorAction; primary: boolean }) {
+  const variant = primary ? ('contained' as const) : ('outlined' as const);
+  return action.to ? (
+    <Button variant={variant} component={RouterLink} to={action.to}>
+      {action.label}
+    </Button>
+  ) : (
+    <Button variant={variant} onClick={action.onClick}>
+      {action.label}
+    </Button>
+  );
+}
+
+/**
+ * The full-page error shell (issue #611): illustration, code chip, headline,
+ * body and the next move - an error page is a failed roll, not a dead end, so
+ * there is always at least one way onward. Entrance is the app's staggered
+ * rise (the EmptyDashboard recipe); reduced-motion users get everything in
+ * place, still. Shell-less contexts (router errorElement) centre themselves
+ * the same way as inside the AppShell.
+ */
+export function ErrorState({
+  code,
+  title,
+  message,
+  illustration,
+  primaryAction = { label: 'Back to dashboard', to: '/' },
+  secondaryAction,
+  tone = 'route',
+}: ErrorStateProps) {
+  const theme = useTheme();
+  const stagger = (index: number) => ({
+    ...fadeUp,
+    animation: `errorStateFadeUp 0.45s ${theme.transitions.easing.easeOut} both`,
+    animationDelay: `${index * 90}ms`,
+    '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+  });
+
   return (
-    <Box sx={{ display: 'grid', placeItems: 'center', minHeight: '60dvh', p: 2 }}>
-      <Stack spacing={1} sx={{ alignItems: 'center', textAlign: 'center' }}>
-        <Typography variant="h1" sx={{ fontSize: '3rem', color: 'text.secondary' }}>
-          {code}
-        </Typography>
-        <Typography variant="h6" component="h1">
-          {title}
-        </Typography>
-        <Typography color="text.secondary">{message}</Typography>
-        <Button component={RouterLink} to="/" sx={{ mt: 1 }}>
-          Zur Startseite
-        </Button>
+    <Box
+      sx={{ display: 'grid', placeItems: 'center', minHeight: '60dvh', p: 2 }}
+      data-testid="error-state"
+    >
+      <Stack
+        spacing={2}
+        role={tone === 'alert' ? 'alert' : undefined}
+        sx={{ alignItems: 'center', textAlign: 'center', maxWidth: 440 }}
+      >
+        <Box aria-hidden sx={{ ...stagger(0), color: 'text.secondary' }}>
+          {illustration}
+        </Box>
+        <Stack spacing={1} sx={{ ...stagger(1), alignItems: 'center' }}>
+          {code && (
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: tokens.font.mono,
+                fontSize: '0.8rem',
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                color: theme.qnop.brand.blue,
+                bgcolor: alpha(theme.qnop.brand.blue, theme.qnop.mode === 'dark' ? 0.16 : 0.1),
+                borderRadius: '999px',
+                px: 1.25,
+                py: 0.25,
+              }}
+            >
+              {code}
+            </Typography>
+          )}
+          <Typography variant="h1" sx={{ fontSize: '1.5rem', lineHeight: 1.25 }}>
+            {title}
+          </Typography>
+          <Typography color="text.secondary">{message}</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1.5} sx={{ ...stagger(2), pt: 0.5 }}>
+          <ActionButton action={primaryAction} primary />
+          {secondaryAction && <ActionButton action={secondaryAction} primary={false} />}
+        </Stack>
       </Stack>
     </Box>
   );

--- a/qnop-ui/src/pages/errors/ForbiddenPage.tsx
+++ b/qnop-ui/src/pages/errors/ForbiddenPage.tsx
@@ -20,13 +20,17 @@
  */
 
 import { ErrorState } from './ErrorState';
+import { ForbiddenIllustration } from './illustrations';
 
+/** 403 - a boundary, not an accusation (issue #611). */
 export function ForbiddenPage() {
   return (
     <ErrorState
       code="403"
-      title="No access"
-      message="You don't have permission to view this area."
+      title="This binder is locked"
+      message="Your account doesn't have access to this area. If your quest leads through here, an administrator can hand you the key."
+      illustration={<ForbiddenIllustration />}
+      primaryAction={{ label: 'Back to dashboard', to: '/' }}
     />
   );
 }

--- a/qnop-ui/src/pages/errors/MaintenancePage.tsx
+++ b/qnop-ui/src/pages/errors/MaintenancePage.tsx
@@ -19,19 +19,21 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useNavigate } from 'react-router';
 import { ErrorState } from './ErrorState';
-import { NotFoundIllustration } from './illustrations';
+import { MaintenanceIllustration } from './illustrations';
 
-/** 404 - the page went for a walk; the user did nothing wrong (issue #611). */
-export function NotFoundPage() {
+/** 503 - the boss is patching itself; reassuring, back shortly (issue #611). */
+export function MaintenancePage() {
+  const navigate = useNavigate();
   return (
     <ErrorState
-      code="404"
-      title="This page folded itself into a paper plane"
-      message="Wherever it landed, it isn't at this address. Head back to the dashboard and pick up your quest from there."
-      illustration={<NotFoundIllustration />}
-      primaryAction={{ label: 'Back to dashboard', to: '/' }}
-      secondaryAction={{ label: 'My reviews', to: '/reviews' }}
+      code="503"
+      title="Out to lunch - back shortly"
+      message="qnop is patching itself up. Your reviews are safe in the cabinet; give it a moment and try again."
+      illustration={<MaintenanceIllustration />}
+      tone="alert"
+      primaryAction={{ label: 'Retry', onClick: () => navigate(0) }}
     />
   );
 }

--- a/qnop-ui/src/pages/errors/OfflinePage.tsx
+++ b/qnop-ui/src/pages/errors/OfflinePage.tsx
@@ -19,19 +19,20 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useNavigate } from 'react-router';
 import { ErrorState } from './ErrorState';
-import { NotFoundIllustration } from './illustrations';
+import { OfflineIllustration } from './illustrations';
 
-/** 404 - the page went for a walk; the user did nothing wrong (issue #611). */
-export function NotFoundPage() {
+/** Offline - calm, not alarming; the string will be re-tied (issue #611). */
+export function OfflinePage() {
+  const navigate = useNavigate();
   return (
     <ErrorState
-      code="404"
-      title="This page folded itself into a paper plane"
-      message="Wherever it landed, it isn't at this address. Head back to the dashboard and pick up your quest from there."
-      illustration={<NotFoundIllustration />}
-      primaryAction={{ label: 'Back to dashboard', to: '/' }}
-      secondaryAction={{ label: 'My reviews', to: '/reviews' }}
+      title="The string between our paper cups snapped"
+      message="You seem to be offline. Nothing is lost - once the connection is back, everything picks up where it stopped."
+      illustration={<OfflineIllustration />}
+      tone="alert"
+      primaryAction={{ label: 'Retry connection', onClick: () => navigate(0) }}
     />
   );
 }

--- a/qnop-ui/src/pages/errors/RateLimitPage.tsx
+++ b/qnop-ui/src/pages/errors/RateLimitPage.tsx
@@ -19,19 +19,22 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useNavigate } from 'react-router';
 import { ErrorState } from './ErrorState';
-import { NotFoundIllustration } from './illustrations';
+import { RateLimitIllustration } from './illustrations';
 
-/** 404 - the page went for a walk; the user did nothing wrong (issue #611). */
-export function NotFoundPage() {
+/** 429 - easy there; the rate limit (ADR-0027) asked for a breather (issue #611). */
+export function RateLimitPage() {
+  const navigate = useNavigate();
   return (
     <ErrorState
-      code="404"
-      title="This page folded itself into a paper plane"
-      message="Wherever it landed, it isn't at this address. Head back to the dashboard and pick up your quest from there."
-      illustration={<NotFoundIllustration />}
-      primaryAction={{ label: 'Back to dashboard', to: '/' }}
-      secondaryAction={{ label: 'My reviews', to: '/reviews' }}
+      code="429"
+      title="Easy there, stamp champion"
+      message="That was a lot of requests in a very short time. Take a breath - a moment from now everything works again."
+      illustration={<RateLimitIllustration />}
+      tone="alert"
+      primaryAction={{ label: 'Try again', onClick: () => navigate(0) }}
+      secondaryAction={{ label: 'Back to dashboard', to: '/' }}
     />
   );
 }

--- a/qnop-ui/src/pages/errors/RouteErrorPage.test.tsx
+++ b/qnop-ui/src/pages/errors/RouteErrorPage.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { RouteErrorPage } from './RouteErrorPage';
+
+function renderWithThrow(thrower: () => never) {
+  const Boom = () => thrower();
+  const router = createMemoryRouter([
+    { path: '/', element: <Boom />, errorElement: <RouteErrorPage /> },
+  ]);
+  return render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <RouterProvider router={router} />
+    </ThemeProvider>,
+  );
+}
+
+describe('RouteErrorPage (#611)', () => {
+  it('renders the branded 500 for an unexpected navigation throw', () => {
+    renderWithThrow(() => {
+      throw new Error('boom');
+    });
+    expect(screen.getByText('500')).toBeInTheDocument();
+    expect(screen.getByText(/not your doing/i)).toBeInTheDocument();
+  });
+
+  it('renders the branded 404 for a 404 route response', async () => {
+    // Only loader/action throws become route error responses - mirror that.
+    const router = createMemoryRouter([
+      {
+        path: '/',
+        loader: () => {
+          throw new Response('gone', { status: 404 });
+        },
+        element: <div />,
+        errorElement: <RouteErrorPage />,
+      },
+    ]);
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <RouterProvider router={router} />
+      </ThemeProvider>,
+    );
+    expect(await screen.findByText('404')).toBeInTheDocument();
+    expect(screen.getByText(/paper plane/)).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/pages/errors/RouteErrorPage.tsx
+++ b/qnop-ui/src/pages/errors/RouteErrorPage.tsx
@@ -19,19 +19,20 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { ErrorState } from './ErrorState';
-import { NotFoundIllustration } from './illustrations';
+import { isRouteErrorResponse, useRouteError } from 'react-router';
+import { NotFoundPage } from './NotFoundPage';
+import { ServerErrorPage } from './ServerErrorPage';
 
-/** 404 - the page went for a walk; the user did nothing wrong (issue #611). */
-export function NotFoundPage() {
-  return (
-    <ErrorState
-      code="404"
-      title="This page folded itself into a paper plane"
-      message="Wherever it landed, it isn't at this address. Head back to the dashboard and pick up your quest from there."
-      illustration={<NotFoundIllustration />}
-      primaryAction={{ label: 'Back to dashboard', to: '/' }}
-      secondaryAction={{ label: 'My reviews', to: '/reviews' }}
-    />
-  );
+/**
+ * The router-level catch (issue #611): a throw during navigation lands on the
+ * branded shell instead of React Router's default screen. A 404 response
+ * renders the not-found page; everything else is, honestly, a 500 of ours.
+ * Pane-level render errors stay with ErrorBoundary/BoundaryFallback (#331).
+ */
+export function RouteErrorPage() {
+  const error = useRouteError();
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return <NotFoundPage />;
+  }
+  return <ServerErrorPage />;
 }

--- a/qnop-ui/src/pages/errors/ServerErrorPage.tsx
+++ b/qnop-ui/src/pages/errors/ServerErrorPage.tsx
@@ -19,19 +19,22 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useNavigate } from 'react-router';
 import { ErrorState } from './ErrorState';
-import { NotFoundIllustration } from './illustrations';
+import { ServerErrorIllustration } from './illustrations';
 
-/** 404 - the page went for a walk; the user did nothing wrong (issue #611). */
-export function NotFoundPage() {
+/** 500 - our shredder, our fault; self-deprecating, never blaming (issue #611). */
+export function ServerErrorPage() {
+  const navigate = useNavigate();
   return (
     <ErrorState
-      code="404"
-      title="This page folded itself into a paper plane"
-      message="Wherever it landed, it isn't at this address. Head back to the dashboard and pick up your quest from there."
-      illustration={<NotFoundIllustration />}
-      primaryAction={{ label: 'Back to dashboard', to: '/' }}
-      secondaryAction={{ label: 'My reviews', to: '/reviews' }}
+      code="500"
+      title="Our shredder grabbed the wrong document"
+      message="Something broke on our side - not your doing. Trying again usually works; if it keeps happening, your admin will want to know."
+      illustration={<ServerErrorIllustration />}
+      tone="alert"
+      primaryAction={{ label: 'Try again', onClick: () => navigate(0) }}
+      secondaryAction={{ label: 'Back to dashboard', to: '/' }}
     />
   );
 }

--- a/qnop-ui/src/pages/errors/illustrations.tsx
+++ b/qnop-ui/src/pages/errors/illustrations.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { alpha, useTheme } from '@mui/material/styles';
+
+/**
+ * The error pages' illustration set (issue #611): self-drawn line art in the
+ * document/review metaphor, so licensing is clean by construction (ADR-0007).
+ * Every motif is stroke-based on theme tokens — one drawing holds up on both
+ * backgrounds, at any DPI. All illustrations are decorative (aria-hidden by
+ * the shell); the copy carries the meaning.
+ */
+interface IlluColors {
+  /** Primary line work. */
+  line: string;
+  /** Secondary/structural lines. */
+  faint: string;
+  /** The one brand accent per motif. */
+  accent: string;
+  /** Soft accent fill. */
+  wash: string;
+}
+
+function useIlluColors(): IlluColors {
+  const theme = useTheme();
+  const accent = theme.qnop.brand.blue;
+  return {
+    line: theme.palette.text.secondary,
+    faint: theme.palette.divider,
+    accent,
+    wash: alpha(accent, theme.qnop.mode === 'dark' ? 0.18 : 0.1),
+  };
+}
+
+/** Shared canvas: fixed viewBox, responsive width, round joins throughout. */
+function Canvas({ children }: { children: ReactNode }) {
+  return (
+    <svg
+      viewBox="0 0 220 150"
+      width="220"
+      height="150"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ maxWidth: '100%', height: 'auto' }}
+    >
+      {children}
+    </svg>
+  );
+}
+
+/** 404 — a paper plane folded from a review page sails off the edge of the desk. */
+export function NotFoundIllustration() {
+  const c = useIlluColors();
+  return (
+    <Canvas>
+      {/* Desk edge, ending mid-air. */}
+      <path d="M14 112 H132" stroke={c.line} strokeWidth="2.5" />
+      <path d="M132 112 L138 118" stroke={c.faint} strokeWidth="2" />
+      {/* The page it was folded from, lines wandering off. */}
+      <rect x="30" y="70" width="52" height="36" rx="4" stroke={c.faint} strokeWidth="2" />
+      <path d="M38 80 H66 M38 88 H58 M38 96 H62" stroke={c.faint} strokeWidth="2" />
+      {/* Dashed flight path over the edge. */}
+      <path
+        d="M84 92 C 116 78, 138 74, 168 52"
+        stroke={c.accent}
+        strokeWidth="2"
+        strokeDasharray="2 7"
+      />
+      {/* The plane. */}
+      <path d="M168 52 L196 40 L182 62 Z" fill={c.wash} stroke={c.accent} strokeWidth="2.5" />
+      <path d="M182 62 L179 50" stroke={c.accent} strokeWidth="2.5" />
+    </Canvas>
+  );
+}
+
+/** 403 — a ring binder with a very serious little padlock; a boundary, not an accusation. */
+export function ForbiddenIllustration() {
+  const c = useIlluColors();
+  return (
+    <Canvas>
+      {/* Binder. */}
+      <rect x="62" y="34" width="96" height="82" rx="8" stroke={c.line} strokeWidth="2.5" />
+      <path d="M80 34 V116" stroke={c.faint} strokeWidth="2" />
+      <circle cx="80" cy="58" r="5" stroke={c.line} strokeWidth="2" />
+      <circle cx="80" cy="92" r="5" stroke={c.line} strokeWidth="2" />
+      {/* Spine label. */}
+      <path d="M96 50 H142 M96 60 H128" stroke={c.faint} strokeWidth="2" />
+      {/* The padlock, front and centre. */}
+      <rect
+        x="106"
+        y="80"
+        width="30"
+        height="24"
+        rx="5"
+        fill={c.wash}
+        stroke={c.accent}
+        strokeWidth="2.5"
+      />
+      <path d="M112 80 V72 a9 9 0 0 1 18 0 V80" stroke={c.accent} strokeWidth="2.5" />
+      <circle cx="121" cy="91" r="2.5" fill={c.accent} />
+    </Canvas>
+  );
+}
+
+/** 409 — two annotation pins land on the same line; the speech bubbles collide. */
+export function ConflictIllustration() {
+  const c = useIlluColors();
+  return (
+    <Canvas>
+      {/* Page with the contested line. */}
+      <rect x="66" y="52" width="88" height="66" rx="6" stroke={c.line} strokeWidth="2.5" />
+      <path d="M76 66 H144 M76 92 H144 M76 104 H120" stroke={c.faint} strokeWidth="2" />
+      <path d="M76 79 H144" stroke={c.accent} strokeWidth="3" />
+      {/* Two pins on the same line. */}
+      <path d="M92 79 L84 60" stroke={c.line} strokeWidth="2" />
+      <circle cx="83" cy="57" r="5" fill={c.wash} stroke={c.accent} strokeWidth="2" />
+      <path d="M128 79 L136 60" stroke={c.line} strokeWidth="2" />
+      <circle cx="137" cy="57" r="5" fill={c.wash} stroke={c.accent} strokeWidth="2" />
+      {/* Colliding bubbles above. */}
+      <path d="M60 30 h34 v18 h-24 l-6 7 v-7 h-4 Z" stroke={c.line} strokeWidth="2" />
+      <path d="M126 26 h34 v18 h-4 v7 l-6 -7 h-24 Z" stroke={c.line} strokeWidth="2" />
+      <path d="M104 34 l12 4 M116 34 l-12 4" stroke={c.accent} strokeWidth="2.5" />
+    </Canvas>
+  );
+}
+
+/** 500 — the shredder ate the document and does not look sorry. Our fault. */
+export function ServerErrorIllustration() {
+  const c = useIlluColors();
+  return (
+    <Canvas>
+      {/* Shredder body. */}
+      <rect x="64" y="62" width="92" height="46" rx="8" stroke={c.line} strokeWidth="2.5" />
+      <path d="M74 74 H146" stroke={c.accent} strokeWidth="3" />
+      {/* Page half-in. */}
+      <path d="M88 62 L92 34 H132 L136 62" stroke={c.line} strokeWidth="2.5" />
+      <path d="M98 44 H126 M98 52 H118" stroke={c.faint} strokeWidth="2" />
+      {/* Strips below. */}
+      <path
+        d="M84 108 v16 M96 108 v22 M108 108 v14 M120 108 v20 M132 108 v15"
+        stroke={c.faint}
+        strokeWidth="2"
+      />
+      {/* A quiet spark: the one thing it should not have done. */}
+      <path d="M158 50 l6 -8 M162 56 l9 -3 M154 44 l2 -10" stroke={c.accent} strokeWidth="2" />
+    </Canvas>
+  );
+}
+
+/** 503 — an "out to lunch" sign hangs on the filing cabinet; back shortly. */
+export function MaintenanceIllustration() {
+  const c = useIlluColors();
+  return (
+    <Canvas>
+      {/* Filing cabinet. */}
+      <rect x="72" y="28" width="76" height="94" rx="6" stroke={c.line} strokeWidth="2.5" />
+      <path d="M72 60 H148 M72 92 H148" stroke={c.faint} strokeWidth="2" />
+      <path d="M102 44 H118 M102 76 H118" stroke={c.line} strokeWidth="2.5" />
+      {/* The sign, hanging slightly askew on a string. */}
+      <path d="M110 92 l-7 10 M110 92 l13 8" stroke={c.faint} strokeWidth="2" />
+      <g transform="rotate(-6 110 116)">
+        <rect
+          x="86"
+          y="102"
+          width="48"
+          height="26"
+          rx="4"
+          fill={c.wash}
+          stroke={c.accent}
+          strokeWidth="2.5"
+        />
+        <path d="M94 111 H126 M94 119 H114" stroke={c.accent} strokeWidth="2" />
+      </g>
+    </Canvas>
+  );
+}
+
+/** 429 — a reviewer stamping far too fast; stamps flying, a queue forming. */
+export function RateLimitIllustration() {
+  const c = useIlluColors();
+  return (
+    <Canvas>
+      {/* Paper stack. */}
+      <path d="M60 116 H150 M66 110 H144 M72 104 H138" stroke={c.faint} strokeWidth="2" />
+      {/* The stamp mid-swing with speed lines. */}
+      <g transform="rotate(14 128 66)">
+        <rect x="116" y="52" width="24" height="14" rx="3" stroke={c.line} strokeWidth="2.5" />
+        <path d="M124 52 V40 h8 v12" stroke={c.line} strokeWidth="2.5" />
+        <path d="M112 70 h32" stroke={c.line} strokeWidth="2.5" />
+      </g>
+      <path d="M96 44 l-12 -6 M98 56 l-14 -1 M100 34 l-9 -10" stroke={c.faint} strokeWidth="2" />
+      {/* Stamped marks scattering — each a tidy little approval. */}
+      <circle cx="70" cy="80" r="9" stroke={c.accent} strokeWidth="2" fill={c.wash} />
+      <path d="M66 80 l3 3 l5 -6" stroke={c.accent} strokeWidth="2" />
+      <circle cx="100" cy="88" r="9" stroke={c.accent} strokeWidth="2" />
+      <path d="M96 88 l3 3 l5 -6" stroke={c.accent} strokeWidth="2" />
+      <circle cx="132" cy="92" r="9" stroke={c.accent} strokeWidth="2" fill={c.wash} />
+      <path d="M128 92 l3 3 l5 -6" stroke={c.accent} strokeWidth="2" />
+    </Canvas>
+  );
+}
+
+/** Offline — two paper cups, and the string between them is cut. Calm, not alarming. */
+export function OfflineIllustration() {
+  const c = useIlluColors();
+  return (
+    <Canvas>
+      {/* Left cup. */}
+      <path d="M40 78 h30 l-4 34 h-22 Z" stroke={c.line} strokeWidth="2.5" />
+      <path d="M44 88 h22" stroke={c.faint} strokeWidth="2" />
+      {/* Right cup. */}
+      <path d="M150 78 h30 l-4 34 h-22 Z" stroke={c.line} strokeWidth="2.5" />
+      <path d="M154 88 h22" stroke={c.faint} strokeWidth="2" />
+      {/* The string, sagging — and cut in the middle. */}
+      <path d="M70 82 C 88 96, 98 100, 104 101" stroke={c.accent} strokeWidth="2" />
+      <path d="M150 82 C 132 96, 122 100, 116 101" stroke={c.accent} strokeWidth="2" />
+      <path d="M104 101 l-3 6 M116 101 l3 6" stroke={c.accent} strokeWidth="2" />
+      {/* A last little signal that did not make it across. */}
+      <path d="M107 92 a6 6 0 0 1 6 0" stroke={c.faint} strokeWidth="2" strokeDasharray="2 4" />
+    </Canvas>
+  );
+}

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -300,12 +300,15 @@ describe('ReviewsPage', () => {
     expect(screen.getByTestId('reviews-loading')).toBeInTheDocument();
   });
 
-  it('shows an error with retry', () => {
+  it('shows the branded failure shell with a working retry (#611)', () => {
     const refetch = vi.fn();
     mockReviews({ isError: true, refetch });
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    // The load failure speaks the error pages' voice - ours, with a way onward.
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/didn't make it to the desk/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
     expect(refetch).toHaveBeenCalled();
   });
 

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -40,6 +40,8 @@ import { LayoutGrid, ListFilter, Plus, Rows3 } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router';
 import type { DocumentSummary } from '../../api/generated';
 import { useReviews } from '../../api/hooks/useReviews';
+import { ErrorState } from '../errors/ErrorState';
+import { ServerErrorIllustration } from '../errors/illustrations';
 import { ClearableSearchField } from '../../components/ClearableSearchField';
 import { PageHeader } from '../../components/admin/layout/PageHeader';
 import { isOpenWorkflowState, workflowLabel } from '../../components/reviews/workflowMeta';
@@ -424,16 +426,16 @@ export function ReviewsPage() {
       />
 
       {isError && (
-        <Alert
-          severity="error"
-          action={
-            <Button color="inherit" size="small" onClick={() => refetch()}>
-              Retry
-            </Button>
-          }
-        >
-          Reviews could not be loaded.
-        </Alert>
+        // The branded failure shell (issue #611) instead of a bare alert -
+        // same voice as the full-page states: our fault, with a way onward.
+        <ErrorState
+          title="Your reviews didn't make it to the desk"
+          message="Loading failed on our side - not your doing. Give it another try; if it keeps happening, your admin will want to know."
+          illustration={<ServerErrorIllustration />}
+          tone="alert"
+          primaryAction={{ label: 'Try again', onClick: () => refetch() }}
+          secondaryAction={{ label: 'Back to dashboard', to: '/' }}
+        />
       )}
 
       {isPending && !isError && (

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -20,7 +20,6 @@
  */
 
 import { useMemo, useState } from 'react';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';

--- a/qnop-ui/src/router/errorRoutes.test.tsx
+++ b/qnop-ui/src/router/errorRoutes.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { RouterProvider } from 'react-router';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../theme/theme';
+import { router } from './index';
+
+/**
+ * Integration over the REAL route table (issue #611): the branded states are
+ * reachable at their addresses, outside the auth shell - 503/offline must
+ * work when nothing else does, so none of these may sit behind a login.
+ */
+const CASES: [string, RegExp][] = [
+  ['/403', /binder is locked/i],
+  ['/409', /two pins landed on the same line/i],
+  ['/500', /shredder grabbed the wrong document/i],
+  ['/503', /out to lunch/i],
+  ['/429', /stamp champion/i],
+  ['/offline', /paper cups/i],
+];
+
+describe('error routes (#611)', () => {
+  afterEach(cleanup);
+
+  it.each(CASES)('serves the branded state at %s without auth', async (path, headline) => {
+    await router.navigate(path);
+    render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <RouterProvider router={router} />
+      </ThemeProvider>,
+    );
+    expect(await screen.findByText(headline)).toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -53,8 +53,14 @@ import { LoginPage } from '../pages/auth/LoginPage';
 import { RegisterPage } from '../pages/auth/RegisterPage';
 import { ResetPasswordPage } from '../pages/auth/ResetPasswordPage';
 import { VerifyEmailPage } from '../pages/auth/VerifyEmailPage';
+import { ConflictPage } from '../pages/errors/ConflictPage';
 import { ForbiddenPage } from '../pages/errors/ForbiddenPage';
+import { MaintenancePage } from '../pages/errors/MaintenancePage';
 import { NotFoundPage } from '../pages/errors/NotFoundPage';
+import { OfflinePage } from '../pages/errors/OfflinePage';
+import { RateLimitPage } from '../pages/errors/RateLimitPage';
+import { RouteErrorPage } from '../pages/errors/RouteErrorPage';
+import { ServerErrorPage } from '../pages/errors/ServerErrorPage';
 import { NewReviewPage } from '../pages/reviews/NewReviewPage';
 import { ReviewsPage } from '../pages/reviews/ReviewsPage';
 import { ReviewParamGate } from '../components/reviews/ReviewParamGate';
@@ -90,7 +96,15 @@ export const router = createBrowserRouter([
   { path: '/reset-password', element: <ResetPasswordPage /> },
   { path: '/verify-email', element: <VerifyEmailPage /> },
   { path: '/change-password', element: <ChangePasswordPage /> },
+  // The branded full-page states (issue #611). They live outside the shell so
+  // 503/offline also work when nothing else does; the in-app catch-all below
+  // keeps 404 inside the shell for signed-in users.
   { path: '/403', element: <ForbiddenPage /> },
+  { path: '/409', element: <ConflictPage /> },
+  { path: '/500', element: <ServerErrorPage /> },
+  { path: '/503', element: <MaintenancePage /> },
+  { path: '/429', element: <RateLimitPage /> },
+  { path: '/offline', element: <OfflinePage /> },
   {
     path: '/',
     element: (
@@ -98,6 +112,9 @@ export const router = createBrowserRouter([
         <AppShell />
       </ProtectedRoute>
     ),
+    // A throw during navigation lands on the branded shell, not the router's
+    // default screen (issue #611); pane render errors stay with #331.
+    errorElement: <RouteErrorPage />,
     children: [
       { index: true, element: <HomePage /> },
       { path: 'profile', element: <ProfilePage /> },

--- a/qnop-ui/vitest.config.ts
+++ b/qnop-ui/vitest.config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
         'src/components/auth/RoleRoute.tsx',
         'src/components/auth/AuthHydrationBoundary.tsx',
         'src/components/shell/navConfig.tsx',
+        // The branded error pages (issue #611): shell, pages, router catch.
+        'src/pages/errors/**/*.tsx',
         // Auth screens — the critical entry flow (issue #352, wave 1).
         'src/pages/auth/**/*.tsx',
         // Admin screens — users, teams, settings, branding and OIDC (issue


### PR DESCRIPTION
Closes #611.

## Summary

- **ErrorState** is now the shared full-page shell: illustration slot, mono code chip, headline, body, primary + optional secondary action, staggered entrance (EmptyDashboard recipe, disabled under prefers-reduced-motion), h1 semantics, role=alert for interrupting states.
- **Seven branded states** — 404, 403, 409, 500, 503, 429, offline — each with a self-drawn, theme-token SVG illustration (paper plane off the desk, locked binder, colliding pins, unrepentant shredder, out-to-lunch cabinet, stamp champion, cut paper-cup string) and copy in the quest voice under the binding editorial rule: never at the user's expense, 500/503 self-deprecating, every page ends with a concrete next move.
- **Router:** routes for the new codes outside the shell (503/offline work when nothing else does), errorElement lands navigation throws on the branded 500 / 404 responses on the not-found page; BoundaryFallback (#331) untouched. The German 'Zur Startseite' is gone.
- **Licensing:** illustrations are self-drawn inline SVG components on theme tokens — clean for AGPL by construction, both themes from one drawing.

## Test plan

- [x] 11 new tests (shell semantics + per-state copy/actions/alert + RouteErrorPage 404-vs-throw); errors added to coverage.include
- [x] pnpm lint / format:check / typecheck / test:run (1098) / build all green
- [x] Browser pass: /500 and shell-embedded 404 verified visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
