### PR TITLE
fix(build): treat a blank SIGNING_KEY as no key (#624)

### DIFF
--- a/build-logic/src/main/kotlin/qnop.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/qnop.publish-conventions.gradle.kts
@@ -93,8 +93,14 @@ publishing {
 // signing is not required and no signature tasks are wired — GitHub Packages
 // does not mandate signatures, so an unsigned SNAPSHOT publish stays frictionless.
 signing {
-    val signingKey = providers.environmentVariable("SIGNING_KEY").orNull
-    val signingPassword = providers.environmentVariable("SIGNING_PASSWORD").orNull
+    // "No key configured" means BLANK, not null (issue #624): GitHub Actions
+    // always defines an env var it maps from a secret, so an undefined secret
+    // arrives as the empty string — never as an absent variable. Deciding on
+    // null alone armed signing with an unusable key on a release without the
+    // secret and failed the run with "Could not read PGP secret key".
+    val signingKey = providers.environmentVariable("SIGNING_KEY").orNull?.takeIf { it.isNotBlank() }
+    val signingPassword =
+        providers.environmentVariable("SIGNING_PASSWORD").orNull?.takeIf { it.isNotBlank() }
     isRequired = signingKey != null
     if (signingKey != null) {
         useInMemoryPgpKeys(signingKey, signingPassword)


### PR DESCRIPTION
Closes #624. Unblocks the failed `v1.1.0` release ([run 30289478230](https://github.com/qnophq/qnop/actions/runs/30289478230/job/90055428111)).

## The bug

`qnop.publish-conventions` makes PGP signing opt-in and decides on `null`:

```kotlin
val signingKey = providers.environmentVariable("SIGNING_KEY").orNull
isRequired = signingKey != null
```

**GitHub Actions never passes "absent".** A secret that does not exist expands to the empty string, so `release.yml` exports `SIGNING_KEY=""`; `.orNull` yields `""`, which is not `null`, and signing is armed with an unusable key:

```
Execution failed for task ':qnop-spi:signMavenPublication'
> Could not read PGP secret key
```

The step sits before the image build, the GitHub Release and the jar upload, so **the entire release stops** — of `v1.1.0` only the tag exists.

**Why it surfaced now:** the publish step and this convention plugin landed in de89c115 (#497, ADR-0046) on 2026-07-22, after `v1.0.0` (2026-07-19). `v1.1.0` is the first release to reach the step. `publish-snapshot.yml` never passes `SIGNING_*`, so snapshots were never affected. A diff of `release.yml` between the two tags confirms the publish step is the only addition besides Renovate action bumps — no second untested step behind it.

## The change

Blank counts as absent, so the documented opt-in behaves as documented. An installation without the secret publishes unsigned (GitHub Packages does not mandate signatures); a configured key still signs. Configuring `SIGNING_KEY`/`SIGNING_PASSWORD` remains the orthogonal path to signed artifacts.

## Test plan

Both directions verified locally:

- [x] `SIGNING_KEY=""` (the CI case) — `signMavenPublication` is no longer registered; the `publish` task graph contains only the three publish tasks. Before the fix this exact env reproduced `Could not read PGP secret key`.
- [x] `SIGNING_KEY` unset — unchanged (no signing tasks)
- [x] Real key — an ephemeral PGP key still produces `qnop-spi-*.jar.asc`, `*-sources.jar.asc`, `*-javadoc.jar.asc`
- [x] `spotlessCheck` + `:build-logic:compileKotlin` green

## Releasing 1.1.0 after this merges

Nothing of `v1.1.0` was published, so the version is free to reuse: delete the `v1.1.0` tag (Prepare Release refuses while it exists), then run **Prepare Release** with `release_version=1.1.0` / `next_version=1.2.0-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Fable 5) via Claude Code
