### PR TITLE
feat(review): purge archived reviews after a configurable retention, incl. unreferenced storage objects (#577)

### DIFF
--- a/docs/adr/0045-scheduler-jobs-dashboard.md
+++ b/docs/adr/0045-scheduler-jobs-dashboard.md
@@ -38,6 +38,15 @@ Authorization is the existing central rule: `/api/v1/admin/**` requires `ADMIN`.
 - **Neutral.** The dashboard shows each job's **default** cron; an operator who overrides `qnop.s3.reaper-cron` sees the default string, not the override. Acceptable — the cron is informational, and the effective-configuration page (issue #522) is the authority on overrides.
 - **Negative / deferred.** There is no per-job run **history** (only the most recent outcome) and no scheduled-run auditing; if compliance later needs a full run log, it is an additive table, not a redesign. Editing a cron from the UI is out of scope — crons stay in configuration.
 
+## Amendment (issue #577, 2026-07-25) — two catalogue flags
+
+Adding the irreversible review purge (ADR-0050) needed the catalogue to express two things it could not:
+
+- **`SchedulerJobDefinition.enabledByDefault`.** All six original jobs are `true`; the purge is `false`, so destroying data is a deliberate operator act. This also **corrects "fail-open" above**: the gate now falls open to the catalogue's default rather than to an unconditional yes, in every place that assumed "no row ⇒ enabled" — `readState`, `SchedulerJob.seed`, `SchedulerJobBootstrap`, and the dashboard's `viewOf` (which would otherwise advertise a disabled job as enabled). Failing open into an irreversible delete is not fail-safe.
+- **`SchedulerJobDefinition.selfTransactional`.** All six original jobs are `false` and keep running inside the gate's transaction. A `true` job is invoked with **no** enclosing transaction and owns its own — the purge commits one review per transaction and touches object storage only after each commit, which an enclosing transaction would defeat by deferring every commit to the end of the run. Such a job takes on the duty the gate otherwise discharges.
+
+The gate's other properties are unchanged: the outcome is still recorded in its own transaction, so a self-transactional job's failure record survives a failed run too.
+
 ## Alternatives considered
 
 - **`@Transactional` on the gate + `REQUIRES_NEW` for the outcome.** Rejected: the sweep methods calling their own gate would hit the Spring self-invocation trap, and `REQUIRES_NEW` self-calls silently don't start a new transaction. The programmatic `TransactionTemplate` sidesteps both.

--- a/docs/adr/0050-purging-archived-reviews.md
+++ b/docs/adr/0050-purging-archived-reviews.md
@@ -1,0 +1,46 @@
+# ADR-0050: Purging archived reviews — irreversible deletion with a shared-object guard
+
+- **Status:** Accepted
+- **Date:** 2026-07-25
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+ADR-0011's amendment for issue #576 added an archive flag: a review finalized or cancelled longer than `review.archive_after_days` leaves the active lists but stays a fully readable record. That is a half-lifecycle — cold records accumulate forever, storage costs accrue, and a retention policy that never deletes is not a policy. Issue #577 closes it: after `review.purge_archived_after_days`, an archived review is deleted **permanently and irreversibly**.
+
+This is the first and only code path in qnop that destroys user data with no recovery, which shapes every decision below. Three problems are specific to this product:
+
+1. **Storage keys are shared.** Keys are content-addressed sha-256 and deduplicated instance-wide (ADR-0005/0036). The very same object can back versions or attachments of *other* documents — two teams uploading the identical PDF get one object. Deleting a purged review's keys naively would break surviving documents.
+2. **The audit trail dies with the document.** `audit_event.document_id` is `ON DELETE CASCADE`, so a purge erases exactly the record that would explain it. "Where did that review go?" must remain answerable.
+3. **The scheduler gate owns one transaction per job** (ADR-0045). A purge that ran inside it would either be one giant transaction — a crash leaving nothing done after minutes of work — or would defer its storage-registry commits to the end of the run, while the objects themselves are already gone.
+
+## Decision
+
+**A dry-run-capable `reviewPurge` scheduler job that ships disabled, deletes one review per transaction, and deletes a storage object only after proving nothing else references it.**
+
+- **Double opt-in.** `review.purge_archived_after_days` defaults to `180` (ADR-0025 machinery, `0` disables, same convention as #576) **and** the job ships **disabled**. Nothing is destroyed until an operator deliberately enables it on `/admin/scheduler`. This required two additions to ADR-0045's catalogue: `SchedulerJobDefinition.enabledByDefault`, honoured by `SchedulerJobBootstrap` when seeding and by the gate wherever a row is missing, and a matching correction to "fail-open" — the gate now falls open to *the catalogue's default*, not to an unconditional yes, because failing open into an irreversible delete is not fail-safe.
+
+- **DB first, storage second — the crash-safety contract.** Each review's aggregate is deleted and **committed**, and only then are its storage keys considered. A crash in between leaves an unreferenced object: harmless, and the storage-consistency scan (ADR-0044) sweeps it. The reverse order would recreate the #575 hole — rows referencing objects that no longer exist.
+
+- **One transaction per review.** A run interrupted halfway leaves reviews either untouched or completely gone, never half-deleted. This is why the job declares `selfTransactional` and the gate invokes it with **no** enclosing transaction. Eligibility is re-checked inside each per-review transaction rather than trusted from the batch read, so a review unarchived between the two is not purged anyway.
+
+- **The shared-key guard.** After the aggregate commit, the purged review's candidate keys are checked against `document_version` and `document_attachment` — reusing ADR-0044's `findVersionRefsByStorageKeyIn` / `findAttachmentRefsByStorageKeyIn` rather than new queries, batched over the whole key set. A key any surviving row references is **left alone**; only the rest go via `StorageService.delete` (object + registry row). Checking *after* the commit is what makes it correct: the purged document's own rows are already gone and cannot make a key look shared.
+
+- **The aggregate delete is the schema's job.** All seven FKs referencing `document` are `ON DELETE CASCADE` (versions, participants, annotations, audit events, visits, version diffs, attachments), and the deeper tables cascade transitively (comments, placements, reactions, mentions). So the DB side is `delete(document)`, verified by `DocumentReviewSchemaIT.cascadesAggregateOnDocumentDelete` — no hand-written deletion order to drift from the schema.
+
+- **One SYSTEM audit event per run**, `review.purged`, carrying the counts plus the purged ids **and titles** (capped at 50, with a `truncated` count). Since the per-document trail is gone, this run-level row is the only surviving trace — titles, not just ids, are what make it useful. Scheduled runs audit here even though ADR-0045 exempts scheduled runs generally: one row per purge run is not noise, it is the record of a destruction.
+
+## Consequences
+
+- **Positive.** The lifecycle is complete and the retention policy real. Deduplicated storage stays correct: a shared object survives the purge of one of its referrers. The double opt-in plus dry-run means an operator can see exactly what would go — including how many objects are genuinely exclusive — before enabling anything. Per-review transactions make a long run safely interruptible.
+- **Neutral.** A concurrent upload can re-reference a key between the check and the delete. Accepted rather than locked away: `StorageService.stage` verifies a dedup hit and re-uploads from the buffered bytes when the object is missing (#575), so the race self-heals instead of yielding a key that points at nothing. Locking the whole content-addressed namespace to close a window this narrow is not worth the contention.
+- **Negative / deferred.** The `job` queue (ADR-0033) carries document ids inside its jsonb `payload` and has **no** FK to `document`, so a purge cannot be blocked by it — but it also leaves any queued job for a purged review behind. A review archived ≥180 days has no in-flight extraction work in practice, so this is an accepted gap rather than a solved problem; the worker fails and dead-letters if it ever happens. There is also no **manual** "purge now" for owners or admins: #576 shipped manual archive/unarchive because archiving is reversible, and a one-click irreversible destructor deserves its own confirmation UX. Finally, a purge is invisible to participants by design — no notification; the review was archived long ago, and purging is an operator-level lifecycle event.
+
+## Alternatives considered
+
+- **Purge as a workflow state (`PURGED`) rather than a deletion.** Rejected — it is soft deletion under another name and delivers none of the point: the rows and the storage objects stay, so the retention policy still never frees anything.
+- **Delete storage objects before the DB aggregate.** Rejected: it recreates the #575 failure mode (rows referencing vanished objects) in the window between the two, and that failure is user-visible (a document that cannot serve its binary) while the opposite leak is invisible and swept automatically.
+- **Reference-count storage objects** (a counter on `storage_object`). Rejected as premature: the two `IN`-clause queries answer the same question against the actual referrers, cannot drift from them, and reuse code ADR-0044 already needed. A counter would add a write to every upload path to save two reads on a nightly sweep.
+- **One transaction for the whole run.** Rejected: a failure after 199 of 200 reviews would roll back all of them while their storage objects are already deleted — the worst of both orderings.
+- **Keeping ADR-0045's gate transaction and using `REQUIRES_NEW` per review.** Rejected: the outer transaction would stay open for the whole run holding a connection, and `StorageService.delete` (a `@Transactional` bean) would join *it* rather than commit per object — so registry rows would commit at the end of the run while objects vanished immediately. The `selfTransactional` opt-out states the intent instead of working around the wrapper.
+- **Purging by `closed_at` instead of `archived_at`.** Rejected: it would let a review skip the archive stage entirely if both windows elapsed before a sweep ran. Chaining the purge to `archived_at` guarantees a review is always archived first, so the archive window is a real grace period.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,6 +66,7 @@ Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-reco
 | [0047](0047-federated-global-search.md) | Federated global search behind a SearchService port | Accepted |
 | [0048](0048-cross-namespace-slug-uniqueness.md) | Cross-namespace slug uniqueness (users and teams) | Accepted |
 | [0049](0049-extension-plugin-packaging-model.md) | Extension packaging model — boot-time SPI plugins, not a runtime plugin framework | Proposed |
+| [0050](0050-purging-archived-reviews.md) | Purging archived reviews: irreversible deletion with a shared-object guard | Accepted |
 
 ## Template
 

--- a/qnop-app/src/test/java/io/qnop/review/ReviewPurgeApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewPurgeApiIT.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.entity.Annotation;
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.AuditScope;
+import io.qnop.entity.Comment;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentAttachment;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.CommentRepository;
+import io.qnop.repository.DocumentAttachmentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.repository.StorageObjectRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.review.ReviewPurgeService;
+import io.qnop.service.scheduler.RunOutcome;
+import io.qnop.service.scheduler.SchedulerJobCatalog;
+import io.qnop.service.scheduler.SchedulerService;
+import io.qnop.service.storage.StagedObject;
+import io.qnop.service.storage.StorageService;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * The archived-review purge end-to-end against a real Postgres + MinIO (issue #577, ADR-0050).
+ *
+ * <p>The case this class exists for is the <strong>shared storage object</strong>: keys are
+ * content-addressed and deduplicated instance-wide (ADR-0005/0036), so purging one review must not
+ * take a binary another review still serves. That cannot be faked — it needs two documents whose
+ * content genuinely dedupes to one key, a real bucket, and the registry.
+ *
+ * <p>Also covered: the full aggregate delete leaving no orphan row, the disabled-by-default job,
+ * the dry run, the retention window and its runtime change, and the surviving SYSTEM audit record.
+ *
+ * <p>Not {@code @Transactional}: object-store writes do not roll back, and the purge deliberately
+ * commits per review. Content is unique per test, so content-addressed keys keep tests isolated.
+ */
+class ReviewPurgeApiIT extends SeededIntegrationTest {
+
+  private static final String SCHEDULER_JOB =
+      "/api/v1/admin/scheduler/" + SchedulerJobCatalog.REVIEW_PURGE;
+  private static final String SCHEDULER_RUN = SCHEDULER_JOB + "/run";
+  private static final String RETENTION_KEY =
+      ApplicationSettingKey.REVIEW_PURGE_ARCHIVED_AFTER_DAYS.getKey();
+
+  /** Jackson 3 (tools.jackson), matching the stack the app itself serializes with. */
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private DocumentAttachmentRepository attachments;
+  @Autowired private AnnotationRepository annotations;
+  @Autowired private CommentRepository comments;
+  @Autowired private ReviewParticipantRepository participants;
+  @Autowired private AuditEventRepository auditEvents;
+  @Autowired private StorageObjectRepository storageObjects;
+  @Autowired private StorageService storage;
+  @Autowired private ApplicationSettingsService settings;
+  @Autowired private SchedulerService scheduler;
+
+  /**
+   * {@code application_setting} deliberately survives {@code clean.sql} (it is migration-seeded),
+   * so a retention change would leak into every later test in the JVM-shared database.
+   */
+  @AfterEach
+  void restoreRetentionDefault() {
+    settings.update(
+        Map.of(
+            RETENTION_KEY,
+            ApplicationSettingKey.REVIEW_PURGE_ARCHIVED_AFTER_DAYS.getDefaultValue()),
+        null);
+  }
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  private void setRetentionDays(int days) {
+    settings.update(Map.of(RETENTION_KEY, String.valueOf(days)), null);
+  }
+
+  private static byte[] uniqueContent() {
+    return ("qnop-purge-" + UUID.randomUUID()).getBytes(UTF_8);
+  }
+
+  private StagedObject stage(byte[] content) {
+    StagedObject staged = storage.stage(new ByteArrayInputStream(content), "application/pdf");
+    storage.commit(staged.key());
+    return staged;
+  }
+
+  /** An archived review owned by MEMBER, with one version backed by {@code staged}. */
+  private Document archivedReview(String title, StagedObject staged, long archivedDaysAgo) {
+    Document document = new Document(MEMBER_ID, title);
+    document.setWorkflowState(WorkflowState.FINALIZED);
+    document.setClosedAt(Instant.now().minus(Duration.ofDays(archivedDaysAgo + 1)));
+    document.setArchivedAt(Instant.now().minus(Duration.ofDays(archivedDaysAgo)));
+    Document saved = documents.save(document);
+    versions.save(
+        new DocumentVersion(
+            saved.getId(),
+            1,
+            staged.key(),
+            staged.contentHash(),
+            "application/pdf",
+            staged.sizeBytes(),
+            MEMBER_ID));
+    return saved;
+  }
+
+  private void runPurgeAsAdmin() throws Exception {
+    mockMvc
+        .perform(as(post(SCHEDULER_RUN), ADMIN_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.lastOutcome").value("SUCCESS"));
+  }
+
+  // ── the shared-object guard (why this IT exists) ─────────────────────────
+
+  @Test
+  @DisplayName("purging one review keeps a storage object another review still references")
+  void sharedStorageObjectSurvivesThePurgeOfOneReferrer() throws Exception {
+    setRetentionDays(90);
+    byte[] identical = uniqueContent();
+    // Two reviews ingesting IDENTICAL content dedupe to ONE content-addressed object.
+    StagedObject first = stage(identical);
+    StagedObject second = stage(identical);
+    assertThat(second.key()).isEqualTo(first.key());
+
+    Document doomed = archivedReview("Purge shared doomed", first, 200);
+    Document survivor = archivedReview("Purge shared survivor", second, 1);
+
+    runPurgeAsAdmin();
+
+    assertThat(documents.findById(doomed.getId())).isEmpty();
+    assertThat(documents.findById(survivor.getId())).isPresent();
+    // The object and its registry row must both survive — the survivor still serves this binary.
+    assertThat(storage.get(first.key())).isPresent();
+    assertThat(storageObjects.findByObjectKey(first.key())).isPresent();
+    // And it is still readable through the survivor's own serving path.
+    mockMvc
+        .perform(
+            as(get("/api/v1/documents/" + survivor.getId() + "/versions/1/original"), MEMBER_ID))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName(
+      "a storage object only the purged review referenced is deleted, registry row and all")
+  void exclusiveStorageObjectIsDeleted() throws Exception {
+    setRetentionDays(90);
+    StagedObject staged = stage(uniqueContent());
+    Document doomed = archivedReview("Purge exclusive", staged, 200);
+
+    runPurgeAsAdmin();
+
+    assertThat(documents.findById(doomed.getId())).isEmpty();
+    assertThat(storage.get(staged.key())).isEmpty();
+    assertThat(storageObjects.findByObjectKey(staged.key())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("an attachment sharing the purged review's object also protects it")
+  void objectSharedWithAnAttachmentSurvives() throws Exception {
+    setRetentionDays(90);
+    byte[] identical = uniqueContent();
+    StagedObject versionObject = stage(identical);
+    StagedObject attachmentObject = stage(identical);
+
+    Document doomed = archivedReview("Purge attachment-shared", versionObject, 200);
+    Document survivor = documents.save(new Document(MEMBER_ID, "Purge attachment host"));
+    attachments.save(
+        new DocumentAttachment(
+            survivor.getId(),
+            MEMBER_ID,
+            "diagram.png",
+            "application/pdf",
+            attachmentObject.contentHash(),
+            attachmentObject.sizeBytes(),
+            attachmentObject.key()));
+
+    runPurgeAsAdmin();
+
+    assertThat(documents.findById(doomed.getId())).isEmpty();
+    assertThat(storage.get(versionObject.key())).isPresent();
+  }
+
+  // ── the full aggregate delete ───────────────────────────────────────────
+
+  @Test
+  @DisplayName("the purge leaves no orphan row anywhere in the review aggregate")
+  void purgeLeavesNoOrphanRows() throws Exception {
+    setRetentionDays(90);
+    StagedObject staged = stage(uniqueContent());
+    Document doomed = archivedReview("Purge aggregate", staged, 200);
+    participants.save(ReviewParticipant.forUser(doomed.getId(), AUDITOR_ID));
+    Annotation annotation = annotations.save(new Annotation(doomed.getId(), AUDITOR_ID));
+    comments.save(new Comment(annotation.getId(), AUDITOR_ID, "please clarify"));
+    attachments.save(
+        new DocumentAttachment(
+            doomed.getId(),
+            MEMBER_ID,
+            "note.png",
+            "application/pdf",
+            staged.contentHash(),
+            staged.sizeBytes(),
+            staged.key()));
+    auditEvents.save(new AuditEvent(doomed.getId(), "workflow.transition", MEMBER_ID, "{}"));
+
+    runPurgeAsAdmin();
+
+    assertThat(documents.findById(doomed.getId())).isEmpty();
+    assertThat(versions.findByDocumentIdOrderByVersionNumberAsc(doomed.getId())).isEmpty();
+    assertThat(participants.findByDocumentId(doomed.getId())).isEmpty();
+    assertThat(annotations.findByDocumentId(doomed.getId())).isEmpty();
+    assertThat(comments.findByAnnotationIdOrderByCreatedAtAsc(annotation.getId())).isEmpty();
+    assertThat(attachments.findStorageKeysByDocumentId(doomed.getId())).isEmpty();
+    assertThat(auditEvents.findByDocumentIdOrderByCreatedAtDesc(doomed.getId())).isEmpty();
+    // The owner and the reviewer survive — the cascade never reaches principals.
+    mockMvc.perform(as(get("/api/v1/users/me"), MEMBER_ID)).andExpect(status().isOk());
+  }
+
+  // ── the retention window ────────────────────────────────────────────────
+
+  @Test
+  @DisplayName(
+      "a recently archived review is untouched; the retention change lands on the next run")
+  void retentionWindowIsRespectedAndRuntimeChangeable() throws Exception {
+    setRetentionDays(90);
+    StagedObject staged = stage(uniqueContent());
+    Document recent = archivedReview("Purge recent", staged, 30);
+
+    runPurgeAsAdmin();
+    assertThat(documents.findById(recent.getId())).isPresent();
+
+    // Shrink the window through the admin settings API — no restart, next run purges it.
+    mockMvc
+        .perform(
+            as(patch("/api/v1/admin/settings"), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"values\":{\"" + RETENTION_KEY + "\":\"7\"}}"))
+        .andExpect(status().isOk());
+
+    runPurgeAsAdmin();
+    assertThat(documents.findById(recent.getId())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a retention of 0 disables purging even for a long-archived review")
+  void retentionZeroDisablesPurging() throws Exception {
+    setRetentionDays(0);
+    StagedObject staged = stage(uniqueContent());
+    Document ancient = archivedReview("Purge disabled", staged, 900);
+
+    runPurgeAsAdmin();
+
+    assertThat(documents.findById(ancient.getId())).isPresent();
+    assertThat(storage.get(staged.key())).isPresent();
+  }
+
+  @Test
+  @DisplayName("an archived-but-not-yet-eligible review and a never-archived one are both spared")
+  void neverArchivedReviewIsNeverPurged() throws Exception {
+    setRetentionDays(90);
+    StagedObject staged = stage(uniqueContent());
+    Document active = documents.save(new Document(MEMBER_ID, "Purge never-archived"));
+    versions.save(
+        new DocumentVersion(
+            active.getId(),
+            1,
+            staged.key(),
+            staged.contentHash(),
+            "application/pdf",
+            staged.sizeBytes(),
+            MEMBER_ID));
+
+    runPurgeAsAdmin();
+
+    assertThat(documents.findById(active.getId())).isPresent();
+    assertThat(storage.get(staged.key())).isPresent();
+  }
+
+  // ── dry run ─────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("a dry run reports but destroys nothing")
+  void dryRunDestroysNothing() throws Exception {
+    setRetentionDays(90);
+    StagedObject staged = stage(uniqueContent());
+    Document doomed = archivedReview("Purge dry-run", staged, 200);
+
+    mockMvc
+        .perform(
+            as(patch(SCHEDULER_JOB), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"dryRun\":true}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.supportsDryRun").value(true))
+        .andExpect(jsonPath("$.dryRun").value(true));
+
+    runPurgeAsAdmin();
+
+    assertThat(documents.findById(doomed.getId())).isPresent();
+    assertThat(storage.get(staged.key())).isPresent();
+    assertThat(purgeAuditEvents()).isEmpty();
+  }
+
+  // ── the double opt-in ───────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("the job ships disabled, so a scheduled tick purges nothing on a fresh instance")
+  void jobIsDisabledByDefault() throws Exception {
+    setRetentionDays(90);
+    StagedObject staged = stage(uniqueContent());
+    Document doomed = archivedReview("Purge disabled-by-default", staged, 200);
+
+    // The dashboard must not advertise it as enabled either.
+    mockMvc
+        .perform(as(get("/api/v1/admin/scheduler"), ADMIN_ID))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.items[?(@.jobId == '" + SchedulerJobCatalog.REVIEW_PURGE + "')].enabled")
+                .value(org.hamcrest.Matchers.contains(false)));
+
+    assertThat(scheduler.runScheduled(SchedulerJobCatalog.REVIEW_PURGE))
+        .isEqualTo(RunOutcome.SKIPPED_DISABLED);
+    assertThat(documents.findById(doomed.getId())).isPresent();
+
+    // Run-now is the explicit override and still works — the second half of the opt-in.
+    runPurgeAsAdmin();
+    assertThat(documents.findById(doomed.getId())).isEmpty();
+  }
+
+  // ── the surviving audit record ───────────────────────────────────────────
+
+  @Test
+  @DisplayName("a purge run leaves a SYSTEM audit row naming what it destroyed")
+  void purgeIsAuditedOnTheSystemStream() throws Exception {
+    setRetentionDays(90);
+    StagedObject staged = stage(uniqueContent());
+    Document doomed = archivedReview("Purge audited review", staged, 200);
+
+    runPurgeAsAdmin();
+
+    List<AuditEvent> purgeEvents = purgeAuditEvents();
+    assertThat(purgeEvents).hasSize(1);
+    AuditEvent event = purgeEvents.get(0);
+    assertThat(event.getScope()).isEqualTo(AuditScope.SYSTEM);
+    assertThat(event.getDocumentId()).isNull();
+    // detail is jsonb, so Postgres re-formats and re-orders it on the round trip — assert on the
+    // parsed structure, never on the serialized string.
+    JsonNode detail = MAPPER.readTree(event.getDetail());
+    assertThat(detail.get("reviews").asInt()).isEqualTo(1);
+    assertThat(detail.get("storageObjects").asInt()).isEqualTo(1);
+    JsonNode purged = detail.get("purged");
+    assertThat(purged).hasSize(1);
+    assertThat(purged.get(0).get("id").asString()).isEqualTo(doomed.getId().toString());
+    // The title is what makes the row useful once the review itself is gone.
+    assertThat(purged.get(0).get("title").asString()).isEqualTo("Purge audited review");
+
+    // And it is visible to an AUDITOR on the audit surface, with its own vocabulary.
+    mockMvc
+        .perform(
+            as(
+                get("/api/v1/audit/events")
+                    .param("eventType", ReviewPurgeService.AUDIT_REVIEWS_PURGED),
+                AUDITOR_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(1))
+        .andExpect(jsonPath("$.items[0].scope").value("SYSTEM"));
+  }
+
+  private List<AuditEvent> purgeAuditEvents() {
+    return auditEvents.findAll().stream()
+        .filter(e -> ReviewPurgeService.AUDIT_REVIEWS_PURGED.equals(e.getEventType()))
+        .toList();
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/scheduler/SchedulerApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/scheduler/SchedulerApiIT.java
@@ -68,7 +68,7 @@ class SchedulerApiIT extends SeededIntegrationTest {
     mockMvc
         .perform(as(get(SCHEDULER), ADMIN_ID))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.items", hasSize(6)))
+        .andExpect(jsonPath("$.items", hasSize(7)))
         .andExpect(jsonPath("$.items[*].jobId", hasItem(STORAGE_ORPHAN_REAPER)))
         .andExpect(jsonPath("$.items[*].jobId", hasItem(REFRESH_TOKEN_SWEEP)));
   }

--- a/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
@@ -75,7 +75,7 @@ class AdminSettingsControllerIT extends AbstractIntegrationTest {
         .perform(get("/api/v1/admin/settings"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.settings").isArray())
-        .andExpect(jsonPath("$.settings.length()").value(24));
+        .andExpect(jsonPath("$.settings.length()").value(25));
   }
 
   @Test

--- a/qnop-core/src/main/java/io/qnop/entity/SchedulerJob.java
+++ b/qnop-core/src/main/java/io/qnop/entity/SchedulerJob.java
@@ -99,9 +99,12 @@ public class SchedulerJob {
     this.dryRun = dryRun;
   }
 
-  /** A freshly seeded job row: enabled, not in dry-run, never run yet. */
-  public static SchedulerJob seed(String jobId) {
-    return new SchedulerJob(jobId, true, false);
+  /**
+   * A freshly seeded job row: not in dry-run, never run yet, and enabled per the catalogue's {@code
+   * enabledByDefault} — a job that destroys data irreversibly seeds disabled (issue #577).
+   */
+  public static SchedulerJob seed(String jobId, boolean enabled) {
+    return new SchedulerJob(jobId, enabled, false);
   }
 
   /** Applies operator settings; a null argument leaves that setting unchanged. */

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentAttachmentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentAttachmentRepository.java
@@ -40,6 +40,13 @@ public interface DocumentAttachmentRepository extends JpaRepository<DocumentAtta
   List<String> findAllStorageKeys();
 
   /**
+   * The storage keys one document's attachments reference — collected before a purge deletes the
+   * aggregate, so the purge knows which keys to re-check for other referrers (issue #577).
+   */
+  @Query("SELECT a.storageKey FROM DocumentAttachment a WHERE a.documentId = :documentId")
+  List<String> findStorageKeysByDocumentId(@Param("documentId") UUID documentId);
+
+  /**
    * Maps missing storage keys back to their document + file name, to explain a data-loss finding.
    */
   @Query(

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -116,4 +116,14 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
    * How many reviews the sweep would archive at {@code cutoff} — the dry-run count (issue #576).
    */
   long countByArchivedAtIsNullAndClosedAtBefore(Instant cutoff);
+
+  /**
+   * Reviews archived before {@code cutoff} — the purge sweep's eligibility set (issue #577).
+   * Bounded by {@code Pageable}: a purge batch is far more expensive than an archive batch (a
+   * cascading delete plus object-storage work per review), so the bound matters more here.
+   */
+  List<Document> findByArchivedAtBefore(Instant cutoff, Pageable pageable);
+
+  /** How many reviews the purge would delete at {@code cutoff} — the dry-run count (issue #577). */
+  long countByArchivedAtBefore(Instant cutoff);
 }

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentVersionRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentVersionRepository.java
@@ -67,6 +67,13 @@ public interface DocumentVersionRepository extends JpaRepository<DocumentVersion
   @Query("SELECT v.storageKey FROM DocumentVersion v")
   List<String> findAllStorageKeys();
 
+  /**
+   * The storage keys one document's versions reference — collected before a purge deletes the
+   * aggregate, so the purge knows which keys to re-check for other referrers (issue #577).
+   */
+  @Query("SELECT v.storageKey FROM DocumentVersion v WHERE v.documentId = :documentId")
+  List<String> findStorageKeysByDocumentId(@Param("documentId") UUID documentId);
+
   /** Maps missing storage keys back to their document + version, to explain a data-loss finding. */
   @Query(
       "SELECT new io.qnop.repository.VersionStorageRef(v.storageKey, v.documentId, v.versionNumber)"

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
@@ -145,7 +145,12 @@ public enum ApplicationSettingKey {
       "review.archive_after_days",
       SettingValueType.INTEGER,
       "90",
-      "Days a completed review stays before it is archived out of the active lists (0 disables auto-archiving).");
+      "Days a completed review stays before it is archived out of the active lists (0 disables auto-archiving)."),
+  REVIEW_PURGE_ARCHIVED_AFTER_DAYS(
+      "review.purge_archived_after_days",
+      SettingValueType.INTEGER,
+      "180",
+      "Days an archived review is kept before it is deleted permanently, including storage objects no other document references (0 disables purging). Irreversible — the Review purge job must be enabled as well.");
 
   private static final Map<String, ApplicationSettingKey> BY_KEY =
       Arrays.stream(values())
@@ -166,6 +171,8 @@ public enum ApplicationSettingKey {
           AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES, SettingConstraints.range(1, 1440),
           // 0 disables auto-archiving; the upper bound (~10 years) is a sanity cap.
           REVIEW_ARCHIVE_AFTER_DAYS, SettingConstraints.range(0, 3650),
+          // 0 disables purging; same ~10-year sanity cap as the archive window.
+          REVIEW_PURGE_ARCHIVED_AFTER_DAYS, SettingConstraints.range(0, 3650),
           SMTP_PORT, SettingConstraints.range(1, 65535),
           SMTP_FROM, SettingConstraints.format(SettingConstraints.ValueFormat.EMAIL),
           GENERAL_BASE_URL, SettingConstraints.format(SettingConstraints.ValueFormat.URL),

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewArchiveService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewArchiveService.java
@@ -102,11 +102,11 @@ public class ReviewArchiveService {
    * retention window are flagged archived (bounded batch). A retention of {@code 0} disables
    * auto-archiving. In {@code dryRun} mode it counts what it would archive but changes nothing.
    */
-  public void archiveOnce(boolean dryRun) {
+  public String archiveOnce(boolean dryRun) {
     int retentionDays = settings.getInteger(ApplicationSettingKey.REVIEW_ARCHIVE_AFTER_DAYS);
     if (retentionDays <= 0) {
       log.info("Review auto-archive is disabled (review.archive_after_days={}).", retentionDays);
-      return;
+      return "Auto-archiving is disabled (review.archive_after_days=" + retentionDays + ")";
     }
     Instant cutoff = Instant.now().minus(Duration.ofDays(retentionDays));
     if (dryRun) {
@@ -115,12 +115,12 @@ public class ReviewArchiveService {
           "Review auto-archive dry-run: would archive {} review(s) closed before {}.",
           count,
           cutoff);
-      return;
+      return "Would archive " + count + " review(s); nothing was changed";
     }
     List<Document> eligible =
         documents.findByArchivedAtIsNullAndClosedAtBefore(cutoff, PageRequest.of(0, MAX_PER_RUN));
     if (eligible.isEmpty()) {
-      return;
+      return "No reviews eligible to archive";
     }
     Instant now = Instant.now();
     for (Document document : eligible) {
@@ -131,6 +131,7 @@ public class ReviewArchiveService {
     documents.saveAll(eligible);
     log.info(
         "Review auto-archive: archived {} review(s) closed before {}.", eligible.size(), cutoff);
+    return "Archived " + eligible.size() + " review(s)";
   }
 
   /**

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewPurgeService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewPurgeService.java
@@ -146,16 +146,15 @@ public class ReviewPurgeService {
    * self-transactional), so this method opens one transaction per review. In {@code dryRun} mode it
    * reports what it would destroy and changes nothing at all.
    */
-  public void purgeOnce(boolean dryRun) {
+  public String purgeOnce(boolean dryRun) {
     int retentionDays = settings.getInteger(ApplicationSettingKey.REVIEW_PURGE_ARCHIVED_AFTER_DAYS);
     if (retentionDays <= 0) {
       log.info("Review purging is disabled (review.purge_archived_after_days={}).", retentionDays);
-      return;
+      return "Purging is disabled (review.purge_archived_after_days=" + retentionDays + ")";
     }
     Instant cutoff = Instant.now().minus(Duration.ofDays(retentionDays));
     if (dryRun) {
-      reportDryRun(cutoff);
-      return;
+      return reportDryRun(cutoff);
     }
 
     List<UUID> eligible =
@@ -165,7 +164,7 @@ public class ReviewPurgeService {
                     .map(Document::getId)
                     .toList());
     if (eligible == null || eligible.isEmpty()) {
-      return;
+      return "No reviews eligible to purge";
     }
 
     List<PurgedReview> purged = new ArrayList<>();
@@ -183,7 +182,7 @@ public class ReviewPurgeService {
     }
 
     if (purged.isEmpty()) {
-      return;
+      return "No reviews eligible to purge";
     }
     auditRun(purged, objectsDeleted);
     log.info(
@@ -191,6 +190,7 @@ public class ReviewPurgeService {
         purged.size(),
         cutoff,
         objectsDeleted);
+    return "Purged " + purged.size() + " review(s) and " + objectsDeleted + " storage object(s)";
   }
 
   /**
@@ -260,7 +260,7 @@ public class ReviewPurgeService {
   /**
    * Logs what a real run would destroy: reviews, and the objects that would become unreferenced.
    */
-  private void reportDryRun(Instant cutoff) {
+  private String reportDryRun(Instant cutoff) {
     DryRunReport report =
         tx.execute(
             status -> {
@@ -283,6 +283,11 @@ public class ReviewPurgeService {
         result.reviews(),
         cutoff,
         result.storageObjects());
+    return "Would purge "
+        + result.reviews()
+        + " review(s) and "
+        + result.storageObjects()
+        + " storage object(s); nothing was changed";
   }
 
   /**

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewPurgeService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewPurgeService.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.Document;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentAttachmentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.scheduler.SchedulerJobCatalog;
+import io.qnop.service.scheduler.SchedulerService;
+import io.qnop.service.storage.StorageService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Deletes long-archived reviews permanently (issue #577), closing the lifecycle #576 opened. An
+ * archived review is a cold record; after {@code review.purge_archived_after_days} it is destroyed
+ * — the whole DB aggregate plus the binaries in object storage that nothing else references.
+ *
+ * <p><strong>This is the only irreversible destruction of user data in the product</strong>, so it
+ * is a double opt-in: the retention setting <em>and</em> the {@code reviewPurge} scheduler job,
+ * which ships disabled (ADR-0050). A retention of {@code 0} disables purging outright, mirroring
+ * #576.
+ *
+ * <h2>Shared storage objects</h2>
+ *
+ * <p>Keys are content-addressed and deduplicated instance-wide (ADR-0005/0036), so the very same
+ * object can back versions or attachments of <em>other</em> documents. A key is therefore deleted
+ * only after proving that no surviving row references it — checked across {@code document_version}
+ * and {@code document_attachment} <em>after</em> the aggregate delete committed, so the purged
+ * document's own rows are already gone and cannot mask a genuinely shared key.
+ *
+ * <h2>Ordering is the crash-safety contract</h2>
+ *
+ * <p>The DB aggregate is deleted and committed <em>first</em>, storage second. A crash in between
+ * leaves an unreferenced object — harmless, and the storage-consistency scan (issue #523) sweeps
+ * it. The reverse order would recreate the #575 hole: rows referencing objects that no longer
+ * exist.
+ *
+ * <p>A concurrent upload can re-reference a key between the check and the delete. That race is
+ * accepted rather than locked away: {@code StorageService.stage} verifies a dedup hit and
+ * re-uploads from the buffered bytes when the object is missing (issue #575), so the loser of the
+ * race self-heals on its next read path instead of returning a key pointing at nothing.
+ *
+ * <h2>Transactions</h2>
+ *
+ * <p>The job is registered as {@code selfTransactional}, so the scheduler gate invokes it with no
+ * enclosing transaction and this service owns its own: <strong>one transaction per review</strong>.
+ * A run interrupted halfway therefore leaves reviews either untouched or completely gone, never
+ * half-deleted — and each storage delete commits its registry row immediately instead of at the end
+ * of the run.
+ */
+@Service
+public class ReviewPurgeService {
+
+  /**
+   * SYSTEM-scoped audit event for one purge run. Per-document events die with the document (the
+   * {@code audit_event.document_id} FK cascades), so this run-level record is the only surviving
+   * answer to "where did that review go?" — which is why it carries titles, not just ids.
+   */
+  public static final String AUDIT_REVIEWS_PURGED = "review.purged";
+
+  /**
+   * Upper bound on reviews purged per run. Deliberately lower than the archive sweep's 500: each
+   * item here is a cascading delete plus object-storage round-trips.
+   */
+  private static final int MAX_PER_RUN = 200;
+
+  /** Cap on how many titles the audit detail spells out, so one row cannot grow unbounded. */
+  private static final int MAX_AUDITED_TITLES = 50;
+
+  private static final Logger log = LoggerFactory.getLogger(ReviewPurgeService.class);
+
+  private final SchedulerService scheduler;
+  private final DocumentRepository documents;
+  private final DocumentVersionRepository versions;
+  private final DocumentAttachmentRepository attachments;
+  private final AuditEventRepository auditEvents;
+  private final ApplicationSettingsService settings;
+  private final StorageService storage;
+  private final TransactionTemplate tx;
+
+  public ReviewPurgeService(
+      SchedulerService scheduler,
+      DocumentRepository documents,
+      DocumentVersionRepository versions,
+      DocumentAttachmentRepository attachments,
+      AuditEventRepository auditEvents,
+      ApplicationSettingsService settings,
+      StorageService storage,
+      PlatformTransactionManager transactionManager) {
+    this.scheduler = scheduler;
+    this.documents = documents;
+    this.versions = versions;
+    this.attachments = attachments;
+    this.auditEvents = auditEvents;
+    this.settings = settings;
+    this.storage = storage;
+    this.tx = new TransactionTemplate(transactionManager);
+  }
+
+  /** Off-peak cron entry point, after the archive sweep; the gate runs {@link #purgeOnce}. */
+  @Scheduled(cron = "${qnop.review.purge-cron:0 55 3 * * *}")
+  @SchedulerLock(name = SchedulerJobCatalog.REVIEW_PURGE, lockAtMostFor = "PT30M")
+  public void purge() {
+    scheduler.runScheduled(SchedulerJobCatalog.REVIEW_PURGE);
+  }
+
+  /**
+   * One purge pass. Invoked by the gate <em>outside</em> any transaction (the job is
+   * self-transactional), so this method opens one transaction per review. In {@code dryRun} mode it
+   * reports what it would destroy and changes nothing at all.
+   */
+  public void purgeOnce(boolean dryRun) {
+    int retentionDays = settings.getInteger(ApplicationSettingKey.REVIEW_PURGE_ARCHIVED_AFTER_DAYS);
+    if (retentionDays <= 0) {
+      log.info("Review purging is disabled (review.purge_archived_after_days={}).", retentionDays);
+      return;
+    }
+    Instant cutoff = Instant.now().minus(Duration.ofDays(retentionDays));
+    if (dryRun) {
+      reportDryRun(cutoff);
+      return;
+    }
+
+    List<UUID> eligible =
+        tx.execute(
+            status ->
+                documents.findByArchivedAtBefore(cutoff, PageRequest.of(0, MAX_PER_RUN)).stream()
+                    .map(Document::getId)
+                    .toList());
+    if (eligible == null || eligible.isEmpty()) {
+      return;
+    }
+
+    List<PurgedReview> purged = new ArrayList<>();
+    int objectsDeleted = 0;
+    for (UUID documentId : eligible) {
+      // One transaction per review: an interrupted run leaves whole reviews, never fragments.
+      PurgedAggregate result = purgeAggregate(documentId, cutoff);
+      if (result == null) {
+        continue; // no longer eligible — unarchived or already gone since the batch was read
+      }
+      // Only now — the aggregate delete has committed, so the document's own rows can no longer
+      // make a key look shared.
+      objectsDeleted += deleteUnreferenced(result.storageKeys());
+      purged.add(new PurgedReview(documentId, result.title()));
+    }
+
+    if (purged.isEmpty()) {
+      return;
+    }
+    auditRun(purged, objectsDeleted);
+    log.info(
+        "Review purge deleted {} review(s) archived before {} and {} storage object(s).",
+        purged.size(),
+        cutoff,
+        objectsDeleted);
+  }
+
+  /**
+   * Deletes one review's DB aggregate in its own transaction and returns its title plus the storage
+   * keys it referenced, or {@code null} if it is no longer eligible.
+   *
+   * <p>The document is re-read and re-checked here rather than trusted from the batch: the batch
+   * was read in an earlier transaction, and an admin may have unarchived a review in between.
+   * Purging is irreversible, so the eligibility decision is made in the same transaction as the
+   * delete. The keys are read before the delete, because afterwards the rows are gone.
+   */
+  private PurgedAggregate purgeAggregate(UUID documentId, Instant cutoff) {
+    return tx.execute(
+        status -> {
+          Document document = documents.findById(documentId).orElse(null);
+          if (document == null
+              || document.getArchivedAt() == null
+              || !document.getArchivedAt().isBefore(cutoff)) {
+            return null;
+          }
+          Set<String> referenced = new LinkedHashSet<>();
+          referenced.addAll(versions.findStorageKeysByDocumentId(documentId));
+          referenced.addAll(attachments.findStorageKeysByDocumentId(documentId));
+          // The schema cascades the whole aggregate (versions, annotations, placements, comments,
+          // reactions, mentions, participants, visits, attachments, version diffs and the
+          // per-document audit trail) — see DocumentReviewSchemaIT.
+          documents.delete(document);
+          return new PurgedAggregate(document.getTitle(), referenced);
+        });
+  }
+
+  /**
+   * Deletes each key that no surviving row references, and returns how many went. Both reference
+   * checks are one query over the whole key set, not one per key.
+   */
+  private int deleteUnreferenced(Set<String> candidateKeys) {
+    if (candidateKeys.isEmpty()) {
+      return 0;
+    }
+    Set<String> stillReferenced =
+        tx.execute(
+            status -> {
+              Set<String> referenced = new LinkedHashSet<>();
+              versions.findVersionRefsByStorageKeyIn(candidateKeys).stream()
+                  .map(ref -> ref.storageKey())
+                  .forEach(referenced::add);
+              attachments.findAttachmentRefsByStorageKeyIn(candidateKeys).stream()
+                  .map(ref -> ref.storageKey())
+                  .forEach(referenced::add);
+              return referenced;
+            });
+    Set<String> shared = stillReferenced == null ? Set.of() : stillReferenced;
+    int deleted = 0;
+    for (String key : candidateKeys) {
+      if (shared.contains(key)) {
+        log.debug("Keeping storage object {} — still referenced by a surviving document.", key);
+        continue;
+      }
+      // Own transaction (StorageService.delete is @Transactional and we hold none), so the object
+      // and its registry row go together, now — not at the end of the run.
+      storage.delete(key);
+      deleted++;
+    }
+    return deleted;
+  }
+
+  /**
+   * Logs what a real run would destroy: reviews, and the objects that would become unreferenced.
+   */
+  private void reportDryRun(Instant cutoff) {
+    DryRunReport report =
+        tx.execute(
+            status -> {
+              long reviews = documents.countByArchivedAtBefore(cutoff);
+              List<Document> eligible =
+                  documents.findByArchivedAtBefore(cutoff, PageRequest.of(0, MAX_PER_RUN));
+              Set<UUID> purgedIds = new LinkedHashSet<>();
+              Set<String> candidates = new LinkedHashSet<>();
+              for (Document document : eligible) {
+                purgedIds.add(document.getId());
+                candidates.addAll(versions.findStorageKeysByDocumentId(document.getId()));
+                candidates.addAll(attachments.findStorageKeysByDocumentId(document.getId()));
+              }
+              return new DryRunReport(reviews, countUnreferenced(candidates, purgedIds));
+            });
+    DryRunReport result = report == null ? new DryRunReport(0, 0) : report;
+    log.info(
+        "Review purge (dry-run) would delete {} review(s) archived before {} and {} storage"
+            + " object(s); nothing was changed.",
+        result.reviews(),
+        cutoff,
+        result.storageObjects());
+  }
+
+  /**
+   * How many of {@code candidates} would actually be deleted: a key survives if a version or
+   * attachment <em>outside</em> the purged set references it. Two batched queries over the whole
+   * key set — never one per key — so the dry run stays honest about shared content without an N+1.
+   */
+  private int countUnreferenced(Set<String> candidates, Set<UUID> purgedDocumentIds) {
+    if (candidates.isEmpty()) {
+      return 0;
+    }
+    Set<String> shared = new LinkedHashSet<>();
+    versions.findVersionRefsByStorageKeyIn(candidates).stream()
+        .filter(ref -> !purgedDocumentIds.contains(ref.documentId()))
+        .forEach(ref -> shared.add(ref.storageKey()));
+    attachments.findAttachmentRefsByStorageKeyIn(candidates).stream()
+        .filter(ref -> !purgedDocumentIds.contains(ref.documentId()))
+        .forEach(ref -> shared.add(ref.storageKey()));
+    return candidates.size() - shared.size();
+  }
+
+  /** One SYSTEM audit row for the run — the trail that outlives the documents it describes. */
+  private void auditRun(List<PurgedReview> purged, int objectsDeleted) {
+    String detail = auditDetail(purged, objectsDeleted);
+    tx.executeWithoutResult(
+        status -> auditEvents.save(AuditEvent.system(AUDIT_REVIEWS_PURGED, null, detail)));
+  }
+
+  private static String auditDetail(List<PurgedReview> purged, int objectsDeleted) {
+    StringBuilder json = new StringBuilder("{\"reviews\":").append(purged.size());
+    json.append(",\"storageObjects\":").append(objectsDeleted);
+    json.append(",\"purged\":[");
+    List<PurgedReview> listed = purged.stream().limit(MAX_AUDITED_TITLES).toList();
+    for (int i = 0; i < listed.size(); i++) {
+      PurgedReview review = listed.get(i);
+      if (i > 0) {
+        json.append(',');
+      }
+      json.append("{\"id\":\"")
+          .append(review.id())
+          .append("\",\"title\":\"")
+          .append(escape(review.title()))
+          .append("\"}");
+    }
+    json.append(']');
+    if (purged.size() > listed.size()) {
+      json.append(",\"truncated\":").append(purged.size() - listed.size());
+    }
+    return json.append('}').toString();
+  }
+
+  /** Minimal JSON string escaping — titles are free text and must not break the detail payload. */
+  private static String escape(String value) {
+    if (value == null) {
+      return "";
+    }
+    StringBuilder out = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"' -> out.append("\\\"");
+        case '\\' -> out.append("\\\\");
+        case '\n' -> out.append("\\n");
+        case '\r' -> out.append("\\r");
+        case '\t' -> out.append("\\t");
+        default -> {
+          if (c < 0x20) {
+            out.append(String.format("\\u%04x", (int) c));
+          } else {
+            out.append(c);
+          }
+        }
+      }
+    }
+    return out.toString();
+  }
+
+  /** What the audit trail keeps of a review once the review itself is gone. */
+  private record PurgedReview(UUID id, String title) {}
+
+  /** What a dry run found, so the log line is assembled outside the transaction. */
+  private record DryRunReport(long reviews, int storageObjects) {}
+
+  /** What one committed aggregate delete leaves the caller to finish: the title and the keys. */
+  private record PurgedAggregate(String title, Set<String> storageKeys) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBinding.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBinding.java
@@ -54,13 +54,28 @@ public class SchedulerJobBinding {
       ReviewPurgeService reviewPurge) {
     scheduler.register(
         SchedulerJobCatalog.EMAIL_VERIFICATION_TOKEN_SWEEP,
-        dryRun -> emailVerificationTokens.sweepOnce());
+        dryRun -> {
+          emailVerificationTokens.sweepOnce();
+          return null;
+        });
     scheduler.register(
-        SchedulerJobCatalog.PASSWORD_RESET_TOKEN_SWEEP, dryRun -> passwordResetTokens.sweepOnce());
+        SchedulerJobCatalog.PASSWORD_RESET_TOKEN_SWEEP,
+        dryRun -> {
+          passwordResetTokens.sweepOnce();
+          return null;
+        });
     scheduler.register(
-        SchedulerJobCatalog.REFRESH_TOKEN_SWEEP, dryRun -> refreshTokens.sweepExpiredOnce());
+        SchedulerJobCatalog.REFRESH_TOKEN_SWEEP,
+        dryRun -> {
+          refreshTokens.sweepExpiredOnce();
+          return null;
+        });
     scheduler.register(
-        SchedulerJobCatalog.REVOKED_TOKEN_SWEEP, dryRun -> revokedTokens.sweepExpiredOnce());
+        SchedulerJobCatalog.REVOKED_TOKEN_SWEEP,
+        dryRun -> {
+          revokedTokens.sweepExpiredOnce();
+          return null;
+        });
     scheduler.register(SchedulerJobCatalog.STORAGE_ORPHAN_REAPER, storage::reapOrphansOnce);
     scheduler.register(SchedulerJobCatalog.REVIEW_ARCHIVE, reviewArchive::archiveOnce);
     scheduler.register(SchedulerJobCatalog.REVIEW_PURGE, reviewPurge::purgeOnce);

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBinding.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBinding.java
@@ -25,6 +25,7 @@ import io.qnop.service.TokenRevocationService;
 import io.qnop.service.auth.EmailVerificationTokenService;
 import io.qnop.service.auth.PasswordResetTokenService;
 import io.qnop.service.review.ReviewArchiveService;
+import io.qnop.service.review.ReviewPurgeService;
 import io.qnop.service.storage.StorageService;
 import org.springframework.stereotype.Component;
 
@@ -35,7 +36,9 @@ import org.springframework.stereotype.Component;
  * of scheduler plumbing. Constructor-time registration completes before any cron tick or run-now
  * can fire.
  *
- * <p>The token sweeps ignore the dry-run flag; only the storage reaper honours it.
+ * <p>The token sweeps ignore the dry-run flag; the storage reaper, the review archive and the
+ * review purge honour it. The purge is also the one {@code selfTransactional} job (issue #577) —
+ * the gate hands it no transaction, and it opens one per review itself.
  */
 @Component
 public class SchedulerJobBinding {
@@ -47,7 +50,8 @@ public class SchedulerJobBinding {
       RefreshTokenService refreshTokens,
       TokenRevocationService revokedTokens,
       StorageService storage,
-      ReviewArchiveService reviewArchive) {
+      ReviewArchiveService reviewArchive,
+      ReviewPurgeService reviewPurge) {
     scheduler.register(
         SchedulerJobCatalog.EMAIL_VERIFICATION_TOKEN_SWEEP,
         dryRun -> emailVerificationTokens.sweepOnce());
@@ -59,5 +63,6 @@ public class SchedulerJobBinding {
         SchedulerJobCatalog.REVOKED_TOKEN_SWEEP, dryRun -> revokedTokens.sweepExpiredOnce());
     scheduler.register(SchedulerJobCatalog.STORAGE_ORPHAN_REAPER, storage::reapOrphansOnce);
     scheduler.register(SchedulerJobCatalog.REVIEW_ARCHIVE, reviewArchive::archiveOnce);
+    scheduler.register(SchedulerJobCatalog.REVIEW_PURGE, reviewPurge::purgeOnce);
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBootstrap.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBootstrap.java
@@ -31,9 +31,10 @@ import org.springframework.stereotype.Component;
 /**
  * Seeds a {@code scheduler_job} row for every catalogued job at start-up (issue #524, ADR-0045).
  * Idempotent: an existing row (with its operator settings and last-run history) is left untouched,
- * so a restart never resets an admin's toggles. A fresh install gets every job enabled and not in
- * dry-run. Missing rows are harmless anyway — the gate fails open — but seeding means the dashboard
- * shows the full set immediately.
+ * so a restart never resets an admin's toggles. A fresh install gets each job at its catalogued
+ * {@code enabledByDefault} — every maintenance sweep on, the irreversible review purge off (issue
+ * #577) — and none in dry-run. Missing rows are harmless anyway (the gate falls back to the same
+ * default), but seeding means the dashboard shows the full set immediately.
  */
 @Component
 public class SchedulerJobBootstrap implements ApplicationRunner {
@@ -49,9 +50,9 @@ public class SchedulerJobBootstrap implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args) {
     int seeded = 0;
-    for (String jobId : SchedulerJobCatalog.jobIds()) {
-      if (!jobs.existsById(jobId)) {
-        jobs.save(SchedulerJob.seed(jobId));
+    for (SchedulerJobDefinition definition : SchedulerJobCatalog.definitions()) {
+      if (!jobs.existsById(definition.jobId())) {
+        jobs.save(SchedulerJob.seed(definition.jobId(), definition.enabledByDefault()));
         seeded++;
       }
     }

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
@@ -49,38 +49,50 @@ public final class SchedulerJobCatalog {
               "Email-verification token sweep",
               "Purges expired e-mail verification tokens so the table does not grow unbounded.",
               "0 30 3 * * *",
+              false,
+              true,
               false),
           new SchedulerJobDefinition(
               PASSWORD_RESET_TOKEN_SWEEP,
               "Password-reset token sweep",
               "Purges expired password-reset tokens once they can no longer be redeemed.",
               "0 35 3 * * *",
+              false,
+              true,
               false),
           new SchedulerJobDefinition(
               REFRESH_TOKEN_SWEEP,
               "Refresh token sweep",
               "Deletes expired refresh tokens; reuse-detection is moot once a token has expired.",
               "0 40 3 * * *",
+              false,
+              true,
               false),
           new SchedulerJobDefinition(
               REVOKED_TOKEN_SWEEP,
               "Revoked access-token sweep",
               "Drops revoked access-token denylist rows once their own expiry has passed.",
               "0 45 3 * * *",
+              false,
+              true,
               false),
           new SchedulerJobDefinition(
               STORAGE_ORPHAN_REAPER,
               "Storage orphan reaper",
               "Deletes uploaded-but-uncommitted storage objects older than the grace period.",
               "0 30 3 * * *",
-              true),
+              true,
+              true,
+              false),
           new SchedulerJobDefinition(
               REVIEW_ARCHIVE,
               "Review archive",
               "Archives reviews closed (finalized/cancelled) longer than the retention window,"
                   + " moving them out of the active lists.",
               "0 50 3 * * *",
-              true));
+              true,
+              true,
+              false));
 
   private static final List<String> IDS =
       DEFINITIONS.stream().map(SchedulerJobDefinition::jobId).toList();

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
@@ -41,6 +41,7 @@ public final class SchedulerJobCatalog {
   public static final String REVOKED_TOKEN_SWEEP = "revokedTokenSweep";
   public static final String STORAGE_ORPHAN_REAPER = "storageOrphanReaper";
   public static final String REVIEW_ARCHIVE = "reviewArchive";
+  public static final String REVIEW_PURGE = "reviewPurge";
 
   private static final List<SchedulerJobDefinition> DEFINITIONS =
       List.of(
@@ -92,7 +93,19 @@ public final class SchedulerJobCatalog {
               "0 50 3 * * *",
               true,
               true,
-              false));
+              false),
+          // Irreversible, so it ships DISABLED (issue #577): purging needs a deliberate
+          // operator act on top of the retention setting. Self-transactional, because it
+          // commits one review per transaction and deletes storage only after each commit.
+          new SchedulerJobDefinition(
+              REVIEW_PURGE,
+              "Review purge",
+              "Permanently deletes reviews archived longer than the purge retention window,"
+                  + " including storage objects no surviving document references.",
+              "0 55 3 * * *",
+              true,
+              false,
+              true));
 
   private static final List<String> IDS =
       DEFINITIONS.stream().map(SchedulerJobDefinition::jobId).toList();

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobDefinition.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobDefinition.java
@@ -29,6 +29,19 @@ package io.qnop.service.scheduler;
  * @param description one sentence on what the sweep does and why
  * @param cron the default cron expression the sweep fires on (informational for the dashboard)
  * @param supportsDryRun whether the job honours a report-only dry-run mode (only the reaper does)
+ * @param enabledByDefault whether the scheduled tick fires before an admin has ever touched the
+ *     job. Maintenance sweeps are on; a job that destroys data irreversibly ships <em>off</em>, so
+ *     enabling it is a deliberate operator act (issue #577)
+ * @param selfTransactional whether the job manages its own transactions. The gate normally wraps
+ *     the work in one transaction; a job that must commit in independent units — e.g. the purge,
+ *     which deletes one review per transaction and touches object storage only after each commit —
+ *     opts out and is invoked with no enclosing transaction (issue #577)
  */
 public record SchedulerJobDefinition(
-    String jobId, String displayName, String description, String cron, boolean supportsDryRun) {}
+    String jobId,
+    String displayName,
+    String description,
+    String cron,
+    boolean supportsDryRun,
+    boolean enabledByDefault,
+    boolean selfTransactional) {}

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerService.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerService.java
@@ -60,11 +60,20 @@ import org.springframework.transaction.support.TransactionTemplate;
  * record — and no Spring self-invocation caveat applies, since the work {@link SchedulerWork}
  * runnable is supplied by the owning service and invoked inside the gate's own transaction.
  *
- * <h2>Fail-open</h2>
+ * <p>A job declared {@link SchedulerJobDefinition#selfTransactional} is the one exception (issue
+ * #577): it is invoked with <em>no</em> enclosing transaction, because it needs to commit in
+ * independent units the gate cannot know about. The review purge deletes one review per transaction
+ * and touches object storage only after each commit; wrapping it would defer every commit to the
+ * end of the run, so a crash mid-run would roll back reviews whose binaries are already gone. Such
+ * a job takes on the duty the gate otherwise discharges: it must open its own transactions.
+ *
+ * <h2>Fail-open — to the catalogue's default, not to "on"</h2>
  *
  * <p>If the state read fails (a broken {@code scheduler_job} table, a transient DB error), the gate
  * runs the job anyway. Maintenance sweeps keep the system healthy; a stuck control table must never
- * silently stop them.
+ * silently stop them. "Anyway" means the catalogued {@link SchedulerJobDefinition#enabledByDefault}
+ * though — a job that destroys data irreversibly stays off when its state is unknown, since failing
+ * open into an irreversible delete is not fail-safe.
  */
 @Service
 public class SchedulerService {
@@ -168,7 +177,9 @@ public class SchedulerService {
     SchedulerJob saved =
         tx.execute(
             status -> {
-              SchedulerJob job = jobs.findById(jobId).orElseGet(() -> SchedulerJob.seed(jobId));
+              SchedulerJob job =
+                  jobs.findById(jobId)
+                      .orElseGet(() -> SchedulerJob.seed(jobId, enabledByDefault(jobId)));
               job.updateSettings(enabled, dryRun);
               SchedulerJob persisted = jobs.save(job);
               auditEvents.save(
@@ -218,7 +229,15 @@ public class SchedulerService {
     }
     boolean dryRun = state.dryRun() && supportsDryRun(jobId);
     try {
-      tx.executeWithoutResult(status -> work.run(dryRun));
+      if (isSelfTransactional(jobId)) {
+        // The job commits in independent units of its own choosing (issue #577), so it must NOT run
+        // inside the gate's transaction: an enclosing transaction would defer every one of those
+        // commits to the end of the run and defeat the point. The outcome is still recorded in its
+        // own transaction below, exactly as for a wrapped job.
+        work.run(dryRun);
+      } else {
+        tx.executeWithoutResult(status -> work.run(dryRun));
+      }
     } catch (RuntimeException e) {
       log.error("Scheduler job {} ({}) failed", jobId, trigger, e);
       recordOutcome(jobId, RunOutcome.FAILURE, trigger, summarize(e), actorId);
@@ -228,19 +247,27 @@ public class SchedulerService {
     return RunOutcome.SUCCESS;
   }
 
-  /** Reads the enabled/dry-run state; fails open (run the job) on any read error. */
+  /**
+   * Reads the enabled/dry-run state; fails open (run the job) on any read error.
+   *
+   * <p>"Fails open" means the <em>catalogue's</em> default, not an unconditional yes: a job
+   * declared {@code enabledByDefault=false} because it destroys data irreversibly (issue #577) must
+   * stay off while its row is missing or unreadable, or a broken control table would silently arm
+   * it.
+   */
   private JobState readState(String jobId) {
+    JobState fallback = new JobState(enabledByDefault(jobId), false);
     try {
       JobState state =
           tx.execute(
               status ->
                   jobs.findById(jobId)
                       .map(job -> new JobState(job.isEnabled(), job.isDryRun()))
-                      .orElse(new JobState(true, false)));
-      return state == null ? new JobState(true, false) : state;
+                      .orElse(fallback));
+      return state == null ? fallback : state;
     } catch (RuntimeException e) {
-      log.warn("Could not read scheduler state for {}; failing open (running)", jobId, e);
-      return new JobState(true, false);
+      log.warn("Could not read scheduler state for {}; falling back to its default", jobId, e);
+      return fallback;
     }
   }
 
@@ -254,7 +281,9 @@ public class SchedulerService {
     try {
       tx.executeWithoutResult(
           status -> {
-            SchedulerJob job = jobs.findById(jobId).orElseGet(() -> SchedulerJob.seed(jobId));
+            SchedulerJob job =
+                jobs.findById(jobId)
+                    .orElseGet(() -> SchedulerJob.seed(jobId, enabledByDefault(jobId)));
             job.recordRun(Instant.now(), outcome.name(), trigger.name(), detail);
             jobs.save(job);
             if (trigger == RunTrigger.MANUAL) {
@@ -282,6 +311,20 @@ public class SchedulerService {
         .orElse(false);
   }
 
+  /** Whether the job runs without the gate's enclosing transaction (issue #577). */
+  private boolean isSelfTransactional(String jobId) {
+    return SchedulerJobCatalog.find(jobId)
+        .map(SchedulerJobDefinition::selfTransactional)
+        .orElse(false);
+  }
+
+  /** The catalogue's enabled default, used wherever no {@code scheduler_job} row exists yet. */
+  private static boolean enabledByDefault(String jobId) {
+    return SchedulerJobCatalog.find(jobId)
+        .map(SchedulerJobDefinition::enabledByDefault)
+        .orElse(true);
+  }
+
   private SchedulerJobDefinition requireDefinition(String jobId) {
     return SchedulerJobCatalog.find(jobId)
         .orElseThrow(() -> new SchedulerJobNotFoundException(jobId));
@@ -305,7 +348,9 @@ public class SchedulerService {
         definition.description(),
         definition.cron(),
         definition.supportsDryRun(),
-        row == null || row.isEnabled(),
+        // No row yet → the catalogue's default, so a disabled-by-default job (issue #577) reads as
+        // disabled on the dashboard instead of advertising a state it does not have.
+        row == null ? definition.enabledByDefault() : row.isEnabled(),
         row != null && row.isDryRun(),
         row == null ? null : row.getLastRunAt(),
         row == null ? null : row.getLastOutcome(),

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerService.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerService.java
@@ -228,23 +228,32 @@ public class SchedulerService {
       return RunOutcome.SKIPPED_DISABLED;
     }
     boolean dryRun = state.dryRun() && supportsDryRun(jobId);
+    String summary;
     try {
       if (isSelfTransactional(jobId)) {
         // The job commits in independent units of its own choosing (issue #577), so it must NOT run
         // inside the gate's transaction: an enclosing transaction would defer every one of those
         // commits to the end of the run and defeat the point. The outcome is still recorded in its
         // own transaction below, exactly as for a wrapped job.
-        work.run(dryRun);
+        summary = work.run(dryRun);
       } else {
-        tx.executeWithoutResult(status -> work.run(dryRun));
+        summary = tx.execute(status -> work.run(dryRun));
       }
     } catch (RuntimeException e) {
       log.error("Scheduler job {} ({}) failed", jobId, trigger, e);
-      recordOutcome(jobId, RunOutcome.FAILURE, trigger, summarize(e), actorId);
+      recordOutcome(jobId, RunOutcome.FAILURE, trigger, summarize(e), dryRun, actorId);
       return RunOutcome.FAILURE;
     }
-    recordOutcome(jobId, RunOutcome.SUCCESS, trigger, dryRun ? "dry-run" : null, actorId);
+    // The job's own summary becomes the dashboard's last-run detail; a job with
+    // nothing to say still leaves a marker for a dry run.
+    String detail = summary != null ? clamp(summary) : (dryRun ? "Dry run" : null);
+    recordOutcome(jobId, RunOutcome.SUCCESS, trigger, detail, dryRun, actorId);
     return RunOutcome.SUCCESS;
+  }
+
+  /** Clamps a job-supplied summary to the {@code last_detail} column, like {@link #summarize}. */
+  private static String clamp(String detail) {
+    return detail.length() <= MAX_DETAIL_LENGTH ? detail : detail.substring(0, MAX_DETAIL_LENGTH);
   }
 
   /**
@@ -277,7 +286,12 @@ public class SchedulerService {
    * logged but never masks the run itself.
    */
   private void recordOutcome(
-      String jobId, RunOutcome outcome, RunTrigger trigger, String detail, UUID actorId) {
+      String jobId,
+      RunOutcome outcome,
+      RunTrigger trigger,
+      String detail,
+      boolean dryRun,
+      UUID actorId) {
     try {
       tx.executeWithoutResult(
           status -> {
@@ -296,7 +310,7 @@ public class SchedulerService {
                           + "\",\"outcome\":\""
                           + outcome.name()
                           + "\",\"dryRun\":"
-                          + "dry-run".equals(detail)
+                          + dryRun
                           + "}"));
             }
           });

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerWork.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerWork.java
@@ -23,11 +23,19 @@ package io.qnop.service.scheduler;
 /**
  * The unit of work a maintenance job performs, registered with {@link SchedulerService} by the
  * owning service (issue #524, ADR-0045). It is called <em>inside</em> a fresh transaction the
- * scheduler owns, so implementations do their raw repository work and need no transaction of their
- * own. The {@code dryRun} flag is honoured only by dry-run-capable jobs (the storage reaper); the
+ * scheduler owns (unless the job is self-transactional, issue #577), so implementations do their
+ * raw repository work and need no transaction of their own. The {@code dryRun} flag is honoured
+ * only by dry-run-capable jobs (the storage reaper, the review archive and the review purge); the
  * token sweeps ignore it.
  */
 @FunctionalInterface
 public interface SchedulerWork {
-  void run(boolean dryRun);
+
+  /**
+   * Performs one run and returns a short human-readable summary of what happened (or, under {@code
+   * dryRun}, what would have happened) — e.g. {@code "Purged 2 review(s) and 1 storage object(s)"}.
+   * The scheduler records it as the job's last-run detail, surfaced on the dashboard (issue #577
+   * follow-up). {@code null} means the job has nothing to report.
+   */
+  String run(boolean dryRun);
 }

--- a/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/StorageService.java
@@ -194,23 +194,24 @@ public class StorageService {
    * {@code dryRun} mode it counts what would be deleted but deletes nothing — a safe operator
    * probe.
    */
-  public void reapOrphansOnce(boolean dryRun) {
+  public String reapOrphansOnce(boolean dryRun) {
     Instant cutoff = Instant.now().minus(properties.reaperGracePeriod());
     List<StorageObject> orphans =
         repository.findByStatusAndCreatedAtBefore(StorageObjectStatus.PENDING, cutoff);
     if (orphans.isEmpty()) {
-      return;
+      return "No orphaned uploads to reap";
     }
     if (dryRun) {
       log.info(
           "Storage orphan reaper (dry-run) would delete {} uncommitted object(s).", orphans.size());
-      return;
+      return "Would delete " + orphans.size() + " uncommitted object(s); nothing was changed";
     }
     for (StorageObject orphan : orphans) {
       provider.delete(orphan.getObjectKey());
       repository.delete(orphan);
     }
     log.info("Storage orphan reaper deleted {} uncommitted object(s).", orphans.size());
+    return "Deleted " + orphans.size() + " uncommitted object(s)";
   }
 
   /**

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -92,6 +92,9 @@ databaseChangeLog:
   - include:
       file: migrations/0027-review-archive-setting.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0028-review-purge-setting.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/migrations/0028-review-purge-setting.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0028-review-purge-setting.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026-present devtank42 GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Seed row for the archived-review purge retention (issue #577). Additive changeset
+# — new keys land in their own changeset (1.0.0 shipped the original seed). The
+# registry (ApplicationSettingKey) stays authoritative per ADR-0025; this row
+# mirrors its default. 0 disables purging.
+#
+# The default of 180 alone purges nothing: the reviewPurge scheduler job ships
+# DISABLED (ADR-0050), so irreversible deletion needs a second, deliberate act.
+databaseChangeLog:
+  - changeSet:
+      id: 0028-review-purge-setting
+      author: qnop
+      comment: Adds the review.purge_archived_after_days application setting (issue #577), default 180.
+      changes:
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "review.purge_archived_after_days" }
+              - column: { name: setting_value, value: "180" }
+              - column: { name: setting_desc, value: "Days an archived review is kept before it is deleted permanently, including storage objects no other document references (0 disables purging). Irreversible — the Review purge job must be enabled as well." }
+              - column: { name: value_type, value: "INTEGER" }

--- a/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
@@ -64,7 +64,8 @@ class ApplicationSettingKeyTest {
           "notifications.review_emails_enabled",
           "review.free_reattach_enabled",
           "review.finalize_with_open_annotations",
-          "review.archive_after_days");
+          "review.archive_after_days",
+          "review.purge_archived_after_days");
 
   @Test
   void registryMatchesSeededKeys() {

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewPurgeServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewPurgeServiceTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.AuditScope;
+import io.qnop.entity.Document;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AttachmentStorageRef;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentAttachmentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.VersionStorageRef;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.scheduler.SchedulerService;
+import io.qnop.service.storage.StorageService;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+/**
+ * DB-free unit tests for the archived-review purge (issue #577, ADR-0050): the retention window and
+ * its {@code 0} kill switch, the dry run's zero side effects, the shared-vs-exclusive storage-key
+ * decision, the eligibility re-check inside the per-review transaction, and the SYSTEM audit
+ * record.
+ *
+ * <p>A mock {@link PlatformTransactionManager} runs each {@code TransactionTemplate} callback
+ * in-line, so the per-review transaction boundaries are exercised without a database. The
+ * shared-key behaviour against a real Postgres + MinIO lives in {@code ReviewPurgeApiIT}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ReviewPurgeServiceTest {
+
+  private static final UUID OWNER = UUID.randomUUID();
+  private static final String KEY_A = "sha256/aa/aaaa";
+  private static final String KEY_B = "sha256/bb/bbbb";
+
+  @Mock private SchedulerService scheduler;
+  @Mock private DocumentRepository documents;
+  @Mock private DocumentVersionRepository versions;
+  @Mock private DocumentAttachmentRepository attachments;
+  @Mock private AuditEventRepository auditEvents;
+  @Mock private ApplicationSettingsService settings;
+  @Mock private StorageService storage;
+  @Mock private PlatformTransactionManager transactionManager;
+
+  private ReviewPurgeService service;
+
+  @BeforeEach
+  void setUp() {
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    service =
+        new ReviewPurgeService(
+            scheduler,
+            documents,
+            versions,
+            attachments,
+            auditEvents,
+            settings,
+            storage,
+            transactionManager);
+    when(settings.getInteger(ApplicationSettingKey.REVIEW_PURGE_ARCHIVED_AFTER_DAYS))
+        .thenReturn(180);
+  }
+
+  /** An archived review with a real id, since the sweep addresses documents by id. */
+  private static Document archived(String title, long daysAgo) {
+    Document document = new Document(OWNER, title);
+    document.setWorkflowState(WorkflowState.FINALIZED);
+    document.setClosedAt(Instant.now().minus(Duration.ofDays(daysAgo + 1)));
+    document.setArchivedAt(Instant.now().minus(Duration.ofDays(daysAgo)));
+    setId(document, UUID.randomUUID());
+    return document;
+  }
+
+  private static void setId(Document document, UUID id) {
+    try {
+      Field field = Document.class.getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(document, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /** Wires the batch read and the per-review re-read for one eligible review. */
+  private void eligible(Document document) {
+    when(documents.findByArchivedAtBefore(any(), any(Pageable.class)))
+        .thenReturn(List.of(document));
+    when(documents.findById(document.getId())).thenReturn(Optional.of(document));
+  }
+
+  // --- the kill switches ---------------------------------------------------
+
+  @Test
+  @DisplayName("a retention of 0 disables purging entirely — nothing is even queried")
+  void retentionZeroDisablesPurging() {
+    when(settings.getInteger(ApplicationSettingKey.REVIEW_PURGE_ARCHIVED_AFTER_DAYS)).thenReturn(0);
+
+    service.purgeOnce(false);
+
+    verifyNoInteractions(documents, versions, attachments, storage, auditEvents);
+  }
+
+  @Test
+  @DisplayName("an empty eligibility set writes no audit event — a no-op run leaves no trace")
+  void emptyRunDoesNotAudit() {
+    when(documents.findByArchivedAtBefore(any(), any(Pageable.class))).thenReturn(List.of());
+
+    service.purgeOnce(false);
+
+    verifyNoInteractions(auditEvents, storage);
+    verify(documents, never()).delete(any());
+  }
+
+  // --- the dry run ---------------------------------------------------------
+
+  @Test
+  @DisplayName("a dry run deletes nothing at all — no document, no object, no audit row")
+  void dryRunChangesNothing() {
+    Document document = archived("Q3 report", 200);
+    when(documents.countByArchivedAtBefore(any())).thenReturn(1L);
+    when(documents.findByArchivedAtBefore(any(), any(Pageable.class)))
+        .thenReturn(List.of(document));
+    when(versions.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of(KEY_A));
+    when(attachments.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of());
+    when(versions.findVersionRefsByStorageKeyIn(any())).thenReturn(List.of());
+    when(attachments.findAttachmentRefsByStorageKeyIn(any())).thenReturn(List.of());
+
+    service.purgeOnce(true);
+
+    verify(documents, never()).delete(any());
+    verify(storage, never()).delete(anyString());
+    verifyNoInteractions(auditEvents);
+  }
+
+  // --- the shared-key decision (the substance of #577) ---------------------
+
+  @Test
+  @DisplayName("a key no surviving row references is deleted from storage")
+  void exclusiveKeyIsDeleted() {
+    Document document = archived("Q3 report", 200);
+    eligible(document);
+    when(versions.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of(KEY_A));
+    when(attachments.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of());
+    // After the aggregate delete committed, nothing references the key any more.
+    when(versions.findVersionRefsByStorageKeyIn(any())).thenReturn(List.of());
+    when(attachments.findAttachmentRefsByStorageKeyIn(any())).thenReturn(List.of());
+
+    service.purgeOnce(false);
+
+    verify(documents).delete(document);
+    verify(storage).delete(KEY_A);
+  }
+
+  @Test
+  @DisplayName("a key a surviving document still references is left untouched")
+  void sharedKeyIsKept() {
+    Document document = archived("Q3 report", 200);
+    eligible(document);
+    when(versions.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of(KEY_A));
+    when(attachments.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of());
+    // Content-addressed dedup (ADR-0005/0036): another document's version shares the object.
+    when(versions.findVersionRefsByStorageKeyIn(any()))
+        .thenReturn(List.of(new VersionStorageRef(KEY_A, UUID.randomUUID(), 1)));
+    when(attachments.findAttachmentRefsByStorageKeyIn(any())).thenReturn(List.of());
+
+    service.purgeOnce(false);
+
+    verify(documents).delete(document);
+    verify(storage, never()).delete(anyString());
+  }
+
+  @Test
+  @DisplayName("an attachment reference also protects a key, not just a version")
+  void sharedKeyViaAttachmentIsKept() {
+    Document document = archived("Q3 report", 200);
+    eligible(document);
+    when(versions.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of());
+    when(attachments.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of(KEY_B));
+    when(versions.findVersionRefsByStorageKeyIn(any())).thenReturn(List.of());
+    when(attachments.findAttachmentRefsByStorageKeyIn(any()))
+        .thenReturn(List.of(new AttachmentStorageRef(KEY_B, UUID.randomUUID(), "shot.png")));
+
+    service.purgeOnce(false);
+
+    verify(storage, never()).delete(anyString());
+  }
+
+  @Test
+  @DisplayName("of two keys, only the exclusive one goes")
+  void mixedKeysDeleteOnlyTheExclusiveOne() {
+    Document document = archived("Q3 report", 200);
+    eligible(document);
+    when(versions.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of(KEY_A, KEY_B));
+    when(attachments.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of());
+    when(versions.findVersionRefsByStorageKeyIn(any()))
+        .thenReturn(List.of(new VersionStorageRef(KEY_B, UUID.randomUUID(), 2)));
+    when(attachments.findAttachmentRefsByStorageKeyIn(any())).thenReturn(List.of());
+
+    service.purgeOnce(false);
+
+    verify(storage).delete(KEY_A);
+    verify(storage, never()).delete(KEY_B);
+  }
+
+  // --- the eligibility re-check -------------------------------------------
+
+  @Test
+  @DisplayName("a review unarchived between the batch read and its own transaction is spared")
+  void unarchivedInFlightIsSkipped() {
+    Document document = archived("Q3 report", 200);
+    when(documents.findByArchivedAtBefore(any(), any(Pageable.class)))
+        .thenReturn(List.of(document));
+    // The per-review transaction re-reads it — and by then an admin has unarchived it.
+    Document restored = archived("Q3 report", 200);
+    setId(restored, document.getId());
+    restored.setArchivedAt(null);
+    when(documents.findById(document.getId())).thenReturn(Optional.of(restored));
+
+    service.purgeOnce(false);
+
+    verify(documents, never()).delete(any());
+    verify(storage, never()).delete(anyString());
+    verifyNoInteractions(auditEvents);
+  }
+
+  @Test
+  @DisplayName("a review archived too recently to be eligible on re-read is spared")
+  void recentlyArchivedOnReReadIsSkipped() {
+    Document document = archived("Q3 report", 200);
+    when(documents.findByArchivedAtBefore(any(), any(Pageable.class)))
+        .thenReturn(List.of(document));
+    Document rearchived = archived("Q3 report", 1);
+    setId(rearchived, document.getId());
+    when(documents.findById(document.getId())).thenReturn(Optional.of(rearchived));
+
+    service.purgeOnce(false);
+
+    verify(documents, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("a review already gone on re-read is skipped without failing the run")
+  void vanishedOnReReadIsSkipped() {
+    Document document = archived("Q3 report", 200);
+    when(documents.findByArchivedAtBefore(any(), any(Pageable.class)))
+        .thenReturn(List.of(document));
+    when(documents.findById(document.getId())).thenReturn(Optional.empty());
+
+    service.purgeOnce(false);
+
+    verify(documents, never()).delete(any());
+    verifyNoInteractions(auditEvents);
+  }
+
+  // --- the audit record ---------------------------------------------------
+
+  @Test
+  @DisplayName("one SYSTEM audit row per run carries the counts and the purged titles")
+  void auditsTheRunWithTitles() {
+    Document document = archived("Q3 report", 200);
+    eligible(document);
+    when(versions.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of(KEY_A));
+    when(attachments.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of());
+    when(versions.findVersionRefsByStorageKeyIn(any())).thenReturn(List.of());
+    when(attachments.findAttachmentRefsByStorageKeyIn(any())).thenReturn(List.of());
+
+    service.purgeOnce(false);
+
+    ArgumentCaptor<AuditEvent> captor = ArgumentCaptor.forClass(AuditEvent.class);
+    verify(auditEvents).save(captor.capture());
+    AuditEvent event = captor.getValue();
+    assertThat(event.getEventType()).isEqualTo(ReviewPurgeService.AUDIT_REVIEWS_PURGED);
+    assertThat(event.getScope()).isEqualTo(AuditScope.SYSTEM);
+    // Machine-driven: the trail renders a null actor as "System".
+    assertThat(event.getActorId()).isNull();
+    // The title is the point — the purged review's own trail died with it.
+    assertThat(event.getDetail())
+        .contains("\"reviews\":1")
+        .contains("\"storageObjects\":1")
+        .contains("\"title\":\"Q3 report\"")
+        .contains(document.getId().toString());
+  }
+
+  @Test
+  @DisplayName("a quote in a review title cannot break the audit detail's JSON")
+  void auditDetailEscapesTitles() {
+    Document document = archived("The \"final\" terms\\draft", 200);
+    eligible(document);
+    when(versions.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of());
+    when(attachments.findStorageKeysByDocumentId(document.getId())).thenReturn(List.of());
+
+    service.purgeOnce(false);
+
+    ArgumentCaptor<AuditEvent> captor = ArgumentCaptor.forClass(AuditEvent.class);
+    verify(auditEvents).save(captor.capture());
+    assertThat(captor.getValue().getDetail())
+        .contains("\\\"final\\\"")
+        .contains("terms\\\\draft")
+        .contains("\"storageObjects\":0");
+  }
+
+  // --- the batch bound ----------------------------------------------------
+
+  @Test
+  @DisplayName("one run is bounded, so a huge backlog cannot be loaded at once")
+  void batchIsBounded() {
+    when(documents.findByArchivedAtBefore(any(), any(Pageable.class))).thenReturn(List.of());
+
+    service.purgeOnce(false);
+
+    ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+    verify(documents).findByArchivedAtBefore(any(), pageable.capture());
+    assertThat(pageable.getValue().getPageSize()).isEqualTo(200);
+    assertThat(pageable.getValue().getPageNumber()).isZero();
+  }
+
+  @Test
+  @DisplayName("the cutoff is derived from the configured retention")
+  void cutoffFollowsTheRetentionSetting() {
+    when(settings.getInteger(ApplicationSettingKey.REVIEW_PURGE_ARCHIVED_AFTER_DAYS))
+        .thenReturn(30);
+    when(documents.findByArchivedAtBefore(any(), any(Pageable.class))).thenReturn(List.of());
+    Instant before = Instant.now().minus(Duration.ofDays(30));
+
+    service.purgeOnce(false);
+
+    ArgumentCaptor<Instant> cutoff = ArgumentCaptor.forClass(Instant.class);
+    verify(documents).findByArchivedAtBefore(cutoff.capture(), any(Pageable.class));
+    assertThat(cutoff.getValue())
+        .isCloseTo(
+            before,
+            org.assertj.core.api.Assertions.within(5, java.time.temporal.ChronoUnit.SECONDS));
+  }
+
+  @Test
+  @DisplayName("the cron entry point delegates to the scheduler gate, never to the work directly")
+  void cronDelegatesToTheGate() {
+    service.purge();
+
+    verify(scheduler).runScheduled(eq("reviewPurge"));
+    verifyNoInteractions(documents, storage);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/scheduler/SchedulerServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/scheduler/SchedulerServiceTest.java
@@ -85,7 +85,12 @@ class SchedulerServiceTest {
     SchedulerJob job = SchedulerJob.seed(TOKEN_JOB, true);
     when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
     AtomicInteger runs = new AtomicInteger();
-    scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
+    scheduler.register(
+        TOKEN_JOB,
+        dryRun -> {
+          runs.incrementAndGet();
+          return null;
+        });
 
     RunOutcome outcome = scheduler.runScheduled(TOKEN_JOB);
 
@@ -104,13 +109,44 @@ class SchedulerServiceTest {
     job.updateSettings(false, null);
     when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
     AtomicInteger runs = new AtomicInteger();
-    scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
+    scheduler.register(
+        TOKEN_JOB,
+        dryRun -> {
+          runs.incrementAndGet();
+          return null;
+        });
 
     RunOutcome outcome = scheduler.runScheduled(TOKEN_JOB);
 
     assertThat(outcome).isEqualTo(RunOutcome.SKIPPED_DISABLED);
     assertThat(runs).hasValue(0);
     verify(jobs, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("the work's summary is recorded as the run's detail (#577 follow-up)")
+  void workSummaryBecomesLastDetail() {
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB, true);
+    when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
+    scheduler.register(TOKEN_JOB, dryRun -> "Purged 2 review(s) and 1 storage object(s)");
+
+    RunOutcome outcome = scheduler.runScheduled(TOKEN_JOB);
+
+    assertThat(outcome).isEqualTo(RunOutcome.SUCCESS);
+    assertThat(job.getLastDetail()).isEqualTo("Purged 2 review(s) and 1 storage object(s)");
+  }
+
+  @Test
+  @DisplayName("a summary-less dry run still leaves a marker as the detail")
+  void summarylessDryRunLeavesMarker() {
+    SchedulerJob job = SchedulerJob.seed(REAPER_JOB, true);
+    job.updateSettings(null, true);
+    when(jobs.findById(REAPER_JOB)).thenReturn(Optional.of(job));
+    scheduler.register(REAPER_JOB, dryRun -> null);
+
+    scheduler.runScheduled(REAPER_JOB);
+
+    assertThat(job.getLastDetail()).isEqualTo("Dry run");
   }
 
   @Test
@@ -138,7 +174,12 @@ class SchedulerServiceTest {
         .thenThrow(new RuntimeException("db down"))
         .thenReturn(Optional.empty()); // recordOutcome's own read
     AtomicInteger runs = new AtomicInteger();
-    scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
+    scheduler.register(
+        TOKEN_JOB,
+        dryRun -> {
+          runs.incrementAndGet();
+          return null;
+        });
 
     RunOutcome outcome = scheduler.runScheduled(TOKEN_JOB);
 
@@ -155,7 +196,12 @@ class SchedulerServiceTest {
     SimpleLock lock = org.mockito.Mockito.mock(SimpleLock.class);
     when(lockProvider.lock(any())).thenReturn(Optional.of(lock));
     AtomicInteger runs = new AtomicInteger();
-    scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
+    scheduler.register(
+        TOKEN_JOB,
+        dryRun -> {
+          runs.incrementAndGet();
+          return null;
+        });
     UUID actor = UUID.randomUUID();
 
     SchedulerService.SchedulerJobView view = scheduler.runNow(actor, TOKEN_JOB);
@@ -246,7 +292,12 @@ class SchedulerServiceTest {
   void disabledByDefaultJobIsSkippedWhenUnseeded() {
     when(jobs.findById(PURGE_JOB)).thenReturn(Optional.empty());
     AtomicInteger runs = new AtomicInteger();
-    scheduler.register(PURGE_JOB, dryRun -> runs.incrementAndGet());
+    scheduler.register(
+        PURGE_JOB,
+        dryRun -> {
+          runs.incrementAndGet();
+          return null;
+        });
 
     RunOutcome outcome = scheduler.runScheduled(PURGE_JOB);
 
@@ -261,7 +312,12 @@ class SchedulerServiceTest {
   void failOpenRespectsDisabledByDefault() {
     when(jobs.findById(PURGE_JOB)).thenThrow(new IllegalStateException("scheduler_job unreadable"));
     AtomicInteger runs = new AtomicInteger();
-    scheduler.register(PURGE_JOB, dryRun -> runs.incrementAndGet());
+    scheduler.register(
+        PURGE_JOB,
+        dryRun -> {
+          runs.incrementAndGet();
+          return null;
+        });
 
     assertThat(scheduler.runScheduled(PURGE_JOB)).isEqualTo(RunOutcome.SKIPPED_DISABLED);
     assertThat(runs).hasValue(0);
@@ -273,7 +329,12 @@ class SchedulerServiceTest {
     when(jobs.findById(PURGE_JOB)).thenReturn(Optional.empty());
     when(jobs.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     AtomicInteger runs = new AtomicInteger();
-    scheduler.register(PURGE_JOB, dryRun -> runs.incrementAndGet());
+    scheduler.register(
+        PURGE_JOB,
+        dryRun -> {
+          runs.incrementAndGet();
+          return null;
+        });
 
     SchedulerService.SchedulerJobView enabled =
         scheduler.updateSettings(UUID.randomUUID(), PURGE_JOB, true, null);
@@ -289,8 +350,8 @@ class SchedulerServiceTest {
   void selfTransactionalJobIsNotWrapped() {
     when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(SchedulerJob.seed(TOKEN_JOB, true)));
     when(jobs.findById(PURGE_JOB)).thenReturn(Optional.of(SchedulerJob.seed(PURGE_JOB, true)));
-    scheduler.register(TOKEN_JOB, dryRun -> {});
-    scheduler.register(PURGE_JOB, dryRun -> {});
+    scheduler.register(TOKEN_JOB, dryRun -> null);
+    scheduler.register(PURGE_JOB, dryRun -> null);
 
     scheduler.runScheduled(TOKEN_JOB);
     // A wrapped job costs three transactions: read state, run work, record outcome.

--- a/qnop-core/src/test/java/io/qnop/service/scheduler/SchedulerServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/scheduler/SchedulerServiceTest.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,7 +81,7 @@ class SchedulerServiceTest {
   @DisplayName(
       "a scheduled run of an enabled job runs the work and records SUCCESS without auditing")
   void scheduledRunEnabled() {
-    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB);
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB, true);
     when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
     AtomicInteger runs = new AtomicInteger();
     scheduler.register(TOKEN_JOB, dryRun -> runs.incrementAndGet());
@@ -97,7 +99,7 @@ class SchedulerServiceTest {
   @Test
   @DisplayName("a scheduled run of a disabled job is skipped: no work, no record")
   void scheduledRunDisabled() {
-    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB);
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB, true);
     job.updateSettings(false, null);
     when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
     AtomicInteger runs = new AtomicInteger();
@@ -113,7 +115,7 @@ class SchedulerServiceTest {
   @Test
   @DisplayName("a failing work records FAILURE and returns FAILURE without throwing")
   void workFailureIsRecordedNotThrown() {
-    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB);
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB, true);
     when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
     scheduler.register(
         TOKEN_JOB,
@@ -146,7 +148,7 @@ class SchedulerServiceTest {
   @Test
   @DisplayName("run-now runs a disabled job (explicit override), audits, and unlocks")
   void runNowOverridesDisabledAndAudits() {
-    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB);
+    SchedulerJob job = SchedulerJob.seed(TOKEN_JOB, true);
     job.updateSettings(false, null);
     when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(job));
     SimpleLock lock = org.mockito.Mockito.mock(SimpleLock.class);
@@ -195,7 +197,7 @@ class SchedulerServiceTest {
   @Test
   @DisplayName("update persists settings and audits the change")
   void updatePersistsAndAudits() {
-    SchedulerJob job = SchedulerJob.seed(REAPER_JOB);
+    SchedulerJob job = SchedulerJob.seed(REAPER_JOB, true);
     when(jobs.findById(REAPER_JOB)).thenReturn(Optional.of(job));
     when(jobs.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
     UUID actor = UUID.randomUUID();
@@ -213,7 +215,7 @@ class SchedulerServiceTest {
   @Test
   @DisplayName("list joins the static catalogue with the persisted rows")
   void listJoinsCatalogueAndRows() {
-    SchedulerJob reaper = SchedulerJob.seed(REAPER_JOB);
+    SchedulerJob reaper = SchedulerJob.seed(REAPER_JOB, true);
     reaper.updateSettings(false, true);
     when(jobs.findAllById(any())).thenReturn(List.of(reaper));
 
@@ -225,10 +227,11 @@ class SchedulerServiceTest {
     assertThat(reaperView.enabled()).isFalse();
     assertThat(reaperView.dryRun()).isTrue();
     assertThat(reaperView.supportsDryRun()).isTrue();
-    // A job with no row defaults to enabled, not dry-run.
+    // A job with no row defaults to its catalogued enabledByDefault, not dry-run.
     SchedulerService.SchedulerJobView tokenView =
         views.stream().filter(v -> v.jobId().equals(TOKEN_JOB)).findFirst().orElseThrow();
     assertThat(tokenView.enabled()).isTrue();
     assertThat(tokenView.dryRun()).isFalse();
   }
+
 }

--- a/qnop-core/src/test/java/io/qnop/service/scheduler/SchedulerServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/scheduler/SchedulerServiceTest.java
@@ -63,6 +63,7 @@ class SchedulerServiceTest {
 
   private static final String TOKEN_JOB = SchedulerJobCatalog.REFRESH_TOKEN_SWEEP;
   private static final String REAPER_JOB = SchedulerJobCatalog.STORAGE_ORPHAN_REAPER;
+  private static final String PURGE_JOB = SchedulerJobCatalog.REVIEW_PURGE;
 
   @Mock private SchedulerJobRepository jobs;
   @Mock private AuditEventRepository auditEvents;
@@ -232,6 +233,75 @@ class SchedulerServiceTest {
         views.stream().filter(v -> v.jobId().equals(TOKEN_JOB)).findFirst().orElseThrow();
     assertThat(tokenView.enabled()).isTrue();
     assertThat(tokenView.dryRun()).isFalse();
+    // …and a disabled-by-default job must not advertise itself as enabled (issue #577).
+    SchedulerService.SchedulerJobView purgeView =
+        views.stream().filter(v -> v.jobId().equals(PURGE_JOB)).findFirst().orElseThrow();
+    assertThat(purgeView.enabled()).isFalse();
   }
 
+  // --- the two catalogue flags of issue #577 -------------------------------
+
+  @Test
+  @DisplayName("a disabled-by-default job with no row is skipped, not run")
+  void disabledByDefaultJobIsSkippedWhenUnseeded() {
+    when(jobs.findById(PURGE_JOB)).thenReturn(Optional.empty());
+    AtomicInteger runs = new AtomicInteger();
+    scheduler.register(PURGE_JOB, dryRun -> runs.incrementAndGet());
+
+    RunOutcome outcome = scheduler.runScheduled(PURGE_JOB);
+
+    // The old "no row ⇒ enabled" fallback would have armed an irreversible purge here.
+    assertThat(outcome).isEqualTo(RunOutcome.SKIPPED_DISABLED);
+    assertThat(runs).hasValue(0);
+  }
+
+  @Test
+  @DisplayName(
+      "fail-open honours the catalogued default: the purge stays off if state is unreadable")
+  void failOpenRespectsDisabledByDefault() {
+    when(jobs.findById(PURGE_JOB)).thenThrow(new IllegalStateException("scheduler_job unreadable"));
+    AtomicInteger runs = new AtomicInteger();
+    scheduler.register(PURGE_JOB, dryRun -> runs.incrementAndGet());
+
+    assertThat(scheduler.runScheduled(PURGE_JOB)).isEqualTo(RunOutcome.SKIPPED_DISABLED);
+    assertThat(runs).hasValue(0);
+  }
+
+  @Test
+  @DisplayName("an admin can enable a disabled-by-default job, and run-now overrides regardless")
+  void disabledByDefaultCanBeEnabledAndRunNow() {
+    when(jobs.findById(PURGE_JOB)).thenReturn(Optional.empty());
+    when(jobs.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    AtomicInteger runs = new AtomicInteger();
+    scheduler.register(PURGE_JOB, dryRun -> runs.incrementAndGet());
+
+    SchedulerService.SchedulerJobView enabled =
+        scheduler.updateSettings(UUID.randomUUID(), PURGE_JOB, true, null);
+    assertThat(enabled.enabled()).isTrue();
+
+    when(lockProvider.lock(any())).thenReturn(Optional.of(() -> {}));
+    scheduler.runNow(UUID.randomUUID(), PURGE_JOB);
+    assertThat(runs).hasValue(1);
+  }
+
+  @Test
+  @DisplayName("a self-transactional job runs outside the gate's transaction")
+  void selfTransactionalJobIsNotWrapped() {
+    when(jobs.findById(TOKEN_JOB)).thenReturn(Optional.of(SchedulerJob.seed(TOKEN_JOB, true)));
+    when(jobs.findById(PURGE_JOB)).thenReturn(Optional.of(SchedulerJob.seed(PURGE_JOB, true)));
+    scheduler.register(TOKEN_JOB, dryRun -> {});
+    scheduler.register(PURGE_JOB, dryRun -> {});
+
+    scheduler.runScheduled(TOKEN_JOB);
+    // A wrapped job costs three transactions: read state, run work, record outcome.
+    verify(transactionManager, times(3)).getTransaction(any());
+
+    reset(transactionManager);
+    when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+
+    scheduler.runScheduled(PURGE_JOB);
+    // The purge costs two — the work itself is invoked with no enclosing transaction (issue #577),
+    // so it can commit per review and delete storage objects between those commits.
+    verify(transactionManager, times(2)).getTransaction(any());
+  }
 }

--- a/qnop-ui/src/components/admin/scheduler/SchedulerJobCard.test.tsx
+++ b/qnop-ui/src/components/admin/scheduler/SchedulerJobCard.test.tsx
@@ -84,6 +84,18 @@ describe('SchedulerJobCard', () => {
     expect(screen.getByText('IllegalStateException: boom')).toBeTruthy();
   });
 
+  it('surfaces the run summary for a successful run too (#577 follow-up)', () => {
+    renderCard({
+      ...BASE,
+      lastOutcome: 'SUCCESS',
+      lastRunAt: '2026-01-01T00:00:00Z',
+      lastDetail: 'Would purge 2 review(s) and 2 storage object(s); nothing was changed',
+    });
+    expect(
+      screen.getByText('— Would purge 2 review(s) and 2 storage object(s); nothing was changed'),
+    ).toBeTruthy();
+  });
+
   it('shows "Never run" when the job has no history', () => {
     renderCard(BASE);
     expect(screen.getByText('Never run')).toBeTruthy();

--- a/qnop-ui/src/components/admin/scheduler/SchedulerJobCard.tsx
+++ b/qnop-ui/src/components/admin/scheduler/SchedulerJobCard.tsx
@@ -127,13 +127,18 @@ export function SchedulerJobCard({
                 {formatRelative(job.lastRunAt)}
               </Typography>
             )}
-            {job.lastOutcome === 'FAILURE' && job.lastDetail && (
+            {job.lastDetail && (
+              // The run's own report (issue #577 follow-up): an error summary in
+              // red mono, a success summary ("Purged 2 review(s)…") as prose.
               <Typography
-                color="error.main"
-                sx={{ fontSize: 12.5, fontFamily: 'ui-monospace, monospace' }}
+                color={job.lastOutcome === 'FAILURE' ? 'error.main' : 'text.secondary'}
+                sx={{
+                  fontSize: 12.5,
+                  fontFamily: job.lastOutcome === 'FAILURE' ? 'ui-monospace, monospace' : undefined,
+                }}
                 title={job.lastDetail}
               >
-                {job.lastDetail}
+                {job.lastOutcome === 'FAILURE' ? job.lastDetail : `— ${job.lastDetail}`}
               </Typography>
             )}
           </Stack>

--- a/qnop-ui/src/utils/auditDetail.test.ts
+++ b/qnop-ui/src/utils/auditDetail.test.ts
@@ -104,6 +104,41 @@ describe('formatAuditDetail', () => {
     expect(formatAuditDetail('annotation.created', '')).toBe('—');
   });
 
+  it('renders a purge run with its counts and the titles that went', () => {
+    // The purged reviews' own audit trail died with them (issue #577), so this row is the only
+    // surviving trace — it must name them, not just count them.
+    expect(
+      formatAuditDetail(
+        'review.purged',
+        '{"reviews":2,"storageObjects":3,"purged":[{"id":"d1","title":"Q3 report"},{"id":"d2","title":"Terms 2024"}]}',
+      ),
+    ).toBe('2 reviews · 3 storage objects · Q3 report, Terms 2024');
+  });
+
+  it('singularises a one-review purge and reports a truncated title list', () => {
+    expect(
+      formatAuditDetail(
+        'review.purged',
+        '{"reviews":1,"storageObjects":1,"purged":[{"id":"d1","title":"Q3 report"}]}',
+      ),
+    ).toBe('1 review · 1 storage object · Q3 report');
+
+    expect(
+      formatAuditDetail(
+        'review.purged',
+        '{"reviews":60,"storageObjects":4,"purged":[{"id":"d1","title":"Q3 report"}],"truncated":59}',
+      ),
+    ).toBe('60 reviews · 4 storage objects · Q3 report +59 more');
+  });
+
+  it('renders a purge that deleted no storage object, and survives a titleless payload', () => {
+    // A review whose binaries are all shared with survivors purges 0 objects — still a real run.
+    expect(formatAuditDetail('review.purged', '{"reviews":1,"storageObjects":0,"purged":[]}')).toBe(
+      '1 review · 0 storage objects',
+    );
+    expect(formatAuditDetail('review.purged', '{}')).toBe('—');
+  });
+
   it('falls back to a compact key: value list for an unknown event shape', () => {
     expect(formatAuditDetail('some.future.event', '{"meta":{"k":1}}')).toBe('meta: {"k":1}');
     expect(formatAuditDetail('some.future.event', '42')).toBe('42');

--- a/qnop-ui/src/utils/auditDetail.ts
+++ b/qnop-ui/src/utils/auditDetail.ts
@@ -34,6 +34,35 @@ function transitionSide(value: unknown): string {
   return value === null || value === undefined ? EM_DASH : humanizeWorkflowState(String(value));
 }
 
+/**
+ * Renders a purge run (issue #577): the counts, then the titles that went. This
+ * is the only surviving trace of those reviews — their own audit trail was
+ * deleted with them — so the titles are shown, not just how many.
+ */
+function purgeSummary(obj: Record<string, unknown>): string {
+  const reviews = typeof obj.reviews === 'number' ? obj.reviews : null;
+  const objects = typeof obj.storageObjects === 'number' ? obj.storageObjects : null;
+  const titles = Array.isArray(obj.purged)
+    ? obj.purged
+        .map((entry) =>
+          entry !== null && typeof entry === 'object'
+            ? (entry as Record<string, unknown>).title
+            : null,
+        )
+        .filter((title): title is string => typeof title === 'string' && title.length > 0)
+    : [];
+
+  const bits: string[] = [];
+  if (reviews !== null) bits.push(`${reviews} review${reviews === 1 ? '' : 's'}`);
+  if (objects !== null) bits.push(`${objects} storage object${objects === 1 ? '' : 's'}`);
+  const truncated = typeof obj.truncated === 'number' ? obj.truncated : 0;
+  if (titles.length > 0) {
+    const listed = titles.join(', ');
+    bits.push(truncated > 0 ? `${listed} +${truncated} more` : listed);
+  }
+  return bits.length > 0 ? bits.join(' · ') : EM_DASH;
+}
+
 function dueDateChange(from: unknown, to: unknown, formatDate: (iso: string) => string): string {
   const before = from === null || from === undefined ? null : formatDate(String(from));
   const after = to === null || to === undefined ? null : formatDate(String(to));
@@ -120,6 +149,8 @@ export function formatAuditDetail(
       return obj.outcome !== null && obj.outcome !== undefined
         ? `Was ${humanizeWorkflowState(String(obj.outcome))}`
         : EM_DASH;
+    case 'review.purged':
+      return purgeSummary(obj);
     default:
       break;
   }

--- a/qnop-ui/src/utils/auditEvents.test.ts
+++ b/qnop-ui/src/utils/auditEvents.test.ts
@@ -66,6 +66,15 @@ describe('auditEventMeta', () => {
     expect(auditEventMeta('scheduler.job.updated').label).toBe('Scheduler job updated');
   });
 
+  it('knows the review lifecycle, and flags the irreversible purge in red', () => {
+    expect(AUDIT_EVENT_TYPES).toEqual(
+      expect.arrayContaining(['review.archived', 'review.unarchived', 'review.purged']),
+    );
+    // The purge destroys data irreversibly (issue #577), so it must not read as routine upkeep.
+    expect(auditEventMeta('review.purged').tone).toBe('red');
+    expect(auditEventMeta('review.archived').tone).toBe('neutral');
+  });
+
   it('falls back to the raw type and a neutral tone for an unknown event', () => {
     const meta = auditEventMeta('some.future.event');
     expect(meta.label).toBe('some.future.event');

--- a/qnop-ui/src/utils/auditEvents.ts
+++ b/qnop-ui/src/utils/auditEvents.ts
@@ -143,6 +143,12 @@ export const AUDIT_EVENT_META: Record<string, AuditEventMeta> = {
     description: 'An owner or admin restored an archived review to the active lists (issue #576).',
     tone: 'blue',
   },
+  'review.purged': {
+    label: 'Reviews purged',
+    description:
+      'Archived reviews passed the purge retention window and were deleted permanently, including storage objects no other document referenced (issue #577). This is the only surviving record of them — their own audit trail was deleted with them; the details list what went.',
+    tone: 'red',
+  },
 };
 
 /** The event types in a sensible display order — drives the filter and the legend. */


### PR DESCRIPTION
Closes #577. Follows #576 (PR #609), which archives long-closed reviews out of the active lists.

That was a half-lifecycle: cold records accumulate forever, storage costs accrue, and a retention policy that never deletes is not a policy. This closes it — after `review.purge_archived_after_days` an archived review is deleted **permanently and irreversibly**, DB aggregate and object storage alike.

## The substance: shared storage objects

Keys are content-addressed and deduplicated instance-wide (ADR-0005/0036), so the same object can back versions or attachments of **other** documents — two teams uploading the identical PDF get one object. Deleting a purged review's keys naively would break surviving documents.

A key is therefore deleted only after proving no surviving row references it, across `document_version` **and** `document_attachment` — reusing #523's `findVersionRefsByStorageKeyIn` / `findAttachmentRefsByStorageKeyIn` rather than new queries, batched over the whole key set. The check runs **after** the aggregate commit, which is what makes it correct: the purged document's own rows are already gone and cannot make a key look shared.

## The other decisions

**Double opt-in.** Retention defaults to `180` (`0` disables, mirroring #576) **and** the `reviewPurge` job ships **disabled**. Nothing is destroyed until an operator deliberately enables it on `/admin/scheduler`. Dry-run reports the reviews *and* the genuinely exclusive objects.

**DB first, storage second — the crash-safety contract.** A crash in between leaves an unreferenced object: harmless, and #523's consistency scan sweeps it. The reverse order would recreate the #575 hole of rows referencing vanished objects.

**One transaction per review**, so an interrupted run leaves reviews either untouched or completely gone. Eligibility is re-checked *inside* that transaction rather than trusted from the batch read, so a review unarchived in between is spared.

**One SYSTEM `review.purged` audit event per run**, carrying counts, ids **and titles**. The per-document trail cascades away with the document, so this is the only surviving answer to "where did that review go?" — which is why it names the reviews rather than just counting them. The audit UI renders it in red; it must not read as routine upkeep.

**No schema change.** `archived_at` already exists from #576; changeset 0028 only seeds the setting. The admin settings page needs no work either — it groups by key prefix and already has a `review` group.

## The scheduler gate needed two flags (ADR-0045 amended)

The catalogue could not express what this job needs, so `SchedulerJobDefinition` gains two components — all six existing jobs keep today's behaviour:

- **`enabledByDefault`** — the purge is the first `false`. This also **corrects "fail-open"**: the gate now falls open to the catalogue's default rather than to an unconditional yes, in *every* place that assumed "no row ⇒ enabled". Beyond the two in `readState` there were two more: `SchedulerJobBootstrap` (seeds at start-up) and the dashboard's `viewOf`, which would otherwise have advertised the disabled purge as enabled. Failing open into an irreversible delete is not fail-safe.
- **`selfTransactional`** — the gate normally wraps the work in one transaction; a `true` job is invoked with none and opens its own. Wrapping the purge would defer every per-review commit to the end of the run and defeat the point.

## Deliberately out of scope

- **Manual "purge now"** for owners/admins. #576 shipped manual archive/unarchive because archiving is reversible; a one-click irreversible destructor deserves its own confirmation UX and its own issue.
- **Stale `job` queue rows.** The queue (ADR-0033) carries document ids inside its jsonb `payload` and has no FK to `document`, so a purge cannot be blocked by it — but a queued job for a purged review is left behind. A review archived ≥180 days has no in-flight extraction work in practice; recorded in ADR-0050 as an accepted gap rather than solved speculatively.

## Run summaries on the dashboard (follow-up commit)

Manual testing surfaced a gap: a dry run reported its counts only to the server log — the dashboard showed a green Success pill and nothing else, because the gate recorded only a `"dry-run"` marker and the job card rendered `lastDetail` exclusively for failures. Now `SchedulerWork` returns a one-line summary the gate clamps and records as the run's detail ("Would purge 2 review(s) and 2 storage object(s); nothing was changed"), the purge/archive/reaper report every path (disabled / dry-run / nothing eligible / done), and the card shows the detail on success as prose while keeping the red mono treatment for failures. The manual-run audit event derives its `dryRun` flag from the actual flag instead of comparing against the sentinel string. A persistent per-run history built on these summaries is filed as #617.

## Test plan

- [x] `./gradlew clean build --no-build-cache` on the merged state → **1280 tests, 0 failures** (189 classes, all Testcontainers ITs)
- [x] **`ReviewPurgeApiIT`** (10 cases, real Postgres + MinIO) — the shared-key case the issue asks for: two documents staged from *identical* content dedupe to one key, one is purged, the object **and** its registry row survive and the other document still serves its binary; the same via an attachment. Plus the exclusive-key case (object and registry row gone), the aggregate leaving no orphan row in any review table, the retention window and its runtime change through `PATCH /admin/settings`, `0` disabling purging, the dry run destroying nothing, the disabled-by-default job skipping a scheduled tick while run-now still overrides, and the surviving SYSTEM audit row.
- [x] **`ReviewPurgeServiceTest`** (15 DB-free cases) — the kill switches, the dry run's zero side effects, shared vs. exclusive vs. mixed keys, the three eligibility re-check paths, the batch bound, and JSON escaping of a title containing quotes.
- [x] **`SchedulerServiceTest`** +4 — a disabled-by-default job skipped when unseeded, fail-open honouring that default, enabling it and run-now overriding, and a self-transactional job costing two transactions instead of three.
- [x] Frontend on the merged state: 1109 tests, `tsc -b --noEmit`, `eslint`, `prettier --check` — all green.

### Notes for the reviewer

**Two defects I found in my own first cut**, both now covered by tests, in case they shape how you read the diff:

1. The batch is read in one transaction and purged one review at a time — so a review unarchived in between would have been deleted anyway. For an irreversible operation that is not acceptable, hence the re-check inside the per-review transaction.
2. The dry run originally issued one reference query per key. It now uses two batched queries, like the real path.

**A local build trap unrelated to this PR.** `qnop-spi:spotlessJavaCheck` fails with `NoClassDefFoundError: com/google/common/collect/ImmutableCollection` after several builds in one Gradle daemon — a corrupted daemon classloader, not a style violation (the `openApiGenerate` metaspace warning in the same log is the likely cause). `./gradlew --stop` and rebuild clears it. Worth its own issue alongside #610 if it bites anyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 5) via Claude Code

