### PR TITLE
fix(ui): team profile spans the full content width (#586)

### DIFF
--- a/qnop-ui/src/components/shell/AppShell.tsx
+++ b/qnop-ui/src/components/shell/AppShell.tsx
@@ -64,6 +64,7 @@ export function AppShell() {
   const searchMatch = useMatch('/search');
   const profileMatch = useMatch('/profile');
   const userProfileMatch = useMatch('/users/:userId');
+  const teamProfileMatch = useMatch('/teams/:teamId');
   // The new-review wizard (#469 polish) spans the full width too — it lays out
   // as form + launch-checklist rail.
   const wizardMatch = Boolean(reviewMatch && reviewMatch.params.documentId === 'new');
@@ -78,6 +79,7 @@ export function AppShell() {
     Boolean(searchMatch) ||
     Boolean(profileMatch) ||
     Boolean(userProfileMatch) ||
+    Boolean(teamProfileMatch) ||
     wizardMatch;
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {


### PR DESCRIPTION
Follow-up to #586.

## Summary

The AppShell caps routes at the lg container unless they are on its wide-route set. `/users/:userId` is on it, `/teams/:teamId` was not — so the team profile rendered narrower than its sibling player card. One predicate entry fixes it; the page itself needed no change.

## Test plan
- [x] Shell tests (36) green; typecheck/lint/prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
