### PR TITLE
feat(review): hide archived reviews from the overview by default (#578)

### DIFF
--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -173,9 +173,10 @@ describe('ReviewsPage', () => {
     expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
     expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
 
-    // The counters agree: 'Every state' stops at the archive line, and the
-    // record is counted by its own chip only.
-    expect(screen.getByText('Every state (3)')).toBeInTheDocument();
+    // The counters agree: the default 'Active' facet stops at the archive
+    // line, while 'Every state' counts the record in.
+    expect(screen.getByText('Active (3)')).toBeInTheDocument();
+    expect(screen.getByText('Every state (4)')).toBeInTheDocument();
     expect(screen.getByText('Archived (1)')).toBeInTheDocument();
 
     // The explicit opt-in brings the records in — and only the records, each
@@ -187,6 +188,22 @@ describe('ReviewsPage', () => {
 
     // Toggling it off hides them again.
     fireEvent.click(screen.getByText('Archived (1)'));
+    expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+  });
+
+  it('spans every state at once — archive included — via Every state (#578)', () => {
+    renderPage();
+
+    // The widest lens is an explicit click, never the default: live work and
+    // the archived record side by side.
+    fireEvent.click(screen.getByText('Every state (4)'));
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('Final contract')).toBeInTheDocument();
+    expect(screen.getByText('Old supplier terms')).toBeInTheDocument();
+
+    // Deselecting falls back to the default, archived hidden again.
+    fireEvent.click(screen.getByText('Every state (4)'));
     expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
     expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
   });
@@ -216,7 +233,7 @@ describe('ReviewsPage', () => {
     renderPage('/reviews?status=bogus');
 
     expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
-    expect(screen.getByText('Every state (3)')).toBeInTheDocument();
+    expect(screen.getByText('Active (3)')).toBeInTheDocument();
   });
 
   it('names the archive instead of blaming filters when only records are left (#578)', () => {

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -236,6 +236,17 @@ describe('ReviewsPage', () => {
     expect(screen.getByText('Active (3)')).toBeInTheDocument();
   });
 
+  it('explains a facet chip on hover', async () => {
+    renderPage();
+
+    fireEvent.mouseOver(screen.getByText('Every state (4)'));
+    expect(
+      await screen.findByRole('tooltip', {
+        name: 'Everything at once — every workflow state, archived records included',
+      }),
+    ).toBeInTheDocument();
+  });
+
   it('names the archive instead of blaming filters when only records are left (#578)', () => {
     mockReviews({
       data: { items: [REVIEWS[3]], total: 1, page: 0, size: 100 },

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -105,10 +105,10 @@ function mockReviews(value: Queryish) {
   } as unknown as ReturnType<typeof useReviews>);
 }
 
-function renderPage() {
+function renderPage(entry = '/reviews') {
   return render(
     <ThemeProvider theme={buildTheme('light')}>
-      <MemoryRouter initialEntries={['/reviews']}>
+      <MemoryRouter initialEntries={[entry]}>
         <Routes>
           <Route path="/reviews" element={<ReviewsPage />} />
           <Route path="/reviews/new" element={<div data-testid="new-review-probe" />} />
@@ -134,8 +134,9 @@ describe('ReviewsPage', () => {
     expect(screen.getByText('Architecture handbook')).toBeInTheDocument();
     expect(screen.getByText('Final contract')).toBeInTheDocument();
     expect(screen.getAllByText('Owner').length).toBeGreaterThanOrEqual(1);
-    // Three foreign-owned rows now: the draft, the closed and the archived one.
-    expect(screen.getAllByText('Reviewer')).toHaveLength(3);
+    // Two foreign-owned rows are live work: the draft and the closed one — the
+    // archived record is not among them by default (issue #578).
+    expect(screen.getAllByText('Reviewer')).toHaveLength(2);
     expect(screen.getByText('In review')).toBeInTheDocument();
     expect(screen.getAllByText('Finalized').length).toBeGreaterThanOrEqual(1);
   });
@@ -160,26 +161,78 @@ describe('ReviewsPage', () => {
     expect(screen.queryByText('Architecture handbook')).not.toBeInTheDocument();
   });
 
-  it('spans every state at once and slices to the records via Archived (#576)', () => {
+  // Issue #578: archived reviews are cold records — invisible until asked for.
+  it('hides archived reviews by default and reveals them only via Archived (#578)', () => {
     renderPage();
 
-    // ONE scope=all fetch backs every facet — no refetch on chip clicks.
+    // ONE scope=all fetch backs every facet — no refetch on chip clicks. The
+    // archived record IS loaded; the default facet just does not show it.
     expect(vi.mocked(useReviews)).toHaveBeenLastCalledWith(
       expect.objectContaining({ scope: 'all' }),
     );
-    // "Every state" shows active work AND the archived record together.
-    expect(screen.getByText('Every state (4)')).toBeInTheDocument();
-    expect(screen.getByText('Old supplier terms')).toBeInTheDocument();
+    expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
     expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
 
+    // The counters agree: 'Every state' stops at the archive line, and the
+    // record is counted by its own chip only.
+    expect(screen.getByText('Every state (3)')).toBeInTheDocument();
+    expect(screen.getByText('Archived (1)')).toBeInTheDocument();
+
+    // The explicit opt-in brings the records in — and only the records, each
+    // badged as a record rather than as live work (#576's neutral tone).
     fireEvent.click(screen.getByText('Archived (1)'));
     expect(screen.getByText('Old supplier terms')).toBeInTheDocument();
     expect(screen.queryByText('NDA Acme Corp')).not.toBeInTheDocument();
+    expect(screen.getByText('Archived · Finalized')).toBeInTheDocument();
 
-    // Closed excludes the archived record — archived is its own slice.
+    // Toggling it off hides them again.
+    fireEvent.click(screen.getByText('Archived (1)'));
+    expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+  });
+
+  it('keeps archived out of the Open and Closed slices too (#578)', () => {
+    renderPage();
+
     fireEvent.click(screen.getByText('Closed (1)'));
     expect(screen.getByText('Final contract')).toBeInTheDocument();
     expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Open (2)'));
+    expect(screen.getByText('NDA Acme Corp')).toBeInTheDocument();
+    expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
+  });
+
+  it('round-trips the archived facet through the URL (#578)', () => {
+    // A shared link carrying the facet opens on the records…
+    renderPage('/reviews?status=archived');
+    expect(screen.getByText('Old supplier terms')).toBeInTheDocument();
+    expect(screen.queryByText('NDA Acme Corp')).not.toBeInTheDocument();
+  });
+
+  it('treats a URL without the facet — and an unknown value — as hidden (#578)', () => {
+    // …while the bare URL, and any value outside the facet set, mean the
+    // default: no param can ever surface a record implicitly.
+    renderPage('/reviews?status=bogus');
+
+    expect(screen.queryByText('Old supplier terms')).not.toBeInTheDocument();
+    expect(screen.getByText('Every state (3)')).toBeInTheDocument();
+  });
+
+  it('names the archive instead of blaming filters when only records are left (#578)', () => {
+    mockReviews({
+      data: { items: [REVIEWS[3]], total: 1, page: 0, size: 100 },
+    });
+    renderPage();
+
+    // No filter is set, so "nothing matches your filters" would be a dead end.
+    expect(
+      screen.getByText('No active reviews — everything here has been archived.'),
+    ).toBeVisible();
+    expect(screen.queryByText('Clear filters')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show archived (1)' }));
+    expect(screen.getByText('Old supplier terms')).toBeInTheDocument();
   });
 
   it('searches by owner name and filters via the advanced menu (#576 follow-up)', () => {

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -35,6 +35,7 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { LayoutGrid, ListFilter, Plus, Rows3 } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router';
@@ -171,23 +172,28 @@ function sortReviews(reviews: DocumentSummary[], sortBy: SortBy): DocumentSummar
 function FilterChip({
   label,
   count,
+  hint,
   selected,
   onClick,
 }: {
   label: string;
   count?: number;
+  /** One-line explanation of what the facet shows, surfaced on hover. */
+  hint: string;
   selected: boolean;
   onClick: () => void;
 }) {
   return (
-    <Chip
-      label={count === undefined ? label : `${label} (${count})`}
-      size="small"
-      color={selected ? 'primary' : 'default'}
-      variant={selected ? 'filled' : 'outlined'}
-      onClick={onClick}
-      sx={{ fontWeight: selected ? 600 : 400 }}
-    />
+    <Tooltip title={hint} arrow>
+      <Chip
+        label={count === undefined ? label : `${label} (${count})`}
+        size="small"
+        color={selected ? 'primary' : 'default'}
+        variant={selected ? 'filled' : 'outlined'}
+        onClick={onClick}
+        sx={{ fontWeight: selected ? 600 : 400 }}
+      />
+    </Tooltip>
   );
 }
 
@@ -524,18 +530,21 @@ export function ReviewsPage() {
           <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
             <FilterChip
               label="All"
+              hint="Every review you can see, whatever your part in it"
               count={roleCounts.all}
               selected={roleFilter === 'all'}
               onClick={() => setRoleFilter('all')}
             />
             <FilterChip
               label="Owned by me"
+              hint="Reviews you own and steer"
               count={roleCounts.owner}
               selected={roleFilter === 'owner'}
               onClick={() => setRoleFilter('owner')}
             />
             <FilterChip
               label="Reviewing"
+              hint="Reviews where you are on the reviewer roster"
               count={roleCounts.reviewer}
               selected={roleFilter === 'reviewer'}
               onClick={() => setRoleFilter('reviewer')}
@@ -543,30 +552,35 @@ export function ReviewsPage() {
             <Box sx={{ width: 8 }} />
             <FilterChip
               label="Active"
+              hint="All live work — every workflow state except archived records (the default)"
               count={statusCounts.active}
               selected={statusFilter === 'active'}
               onClick={() => setStatusFilter('active')}
             />
             <FilterChip
               label="Open"
+              hint="Live reviews the workflow has not closed yet"
               count={statusCounts.open}
               selected={statusFilter === 'open'}
               onClick={() => setStatusFilter(statusFilter === 'open' ? 'active' : 'open')}
             />
             <FilterChip
               label="Closed"
+              hint="Finalized or cancelled reviews that are not archived yet"
               count={statusCounts.closed}
               selected={statusFilter === 'closed'}
               onClick={() => setStatusFilter(statusFilter === 'closed' ? 'active' : 'closed')}
             />
             <FilterChip
               label="Archived"
+              hint="Only the records archived out of the active lists"
               count={statusCounts.archived}
               selected={statusFilter === 'archived'}
               onClick={() => setStatusFilter(statusFilter === 'archived' ? 'active' : 'archived')}
             />
             <FilterChip
               label="Every state"
+              hint="Everything at once — every workflow state, archived records included"
               count={statusCounts.all}
               selected={statusFilter === 'all'}
               onClick={() => setStatusFilter(statusFilter === 'all' ? 'active' : 'all')}

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -50,9 +50,12 @@ import { ReviewsEmptyState } from './ReviewsEmptyState';
 import { useAuthStore } from '../../stores/authStore';
 
 type RoleFilter = 'all' | 'owner' | 'reviewer';
-// Client facets over ONE scope=all fetch (issue #576 follow-up): 'all' truly
-// spans every state at once — active work and archived records together —
-// while open/closed/archived slice it. All facets are URL-persisted.
+// Client facets over ONE scope=all fetch (issue #576 follow-up), so every chip
+// carries a count without a refetch. Archiving is a retention flag, not a
+// workflow state (#576): 'all' spans every workflow STATE but stops at the
+// archive line, and the records are reachable only through the explicit
+// 'archived' facet (issue #578 — cold records never mix into living work).
+// All facets are URL-persisted; no param means the default, archived hidden.
 type StatusFilter = 'all' | 'open' | 'closed' | 'archived';
 type DueFilter = 'any' | 'overdue' | 'soon' | 'none';
 type FormatFilter = 'any' | 'pdf' | 'docx' | 'md';
@@ -79,9 +82,11 @@ function matchesRole(review: DocumentSummary, filter: RoleFilter, userId: string
 
 function matchesStatus(review: DocumentSummary, filter: StatusFilter): boolean {
   const archived = Boolean(review.archivedAt);
-  if (filter === 'all') return true;
+  // 'archived' is the ONLY facet that surfaces a record (issue #578); every
+  // other one — including the default 'all' — stays on this side of the line.
   if (filter === 'archived') return archived;
   if (archived) return false;
+  if (filter === 'all') return true;
   return isOpenWorkflowState(review.workflowState) === (filter === 'open');
 }
 
@@ -363,11 +368,14 @@ export function ReviewsPage() {
   })();
   const statusCounts = (() => {
     const base = searched.filter((r) => matchesRole(r, roleFilter, userId));
+    // Every count goes through the SAME predicate the list uses, so a chip's
+    // number keeps predicting what clicking it shows — the archived records sit
+    // outside 'all'/'open'/'closed' and are counted only by their own chip.
     return {
-      all: base.length,
+      all: base.filter((r) => matchesStatus(r, 'all')).length,
       open: base.filter((r) => matchesStatus(r, 'open')).length,
       closed: base.filter((r) => matchesStatus(r, 'closed')).length,
-      archived: base.filter((r) => Boolean(r.archivedAt)).length,
+      archived: base.filter((r) => matchesStatus(r, 'archived')).length,
     };
   })();
 
@@ -375,6 +383,13 @@ export function ReviewsPage() {
     searched.filter((r) => matchesRole(r, roleFilter, userId) && matchesStatus(r, statusFilter)),
     sortBy,
   );
+
+  // A workspace whose living work is all done holds nothing but records. Saying
+  // "nothing matches your filters" there would be a dead end — no filter is set
+  // and none can be cleared — so the archive gets named and offered instead
+  // (issue #578); the opt-in stays a deliberate click either way.
+  const onlyArchivedLeft =
+    visible.length === 0 && statusFilter !== 'archived' && statusCounts.archived > 0;
 
   // The owner facet offers everyone who owns a loaded review, alphabetically.
   const owners = (() => {
@@ -557,9 +572,22 @@ export function ReviewsPage() {
 
           {visible.length === 0 ? (
             <Paper variant="outlined" sx={{ py: 6, px: 3, textAlign: 'center' }}>
-              <Typography color="text.secondary">No reviews match your filters.</Typography>
+              <Typography color="text.secondary">
+                {onlyArchivedLeft
+                  ? 'No active reviews — everything here has been archived.'
+                  : 'No reviews match your filters.'}
+              </Typography>
+              {onlyArchivedLeft && (
+                <Button
+                  size="small"
+                  onClick={() => setStatusFilter('archived')}
+                  sx={{ mt: 1.5, mx: 0.5 }}
+                >
+                  Show archived ({statusCounts.archived})
+                </Button>
+              )}
               {hasActiveFilters && (
-                <Button size="small" onClick={clearFilters} sx={{ mt: 1.5 }}>
+                <Button size="small" onClick={clearFilters} sx={{ mt: 1.5, mx: 0.5 }}>
                   Clear filters
                 </Button>
               )}

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -52,11 +52,12 @@ import { useAuthStore } from '../../stores/authStore';
 type RoleFilter = 'all' | 'owner' | 'reviewer';
 // Client facets over ONE scope=all fetch (issue #576 follow-up), so every chip
 // carries a count without a refetch. Archiving is a retention flag, not a
-// workflow state (#576): 'all' spans every workflow STATE but stops at the
-// archive line, and the records are reachable only through the explicit
-// 'archived' facet (issue #578 — cold records never mix into living work).
+// workflow state (#576): the default 'active' facet spans every workflow state
+// but stops at the archive line (issue #578 — a fresh visit never surfaces cold
+// records), while 'all' ("Every state") and 'archived' are the two explicit
+// ways in — 'all' truly shows everything at once, archive included.
 // All facets are URL-persisted; no param means the default, archived hidden.
-type StatusFilter = 'all' | 'open' | 'closed' | 'archived';
+type StatusFilter = 'active' | 'all' | 'open' | 'closed' | 'archived';
 type DueFilter = 'any' | 'overdue' | 'soon' | 'none';
 type FormatFilter = 'any' | 'pdf' | 'docx' | 'md';
 type SortBy = 'updated' | 'name' | 'due';
@@ -82,11 +83,13 @@ function matchesRole(review: DocumentSummary, filter: RoleFilter, userId: string
 
 function matchesStatus(review: DocumentSummary, filter: StatusFilter): boolean {
   const archived = Boolean(review.archivedAt);
-  // 'archived' is the ONLY facet that surfaces a record (issue #578); every
-  // other one — including the default 'all' — stays on this side of the line.
+  // Only the explicit facets cross the archive line (issue #578): 'all' spans
+  // everything at once, 'archived' shows only the records; the default
+  // 'active' and the open/closed slices stay on this side of it.
+  if (filter === 'all') return true;
   if (filter === 'archived') return archived;
   if (archived) return false;
-  if (filter === 'all') return true;
+  if (filter === 'active') return true;
   return isOpenWorkflowState(review.workflowState) === (filter === 'open');
 }
 
@@ -117,7 +120,7 @@ function matchesDue(review: DocumentSummary, filter: DueFilter, now: number): bo
   return due >= now && due <= now + DUE_SOON_DAYS * 24 * 60 * 60 * 1000;
 }
 
-const STATUS_FILTERS: readonly StatusFilter[] = ['all', 'open', 'closed', 'archived'];
+const STATUS_FILTERS: readonly StatusFilter[] = ['active', 'all', 'open', 'closed', 'archived'];
 const ROLE_FILTERS: readonly RoleFilter[] = ['all', 'owner', 'reviewer'];
 const DUE_FILTERS: readonly DueFilter[] = ['any', 'overdue', 'soon', 'none'];
 // The fine-grained workflow facet (open string set, ADR-0011 — the known states).
@@ -314,13 +317,13 @@ export function ReviewsPage() {
       },
       { replace: true },
     );
-  const statusFilter = parseParam(searchParams.get('status'), STATUS_FILTERS, 'all');
+  const statusFilter = parseParam(searchParams.get('status'), STATUS_FILTERS, 'active');
   const roleFilter = parseParam(searchParams.get('role'), ROLE_FILTERS, 'all');
   const dueFilter = parseParam(searchParams.get('due'), DUE_FILTERS, 'any');
   const formatFilter = parseParam(searchParams.get('format'), FORMAT_FILTERS, 'any');
   const stateFilter = parseParam(searchParams.get('state'), STATE_FILTERS, 'any');
   const ownerFilter = searchParams.get('owner');
-  const setStatusFilter = (next: StatusFilter) => setParam('status', next, 'all');
+  const setStatusFilter = (next: StatusFilter) => setParam('status', next, 'active');
   const setRoleFilter = (next: RoleFilter) => setParam('role', next, 'all');
 
   const { data, isPending, isError, refetch } = useReviews({
@@ -369,9 +372,10 @@ export function ReviewsPage() {
   const statusCounts = (() => {
     const base = searched.filter((r) => matchesRole(r, roleFilter, userId));
     // Every count goes through the SAME predicate the list uses, so a chip's
-    // number keeps predicting what clicking it shows — the archived records sit
-    // outside 'all'/'open'/'closed' and are counted only by their own chip.
+    // number keeps predicting what clicking it shows — 'all' counts the archive
+    // in, the default 'active' and open/closed stop at the archive line.
     return {
+      active: base.filter((r) => matchesStatus(r, 'active')).length,
       all: base.filter((r) => matchesStatus(r, 'all')).length,
       open: base.filter((r) => matchesStatus(r, 'open')).length,
       closed: base.filter((r) => matchesStatus(r, 'closed')).length,
@@ -389,7 +393,10 @@ export function ReviewsPage() {
   // and none can be cleared — so the archive gets named and offered instead
   // (issue #578); the opt-in stays a deliberate click either way.
   const onlyArchivedLeft =
-    visible.length === 0 && statusFilter !== 'archived' && statusCounts.archived > 0;
+    visible.length === 0 &&
+    statusFilter !== 'archived' &&
+    statusFilter !== 'all' &&
+    statusCounts.archived > 0;
 
   // The owner facet offers everyone who owns a loaded review, alphabetically.
   const owners = (() => {
@@ -401,7 +408,7 @@ export function ReviewsPage() {
   })();
 
   const hasActiveFilters =
-    query !== '' || roleFilter !== 'all' || statusFilter !== 'all' || advancedCount > 0;
+    query !== '' || roleFilter !== 'all' || statusFilter !== 'active' || advancedCount > 0;
 
   const changeView = (next: ViewMode | null) => {
     if (!next) return;
@@ -535,28 +542,34 @@ export function ReviewsPage() {
             />
             <Box sx={{ width: 8 }} />
             <FilterChip
-              label="Every state"
-              count={statusCounts.all}
-              selected={statusFilter === 'all'}
-              onClick={() => setStatusFilter('all')}
+              label="Active"
+              count={statusCounts.active}
+              selected={statusFilter === 'active'}
+              onClick={() => setStatusFilter('active')}
             />
             <FilterChip
               label="Open"
               count={statusCounts.open}
               selected={statusFilter === 'open'}
-              onClick={() => setStatusFilter(statusFilter === 'open' ? 'all' : 'open')}
+              onClick={() => setStatusFilter(statusFilter === 'open' ? 'active' : 'open')}
             />
             <FilterChip
               label="Closed"
               count={statusCounts.closed}
               selected={statusFilter === 'closed'}
-              onClick={() => setStatusFilter(statusFilter === 'closed' ? 'all' : 'closed')}
+              onClick={() => setStatusFilter(statusFilter === 'closed' ? 'active' : 'closed')}
             />
             <FilterChip
               label="Archived"
               count={statusCounts.archived}
               selected={statusFilter === 'archived'}
-              onClick={() => setStatusFilter(statusFilter === 'archived' ? 'all' : 'archived')}
+              onClick={() => setStatusFilter(statusFilter === 'archived' ? 'active' : 'archived')}
+            />
+            <FilterChip
+              label="Every state"
+              count={statusCounts.all}
+              selected={statusFilter === 'all'}
+              onClick={() => setStatusFilter(statusFilter === 'all' ? 'active' : 'all')}
             />
             {hasActiveFilters && (
               <Chip


### PR DESCRIPTION
Closes #578. Companion to #576 (auto-archiving).

## What was already there

Most of #578's machinery shipped with #576 (#609), so this PR is deliberately small. Already in place and untouched here:

- the **`Archived` chip** on the status row — #578 explicitly sanctions "an `Archived` facet on the existing status chip row" as the control;
- **URL persistence** via `parseParam(searchParams.get('status'), …)`;
- the neutral **`Archived · <outcome>` badge** in `WorkflowBadge`;
- a **server-side `scope` parameter** on `GET /documents` (`DocumentsController` → `includeActive`/`includeArchived`, both booleans threaded into `DocumentRepository.findVisibleTo`).

## The gap this closes

`matchesStatus` returned `true` for the default `'all'` facet, so a fresh visit to `/reviews` — no `status` param — listed archived records among living work. That missed #578's first acceptance criterion **and** #576's own issue text ("archived reviews leave the default view").

## The change

The default and the widest lens are now **two different facets**, so hiding-by-default never falsifies the "Every state" label:

- **`active` (new, the default).** Every workflow state, but stops at the archive line. This is the URL-less state — a fresh visit, and any unknown `status` value, never surfaces an archived review. Deselecting any chip falls back here.
- **`all` ("Every state") keeps meaning what it says**: every workflow state **and** the archived records, all at once — as an explicit, URL-persisted click (`?status=all`).
- **`archived`** stays the records-only slice; `open`/`closed` stay slices of living work.

Knock-on fixes keeping the page consistent:

- **Counts** all route through `matchesStatus` — `Active (n)` stops at the archive line, `Every state (n)` counts the records in, so a chip's number always predicts what clicking it shows.
- **Empty state.** A workspace whose living work is finished now names the archive and offers `Show archived (n)` instead of the dead-end "No reviews match your filters" (shown in the archive-hiding facets only).
- **Hover explanations.** Every role and status chip carries a one-line tooltip saying what the facet shows — most usefully the Active/Archived/Every state trio, whose archive-line semantics a label alone cannot carry.

**Deliberately unchanged:** the single `scope=all` fetch. That is what gives every chip a count without a refetch. Trimming the payload through the existing `scope` parameter stays the follow-up #578 itself leaves open.

## Test plan

Seven cases in `ReviewsPage.test.tsx`; the old #576 test is rewritten to the new semantics rather than deleted, and `renderPage()` now takes an entry URL.

- [x] Default hides the archived record; `Active (3)` / `Every state (4)` / `Archived (1)` counts agree with the list
- [x] The `Archived` opt-in reveals only the records, badged `Archived · Finalized`; toggling off hides them again
- [x] `Every state` shows live work and the archived record together; deselecting falls back to the hidden default
- [x] `Open` and `Closed` exclude archived too
- [x] URL round-trip: `?status=archived` opens on the records; `?status=bogus` falls back to hidden
- [x] Only-records workspace shows the archive hint and no "Clear filters"
- [x] A facet chip explains itself on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
