### PR TITLE
chore(testdata): dev-only generator for a realistic notification backlog (#633)

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -31,9 +31,10 @@ testdata/
 │   └── not-an-image.txt      # plain text — must be rejected as an unsupported type (415)
 ├── db/                       # deterministic SQL fixtures (issue #163)
 │   ├── clean.sql             # wipes the seeded tables to a known-empty slate
-│   └── seed.sql              # the shared seeded dataset (users, teams, OIDC provider,
-│                             # Mailpit SMTP settings; issue #401 adds a 20-user crowd
-│                             # and 5 department teams for manual testing)
+│   ├── seed.sql              # the shared seeded dataset (users, teams, OIDC provider,
+│   │                         # Mailpit SMTP settings; issue #401 adds a 20-user crowd
+│   │                         # and 5 department teams for manual testing)
+│   └── demo-notifications.sql # OPTIONAL, dev-only: fills the in-app inboxes (issue #633)
 └── documents/                # review document payloads (issues #308, #370)
     ├── sample.pdf            # minimal valid single-page PDF, text "QNOP SMOKE TEST"
     ├── doc1/                 # multi-version dummy: test-dummy-v1..v5.pdf (1 page each)
@@ -63,6 +64,39 @@ the smoke's multi-version/diff steps:
   near-duplicate → **ORPHANED**. v3 prepends a preamble that shifts the whole
   document once more, so placed (and freshly re-attached) annotations go
   MOVED again for a second round.
+
+### `demo-notifications.sql` — dev only, never loaded by tests
+
+The in-app inbox (issue #538) cannot be judged on three rows: row density, the
+read/unread balance, paging and the relative timestamps only show their problems
+once an inbox holds a realistic backlog. This script produces one — roughly 130
+notifications per eligible inbox, spread over twelve weeks.
+
+It is deliberately **not** part of `seed.sql`. The seeded integration tests load
+that file on every test and assert exact counts, so hundreds of extra rows would
+both slow the suite and break those assertions. Run it by hand against a seeded
+dev database:
+
+```bash
+PGPASSWORD=qnop psql -h 127.0.0.1 -U qnop -d qnop -f testdata/db/demo-notifications.sql
+```
+
+It is additive and repeatable — each run appends another batch; `DELETE FROM
+notification;` starts over. Two properties are what make the output usable
+rather than merely numerous, and both are easy to lose when editing it:
+
+- **Every row points at a review its recipient may really see** (owner, direct
+  participant, or via a team — the three paths `DocumentAccessService` uses).
+  The detail view re-checks visibility and renders a tombstone otherwise, so a
+  naive cross join yields an inbox of *"A review you no longer have access to"*.
+- **Annotation- and comment-shaped types reuse the real annotation and comment
+  ids** of their document, so the deep links land somewhere.
+
+Everything stays inside the default retention window (`notifications.retain_days`
+= 90, issue #626) so the `notificationSweep` job does not quietly eat the demo
+data on its next run. Users with no visible review are skipped rather than being
+added to review circles to manufacture visibility — silently rewriting the
+seeded participation would corrupt other manual test scenarios.
 
 The seed's role/state users (`admin`, `member`, `auditor`, …) are pinned by
 `SeededAdminUsersIT`/`SeededTeamIT` — keep their rows and the Alpha/Beta teams

--- a/testdata/db/demo-notifications.sql
+++ b/testdata/db/demo-notifications.sql
@@ -1,0 +1,166 @@
+-- Copyright (c) 2026-present devtank42 GmbH
+-- SPDX-License-Identifier: AGPL-3.0-only
+--
+-- Fills the in-app inboxes (issue #538) with a realistic backlog for manual
+-- testing: ~130 notifications per user, spread over the last twelve weeks,
+-- varied in type, mostly read with a recent unread head.
+--
+-- DEV ONLY, and deliberately NOT part of seed.sql: the integration tests load
+-- clean.sql + seed.sql and assert exact counts, so thousands of rows there
+-- would slow every seeded IT and break those assertions. Run it by hand:
+--
+--   PGPASSWORD=qnop psql -h 127.0.0.1 -U qnop -d qnop -f testdata/db/demo-notifications.sql
+--
+-- It is additive and repeatable — each run appends another batch. To start over:
+--   DELETE FROM notification;
+--
+-- Two properties make the result actually usable rather than merely numerous:
+--
+--   * Every row points at a review its recipient may really see (owner, direct
+--     participant or via a team). The detail view re-checks visibility and
+--     renders a tombstone otherwise, so a naive cross join would produce an
+--     inbox of "A review you no longer have access to".
+--   * Annotation- and comment-shaped types reuse the REAL annotation and
+--     comment ids of their document, so the deep links land somewhere.
+--
+-- Everything stays inside the default retention window (notifications.retain_days
+-- = 90, issue #626) so the notificationSweep job does not quietly eat the demo
+-- data on its next run.
+
+WITH
+  -- Who may see which review — the same three paths DocumentAccessService uses.
+  visible AS (
+    SELECT owner_id AS recipient_id, id AS document_id FROM document
+    UNION
+    SELECT p.user_id, p.document_id
+      FROM review_participant p
+     WHERE p.user_id IS NOT NULL
+    UNION
+    SELECT tm.user_id, p.document_id
+      FROM review_participant p
+      JOIN team_membership tm ON tm.team_id = p.team_id
+     WHERE p.team_id IS NOT NULL
+  ),
+  ranked AS (
+    SELECT v.recipient_id,
+           v.document_id,
+           row_number() OVER (PARTITION BY v.recipient_id ORDER BY v.document_id) - 1 AS doc_idx,
+           count(*)     OVER (PARTITION BY v.recipient_id)                          AS doc_count
+      FROM visible v
+      JOIN qnop_user u ON u.id = v.recipient_id AND u.enabled
+  ),
+  recipients AS (
+    SELECT DISTINCT recipient_id, doc_count FROM ranked
+  ),
+  -- 130 per recipient, cycling through the reviews they can see.
+  gen AS (
+    SELECT r.recipient_id, r.doc_count, g.n
+      FROM recipients r
+      CROSS JOIN generate_series(1, 130) AS g(n)
+  ),
+  -- One quotable line per row; the pool is small on purpose, real inboxes repeat.
+  lines AS (
+    SELECT * FROM (VALUES
+      (0,  'The liability cap in section 7 contradicts the indemnity clause.'),
+      (1,  'Can we align this wording with the master agreement?'),
+      (2,  'This paragraph still refers to the previous vendor.'),
+      (3,  'Numbers here do not add up against the appendix.'),
+      (4,  'Suggest dropping this sentence entirely — it repeats §2.'),
+      (5,  'Please confirm the effective date before we sign off.'),
+      (6,  'Typo: "notwithstanding" is misspelled twice on this page.'),
+      (7,  'Is this clause still required after the scope change?'),
+      (8,  'The termination notice period differs from what we agreed.'),
+      (9,  'Good catch — I have reworded it in the new version.'),
+      (10, 'Legal asked for a stricter formulation here.'),
+      (11, 'This table lost its header in the last export.')
+    ) AS t(idx, body)
+  )
+INSERT INTO notification (
+  id, recipient_id, type, actor_id, document_id, annotation_id, comment_id,
+  excerpt, decision, version_number, from_state, to_state, read_at, created_at
+)
+SELECT
+  gen_random_uuid(),
+  gen.recipient_id,
+  kind.type,
+  actor.id,
+  ranked.document_id,
+  CASE WHEN kind.type IN ('MENTION', 'COMMENT_ADDED', 'ANNOTATION_CREATED', 'ANNOTATION_DECIDED')
+       THEN anno.id END,
+  CASE WHEN kind.type IN ('MENTION', 'COMMENT_ADDED') THEN cmt.id END,
+  CASE WHEN kind.type IN ('MENTION', 'COMMENT_ADDED', 'ANNOTATION_CREATED', 'ANNOTATION_DECIDED')
+       THEN lines.body END,
+  CASE kind.type WHEN 'ANNOTATION_DECIDED'
+       THEN (ARRAY['resolved', 'reopened', 'dismissed'])[1 + (gen.n % 3)] END,
+  CASE kind.type WHEN 'VERSION_UPLOADED' THEN 2 + (gen.n % 4) END,
+  CASE kind.type WHEN 'WORKFLOW_CHANGED'
+       THEN (ARRAY['DRAFT', 'IN_REVIEW', 'CHANGES_REQUESTED'])[1 + (gen.n % 3)] END,
+  CASE kind.type WHEN 'WORKFLOW_CHANGED'
+       THEN (ARRAY['IN_REVIEW', 'CHANGES_REQUESTED', 'FINALIZED'])[1 + (gen.n % 3)] END,
+  -- Unread is the recent head plus the odd older one somebody skipped.
+  CASE WHEN gen.n <= 28 OR (gen.n % 23) = 0
+       THEN NULL
+       ELSE stamp.at + interval '3 hours' END,
+  stamp.at
+FROM gen
+JOIN ranked
+  ON ranked.recipient_id = gen.recipient_id
+ AND ranked.doc_idx = gen.n % gen.doc_count
+-- n = 1 is the newest; older rows fan out across twelve weeks.
+CROSS JOIN LATERAL (
+  SELECT now()
+         - (interval '84 days' * gen.n / 130.0)
+         - (interval '1 minute' * ((gen.n * 37) % 1440)) AS at
+) AS stamp
+-- A weighted type mix: conversation dominates, invitations are rare.
+CROSS JOIN LATERAL (
+  SELECT CASE
+           WHEN gen.n % 20 < 7  THEN 'COMMENT_ADDED'
+           WHEN gen.n % 20 < 11 THEN 'ANNOTATION_CREATED'
+           WHEN gen.n % 20 < 14 THEN 'MENTION'
+           WHEN gen.n % 20 < 16 THEN 'ANNOTATION_DECIDED'
+           WHEN gen.n % 20 < 18 THEN 'VERSION_UPLOADED'
+           WHEN gen.n % 20 < 19 THEN 'WORKFLOW_CHANGED'
+           ELSE 'PARTICIPANT_ADDED'
+         END AS type
+) AS kind
+JOIN lines ON lines.idx = gen.n % 12
+-- Somebody from the review's own circle, never the recipient themselves.
+CROSS JOIN LATERAL (
+  SELECT c.id
+    FROM (
+      SELECT d.owner_id AS id FROM document d WHERE d.id = ranked.document_id
+      UNION
+      SELECT p.user_id FROM review_participant p
+       WHERE p.document_id = ranked.document_id AND p.user_id IS NOT NULL
+    ) AS c
+   WHERE c.id <> gen.recipient_id
+   ORDER BY md5(c.id::text || gen.n::text)
+   LIMIT 1
+) AS actor
+-- Real ids where the document has them, so the deep links resolve.
+LEFT JOIN LATERAL (
+  SELECT a.id FROM annotation a
+   WHERE a.document_id = ranked.document_id
+   ORDER BY a.created_at
+   LIMIT 1
+) AS anno ON true
+LEFT JOIN LATERAL (
+  SELECT c.id FROM comment c
+    JOIN annotation a ON a.id = c.annotation_id
+   WHERE a.document_id = ranked.document_id
+   ORDER BY c.created_at
+   LIMIT 1
+) AS cmt ON true;
+
+-- What landed, per inbox.
+SELECT u.display_name,
+       count(*)                                    AS total,
+       count(*) FILTER (WHERE n.read_at IS NULL)   AS unread,
+       count(DISTINCT n.type)                      AS types,
+       min(n.created_at)::date                     AS oldest,
+       max(n.created_at)::date                     AS newest
+  FROM notification n
+  JOIN qnop_user u ON u.id = n.recipient_id
+ GROUP BY u.display_name
+ ORDER BY u.display_name;


### PR DESCRIPTION
Closes #633.

Adds `testdata/db/demo-notifications.sql`: an optional, dev-only script that fills the in-app inboxes with ~130 notifications each, spread over twelve weeks.

## Why it is not in `seed.sql`

The seeded integration tests load `seed.sql` on **every** test and assert exact counts (`ApplicationSettingKeyTest`, `AdminSettingsControllerIT`, `NotificationInboxIT`, …). Hundreds of extra rows there would both slow the suite and break those assertions. Nothing in the harness references this file; it is run by hand:

```bash
PGPASSWORD=qnop psql -h 127.0.0.1 -U qnop -d qnop -f testdata/db/demo-notifications.sql
```

## Why it needed writing at all

The inbox (#538) cannot be judged on three rows. The columnar row layout that shipped with #626 only became obviously necessary once ~135 notifications sat in one list — at that volume the stacked row was 104px tall and showed six per screen.

## The two properties that make it usable rather than merely numerous

Both are easy to lose when editing it, so both are commented in the file and the README:

1. **Every row points at a review its recipient may really see** — owner, direct participant or via a team, the same three paths `DocumentAccessService` uses. The detail view re-checks visibility and renders a tombstone otherwise, so a naive cross join produces an inbox full of *"A review you no longer have access to"*.
2. **Annotation- and comment-shaped types reuse the real annotation and comment ids** of their document, so the deep links land somewhere instead of 404-ing.

Beyond that: a weighted type mix (conversation dominates, invitations are rare), an unread head plus the odd skipped older one, per-type payloads (excerpt, decision, version number, state transition), and an actor drawn from the review's own circle who is never the recipient.

Everything stays inside the default retention window (`notifications.retain_days` = 90, #626) so `notificationSweep` does not quietly eat the demo data on its next run. Users with no visible review are **skipped** rather than added to review circles to manufacture visibility — silently rewriting the seeded participation would corrupt other manual test scenarios.

## Test plan

Run against the seeded dev database, then verified in SQL across all 799 rows:

| check | result |
|---|---|
| rows whose review the recipient cannot see | **0** |
| dangling `annotation_id` | **0** |
| dangling `comment_id` | **0** |
| rows outside the 90-day retention window | **0** |

- [x] Six inboxes at 130–135 notifications, ~32–37 unread each, all seven types, spread evenly across twelve weeks (~10/week)
- [x] Rendered through the API: 0 `accessible=false`, 0 missing `actorSlug`, 0 missing `actionPath`
- [x] Verified in the browser — avatars, hover cards, deep links and the type crests all resolve
- [x] Script is additive and repeatable; the header documents `DELETE FROM notification;` as the reset

No production code changes; the seeded integration tests are untouched by its existence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 5) via Claude Code
