### PR TITLE
feat(review): export review annotations to Excel (#547)

### DIFF
--- a/docs/adr/0052-annotation-xlsx-export.md
+++ b/docs/adr/0052-annotation-xlsx-export.md
@@ -1,0 +1,61 @@
+# ADR-0052: Exporting annotations to Excel — server-side, in reading order
+
+- **Status:** Accepted
+- **Date:** 2026-07-28
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+Annotations only ever existed inside qnop — as a board and a list on the Tasks workspace (issue #547). Both are good for *working* a review and poor for reporting it: handing findings to someone without an account, filtering a few hundred rows, or archiving the outcome of a sign-off. A spreadsheet is the universal format for exactly that.
+
+Three properties of the existing model shape the decision.
+
+1. **Author names are not a property of an author.** Under per-review anonymity (ADR-0038) the same person is a real name to the owner and `Participant 2` to a peer, and `AnnotationService.list` already resolves that per caller while also dropping PRIVATE threads the caller may not see.
+2. **Annotations have no position.** They are deliberately position-free (ADR-0009): identity and status are version-independent, and the physical location lives in the placement's opaque `jsonb` anchor. Nothing in qnop sorts by document position, and nothing can — there is no column to `ORDER BY`.
+3. **Binary responses are already outside the contract.** `DocumentContentController.downloadOriginal` and `DocumentAttachmentController.serve` are plain controllers by design (ADR-0028); `openapi.yaml` describes JSON exclusively.
+
+## Decision
+
+**Generate the workbook on the server, from the same read path the Tasks page uses, sorted into document reading order, and stream it from a plain controller outside the OpenAPI contract.**
+
+### Server-side, and specifically through `AnnotationService.list`
+
+The alternative — generating the sheet in the browser from the `AnnotationView[]` the Tasks page already holds — was rejected. It would add an `xlsx`/`exceljs` frontend dependency, and it would only ever export the rows currently loaded and filtered. But the deciding reason is privacy: it moves the rendering of identity-bearing data into the client. The frontend only holds already-resolved names, so no leak follows immediately — yet "anonymity that only lives in the frontend is none", and an export is precisely the artifact that outlives the session and gets forwarded.
+
+Building on `list()` rather than on the repository means visibility filtering and identity resolution are inherited **by construction**: there is no code path in the exporter that could forget them.
+
+### Reading order is new behaviour, computed in memory
+
+Rows are sorted by page (`region.surfaceIndex`), then top to bottom (`box.y`), then left to right (`box.x`), then the text offset where a text layer exists, with creation time and id as a stable tail so an unchanged review exports identically twice. Because the anchor is opaque `jsonb`, this is parsed and sorted after loading — `AnnotationPosition` — not expressed in JPQL.
+
+The parser is deliberately forgiving: the anchor format is open by design (ADR-0009 — a region-only image anchor carries no text layer, future formats may add fields), so anything unreadable yields `UNPLACED` and sorts last rather than throwing. One odd anchor must not cost the whole export.
+
+**The version has to be resolved, not defaulted to null.** `list()` only loads placements for a concrete version; without one every anchor comes back empty and the reading order silently collapses into creation order. The exporter therefore resolves the latest version exactly as the Tasks page does.
+
+### Task keys keep creation order
+
+The `#` column carries the `T-1`, `T-2`, … shorthand people use to talk about annotations, and it is assigned in **creation** order — not in the export's reading order — because the key has to agree with the board the user has been looking at. That rule now exists twice, in `tasksModel.taskKeys()` and in the exporter; both are named and tested, and the duplication is the price of putting the key in the sheet at all.
+
+Two columns from the original proposal were dropped rather than duplicated further: a *Board column* (`Open`/`In discussion`/`Resolved`) is a pure derivation of two columns already in the sheet and Excel can filter it itself, and a *Position* ordinal would be identical to the row number while the sheet is in its default order and misleading the moment the user re-sorts.
+
+### A plain controller, not the generated contract
+
+`GET /api/v1/documents/{documentId}/annotations/export` mirrors the existing binary downloads: a hand-written `@RestController`, `Content-Disposition: attachment`, deliberately absent from `openapi.yaml` (ADR-0028/0021). Unlike a version download it carries no ETag — annotations change constantly and there is no content hash to hang one on.
+
+## Consequences
+
+**Positive.** One canonical, authorized, privacy-correct artifact. The export cannot show more than its caller may see, and an anonymous review cannot leak a real name into a file that gets e-mailed onward. Cells are typed (numbers as numbers, timestamps as Excel dates) with a frozen header and auto-filter, so Excel's own sorting works without any post-processing.
+
+**Negative.** `poi-ooxml` enters the runtime classpath of `qnop-core` — the first Office-format dependency, previously only pinned. The `T-N` rule now lives in two places. Generation is synchronous: a review with very many annotations occupies a request thread for the duration, mitigated by the streaming `SXSSFWorkbook` but not eliminated; an async job would be the answer if that ever becomes real.
+
+**Neutral.** The endpoint is invisible to the generated client, so the frontend calls it through the shared axios instance by hand — a bare `<a href>` would carry no bearer token.
+
+## Related
+
+- **ADR-0038** — per-review privacy; the resolution this export inherits rather than repeats
+- **ADR-0009** — the anchor model the reading order is parsed out of
+- **ADR-0011** — the workflow whose `AnnotationStatus` the sheet reports
+- **ADR-0028** — binary downloads as plain controllers outside the contract
+- **ADR-0021 / ADR-0015** — OpenAPI-first, and why this endpoint is the deliberate exception
+- **ADR-0004** — the layering that puts the workbook in the service and leaves the controller streaming
+- Issue **#547**

--- a/docs/adr/0052-annotation-xlsx-export.md
+++ b/docs/adr/0052-annotation-xlsx-export.md
@@ -38,6 +38,14 @@ The `#` column carries the `T-1`, `T-2`, … shorthand people use to talk about 
 
 Two columns from the original proposal were dropped rather than duplicated further: a *Board column* (`Open`/`In discussion`/`Resolved`) is a pure derivation of two columns already in the sheet and Excel can filter it itself, and a *Position* ordinal would be identical to the row number while the sheet is in its default order and misleading the moment the user re-sorts.
 
+### Comment threads become a second sheet, off the wire unless asked for
+
+An annotation's thread has no fixed length, so it cannot become columns on the annotation row, and folding a whole conversation into one cell would be neither sortable nor readable. The threads therefore go on their own `Comments` sheet, one row per comment (`#`, `Author`, `Written`, `Comment`), keyed back to the annotation by the same `T-N` shorthand — a relational shape is what a spreadsheet is actually good at.
+
+The rows are read through `AnnotationService.listComments`, for the same reason the annotation rows go through `list`: it applies the PRIVATE-thread visibility check and resolves every author through `ReviewIdentityResolver`, so a pseudonymised reviewer stays pseudonymised in the export by construction. The owner is the one identity that stays real — anonymity never covered them, since it is their review.
+
+That costs one query round per annotation. It is accepted rather than batched: an export is a rare, deliberate action, and re-implementing the visibility rules to avoid the round trips would trade a bounded cost for an unbounded correctness risk. The sheet is opt-in on the wire (`?comments=true`) so an export that does not want it does not pay for it — but the wizard defaults it on, because someone exporting a review usually wants what was said, not just that something was said.
+
 ### A plain controller, not the generated contract
 
 `GET /api/v1/documents/{documentId}/annotations/export` mirrors the existing binary downloads: a hand-written `@RestController`, `Content-Disposition: attachment`, deliberately absent from `openapi.yaml` (ADR-0028/0021). Unlike a version download it carries no ETag — annotations change constantly and there is no content hash to hang one on.
@@ -46,7 +54,7 @@ Two columns from the original proposal were dropped rather than duplicated furth
 
 **Positive.** One canonical, authorized, privacy-correct artifact. The export cannot show more than its caller may see, and an anonymous review cannot leak a real name into a file that gets e-mailed onward. Cells are typed (numbers as numbers, timestamps as Excel dates) with a frozen header and auto-filter, so Excel's own sorting works without any post-processing.
 
-**Negative.** `poi-ooxml` enters the runtime classpath of `qnop-core` — the first Office-format dependency, previously only pinned. The `T-N` rule now lives in two places. Generation is synchronous: a review with very many annotations occupies a request thread for the duration, mitigated by the streaming `SXSSFWorkbook` but not eliminated; an async job would be the answer if that ever becomes real.
+**Negative.** The comment sheet is N+1 by construction (see above). `poi-ooxml` enters the runtime classpath of `qnop-core` — the first Office-format dependency, previously only pinned. The `T-N` rule now lives in two places. Generation is synchronous: a review with very many annotations occupies a request thread for the duration, mitigated by the streaming `SXSSFWorkbook` but not eliminated; an async job would be the answer if that ever becomes real.
 
 **Neutral.** The endpoint is invisible to the generated client, so the frontend calls it through the shared axios instance by hand — a bare `<a href>` would carry no bearer token.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ javaDiffUtils = "4.15"
 
 # --- Pinned for later phases (NOT yet applied) -------------------------
 pdfbox = "3.0.8"            # PDF text extraction with glyph positions
-poi = "5.4.1"              # .docx structural extraction (XWPF)
+poi = "5.4.1"              # XLSX writing (issue #547); .docx extraction (XWPF) later
 
 [libraries]
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit" }
@@ -93,6 +93,7 @@ jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations
 jackson3-databind = { module = "tools.jackson.core:jackson-databind" }
 # PDF text extraction with glyph positions (ADR-0032, issue #245).
 pdfbox = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfbox" }
+poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
 swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swaggerAnnotations" }
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version.ref = "jakartaValidation" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakartaAnnotation" }

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -160,5 +160,7 @@ dependencies {
     // The document-ingest ITs (issue #245) generate their PDF fixtures with PDFBox
     // instead of committing binary blobs.
     testImplementation(libs.pdfbox)
+    // Reads the generated workbook back to assert its contents (issue #547).
+    testImplementation(libs.poi.ooxml)
     testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationExportController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationExportController.java
@@ -66,12 +66,16 @@ public class AnnotationExportController {
       @RequestParam(value = "version", required = false) Integer version,
       // Repeated or comma-separated; empty means every column (the wizard's default).
       @RequestParam(value = "fields", required = false) List<String> fields,
-      @RequestParam(value = "scope", required = false, defaultValue = "all") String scope) {
+      @RequestParam(value = "scope", required = false, defaultValue = "all") String scope,
+      // Off unless asked for: the comment sheet costs a query round per annotation.
+      @RequestParam(value = "comments", required = false, defaultValue = "false")
+          boolean includeComments) {
     AnnotationExportService.Export export =
         exports.export(
             documentId,
             version,
-            new AnnotationExportService.ExportRequest(fields == null ? List.of() : fields, scope),
+            new AnnotationExportService.ExportRequest(
+                fields == null ? List.of() : fields, scope, includeComments),
             CurrentUser.requireUserId(),
             CurrentUser.isAdmin());
 

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationExportController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationExportController.java
@@ -22,6 +22,7 @@ package io.qnop.web;
 
 import io.qnop.service.review.AnnotationExportService;
 import java.io.ByteArrayInputStream;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.CacheControl;
@@ -62,9 +63,17 @@ public class AnnotationExportController {
   @GetMapping("/documents/{documentId}/annotations/export")
   public ResponseEntity<InputStreamResource> exportAnnotations(
       @PathVariable UUID documentId,
-      @RequestParam(value = "version", required = false) Integer version) {
+      @RequestParam(value = "version", required = false) Integer version,
+      // Repeated or comma-separated; empty means every column (the wizard's default).
+      @RequestParam(value = "fields", required = false) List<String> fields,
+      @RequestParam(value = "scope", required = false, defaultValue = "all") String scope) {
     AnnotationExportService.Export export =
-        exports.export(documentId, version, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+        exports.export(
+            documentId,
+            version,
+            new AnnotationExportService.ExportRequest(fields == null ? List.of() : fields, scope),
+            CurrentUser.requireUserId(),
+            CurrentUser.isAdmin());
 
     ContentDisposition disposition =
         ContentDisposition.attachment()

--- a/qnop-app/src/main/java/io/qnop/web/AnnotationExportController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AnnotationExportController.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.service.review.AnnotationExportService;
+import java.io.ByteArrayInputStream;
+import java.util.UUID;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Downloads a review's annotations as an Excel workbook (issue #547).
+ *
+ * <p>A plain controller by design (ADR-0028), like {@code DocumentContentController}: binary
+ * downloads stay outside the generated OpenAPI contract, which describes JSON only. Authorization
+ * is not re-implemented here — the service reads through {@code AnnotationService.list}, so a
+ * caller who cannot see the review cannot export it, and an anonymous review exports pseudonyms
+ * (ADR-0038).
+ *
+ * <p>Deliberately not cached: annotations change constantly and the workbook is cheap to rebuild,
+ * so there is no content hash to hang an ETag on the way a version download does.
+ */
+@RestController
+public class AnnotationExportController {
+
+  private static final String XLSX =
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+  private final AnnotationExportService exports;
+
+  public AnnotationExportController(AnnotationExportService exports) {
+    this.exports = exports;
+  }
+
+  // mounted under /api/v1 by ApiPathConfig
+  @GetMapping("/documents/{documentId}/annotations/export")
+  public ResponseEntity<InputStreamResource> exportAnnotations(
+      @PathVariable UUID documentId,
+      @RequestParam(value = "version", required = false) Integer version) {
+    AnnotationExportService.Export export =
+        exports.export(documentId, version, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+
+    ContentDisposition disposition =
+        ContentDisposition.attachment()
+            .filename(DownloadFilename.forAnnotationExport(export.documentTitle()))
+            .build();
+    return ResponseEntity.ok()
+        .cacheControl(CacheControl.noStore())
+        .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
+        .contentLength(export.workbook().length)
+        .contentType(MediaType.parseMediaType(XLSX))
+        .body(new InputStreamResource(new ByteArrayInputStream(export.workbook())));
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/DownloadFilename.java
+++ b/qnop-app/src/main/java/io/qnop/web/DownloadFilename.java
@@ -37,6 +37,11 @@ final class DownloadFilename {
     return title + "-v" + versionNumber + extensionFor(contentType);
   }
 
+  /** The annotation export's filename (issue #547) — the review's title plus a fixed suffix. */
+  static String forAnnotationExport(String title) {
+    return (title == null || title.isBlank() ? "annotations" : title) + "-annotations.xlsx";
+  }
+
   /** The dotted file extension for a content type, or an empty string when it is not recognized. */
   static String extensionFor(String contentType) {
     if (contentType == null) {

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
@@ -101,6 +101,35 @@ class AnnotationExportIT extends SeededIntegrationTest {
         .andExpect(status().isCreated());
   }
 
+  /** Creates an annotation and returns its id, for tests that need to act on it. */
+  private String createAnnotationReturningId(
+      UUID author, int surface, double x, double y, String comment) throws Exception {
+    String anchor =
+        "{\"region\":{\"surfaceIndex\":"
+            + surface
+            + ",\"box\":{\"x\":"
+            + x
+            + ",\"y\":"
+            + y
+            + ",\"width\":0.3,\"height\":0.05}},\"textQuote\":{\"quote\":\"the clause\"}}";
+    String json =
+        mockMvc
+            .perform(
+                as(post("/api/v1/documents/" + documentId + "/annotations"), author)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        "{\"versionNumber\":1,\"anchor\":"
+                            + anchor
+                            + ",\"comment\":\""
+                            + comment
+                            + "\"}"))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return com.jayway.jsonpath.JsonPath.read(json, "$.id");
+  }
+
   private Sheet download(UUID actor) throws Exception {
     byte[] body =
         mockMvc
@@ -208,6 +237,87 @@ class AnnotationExportIT extends SeededIntegrationTest {
     mockMvc
         .perform(as(get("/api/v1/documents/" + documentId + "/annotations/export"), EXTERNAL_ID))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("the wizard's field selection decides the columns, in the fixed order")
+  void selectedFieldsDecideTheColumns() throws Exception {
+    seedDocument(false);
+    annotate(MEMBER_ID, 0, 0.1, 0.1, "Only a few columns wanted");
+
+    // Deliberately requested out of order — the sheet's column order is the
+    // server's, so two exports of the same review stay comparable.
+    byte[] body =
+        mockMvc
+            .perform(
+                as(
+                    get("/api/v1/documents/" + documentId + "/annotations/export")
+                        .param("fields", "status")
+                        .param("fields", "taskKey"),
+                    MEMBER_ID))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+    Sheet sheet = new XSSFWorkbook(new ByteArrayInputStream(body)).getSheetAt(0);
+
+    Row header = sheet.getRow(0);
+    assertThat(header.getCell(0).getStringCellValue()).isEqualTo("#");
+    assertThat(header.getCell(1).getStringCellValue()).isEqualTo("Status");
+    assertThat(header.getCell(2)).isNull();
+  }
+
+  @Test
+  @DisplayName("an unknown field is ignored rather than failing the export")
+  void unknownFieldsAreIgnored() throws Exception {
+    seedDocument(false);
+    annotate(MEMBER_ID, 0, 0.1, 0.1, "Still exports");
+
+    // A client one release ahead must get a file, not a 400.
+    byte[] body =
+        mockMvc
+            .perform(
+                as(
+                    get("/api/v1/documents/" + documentId + "/annotations/export")
+                        .param("fields", "status")
+                        .param("fields", "somethingNew"),
+                    MEMBER_ID))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+    Sheet sheet = new XSSFWorkbook(new ByteArrayInputStream(body)).getSheetAt(0);
+
+    assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("Status");
+  }
+
+  @Test
+  @DisplayName("the scope narrows the rows, and task keys keep their whole-review numbering")
+  void scopeNarrowsTheRows() throws Exception {
+    seedDocument(false);
+    annotate(MEMBER_ID, 0, 0.1, 0.1, "Stays open");
+    String resolvedId = createAnnotationReturningId(MEMBER_ID, 0, 0.1, 0.5, "Gets resolved");
+    mockMvc
+        .perform(as(post("/api/v1/annotations/" + resolvedId + "/resolve"), MEMBER_ID))
+        .andExpect(status().isOk());
+
+    byte[] body =
+        mockMvc
+            .perform(
+                as(
+                    get("/api/v1/documents/" + documentId + "/annotations/export")
+                        .param("scope", "resolved"),
+                    MEMBER_ID))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+    Sheet sheet = new XSSFWorkbook(new ByteArrayInputStream(body)).getSheetAt(0);
+
+    assertThat(column(sheet, 5)).containsExactly("Gets resolved");
+    // T-2, not T-1: the key numbers the review, not the filtered slice, so it
+    // still matches what the board shows.
+    assertThat(column(sheet, 0)).containsExactly("T-2");
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * The XLSX export end to end (issue #547): the workbook is read back with POI and asserted on, so
+ * the test proves an actual spreadsheet rather than "some bytes came out".
+ */
+class AnnotationExportIT extends SeededIntegrationTest {
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+
+  private UUID documentId;
+
+  private void seedDocument(boolean anonymous) {
+    Document document = new Document(MEMBER_ID, "Vendor agreement");
+    document.setAnonymous(anonymous);
+    document.setWorkflowState(WorkflowState.IN_REVIEW);
+    documentId = documents.save(document).getId();
+    versions.save(
+        new DocumentVersion(
+            documentId, 1, "sha256/aa/deadbeef", "deadbeef", "application/pdf", 1234L, MEMBER_ID));
+    participants.save(ReviewParticipant.forUser(documentId, AUDITOR_ID));
+    participants.save(ReviewParticipant.forUser(documentId, MEMBER2_ID));
+  }
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  /** Creates an annotation anchored at a given page and position. */
+  private void annotate(UUID author, int surface, double x, double y, String comment)
+      throws Exception {
+    String anchor =
+        "{\"region\":{\"surfaceIndex\":"
+            + surface
+            + ",\"box\":{\"x\":"
+            + x
+            + ",\"y\":"
+            + y
+            + ",\"width\":0.3,\"height\":0.05}},\"textQuote\":{\"quote\":\"the clause\"}}";
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), author)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"versionNumber\":1,\"anchor\":"
+                        + anchor
+                        + ",\"comment\":\""
+                        + comment
+                        + "\"}"))
+        .andExpect(status().isCreated());
+  }
+
+  private Sheet download(UUID actor) throws Exception {
+    byte[] body =
+        mockMvc
+            .perform(as(get("/api/v1/documents/" + documentId + "/annotations/export"), actor))
+            .andExpect(status().isOk())
+            .andExpect(
+                header()
+                    .string(
+                        "Content-Type",
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+            .andExpect(
+                header()
+                    .string(
+                        "Content-Disposition", org.hamcrest.Matchers.containsString("attachment")))
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+    Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(body));
+    return workbook.getSheetAt(0);
+  }
+
+  private static List<String> column(Sheet sheet, int index) {
+    List<String> values = new ArrayList<>();
+    for (int row = 1; row <= sheet.getLastRowNum(); row++) {
+      Row current = sheet.getRow(row);
+      Cell cell = current == null ? null : current.getCell(index);
+      values.add(
+          cell == null
+              ? ""
+              : switch (cell.getCellType()) {
+                case NUMERIC -> String.valueOf((int) cell.getNumericCellValue());
+                default -> cell.getStringCellValue();
+              });
+    }
+    return values;
+  }
+
+  @Test
+  @DisplayName("the workbook has a header row and one row per annotation, in reading order")
+  void exportsInReadingOrder() throws Exception {
+    seedDocument(false);
+    // Created deliberately out of document order, so the sort has something to do.
+    annotate(MEMBER_ID, 1, 0.1, 0.2, "Second page note");
+    annotate(AUDITOR_ID, 0, 0.8, 0.6, "Page one, lower right");
+    annotate(MEMBER2_ID, 0, 0.1, 0.6, "Page one, lower left");
+    annotate(MEMBER_ID, 0, 0.5, 0.1, "Page one, top");
+
+    Sheet sheet = download(MEMBER_ID);
+
+    Row header = sheet.getRow(0);
+    assertThat(header.getCell(0).getStringCellValue()).isEqualTo("#");
+    assertThat(header.getCell(1).getStringCellValue()).isEqualTo("Page");
+    assertThat(header.getCell(2).getStringCellValue()).isEqualTo("Status");
+    assertThat(sheet.getLastRowNum()).isEqualTo(4); // 4 annotations + header
+
+    // Page, then top-to-bottom, then left-to-right.
+    assertThat(column(sheet, 5))
+        .containsExactly(
+            "Page one, top", "Page one, lower left", "Page one, lower right", "Second page note");
+    assertThat(column(sheet, 1)).containsExactly("1", "1", "1", "2");
+    // The status column is populated for every row.
+    assertThat(column(sheet, 2))
+        .allMatch(value -> value.equals("Open") || value.equals("Resolved"));
+  }
+
+  @Test
+  @DisplayName("task keys follow creation order, not the export's reading order")
+  void taskKeysFollowCreationOrder() throws Exception {
+    seedDocument(false);
+    annotate(MEMBER_ID, 1, 0.1, 0.1, "Created first, sorts last");
+    annotate(MEMBER_ID, 0, 0.1, 0.1, "Created second, sorts first");
+
+    Sheet sheet = download(MEMBER_ID);
+
+    // Reading order puts the page-1 annotation first, but it is still T-2 — the
+    // key must agree with the board the user has been looking at.
+    assertThat(column(sheet, 5))
+        .containsExactly("Created second, sorts first", "Created first, sorts last");
+    assertThat(column(sheet, 0)).containsExactly("T-2", "T-1");
+  }
+
+  @Test
+  @DisplayName("an anonymous review never exports a foreign author's real name (ADR-0038)")
+  void anonymousReviewExportsPseudonyms() throws Exception {
+    seedDocument(true);
+    annotate(AUDITOR_ID, 0, 0.1, 0.1, "From a peer");
+
+    // MEMBER2 is a peer participant: to them the auditor is "Participant N".
+    Sheet sheet = download(MEMBER2_ID);
+
+    assertThat(column(sheet, 6)).singleElement().asString().startsWith("Participant");
+    assertThat(column(sheet, 6)).noneMatch(name -> name.contains("Avery"));
+  }
+
+  @Test
+  @DisplayName("a user who cannot see the review cannot export it")
+  void foreignUserIsRefused() throws Exception {
+    seedDocument(false);
+    annotate(MEMBER_ID, 0, 0.1, 0.1, "Private to this review");
+
+    // EXTERNAL is neither owner nor participant — and, unlike the admins, has no
+    // blanket visibility. The review answers 404 rather than 403 on purpose
+    // (anti-enumeration: a stranger cannot tell an inaccessible review from a
+    // non-existent one), which is exactly what listAnnotations does.
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId + "/annotations/export"), EXTERNAL_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("a review without annotations still yields a valid header-only workbook")
+  void emptyReviewYieldsHeaderOnly() throws Exception {
+    seedDocument(false);
+
+    Sheet sheet = download(MEMBER_ID);
+
+    assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("#");
+    assertThat(sheet.getLastRowNum()).isZero();
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
@@ -268,6 +268,30 @@ class AnnotationExportIT extends SeededIntegrationTest {
   }
 
   @Test
+  @DisplayName("Replies counts answers, not the annotation's own opening comment")
+  void repliesExcludeTheOpeningComment() throws Exception {
+    seedDocument(false);
+    String quiet = createAnnotationReturningId(MEMBER_ID, 0, 0.1, 0.1, "Nobody answered this");
+    String discussed = createAnnotationReturningId(MEMBER_ID, 0, 0.1, 0.5, "This got answers");
+    for (String reply : List.of("First answer", "Second answer")) {
+      mockMvc
+          .perform(
+              as(post("/api/v1/annotations/" + discussed + "/comments"), AUDITOR_ID)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"body\":\"" + reply + "\"}"))
+          .andExpect(status().isCreated());
+    }
+    assertThat(quiet).isNotBlank();
+
+    Sheet sheet = download(MEMBER_ID);
+
+    // The opening comment IS the annotation, so an unanswered one reads 0 —
+    // not 1, which is what the raw commentCount would have shown.
+    assertThat(sheet.getRow(0).getCell(7).getStringCellValue()).isEqualTo("Replies");
+    assertThat(column(sheet, 7)).containsExactly("0", "2");
+  }
+
+  @Test
   @DisplayName("an unknown field is ignored rather than failing the export")
   void unknownFieldsAreIgnored() throws Exception {
     seedDocument(false);

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
@@ -151,6 +151,32 @@ class AnnotationExportIT extends SeededIntegrationTest {
     return workbook.getSheetAt(0);
   }
 
+  /** Downloads with the comment sheet switched on and returns that second sheet. */
+  private Sheet downloadComments(UUID actor) throws Exception {
+    byte[] body =
+        mockMvc
+            .perform(
+                as(
+                    get("/api/v1/documents/" + documentId + "/annotations/export")
+                        .param("comments", "true"),
+                    actor))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+    Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(body));
+    return workbook.getSheet("Comments");
+  }
+
+  private void reply(String annotationId, UUID author, String body) throws Exception {
+    mockMvc
+        .perform(
+            as(post("/api/v1/annotations/" + annotationId + "/comments"), author)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"body\":\"" + body + "\"}"))
+        .andExpect(status().isCreated());
+  }
+
   private static List<String> column(Sheet sheet, int index) {
     List<String> values = new ArrayList<>();
     for (int row = 1; row <= sheet.getLastRowNum(); row++) {
@@ -273,13 +299,8 @@ class AnnotationExportIT extends SeededIntegrationTest {
     seedDocument(false);
     String quiet = createAnnotationReturningId(MEMBER_ID, 0, 0.1, 0.1, "Nobody answered this");
     String discussed = createAnnotationReturningId(MEMBER_ID, 0, 0.1, 0.5, "This got answers");
-    for (String reply : List.of("First answer", "Second answer")) {
-      mockMvc
-          .perform(
-              as(post("/api/v1/annotations/" + discussed + "/comments"), AUDITOR_ID)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{\"body\":\"" + reply + "\"}"))
-          .andExpect(status().isCreated());
+    for (String answer : List.of("First answer", "Second answer")) {
+      reply(discussed, AUDITOR_ID, answer);
     }
     assertThat(quiet).isNotBlank();
 
@@ -342,6 +363,60 @@ class AnnotationExportIT extends SeededIntegrationTest {
     // T-2, not T-1: the key numbers the review, not the filtered slice, so it
     // still matches what the board shows.
     assertThat(column(sheet, 0)).containsExactly("T-2");
+  }
+
+  @Test
+  @DisplayName("the comment sheet carries every comment's text under its annotation's task key")
+  void commentSheetCarriesTheThreads() throws Exception {
+    seedDocument(false);
+    String first = createAnnotationReturningId(MEMBER_ID, 0, 0.1, 0.1, "The opening remark");
+    String second = createAnnotationReturningId(MEMBER_ID, 0, 0.1, 0.5, "A second finding");
+    reply(first, AUDITOR_ID, "Answering the first");
+    reply(first, MEMBER_ID, "And once more");
+
+    Sheet sheet = downloadComments(MEMBER_ID);
+
+    Row header = sheet.getRow(0);
+    assertThat(header.getCell(0).getStringCellValue()).isEqualTo("#");
+    assertThat(header.getCell(3).getStringCellValue()).isEqualTo("Comment");
+    // The opening comment is part of the thread: the annotation body is the
+    // first thing said about it, so leaving it out would lose the context every
+    // reply is answering.
+    assertThat(column(sheet, 3))
+        .containsExactly(
+            "The opening remark", "Answering the first", "And once more", "A second finding");
+    assertThat(column(sheet, 0)).containsExactly("T-1", "T-1", "T-1", "T-2");
+    assertThat(second).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("the comment sheet is left out unless it was asked for")
+  void commentSheetIsOptional() throws Exception {
+    seedDocument(false);
+    annotate(MEMBER_ID, 0, 0.1, 0.1, "No second sheet wanted");
+
+    // It costs a query round per annotation, so a plain export must not pay it.
+    assertThat(download(MEMBER_ID).getWorkbook().getSheet("Comments")).isNull();
+  }
+
+  @Test
+  @DisplayName("an anonymous review pseudonymises the comment sheet's authors too (ADR-0038)")
+  void anonymousReviewPseudonymisesComments() throws Exception {
+    seedDocument(true);
+    String annotationId = createAnnotationReturningId(AUDITOR_ID, 0, 0.1, 0.1, "Opened by a peer");
+    reply(annotationId, MEMBER_ID, "The owner answers");
+    reply(annotationId, AUDITOR_ID, "And the peer again");
+
+    // MEMBER2 is a peer participant: the second sheet must not become the hole
+    // through which a foreign reviewer's real name leaks out of the review.
+    List<String> authors = column(downloadComments(MEMBER2_ID), 1);
+
+    assertThat(authors).hasSize(3);
+    assertThat(authors.get(0)).startsWith("Participant");
+    assertThat(authors.get(2)).startsWith("Participant");
+    // MEMBER owns the document, and the owner is the one identity anonymity does
+    // not cover — it is their review, and everybody already knows that.
+    assertThat(authors.get(1)).doesNotStartWith("Participant");
   }
 
   @Test

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -76,6 +76,10 @@ dependencies {
     implementation(libs.pdfbox)
     implementation(libs.jackson3.databind)
 
+    // Annotation export to Excel (issue #547, ADR-0052): POI writes the workbook in
+    // the service layer; the controller only streams what it produced.
+    implementation(libs.poi.ooxml)
+
     // Inter-version diff (issue #249, ADR-0034): Myers diff at word granularity
     // over the two versions' extracted text layers.
     implementation(libs.java.diff.utils)

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportColumn.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportColumn.java
@@ -47,7 +47,7 @@ public enum AnnotationExportColumn {
   PRIORITY("priority", "Priority"),
   SUMMARY("summary", "Summary"),
   AUTHOR("author", "Author"),
-  COMMENTS("comments", "Comments"),
+  REPLIES("replies", "Replies"),
   PLACEMENT("placement", "Placement"),
   CREATED("created", "Created"),
   UPDATED("updated", "Updated");

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportColumn.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportColumn.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The columns an annotation export can carry (issue #547).
+ *
+ * <p>One registry rather than a list of header strings and a parallel switch of cell writers: the
+ * export wizard offers exactly these, the request names them, and every format that follows
+ * (#635–#639) renders the same set. A column that exists in one place and not the other is the
+ * failure mode this type exists to prevent.
+ *
+ * <p>Declaration order is the column order. It is deliberately not the caller's to choose — a
+ * spreadsheet whose columns arrive in a different order per request is unreadable across two
+ * exports of the same review.
+ */
+public enum AnnotationExportColumn {
+  TASK_KEY("taskKey", "#"),
+  PAGE("page", "Page"),
+  STATUS("status", "Status"),
+  TYPE("type", "Type"),
+  PRIORITY("priority", "Priority"),
+  SUMMARY("summary", "Summary"),
+  AUTHOR("author", "Author"),
+  COMMENTS("comments", "Comments"),
+  PLACEMENT("placement", "Placement"),
+  CREATED("created", "Created"),
+  UPDATED("updated", "Updated");
+
+  private final String id;
+  private final String header;
+
+  AnnotationExportColumn(String id, String header) {
+    this.id = id;
+    this.header = header;
+  }
+
+  /** Stable wire name — what the export request lists. */
+  public String getId() {
+    return id;
+  }
+
+  /** The human-readable column heading. */
+  public String getHeader() {
+    return header;
+  }
+
+  public static Optional<AnnotationExportColumn> fromId(String id) {
+    if (id == null) {
+      return Optional.empty();
+    }
+    String needle = id.trim().toLowerCase(Locale.ROOT);
+    return Arrays.stream(values())
+        .filter(column -> column.id.toLowerCase(Locale.ROOT).equals(needle))
+        .findFirst();
+  }
+
+  /** Everything, in declaration order — the default when a request names no columns. */
+  public static List<AnnotationExportColumn> all() {
+    return List.of(values());
+  }
+
+  /**
+   * Resolves a requested selection into columns, in declaration order.
+   *
+   * <p>Unknown ids are ignored rather than rejected: a client one release ahead of its server would
+   * otherwise get an error instead of an export. An empty or entirely unrecognised selection falls
+   * back to {@link #all()}, because a sheet with no columns is never what anyone meant.
+   */
+  public static List<AnnotationExportColumn> resolve(List<String> requestedIds) {
+    if (requestedIds == null || requestedIds.isEmpty()) {
+      return all();
+    }
+    Set<AnnotationExportColumn> selected = new LinkedHashSet<>();
+    for (String id : requestedIds) {
+      fromId(id).ifPresent(selected::add);
+    }
+    if (selected.isEmpty()) {
+      return all();
+    }
+    return Arrays.stream(values()).filter(selected::contains).toList();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
@@ -24,7 +24,9 @@ import io.qnop.entity.Document;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.document.DocumentValidationException;
 import io.qnop.service.review.AnnotationService.AnnotationView;
+import io.qnop.service.review.AnnotationService.CommentView;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
@@ -45,6 +47,8 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,8 +67,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AnnotationExportService {
 
+  private static final Logger log = LoggerFactory.getLogger(AnnotationExportService.class);
+
   /** Excel's own hard ceiling is 32767; a shorter cap keeps the sheet readable. */
   private static final int SUMMARY_MAX = 500;
+
+  /** Headers of the optional second sheet — one row per comment, not per annotation. */
+  private static final List<String> COMMENT_HEADERS = List.of("#", "Author", "Written", "Comment");
+
+  /** Excel's own hard per-cell ceiling, minus room for the ellipsis. */
+  private static final int BODY_MAX = 32_000;
 
   private final AnnotationService annotations;
   private final DocumentRepository documents;
@@ -82,10 +94,10 @@ public class AnnotationExportService {
   /** The finished workbook plus the title the download filename is built from. */
   public record Export(byte[] workbook, String documentTitle) {}
 
-  /** What the wizard asked for: which columns, and which slice of the review. */
-  public record ExportRequest(List<String> columnIds, String scope) {
+  /** What the wizard asked for: which columns, which slice, and whether threads come along. */
+  public record ExportRequest(List<String> columnIds, String scope, boolean includeComments) {
     public static ExportRequest everything() {
-      return new ExportRequest(List.of(), "all");
+      return new ExportRequest(List.of(), "all", false);
     }
   }
 
@@ -141,7 +153,8 @@ public class AnnotationExportService {
                     .thenComparing(o -> o.view().id()))
             .toList();
 
-    return new Export(write(ordered, taskKeys, columns), title);
+    return new Export(
+        write(ordered, taskKeys, columns, request.includeComments(), actor, admin), title);
   }
 
   /** Whether an annotation belongs in the requested slice; anything unknown means "all". */
@@ -172,7 +185,12 @@ public class AnnotationExportService {
   }
 
   private byte[] write(
-      List<Ordered> rows, Map<UUID, String> taskKeys, List<AnnotationExportColumn> columns) {
+      List<Ordered> rows,
+      Map<UUID, String> taskKeys,
+      List<AnnotationExportColumn> columns,
+      boolean includeComments,
+      UUID actor,
+      boolean admin) {
     // Streaming workbook: a review with thousands of annotations must not have to
     // fit in memory as a DOM.
     try (SXSSFWorkbook workbook = new SXSSFWorkbook(200);
@@ -202,12 +220,89 @@ public class AnnotationExportService {
         sheet.setColumnWidth(index, columnWidth(columns.get(index)));
       }
 
+      if (includeComments) {
+        writeComments(workbook, rows, taskKeys, dateStyle, headerStyle, actor, admin);
+      }
+
       workbook.write(out);
       workbook.dispose(); // drops the streaming temp files
       return out.toByteArray();
     } catch (IOException e) {
       throw new AnnotationExportException(documentIdOf(rows), e);
     }
+  }
+
+  /**
+   * The optional second sheet: one row per comment, keyed back to its annotation by task key.
+   *
+   * <p>A thread has no fixed length, so it cannot become columns on the annotation row, and pasting
+   * a whole conversation into one cell would be neither sortable nor readable. A relational second
+   * sheet is what a spreadsheet is actually good at.
+   *
+   * <p>It reads through {@link AnnotationService#listComments}, which applies the PRIVATE-thread
+   * check and resolves each author through {@link ReviewIdentityResolver} — so a pseudonymised
+   * author stays pseudonymised here too (ADR-0038). That costs a query round per annotation; an
+   * export is a rare, deliberate action, and re-implementing the visibility rules to batch it is a
+   * far worse trade than the round trips.
+   */
+  private void writeComments(
+      Workbook workbook,
+      List<Ordered> rows,
+      Map<UUID, String> taskKeys,
+      CellStyle dateStyle,
+      CellStyle headerStyle,
+      UUID actor,
+      boolean admin) {
+    Sheet sheet = workbook.createSheet("Comments");
+    Row header = sheet.createRow(0);
+    for (int index = 0; index < COMMENT_HEADERS.size(); index++) {
+      Cell cell = header.createCell(index);
+      cell.setCellValue(COMMENT_HEADERS.get(index));
+      cell.setCellStyle(headerStyle);
+    }
+
+    int rowIndex = 1;
+    for (Ordered ordered : rows) {
+      UUID annotationId = ordered.view().id();
+      List<CommentView> thread;
+      try {
+        thread = annotations.listComments(annotationId, actor, admin);
+      } catch (DocumentValidationException e) {
+        // Only the not-found case is tolerated, and only because the two reads are
+        // not one snapshot: an annotation deleted mid-export must not take the whole
+        // download down with it. Anything else propagates.
+        log.warn("Annotation {} disappeared while exporting its comments", annotationId, e);
+        continue;
+      }
+      for (CommentView comment : thread) {
+        Row row = sheet.createRow(rowIndex++);
+        row.createCell(0).setCellValue(taskKeys.getOrDefault(annotationId, ""));
+        row.createCell(1)
+            .setCellValue(comment.authorDisplayName() == null ? "" : comment.authorDisplayName());
+        writeDate(row, 2, comment.createdAt(), dateStyle);
+        row.createCell(3).setCellValue(body(comment.body()));
+      }
+    }
+
+    sheet.createFreezePane(0, 1);
+    sheet.setAutoFilter(
+        new CellRangeAddress(0, Math.max(rowIndex - 1, 1), 0, COMMENT_HEADERS.size() - 1));
+    sheet.setColumnWidth(0, 12 * 256);
+    sheet.setColumnWidth(1, 22 * 256);
+    sheet.setColumnWidth(2, 20 * 256);
+    sheet.setColumnWidth(3, 90 * 256);
+  }
+
+  /**
+   * A comment's full text for the thread sheet — unlike the annotation row's {@code summary} this
+   * is not an excerpt, because the point of the sheet is to carry what was actually said. Only
+   * Excel's own per-cell ceiling truncates it.
+   */
+  static String body(String raw) {
+    if (raw == null) {
+      return "";
+    }
+    return raw.length() <= BODY_MAX ? raw : raw.substring(0, BODY_MAX - 1) + "…";
   }
 
   private void writeRow(

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
@@ -63,23 +63,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AnnotationExportService {
 
-  /** Columns, left to right. The order is the contract the acceptance criteria describe. */
-  private static final List<String> HEADERS =
-      List.of(
-          "#",
-          "Page",
-          "Status",
-          "Type",
-          "Priority",
-          "Summary",
-          "Author",
-          "Comments",
-          "Placement",
-          "Created",
-          "Updated");
-
-  private static final int SUMMARY_COLUMN = 5;
-
   /** Excel's own hard ceiling is 32767; a shorter cap keeps the sheet readable. */
   private static final int SUMMARY_MAX = 500;
 
@@ -99,6 +82,13 @@ public class AnnotationExportService {
   /** The finished workbook plus the title the download filename is built from. */
   public record Export(byte[] workbook, String documentTitle) {}
 
+  /** What the wizard asked for: which columns, and which slice of the review. */
+  public record ExportRequest(List<String> columnIds, String scope) {
+    public static ExportRequest everything() {
+      return new ExportRequest(List.of(), "all");
+    }
+  }
+
   /**
    * Builds the workbook for one review, containing exactly the annotations {@code actor} may see.
    *
@@ -106,6 +96,16 @@ public class AnnotationExportService {
    */
   @Transactional(readOnly = true)
   public Export export(UUID documentId, Integer versionNumber, UUID actor, boolean admin) {
+    return export(documentId, versionNumber, ExportRequest.everything(), actor, admin);
+  }
+
+  /**
+   * Builds the workbook for one review, containing exactly the annotations {@code actor} may see,
+   * narrowed to the requested columns and scope.
+   */
+  @Transactional(readOnly = true)
+  public Export export(
+      UUID documentId, Integer versionNumber, ExportRequest request, UUID actor, boolean admin) {
     // The version must be resolved, not left null: list() only loads placements for
     // a concrete version, and without them every anchor is empty and the whole
     // reading order collapses back to creation order. The Tasks page passes the
@@ -122,12 +122,14 @@ public class AnnotationExportService {
     // review gets the same refusal the Tasks page would give them.
     List<AnnotationView> views = annotations.list(documentId, version, null, null, actor, admin);
 
-    String title = documents.findById(documentId).map(Document::getTitle).orElse("annotations");
-
-    // Task keys are assigned in creation order — the same rule the board shows as
-    // "T-1, T-2, …" — and must NOT follow the export's reading order, or the export
-    // would disagree with every screen the user has seen.
+    // Task keys number the WHOLE review, so T-7 stays T-7 in an export narrowed
+    // to the open items — a key that renumbers per filter would be worthless
+    // for talking about an annotation.
     Map<UUID, String> taskKeys = taskKeys(views);
+    views = views.stream().filter(view -> matchesScope(view, request.scope())).toList();
+    List<AnnotationExportColumn> columns = AnnotationExportColumn.resolve(request.columnIds());
+
+    String title = documents.findById(documentId).map(Document::getTitle).orElse("annotations");
 
     List<Ordered> ordered =
         views.stream()
@@ -139,7 +141,16 @@ public class AnnotationExportService {
                     .thenComparing(o -> o.view().id()))
             .toList();
 
-    return new Export(write(ordered, taskKeys), title);
+    return new Export(write(ordered, taskKeys, columns), title);
+  }
+
+  /** Whether an annotation belongs in the requested slice; anything unknown means "all". */
+  private static boolean matchesScope(AnnotationView view, String scope) {
+    if (scope == null || "all".equalsIgnoreCase(scope)) {
+      return true;
+    }
+    boolean resolved = "RESOLVED".equalsIgnoreCase(view.status());
+    return "resolved".equalsIgnoreCase(scope) == resolved;
   }
 
   /**
@@ -160,7 +171,8 @@ public class AnnotationExportService {
     return keys;
   }
 
-  private byte[] write(List<Ordered> rows, Map<UUID, String> taskKeys) {
+  private byte[] write(
+      List<Ordered> rows, Map<UUID, String> taskKeys, List<AnnotationExportColumn> columns) {
     // Streaming workbook: a review with thousands of annotations must not have to
     // fit in memory as a DOM.
     try (SXSSFWorkbook workbook = new SXSSFWorkbook(200);
@@ -170,24 +182,24 @@ public class AnnotationExportService {
       CellStyle dateStyle = dateStyle(workbook);
 
       Row header = sheet.createRow(0);
-      for (int column = 0; column < HEADERS.size(); column++) {
-        Cell cell = header.createCell(column);
-        cell.setCellValue(HEADERS.get(column));
+      for (int index = 0; index < columns.size(); index++) {
+        Cell cell = header.createCell(index);
+        cell.setCellValue(columns.get(index).getHeader());
         cell.setCellStyle(headerStyle);
       }
 
       int rowIndex = 1;
       for (Ordered row : rows) {
-        writeRow(sheet.createRow(rowIndex++), row, taskKeys, dateStyle);
+        writeRow(sheet.createRow(rowIndex++), row, taskKeys, columns, dateStyle);
       }
 
       // Freeze the header and switch on the filter dropdowns, so Excel's own
       // per-column sort works the moment the file opens — the whole reason the
       // cells are typed rather than pre-formatted strings.
       sheet.createFreezePane(0, 1);
-      sheet.setAutoFilter(new CellRangeAddress(0, Math.max(rows.size(), 1), 0, HEADERS.size() - 1));
-      for (int column = 0; column < HEADERS.size(); column++) {
-        sheet.setColumnWidth(column, columnWidth(column));
+      sheet.setAutoFilter(new CellRangeAddress(0, Math.max(rows.size(), 1), 0, columns.size() - 1));
+      for (int index = 0; index < columns.size(); index++) {
+        sheet.setColumnWidth(index, columnWidth(columns.get(index)));
       }
 
       workbook.write(out);
@@ -198,25 +210,36 @@ public class AnnotationExportService {
     }
   }
 
-  private void writeRow(Row row, Ordered ordered, Map<UUID, String> taskKeys, CellStyle dateStyle) {
+  private void writeRow(
+      Row row,
+      Ordered ordered,
+      Map<UUID, String> taskKeys,
+      List<AnnotationExportColumn> columns,
+      CellStyle dateStyle) {
     AnnotationView view = ordered.view();
-    row.createCell(0).setCellValue(taskKeys.getOrDefault(view.id(), ""));
-
-    Integer page = ordered.position().pageNumber();
-    if (page != null) {
-      // Numeric, not text: "10" must sort after "9" in Excel.
-      row.createCell(1).setCellValue(page);
+    for (int index = 0; index < columns.size(); index++) {
+      switch (columns.get(index)) {
+        case TASK_KEY -> row.createCell(index).setCellValue(taskKeys.getOrDefault(view.id(), ""));
+        case PAGE -> {
+          Integer page = ordered.position().pageNumber();
+          if (page != null) {
+            // Numeric, not text: "10" must sort after "9" in Excel.
+            row.createCell(index).setCellValue(page);
+          }
+        }
+        case STATUS -> row.createCell(index).setCellValue(humanize(view.status()));
+        case TYPE -> row.createCell(index).setCellValue(humanize(view.type()));
+        case PRIORITY -> row.createCell(index).setCellValue(humanize(view.priority()));
+        case SUMMARY -> row.createCell(index).setCellValue(summary(view.firstComment()));
+        case AUTHOR ->
+            row.createCell(index)
+                .setCellValue(view.authorDisplayName() == null ? "" : view.authorDisplayName());
+        case COMMENTS -> row.createCell(index).setCellValue(view.commentCount());
+        case PLACEMENT -> row.createCell(index).setCellValue(humanize(view.placementStatus()));
+        case CREATED -> writeDate(row, index, view.createdAt(), dateStyle);
+        case UPDATED -> writeDate(row, index, view.updatedAt(), dateStyle);
+      }
     }
-    row.createCell(2).setCellValue(humanize(view.status()));
-    row.createCell(3).setCellValue(humanize(view.type()));
-    row.createCell(4).setCellValue(humanize(view.priority()));
-    row.createCell(5).setCellValue(summary(view.firstComment()));
-    row.createCell(6)
-        .setCellValue(view.authorDisplayName() == null ? "" : view.authorDisplayName());
-    row.createCell(7).setCellValue(view.commentCount());
-    row.createCell(8).setCellValue(humanize(view.placementStatus()));
-    writeDate(row, 9, view.createdAt(), dateStyle);
-    writeDate(row, 10, view.updatedAt(), dateStyle);
   }
 
   private static void writeDate(Row row, int column, Instant instant, CellStyle style) {
@@ -270,8 +293,8 @@ public class AnnotationExportService {
   }
 
   /** Roughly sized columns; the summary gets the room, the rest stay compact. */
-  private static int columnWidth(int column) {
-    int characters = column == SUMMARY_COLUMN ? 70 : 16;
+  private static int columnWidth(AnnotationExportColumn column) {
+    int characters = column == AnnotationExportColumn.SUMMARY ? 70 : 16;
     return characters * 256;
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
@@ -234,7 +234,11 @@ public class AnnotationExportService {
         case AUTHOR ->
             row.createCell(index)
                 .setCellValue(view.authorDisplayName() == null ? "" : view.authorDisplayName());
-        case COMMENTS -> row.createCell(index).setCellValue(view.commentCount());
+        case REPLIES ->
+            // commentCount includes the opening comment, which IS the annotation
+            // — a fresh one would otherwise read as "1 comment" when nobody has
+            // answered yet. The column counts answers.
+            row.createCell(index).setCellValue(Math.max(0, view.commentCount() - 1));
         case PLACEMENT -> row.createCell(index).setCellValue(humanize(view.placementStatus()));
         case CREATED -> writeDate(row, index, view.createdAt(), dateStyle);
         case UPDATED -> writeDate(row, index, view.updatedAt(), dateStyle);

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.review.AnnotationService.AnnotationView;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Turns a review's annotations into an Excel workbook (issue #547, ADR-0052).
+ *
+ * <p>It reads through {@link AnnotationService#list} — the very source the Tasks workspace uses —
+ * rather than the repository, and that is the point rather than a convenience: the list already
+ * filters PRIVATE threads by visibility and resolves author names through {@link
+ * ReviewIdentityResolver} (ADR-0038). Building the sheet on it means an anonymous review cannot
+ * leak a real name into a spreadsheet, by construction rather than by remembering to.
+ *
+ * <p>Rows come out in reading order (see {@link AnnotationPosition}), which is new behaviour: the
+ * annotation model is position-free (ADR-0009), so nothing else in qnop sorts this way.
+ */
+@Service
+public class AnnotationExportService {
+
+  /** Columns, left to right. The order is the contract the acceptance criteria describe. */
+  private static final List<String> HEADERS =
+      List.of(
+          "#",
+          "Page",
+          "Status",
+          "Type",
+          "Priority",
+          "Summary",
+          "Author",
+          "Comments",
+          "Placement",
+          "Created",
+          "Updated");
+
+  private static final int SUMMARY_COLUMN = 5;
+
+  /** Excel's own hard ceiling is 32767; a shorter cap keeps the sheet readable. */
+  private static final int SUMMARY_MAX = 500;
+
+  private final AnnotationService annotations;
+  private final DocumentRepository documents;
+  private final DocumentVersionRepository versions;
+
+  public AnnotationExportService(
+      AnnotationService annotations,
+      DocumentRepository documents,
+      DocumentVersionRepository versions) {
+    this.annotations = annotations;
+    this.documents = documents;
+    this.versions = versions;
+  }
+
+  /** The finished workbook plus the title the download filename is built from. */
+  public record Export(byte[] workbook, String documentTitle) {}
+
+  /**
+   * Builds the workbook for one review, containing exactly the annotations {@code actor} may see.
+   *
+   * @param versionNumber which version's placements decide the positions; null = latest
+   */
+  @Transactional(readOnly = true)
+  public Export export(UUID documentId, Integer versionNumber, UUID actor, boolean admin) {
+    // The version must be resolved, not left null: list() only loads placements for
+    // a concrete version, and without them every anchor is empty and the whole
+    // reading order collapses back to creation order. The Tasks page passes the
+    // latest version for the same reason.
+    Integer version =
+        versionNumber != null
+            ? versionNumber
+            : versions
+                .findTopByDocumentIdOrderByVersionNumberDesc(documentId)
+                .map(DocumentVersion::getVersionNumber)
+                .orElse(null);
+
+    // Authorization and privacy both live in list(): a caller who may not see the
+    // review gets the same refusal the Tasks page would give them.
+    List<AnnotationView> views = annotations.list(documentId, version, null, null, actor, admin);
+
+    String title = documents.findById(documentId).map(Document::getTitle).orElse("annotations");
+
+    // Task keys are assigned in creation order — the same rule the board shows as
+    // "T-1, T-2, …" — and must NOT follow the export's reading order, or the export
+    // would disagree with every screen the user has seen.
+    Map<UUID, String> taskKeys = taskKeys(views);
+
+    List<Ordered> ordered =
+        views.stream()
+            .map(view -> new Ordered(view, AnnotationPosition.parse(view.anchorJson())))
+            .sorted(
+                Comparator.comparing(Ordered::position, AnnotationPosition.READING_ORDER)
+                    // A stable tail so an unchanged review exports identically twice.
+                    .thenComparing(o -> o.view().createdAt())
+                    .thenComparing(o -> o.view().id()))
+            .toList();
+
+    return new Export(write(ordered, taskKeys), title);
+  }
+
+  /**
+   * {@code T-1}, {@code T-2}, … in creation order — the shorthand people use to talk about an
+   * annotation. The rule is mirrored from the Tasks board's {@code taskKeys()}; keep the two in
+   * step, since a key that disagrees with the screen is worse than no key at all.
+   */
+  static Map<UUID, String> taskKeys(List<AnnotationView> views) {
+    List<AnnotationView> byCreation =
+        views.stream()
+            .sorted(
+                Comparator.comparing(AnnotationView::createdAt).thenComparing(AnnotationView::id))
+            .toList();
+    Map<UUID, String> keys = new LinkedHashMap<>();
+    for (int index = 0; index < byCreation.size(); index++) {
+      keys.put(byCreation.get(index).id(), "T-" + (index + 1));
+    }
+    return keys;
+  }
+
+  private byte[] write(List<Ordered> rows, Map<UUID, String> taskKeys) {
+    // Streaming workbook: a review with thousands of annotations must not have to
+    // fit in memory as a DOM.
+    try (SXSSFWorkbook workbook = new SXSSFWorkbook(200);
+        ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      Sheet sheet = workbook.createSheet("Annotations");
+      CellStyle headerStyle = headerStyle(workbook);
+      CellStyle dateStyle = dateStyle(workbook);
+
+      Row header = sheet.createRow(0);
+      for (int column = 0; column < HEADERS.size(); column++) {
+        Cell cell = header.createCell(column);
+        cell.setCellValue(HEADERS.get(column));
+        cell.setCellStyle(headerStyle);
+      }
+
+      int rowIndex = 1;
+      for (Ordered row : rows) {
+        writeRow(sheet.createRow(rowIndex++), row, taskKeys, dateStyle);
+      }
+
+      // Freeze the header and switch on the filter dropdowns, so Excel's own
+      // per-column sort works the moment the file opens — the whole reason the
+      // cells are typed rather than pre-formatted strings.
+      sheet.createFreezePane(0, 1);
+      sheet.setAutoFilter(new CellRangeAddress(0, Math.max(rows.size(), 1), 0, HEADERS.size() - 1));
+      for (int column = 0; column < HEADERS.size(); column++) {
+        sheet.setColumnWidth(column, columnWidth(column));
+      }
+
+      workbook.write(out);
+      workbook.dispose(); // drops the streaming temp files
+      return out.toByteArray();
+    } catch (IOException e) {
+      throw new AnnotationExportException(documentIdOf(rows), e);
+    }
+  }
+
+  private void writeRow(Row row, Ordered ordered, Map<UUID, String> taskKeys, CellStyle dateStyle) {
+    AnnotationView view = ordered.view();
+    row.createCell(0).setCellValue(taskKeys.getOrDefault(view.id(), ""));
+
+    Integer page = ordered.position().pageNumber();
+    if (page != null) {
+      // Numeric, not text: "10" must sort after "9" in Excel.
+      row.createCell(1).setCellValue(page);
+    }
+    row.createCell(2).setCellValue(humanize(view.status()));
+    row.createCell(3).setCellValue(humanize(view.type()));
+    row.createCell(4).setCellValue(humanize(view.priority()));
+    row.createCell(5).setCellValue(summary(view.firstComment()));
+    row.createCell(6)
+        .setCellValue(view.authorDisplayName() == null ? "" : view.authorDisplayName());
+    row.createCell(7).setCellValue(view.commentCount());
+    row.createCell(8).setCellValue(humanize(view.placementStatus()));
+    writeDate(row, 9, view.createdAt(), dateStyle);
+    writeDate(row, 10, view.updatedAt(), dateStyle);
+  }
+
+  private static void writeDate(Row row, int column, Instant instant, CellStyle style) {
+    if (instant == null) {
+      return;
+    }
+    Cell cell = row.createCell(column);
+    // A real Excel date, not a formatted string: sorting and date filters depend on it.
+    cell.setCellValue(instant.atOffset(ZoneOffset.UTC).toLocalDateTime());
+    cell.setCellStyle(style);
+  }
+
+  /** {@code CHANGES_REQUESTED} → {@code Changes requested}; null/blank → empty cell. */
+  static String humanize(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return "";
+    }
+    String lower = raw.replace('_', ' ').toLowerCase(Locale.ROOT);
+    return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+  }
+
+  /** The opening comment as one flat cell — markdown noise stripped, length capped. */
+  static String summary(String firstComment) {
+    if (firstComment == null) {
+      return "";
+    }
+    String flat =
+        firstComment
+            .replaceAll("!\\[[^\\]]*\\]\\([^)]*\\)", " ")
+            .replaceAll("\\[([^\\]]*)\\]\\([^)]*\\)", "$1")
+            .replaceAll("[`*_>#~]", "")
+            .replaceAll("\\s+", " ")
+            .trim();
+    return flat.length() <= SUMMARY_MAX ? flat : flat.substring(0, SUMMARY_MAX - 1) + "…";
+  }
+
+  private static CellStyle headerStyle(Workbook workbook) {
+    CellStyle style = workbook.createCellStyle();
+    Font bold = workbook.createFont();
+    bold.setBold(true);
+    style.setFont(bold);
+    style.setBorderBottom(BorderStyle.THIN);
+    return style;
+  }
+
+  private static CellStyle dateStyle(Workbook workbook) {
+    CellStyle style = workbook.createCellStyle();
+    CreationHelper helper = workbook.getCreationHelper();
+    style.setDataFormat(helper.createDataFormat().getFormat("yyyy-mm-dd hh:mm"));
+    return style;
+  }
+
+  /** Roughly sized columns; the summary gets the room, the rest stay compact. */
+  private static int columnWidth(int column) {
+    int characters = column == SUMMARY_COLUMN ? 70 : 16;
+    return characters * 256;
+  }
+
+  private static UUID documentIdOf(List<Ordered> rows) {
+    return rows.isEmpty() ? null : rows.getFirst().view().documentId();
+  }
+
+  private record Ordered(AnnotationView view, AnnotationPosition position) {}
+
+  /** The workbook could not be assembled — an infrastructure failure, not a user error. */
+  public static class AnnotationExportException extends RuntimeException {
+    public AnnotationExportException(UUID documentId, Throwable cause) {
+      super("Could not build the annotation export for document " + documentId, cause);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationPosition.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationPosition.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import java.util.Comparator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Where an annotation sits in the document (issue #547) — the reading order a person would follow.
+ *
+ * <p>Annotations are deliberately position-free (ADR-0009): identity and status are
+ * version-independent, and the physical location lives in the placement's opaque {@code jsonb}
+ * anchor. So there is nothing to {@code ORDER BY} in SQL; a document order has to be parsed out of
+ * that anchor and applied in memory.
+ *
+ * <p>The parsing is deliberately forgiving. The anchor format is open by design — a region-only
+ * image anchor carries no text layer, and future formats may add fields — so anything unreadable
+ * yields {@link #UNPLACED} rather than an exception. An export must not fail because one annotation
+ * has an anchor shape this code did not expect.
+ */
+public record AnnotationPosition(
+    boolean placed, int surfaceIndex, double y, double x, int textStart) {
+
+  private static final Logger log = LoggerFactory.getLogger(AnnotationPosition.class);
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  /** Anchor-less or unreadable: sorts after everything that has a place on a page. */
+  public static final AnnotationPosition UNPLACED =
+      new AnnotationPosition(false, Integer.MAX_VALUE, 0, 0, 0);
+
+  /**
+   * Reading order: page, then top to bottom, then left to right, then — where a text layer exists —
+   * the character offset, which disambiguates two annotations sharing a line.
+   *
+   * <p>It is deliberately NOT a total order on its own: two annotations can occupy the same spot.
+   * Callers append a stable tiebreaker (creation time, then id) so the export of an unchanged
+   * review is byte-identical run over run.
+   */
+  public static final Comparator<AnnotationPosition> READING_ORDER =
+      Comparator.comparing(AnnotationPosition::placed, Comparator.reverseOrder())
+          .thenComparingInt(AnnotationPosition::surfaceIndex)
+          .thenComparingDouble(AnnotationPosition::y)
+          .thenComparingDouble(AnnotationPosition::x)
+          .thenComparingInt(AnnotationPosition::textStart);
+
+  /**
+   * Reads the position out of an anchor, or {@link #UNPLACED} when there is none to read.
+   *
+   * @param anchorJson the placement's raw anchor, as {@code AnnotationView} carries it
+   */
+  public static AnnotationPosition parse(String anchorJson) {
+    if (anchorJson == null || anchorJson.isBlank()) {
+      return UNPLACED;
+    }
+    try {
+      JsonNode anchor = MAPPER.readTree(anchorJson);
+      JsonNode region = anchor.path("region");
+      JsonNode surface = region.path("surfaceIndex");
+      if (!surface.isNumber()) {
+        // A document-scoped annotation (issue #395) has no region at all.
+        return UNPLACED;
+      }
+      JsonNode box = region.path("box");
+      return new AnnotationPosition(
+          true,
+          surface.asInt(),
+          box.path("y").asDouble(0),
+          box.path("x").asDouble(0),
+          anchor.path("textPosition").path("start").asInt(0));
+      // Jackson 3's JacksonException IS a RuntimeException, so one catch covers both
+      // a malformed document and an unexpected shape.
+    } catch (RuntimeException e) {
+      // Never fatal: one odd anchor must not cost the whole export (ADR-0009 keeps
+      // the format open, so an unknown shape is expected rather than exceptional).
+      log.debug("Unreadable annotation anchor; sorting it last", e);
+      return UNPLACED;
+    }
+  }
+
+  /** 1-based page for display, or {@code null} when the annotation is not placed on one. */
+  public Integer pageNumber() {
+    return placed ? surfaceIndex + 1 : null;
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/AnnotationPositionTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/AnnotationPositionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The reading order the export sorts by (issue #547). Pure parsing and comparison — exactly the
+ * kind of logic that must stay testable without a database (CLAUDE.md guardrail), because the
+ * anchor it reads is opaque {@code jsonb} the rest of the system never interprets.
+ */
+class AnnotationPositionTest {
+
+  private static String anchor(int surface, double x, double y) {
+    return "{\"region\":{\"surfaceIndex\":"
+        + surface
+        + ",\"box\":{\"x\":"
+        + x
+        + ",\"y\":"
+        + y
+        + ",\"width\":0.2,\"height\":0.05}}}";
+  }
+
+  @Test
+  @DisplayName("a region anchor yields its page and coordinates")
+  void parsesRegion() {
+    AnnotationPosition position = AnnotationPosition.parse(anchor(2, 0.4, 0.75));
+
+    assertThat(position.placed()).isTrue();
+    assertThat(position.surfaceIndex()).isEqualTo(2);
+    assertThat(position.pageNumber()).isEqualTo(3); // surfaceIndex is 0-based
+    assertThat(position.x()).isEqualTo(0.4);
+    assertThat(position.y()).isEqualTo(0.75);
+  }
+
+  @Test
+  @DisplayName("the text layer's offset is picked up when present")
+  void parsesTextPosition() {
+    String withText =
+        "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.1,\"y\":0.1}},"
+            + "\"textPosition\":{\"start\":420,\"end\":460}}";
+
+    assertThat(AnnotationPosition.parse(withText).textStart()).isEqualTo(420);
+  }
+
+  @Test
+  @DisplayName("anything unreadable is unplaced rather than fatal")
+  void unreadableAnchorsAreUnplaced() {
+    // One odd anchor must never cost the whole export. The format is open by
+    // design (ADR-0009), so an unknown shape is expected, not exceptional.
+    assertThat(AnnotationPosition.parse(null)).isEqualTo(AnnotationPosition.UNPLACED);
+    assertThat(AnnotationPosition.parse("")).isEqualTo(AnnotationPosition.UNPLACED);
+    assertThat(AnnotationPosition.parse("not json at all")).isEqualTo(AnnotationPosition.UNPLACED);
+    assertThat(AnnotationPosition.parse("{}")).isEqualTo(AnnotationPosition.UNPLACED);
+    // A document-scoped annotation (issue #395) legitimately has no region.
+    assertThat(AnnotationPosition.parse("{\"scope\":\"document\"}"))
+        .isEqualTo(AnnotationPosition.UNPLACED);
+    // A shape that looks like an anchor but is not one.
+    assertThat(AnnotationPosition.parse("{\"region\":{\"surfaceIndex\":\"two\"}}"))
+        .isEqualTo(AnnotationPosition.UNPLACED);
+  }
+
+  @Test
+  @DisplayName("reading order is page, then top to bottom, then left to right")
+  void readingOrder() {
+    List<AnnotationPosition> sorted =
+        Stream.of(
+                AnnotationPosition.parse(anchor(1, 0.1, 0.2)), // page 2, high
+                AnnotationPosition.parse(anchor(0, 0.8, 0.5)), // page 1, right
+                AnnotationPosition.parse(anchor(0, 0.1, 0.5)), // page 1, left, same line
+                AnnotationPosition.parse(anchor(0, 0.5, 0.1))) // page 1, top
+            .sorted(AnnotationPosition.READING_ORDER)
+            .toList();
+
+    assertThat(sorted)
+        .extracting(AnnotationPosition::surfaceIndex, AnnotationPosition::y, AnnotationPosition::x)
+        .containsExactly(
+            org.assertj.core.groups.Tuple.tuple(0, 0.1, 0.5),
+            org.assertj.core.groups.Tuple.tuple(0, 0.5, 0.1),
+            org.assertj.core.groups.Tuple.tuple(0, 0.5, 0.8),
+            org.assertj.core.groups.Tuple.tuple(1, 0.2, 0.1));
+  }
+
+  @Test
+  @DisplayName("unplaced annotations sort last, whatever their page number would be")
+  void unplacedSortLast() {
+    List<AnnotationPosition> sorted =
+        Stream.of(
+                AnnotationPosition.UNPLACED,
+                AnnotationPosition.parse(anchor(9, 0.9, 0.9)),
+                AnnotationPosition.UNPLACED,
+                AnnotationPosition.parse(anchor(0, 0.1, 0.1)))
+            .sorted(AnnotationPosition.READING_ORDER)
+            .toList();
+
+    assertThat(sorted)
+        .extracting(AnnotationPosition::placed)
+        .containsExactly(true, true, false, false);
+  }
+}

--- a/qnop-ui/src/api/annotationExport.test.ts
+++ b/qnop-ui/src/api/annotationExport.test.ts
@@ -49,10 +49,13 @@ describe('downloadAnnotationExport', () => {
     await downloadAnnotationExport('doc-1', 3);
 
     // A bare <a href> or window.open would carry no bearer token and simply 401.
-    expect(axiosInstance.get).toHaveBeenCalledWith('/documents/doc-1/annotations/export', {
-      params: { version: 3 },
-      responseType: 'blob',
-    });
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      '/documents/doc-1/annotations/export',
+      expect.objectContaining({
+        params: { version: 3 },
+        responseType: 'blob',
+      }),
+    );
   });
 
   it('omits the version when there is none, letting the server pick the latest', async () => {
@@ -62,7 +65,32 @@ describe('downloadAnnotationExport', () => {
 
     expect(axiosInstance.get).toHaveBeenCalledWith(
       '/documents/doc-1/annotations/export',
-      expect.objectContaining({ params: undefined }),
+      expect.objectContaining({ params: {} }),
+    );
+  });
+
+  it('passes the wizard field selection and scope', async () => {
+    respond();
+
+    await downloadAnnotationExport('doc-1', 2, { fields: ['taskKey', 'status'], scope: 'open' });
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      '/documents/doc-1/annotations/export',
+      expect.objectContaining({
+        params: { version: 2, fields: ['taskKey', 'status'], scope: 'open' },
+      }),
+    );
+  });
+
+  it('leaves the default scope off the wire', async () => {
+    respond();
+
+    await downloadAnnotationExport('doc-1', 1, { fields: [], scope: 'all' });
+
+    // "all" is the server's default; sending it would only make links noisier.
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      '/documents/doc-1/annotations/export',
+      expect.objectContaining({ params: { version: 1 } }),
     );
   });
 

--- a/qnop-ui/src/api/annotationExport.test.ts
+++ b/qnop-ui/src/api/annotationExport.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { downloadAnnotationExport } from './annotationExport';
+import { axiosInstance } from './config';
+
+vi.mock('./config', () => ({
+  axiosInstance: { get: vi.fn() },
+}));
+
+const objectUrl = 'blob:mock-url';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  URL.createObjectURL = vi.fn(() => objectUrl);
+  URL.revokeObjectURL = vi.fn();
+});
+
+function respond(disposition?: string) {
+  vi.mocked(axiosInstance.get).mockResolvedValue({
+    data: new Blob(['xlsx']),
+    headers: disposition ? { 'content-disposition': disposition } : {},
+  } as never);
+}
+
+describe('downloadAnnotationExport', () => {
+  it('requests the export through the authenticated client, as a blob', async () => {
+    respond();
+
+    await downloadAnnotationExport('doc-1', 3);
+
+    // A bare <a href> or window.open would carry no bearer token and simply 401.
+    expect(axiosInstance.get).toHaveBeenCalledWith('/documents/doc-1/annotations/export', {
+      params: { version: 3 },
+      responseType: 'blob',
+    });
+  });
+
+  it('omits the version when there is none, letting the server pick the latest', async () => {
+    respond();
+
+    await downloadAnnotationExport('doc-1');
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      '/documents/doc-1/annotations/export',
+      expect.objectContaining({ params: undefined }),
+    );
+  });
+
+  it('saves under the filename the server chose', async () => {
+    respond('attachment; filename="Vendor agreement-annotations.xlsx"');
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    await downloadAnnotationExport('doc-1');
+
+    expect(click).toHaveBeenCalled();
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    // The object URL is released again — a download must not leak it.
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(objectUrl);
+  });
+
+  it('falls back to a sensible name when the header is missing', async () => {
+    respond();
+    let downloadName = '';
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      downloadName = this.download;
+    });
+
+    await downloadAnnotationExport('doc-1');
+
+    expect(downloadName).toBe('annotations.xlsx');
+  });
+
+  it('propagates a failure so the caller can surface it', async () => {
+    vi.mocked(axiosInstance.get).mockRejectedValue(new Error('boom'));
+
+    await expect(downloadAnnotationExport('doc-1')).rejects.toThrow('boom');
+  });
+});

--- a/qnop-ui/src/api/annotationExport.ts
+++ b/qnop-ui/src/api/annotationExport.ts
@@ -41,7 +41,7 @@ function filenameFrom(disposition: string | undefined, fallback: string): string
 export async function downloadAnnotationExport(
   documentId: string,
   version?: number,
-  options?: { fields?: string[]; scope?: string },
+  options?: { fields?: string[]; scope?: string; comments?: boolean },
 ): Promise<void> {
   const response = await axiosInstance.get(`/documents/${documentId}/annotations/export`, {
     params: {
@@ -51,6 +51,7 @@ export async function downloadAnnotationExport(
       // thing to escape if that ever changes.
       ...(options?.fields?.length ? { fields: options.fields } : {}),
       ...(options?.scope && options.scope !== 'all' ? { scope: options.scope } : {}),
+      ...(options?.comments ? { comments: true } : {}),
     },
     paramsSerializer: { indexes: null },
     responseType: 'blob',

--- a/qnop-ui/src/api/annotationExport.ts
+++ b/qnop-ui/src/api/annotationExport.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { axiosInstance } from './config';
+
+/** Pulled out of `Content-Disposition`, so the saved file keeps the server's name. */
+function filenameFrom(disposition: string | undefined, fallback: string): string {
+  if (!disposition) return fallback;
+  const utf8 = /filename\*=UTF-8''([^;]+)/i.exec(disposition);
+  if (utf8) return decodeURIComponent(utf8[1]);
+  const plain = /filename="?([^";]+)"?/i.exec(disposition);
+  return plain ? plain[1] : fallback;
+}
+
+/**
+ * Downloads a review's annotations as an Excel workbook (issue #547).
+ *
+ * <p>It goes through the shared axios instance rather than a bare `<a href>` or
+ * `window.open`, because the endpoint is bearer-authenticated: a plain browser
+ * navigation carries no Authorization header and would simply 401. So the file
+ * arrives as a blob and is handed to the browser through an object URL.
+ */
+export async function downloadAnnotationExport(
+  documentId: string,
+  version?: number,
+): Promise<void> {
+  const response = await axiosInstance.get(`/documents/${documentId}/annotations/export`, {
+    params: version ? { version } : undefined,
+    responseType: 'blob',
+  });
+
+  const filename = filenameFrom(
+    response.headers['content-disposition'] as string | undefined,
+    'annotations.xlsx',
+  );
+  const url = URL.createObjectURL(response.data as Blob);
+  try {
+    const link = window.document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    window.document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    // Revoking immediately is safe — the click has already handed the blob over.
+    URL.revokeObjectURL(url);
+  }
+}

--- a/qnop-ui/src/api/annotationExport.ts
+++ b/qnop-ui/src/api/annotationExport.ts
@@ -41,9 +41,18 @@ function filenameFrom(disposition: string | undefined, fallback: string): string
 export async function downloadAnnotationExport(
   documentId: string,
   version?: number,
+  options?: { fields?: string[]; scope?: string },
 ): Promise<void> {
   const response = await axiosInstance.get(`/documents/${documentId}/annotations/export`, {
-    params: version ? { version } : undefined,
+    params: {
+      ...(version ? { version } : {}),
+      // Repeated params rather than one comma-joined value: a column id is a
+      // plain identifier today, but the list format should not become a second
+      // thing to escape if that ever changes.
+      ...(options?.fields?.length ? { fields: options.fields } : {}),
+      ...(options?.scope && options.scope !== 'all' ? { scope: options.scope } : {}),
+    },
+    paramsSerializer: { indexes: null },
     responseType: 'blob',
   });
 

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { downloadAnnotationExport } from '../../api/annotationExport';
+import { ExportAnnotationsButton } from './ExportAnnotationsButton';
+
+vi.mock('../../api/annotationExport', () => ({
+  downloadAnnotationExport: vi.fn(),
+}));
+
+function renderButton(onError = vi.fn()) {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <ExportAnnotationsButton documentId="doc-1" version={3} onError={onError} />
+    </ThemeProvider>,
+  );
+  return onError;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(downloadAnnotationExport).mockResolvedValue(undefined);
+});
+
+describe('ExportAnnotationsButton', () => {
+  it('is a labelled menu trigger, not a direct download', async () => {
+    const user = userEvent.setup();
+    renderButton();
+
+    const trigger = screen.getByRole('button', { name: 'Export' });
+    // Icon-only, so the accessible name has to come from the label.
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(downloadAnnotationExport).not.toHaveBeenCalled();
+
+    await user.click(trigger);
+    expect(await screen.findByRole('menuitem', { name: /Export to Excel/ })).toBeInTheDocument();
+  });
+
+  it('downloads the chosen format for the current review and version', async () => {
+    const user = userEvent.setup();
+    renderButton();
+
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(await screen.findByRole('menuitem', { name: /Export to Excel/ }));
+
+    expect(downloadAnnotationExport).toHaveBeenCalledWith('doc-1', 3);
+    // The menu closes on choice rather than lingering over the download.
+    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+  });
+
+  it('hands a failure to the surface that owns the toast', async () => {
+    const user = userEvent.setup();
+    vi.mocked(downloadAnnotationExport).mockRejectedValue(new Error('boom'));
+    const onError = renderButton();
+
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(await screen.findByRole('menuitem', { name: /Export to Excel/ }));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.stringMatching(/could not/i)));
+    // …and the trigger is usable again for another try.
+    expect(screen.getByRole('button', { name: 'Export' })).toBeEnabled();
+  });
+});

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
@@ -31,56 +31,128 @@ vi.mock('../../api/annotationExport', () => ({
   downloadAnnotationExport: vi.fn(),
 }));
 
+const COUNTS = { all: 12, open: 5, resolved: 7 };
+
 function renderButton(onError = vi.fn()) {
   render(
     <ThemeProvider theme={buildTheme('light')}>
-      <ExportAnnotationsButton documentId="doc-1" version={3} onError={onError} />
+      <ExportAnnotationsButton documentId="doc-1" version={3} counts={COUNTS} onError={onError} />
     </ThemeProvider>,
   );
   return onError;
 }
 
+/** Opens the wizard and walks to the field step. */
+async function openWizard(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'Export' }));
+  return screen.findByRole('dialog');
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   vi.mocked(downloadAnnotationExport).mockResolvedValue(undefined);
 });
 
 describe('ExportAnnotationsButton', () => {
-  it('is a labelled menu trigger, not a direct download', async () => {
+  it('opens the wizard instead of downloading straight away', async () => {
     const user = userEvent.setup();
     renderButton();
 
-    const trigger = screen.getByRole('button', { name: 'Export' });
-    // Icon-only, so the accessible name has to come from the label.
-    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
     expect(downloadAnnotationExport).not.toHaveBeenCalled();
+    await openWizard(user);
 
-    await user.click(trigger);
-    expect(await screen.findByRole('menuitem', { name: /Export to Excel/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /What do you need/ })).toBeInTheDocument();
+    expect(downloadAnnotationExport).not.toHaveBeenCalled();
   });
 
-  it('downloads the chosen format for the current review and version', async () => {
+  it('exports everything with every column by default', async () => {
     const user = userEvent.setup();
     renderButton();
+    await openWizard(user);
 
-    await user.click(screen.getByRole('button', { name: 'Export' }));
-    await user.click(await screen.findByRole('menuitem', { name: /Export to Excel/ }));
+    await user.click(screen.getByRole('button', { name: /Next/ }));
+    await user.click(screen.getByRole('button', { name: /^Export$/ }));
 
-    expect(downloadAnnotationExport).toHaveBeenCalledWith('doc-1', 3);
-    // The menu closes on choice rather than lingering over the download.
-    await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+    await waitFor(() => expect(downloadAnnotationExport).toHaveBeenCalled());
+    const [, , options] = vi.mocked(downloadAnnotationExport).mock.calls[0];
+    expect(options?.scope).toBe('all');
+    // All eleven columns, because everything starts selected.
+    expect(options?.fields).toHaveLength(11);
   });
 
-  it('hands a failure to the surface that owns the toast', async () => {
+  it('narrows the export to the chosen scope', async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await openWizard(user);
+
+    await user.click(screen.getByRole('button', { name: /Open only/ }));
+    await user.click(screen.getByRole('button', { name: /Next/ }));
+    await user.click(screen.getByRole('button', { name: /^Export$/ }));
+
+    await waitFor(() => expect(downloadAnnotationExport).toHaveBeenCalled());
+    expect(vi.mocked(downloadAnnotationExport).mock.calls[0][2]?.scope).toBe('open');
+  });
+
+  it('drops deselected columns but keeps the required one', async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await openWizard(user);
+    await user.click(screen.getByRole('button', { name: /Next/ }));
+
+    await user.click(screen.getByRole('button', { name: 'None' }));
+    await user.click(screen.getByRole('button', { name: /^Export$/ }));
+
+    await waitFor(() => expect(downloadAnnotationExport).toHaveBeenCalled());
+    // Clearing everything still leaves the task key: rows with nothing naming
+    // them would be useless, so it cannot be switched off.
+    expect(vi.mocked(downloadAnnotationExport).mock.calls[0][2]?.fields).toEqual(['taskKey']);
+  });
+
+  it('shows what the download will contain before it runs', async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await openWizard(user);
+
+    // An export has no preview and no undo once it lands in the downloads folder.
+    expect(screen.getByText(/12 annotations/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Resolved only/ }));
+    expect(screen.getByText(/7 annotations/)).toBeInTheDocument();
+  });
+
+  it('remembers the configuration for the next export', async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await openWizard(user);
+    await user.click(screen.getByRole('button', { name: /Open only/ }));
+    await user.click(screen.getByRole('button', { name: /Next/ }));
+    await user.click(screen.getByRole('button', { name: /^Export$/ }));
+    await waitFor(() => expect(downloadAnnotationExport).toHaveBeenCalled());
+
+    // Reopening comes back with the previous scope rather than the default.
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    expect(await screen.findByText(/5 annotations/)).toBeInTheDocument();
+  });
+
+  it('keeps the wizard open on failure so the selection is not lost', async () => {
     const user = userEvent.setup();
     vi.mocked(downloadAnnotationExport).mockRejectedValue(new Error('boom'));
     const onError = renderButton();
-
-    await user.click(screen.getByRole('button', { name: 'Export' }));
-    await user.click(await screen.findByRole('menuitem', { name: /Export to Excel/ }));
+    await openWizard(user);
+    await user.click(screen.getByRole('button', { name: /Next/ }));
+    await user.click(screen.getByRole('button', { name: /^Export$/ }));
 
     await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.stringMatching(/could not/i)));
-    // …and the trigger is usable again for another try.
-    expect(screen.getByRole('button', { name: 'Export' })).toBeEnabled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('names the planned formats without offering them', async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await openWizard(user);
+
+    // Answering "is Word coming?" in the wizard beats a support request.
+    expect(screen.getByRole('button', { name: /Word/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Excel/ })).toBeEnabled();
   });
 });

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
@@ -79,6 +79,30 @@ describe('ExportAnnotationsButton', () => {
     expect(options?.scope).toBe('all');
     // All eleven columns, because everything starts selected.
     expect(options?.fields).toHaveLength(11);
+    expect(options?.comments).toBe(true);
+  });
+
+  it('can leave the comment threads out', async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await openWizard(user);
+    await user.click(screen.getByRole('button', { name: /Next/ }));
+
+    await user.click(screen.getByRole('switch', { name: /Comment threads/ }));
+    await user.click(screen.getByRole('button', { name: /^Export$/ }));
+
+    await waitFor(() => expect(downloadAnnotationExport).toHaveBeenCalled());
+    expect(vi.mocked(downloadAnnotationExport).mock.calls[0][2]?.comments).toBe(false);
+  });
+
+  it('says on the summary line that the threads are coming along', async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await openWizard(user);
+
+    // The threads land on a second sheet, which is invisible until the file is
+    // open — so the wizard says so while there is still a choice to make.
+    expect(screen.getByText(/with comment threads/)).toBeInTheDocument();
   });
 
   it('narrows the export to the chosen scope', async () => {

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
@@ -20,18 +20,45 @@
  */
 
 import { useState } from 'react';
-import { FileDown } from 'lucide-react';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import type { LucideIcon } from 'lucide-react';
+import { Download, FileSpreadsheet } from 'lucide-react';
 import { downloadAnnotationExport } from '../../api/annotationExport';
 import { ToolbarIconButton } from './ToolbarIconButton';
 
+/** One offered format. Adding Word, Markdown or HTML is one more entry here. */
+interface ExportFormat {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  download: (documentId: string, version?: number) => Promise<void>;
+}
+
+const FORMATS: ExportFormat[] = [
+  {
+    id: 'xlsx',
+    label: 'Export to Excel',
+    icon: FileSpreadsheet,
+    download: downloadAnnotationExport,
+  },
+];
+
 /**
- * Downloads the review's annotations as a spreadsheet (issue #547).
+ * Exports the review's annotations (issue #547).
  *
- * <p>One component for both surfaces — the Tasks toolbar and the review's
- * annotation panel — so the two cannot drift in label, icon or busy behaviour.
- * It owns the in-flight state, because the request is the only thing it does;
- * reporting a failure is the caller's, since each surface already has its own
- * toast.
+ * <p>A menu rather than a single button, even while it offers exactly one
+ * format: Word, Markdown and HTML are planned, and a button that has to be
+ * rebuilt into a menu later would take its label, its tooltip and every test
+ * that names it along. The list above is the extension point — a new format is
+ * an entry, not a change to this component.
+ *
+ * <p>One component for both surfaces (the Tasks toolbar and the review's
+ * annotation panel), so the two cannot drift. It owns the in-flight state,
+ * because the request is the only thing it does; reporting a failure is the
+ * caller's, since each surface already has its own toast.
  */
 export function ExportAnnotationsButton({
   documentId,
@@ -42,15 +69,17 @@ export function ExportAnnotationsButton({
   version?: number;
   onError?: (message: string) => void;
 }) {
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const [exporting, setExporting] = useState(false);
 
-  const run = async () => {
+  const run = async (format: ExportFormat) => {
+    setAnchor(null);
     setExporting(true);
     try {
-      await downloadAnnotationExport(documentId, version);
+      await format.download(documentId, version);
     } catch {
       // A failed download leaves nothing behind, so the surface's own toast is
-      // the whole recovery story — the button stays available for another try.
+      // the whole recovery story — the action stays available for another try.
       onError?.('The export could not be generated. Please try again.');
     } finally {
       setExporting(false);
@@ -58,6 +87,33 @@ export function ExportAnnotationsButton({
   };
 
   return (
-    <ToolbarIconButton label="Export to Excel" icon={FileDown} onClick={run} busy={exporting} />
+    <>
+      <ToolbarIconButton
+        label="Export"
+        icon={Download}
+        busy={exporting}
+        onClick={(event) => setAnchor(event.currentTarget)}
+        expanded={Boolean(anchor)}
+      />
+      <Menu
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={() => setAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { minWidth: 210 } } }}
+      >
+        {FORMATS.map((format) => (
+          <MenuItem key={format.id} onClick={() => run(format)}>
+            <ListItemIcon>
+              <format.icon size={16} />
+            </ListItemIcon>
+            <ListItemText slotProps={{ primary: { sx: { fontSize: 14 } } }}>
+              {format.label}
+            </ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
   );
 }

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
@@ -58,6 +58,7 @@ export function ExportAnnotationsButton({
       await downloadAnnotationExport(documentId, version, {
         fields: settings.fields,
         scope: settings.scope,
+        comments: settings.includeComments,
       });
       // Closing only after it succeeded keeps the configuration on screen when
       // it did not — the user retries instead of rebuilding their selection.

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
@@ -20,40 +20,18 @@
  */
 
 import { useState } from 'react';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import type { LucideIcon } from 'lucide-react';
-import { Download, FileSpreadsheet } from 'lucide-react';
+import { Download } from 'lucide-react';
 import { downloadAnnotationExport } from '../../api/annotationExport';
 import { ToolbarIconButton } from './ToolbarIconButton';
-
-/** One offered format. Adding Word, Markdown or HTML is one more entry here. */
-interface ExportFormat {
-  id: string;
-  label: string;
-  icon: LucideIcon;
-  download: (documentId: string, version?: number) => Promise<void>;
-}
-
-const FORMATS: ExportFormat[] = [
-  {
-    id: 'xlsx',
-    label: 'Export to Excel',
-    icon: FileSpreadsheet,
-    download: downloadAnnotationExport,
-  },
-];
+import { ExportWizard, type ExportCounts } from './export/ExportWizard';
+import type { ExportSettings } from './export/exportModel';
 
 /**
- * Exports the review's annotations (issue #547).
+ * Opens the export wizard for a review's annotations (issue #547).
  *
- * <p>A menu rather than a single button, even while it offers exactly one
- * format: Word, Markdown and HTML are planned, and a button that has to be
- * rebuilt into a menu later would take its label, its tooltip and every test
- * that names it along. The list above is the extension point — a new format is
- * an entry, not a change to this component.
+ * <p>A wizard rather than a format menu, because choosing a format is only part
+ * of the decision: which annotations and which columns matter just as much, and
+ * a dropdown has nowhere to put them.
  *
  * <p>One component for both surfaces (the Tasks toolbar and the review's
  * annotation panel), so the two cannot drift. It owns the in-flight state,
@@ -63,23 +41,28 @@ const FORMATS: ExportFormat[] = [
 export function ExportAnnotationsButton({
   documentId,
   version,
+  counts,
   onError,
 }: {
   documentId: string;
   version?: number;
+  counts?: ExportCounts;
   onError?: (message: string) => void;
 }) {
-  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const [open, setOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
 
-  const run = async (format: ExportFormat) => {
-    setAnchor(null);
+  const run = async (settings: ExportSettings) => {
     setExporting(true);
     try {
-      await format.download(documentId, version);
+      await downloadAnnotationExport(documentId, version, {
+        fields: settings.fields,
+        scope: settings.scope,
+      });
+      // Closing only after it succeeded keeps the configuration on screen when
+      // it did not — the user retries instead of rebuilding their selection.
+      setOpen(false);
     } catch {
-      // A failed download leaves nothing behind, so the surface's own toast is
-      // the whole recovery story — the action stays available for another try.
       onError?.('The export could not be generated. Please try again.');
     } finally {
       setExporting(false);
@@ -91,29 +74,20 @@ export function ExportAnnotationsButton({
       <ToolbarIconButton
         label="Export"
         icon={Download}
-        busy={exporting}
-        onClick={(event) => setAnchor(event.currentTarget)}
-        expanded={Boolean(anchor)}
+        onClick={() => setOpen(true)}
+        expanded={open}
       />
-      <Menu
-        open={Boolean(anchor)}
-        anchorEl={anchor}
-        onClose={() => setAnchor(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-        slotProps={{ paper: { sx: { minWidth: 210 } } }}
-      >
-        {FORMATS.map((format) => (
-          <MenuItem key={format.id} onClick={() => run(format)}>
-            <ListItemIcon>
-              <format.icon size={16} />
-            </ListItemIcon>
-            <ListItemText slotProps={{ primary: { sx: { fontSize: 14 } } }}>
-              {format.label}
-            </ListItemText>
-          </MenuItem>
-        ))}
-      </Menu>
+      {/* Mounted only while open, so the wizard opens on step 1 with the last
+          saved configuration without needing a reset effect. */}
+      {open && (
+        <ExportWizard
+          open
+          onClose={() => setOpen(false)}
+          onExport={run}
+          counts={counts}
+          exporting={exporting}
+        />
+      )}
     </>
   );
 }

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
@@ -58,11 +58,6 @@ export function ExportAnnotationsButton({
   };
 
   return (
-    <ToolbarIconButton
-      label="Export to Excel"
-      icon={<FileDown size={16} />}
-      onClick={run}
-      busy={exporting}
-    />
+    <ToolbarIconButton label="Export to Excel" icon={FileDown} onClick={run} busy={exporting} />
   );
 }

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import { FileDown } from 'lucide-react';
+import { downloadAnnotationExport } from '../../api/annotationExport';
+
+/**
+ * Downloads the review's annotations as a spreadsheet (issue #547).
+ *
+ * <p>One component for both surfaces — the Tasks toolbar and the review's
+ * annotation panel — so the two cannot drift in label, icon or busy behaviour.
+ * It owns the in-flight state, because the request is the only thing it does;
+ * reporting a failure is the caller's, since each surface already has its own
+ * toast.
+ */
+export function ExportAnnotationsButton({
+  documentId,
+  version,
+  onError,
+  /** Icon-only, for toolbars that are already dense. */
+  compact = false,
+}: {
+  documentId: string;
+  version?: number;
+  onError?: (message: string) => void;
+  compact?: boolean;
+}) {
+  const [exporting, setExporting] = useState(false);
+
+  const run = async () => {
+    setExporting(true);
+    try {
+      await downloadAnnotationExport(documentId, version);
+    } catch {
+      // A failed download leaves nothing behind, so the surface's own toast is
+      // the whole recovery story — the button stays available for another try.
+      onError?.('The export could not be generated. Please try again.');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const spinner = <CircularProgress size={14} color="inherit" />;
+
+  if (compact) {
+    return (
+      <Tooltip title="Export to Excel">
+        <span>
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={exporting}
+            onClick={run}
+            aria-label="Export to Excel"
+            sx={{ minWidth: 36, px: 1 }}
+          >
+            {exporting ? spinner : <FileDown size={15} />}
+          </Button>
+        </span>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Button
+      size="small"
+      variant="outlined"
+      startIcon={exporting ? spinner : <FileDown size={16} />}
+      disabled={exporting}
+      onClick={run}
+      sx={{ flexShrink: 0 }}
+    >
+      Export to Excel
+    </Button>
+  );
+}

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
@@ -20,11 +20,9 @@
  */
 
 import { useState } from 'react';
-import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
-import Tooltip from '@mui/material/Tooltip';
 import { FileDown } from 'lucide-react';
 import { downloadAnnotationExport } from '../../api/annotationExport';
+import { ToolbarIconButton } from './ToolbarIconButton';
 
 /**
  * Downloads the review's annotations as a spreadsheet (issue #547).
@@ -39,13 +37,10 @@ export function ExportAnnotationsButton({
   documentId,
   version,
   onError,
-  /** Icon-only, for toolbars that are already dense. */
-  compact = false,
 }: {
   documentId: string;
   version?: number;
   onError?: (message: string) => void;
-  compact?: boolean;
 }) {
   const [exporting, setExporting] = useState(false);
 
@@ -62,37 +57,12 @@ export function ExportAnnotationsButton({
     }
   };
 
-  const spinner = <CircularProgress size={14} color="inherit" />;
-
-  if (compact) {
-    return (
-      <Tooltip title="Export to Excel">
-        <span>
-          <Button
-            size="small"
-            variant="outlined"
-            disabled={exporting}
-            onClick={run}
-            aria-label="Export to Excel"
-            sx={{ minWidth: 36, px: 1 }}
-          >
-            {exporting ? spinner : <FileDown size={15} />}
-          </Button>
-        </span>
-      </Tooltip>
-    );
-  }
-
   return (
-    <Button
-      size="small"
-      variant="outlined"
-      startIcon={exporting ? spinner : <FileDown size={16} />}
-      disabled={exporting}
+    <ToolbarIconButton
+      label="Export to Excel"
+      icon={<FileDown size={16} />}
       onClick={run}
-      sx={{ flexShrink: 0 }}
-    >
-      Export to Excel
-    </Button>
+      busy={exporting}
+    />
   );
 }

--- a/qnop-ui/src/components/reviews/ToolbarIconButton.tsx
+++ b/qnop-ui/src/components/reviews/ToolbarIconButton.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+
+/**
+ * An icon-only action in a review toolbar — the shape the Tasks toolbar and the
+ * annotation panel both use, defined once so the four of them cannot drift in
+ * size, spacing or hover behaviour.
+ *
+ * <p>The label is not decoration: it is the button's <em>accessible name</em>
+ * (`aria-label`) as well as its tooltip. Dropping the visible text may not cost
+ * a screen-reader user anything, and it must not — an icon-only control with no
+ * name is an unlabelled button.
+ *
+ * <p>The tooltip wraps a `span` because a disabled MUI button fires no pointer
+ * events, and a tooltip on it would simply never appear while busy.
+ */
+export function ToolbarIconButton({
+  label,
+  icon,
+  onClick,
+  variant = 'outlined',
+  busy = false,
+  disabled = false,
+}: {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  variant?: 'outlined' | 'contained';
+  busy?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <Tooltip title={label}>
+      <span style={{ display: 'inline-flex', flexShrink: 0 }}>
+        <Button
+          size="small"
+          variant={variant}
+          onClick={onClick}
+          disabled={disabled || busy}
+          aria-label={label}
+          sx={{ minWidth: 36, px: 1 }}
+        >
+          {busy ? <CircularProgress size={14} color="inherit" /> : icon}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+}

--- a/qnop-ui/src/components/reviews/ToolbarIconButton.tsx
+++ b/qnop-ui/src/components/reviews/ToolbarIconButton.tsx
@@ -19,10 +19,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { ReactNode } from 'react';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Tooltip from '@mui/material/Tooltip';
+import type { LucideIcon } from 'lucide-react';
 
 /**
  * An icon-only action in a review toolbar — the shape the Tasks toolbar and the
@@ -36,19 +36,21 @@ import Tooltip from '@mui/material/Tooltip';
  *
  * <p>The tooltip wraps a `span` because a disabled MUI button fires no pointer
  * events, and a tooltip on it would simply never appear while busy.
+ *
+ * <p>It takes the icon as a component and sizes it itself, and offers no
+ * variant: these actions had drifted to different emphases and glyph sizes on
+ * the two surfaces, and the fix is that the call site cannot choose either.
  */
 export function ToolbarIconButton({
   label,
-  icon,
+  icon: Icon,
   onClick,
-  variant = 'outlined',
   busy = false,
   disabled = false,
 }: {
   label: string;
-  icon: ReactNode;
+  icon: LucideIcon;
   onClick: () => void;
-  variant?: 'outlined' | 'contained';
   busy?: boolean;
   disabled?: boolean;
 }) {
@@ -57,13 +59,13 @@ export function ToolbarIconButton({
       <span style={{ display: 'inline-flex', flexShrink: 0 }}>
         <Button
           size="small"
-          variant={variant}
+          variant="outlined"
           onClick={onClick}
           disabled={disabled || busy}
           aria-label={label}
           sx={{ minWidth: 36, px: 1 }}
         >
-          {busy ? <CircularProgress size={14} color="inherit" /> : icon}
+          {busy ? <CircularProgress size={14} color="inherit" /> : <Icon size={16} />}
         </Button>
       </span>
     </Tooltip>

--- a/qnop-ui/src/components/reviews/ToolbarIconButton.tsx
+++ b/qnop-ui/src/components/reviews/ToolbarIconButton.tsx
@@ -22,6 +22,7 @@
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Tooltip from '@mui/material/Tooltip';
+import type React from 'react';
 import type { LucideIcon } from 'lucide-react';
 
 /**
@@ -47,12 +48,16 @@ export function ToolbarIconButton({
   onClick,
   busy = false,
   disabled = false,
+  expanded,
 }: {
   label: string;
   icon: LucideIcon;
-  onClick: () => void;
+  /** Receives the event so a menu trigger can anchor to the button. */
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   busy?: boolean;
   disabled?: boolean;
+  /** Set on a trigger that opens a menu, so assistive tech announces its state. */
+  expanded?: boolean;
 }) {
   return (
     <Tooltip title={label}>
@@ -63,6 +68,8 @@ export function ToolbarIconButton({
           onClick={onClick}
           disabled={disabled || busy}
           aria-label={label}
+          aria-haspopup={expanded === undefined ? undefined : 'menu'}
+          aria-expanded={expanded ? true : undefined}
           sx={{ minWidth: 36, px: 1 }}
         >
           {busy ? <CircularProgress size={14} color="inherit" /> : <Icon size={16} />}

--- a/qnop-ui/src/components/reviews/export/ExportWizard.tsx
+++ b/qnop-ui/src/components/reviews/export/ExportWizard.tsx
@@ -31,12 +31,13 @@ import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
 import Stepper from '@mui/material/Stepper';
 import Typography from '@mui/material/Typography';
 import { alpha } from '@mui/material/styles';
-import { ArrowLeft, ArrowRight, Check, Download } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Check, Download, MessagesSquare } from 'lucide-react';
 import { ToneBadge } from '../../admin/ToneBadge';
 import {
   EXPORT_FIELDS,
@@ -313,6 +314,52 @@ export function ExportWizard({
                 </Box>
               </Box>
             ))}
+
+            <Divider />
+
+            {/* Deliberately not a twelfth checkbox: a thread has no fixed length,
+                so it cannot be a column. It becomes its own sheet, and saying so
+                here is cheaper than a support question about the second tab. */}
+            <Box
+              sx={{
+                px: 1.5,
+                py: 1,
+                borderRadius: 2,
+                border: '1px solid',
+                borderColor: settings.includeComments ? 'primary.main' : 'divider',
+                bgcolor: (t) =>
+                  settings.includeComments ? alpha(t.palette.primary.main, 0.06) : 'transparent',
+                transition: 'border-color 150ms, background-color 150ms',
+              }}
+            >
+              <FormControlLabel
+                sx={{ m: 0, width: '100%', alignItems: 'flex-start' }}
+                control={
+                  <Switch
+                    size="small"
+                    sx={{ mt: 0.25, mr: 1 }}
+                    checked={settings.includeComments}
+                    onChange={(event) =>
+                      setSettings((c) => ({ ...c, includeComments: event.target.checked }))
+                    }
+                  />
+                }
+                label={
+                  <Box>
+                    <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                      <MessagesSquare size={14} />
+                      <Typography sx={{ fontSize: 13.5, fontWeight: 700 }}>
+                        Comment threads
+                      </Typography>
+                    </Stack>
+                    <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
+                      A second sheet with the full text of every comment and who wrote it. In an
+                      anonymous review the authors stay pseudonymous here too.
+                    </Typography>
+                  </Box>
+                }
+              />
+            </Box>
           </Stack>
         )}
       </DialogContent>
@@ -323,6 +370,7 @@ export function ExportWizard({
         <Typography sx={{ fontSize: 12.5, color: 'text.secondary' }}>
           {format?.label} {format?.extension} · {selected.length} of {EXPORT_FIELDS.length} columns
           {rows !== null && ` · ${rows} annotation${rows === 1 ? '' : 's'}`}
+          {settings.includeComments && ' · with comment threads'}
         </Typography>
       </Box>
       <Divider />

--- a/qnop-ui/src/components/reviews/export/ExportWizard.tsx
+++ b/qnop-ui/src/components/reviews/export/ExportWizard.tsx
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Stack from '@mui/material/Stack';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import Stepper from '@mui/material/Stepper';
+import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
+import { ArrowLeft, ArrowRight, Check, Download } from 'lucide-react';
+import { ToneBadge } from '../../admin/ToneBadge';
+import {
+  EXPORT_FIELDS,
+  EXPORT_FORMATS,
+  FIELD_GROUPS,
+  effectiveFields,
+  loadSettings,
+  saveSettings,
+  type ExportScope,
+  type ExportSettings,
+} from './exportModel';
+
+const STEPS = ['Format & scope', 'Fields'];
+
+const SCOPES: { id: ExportScope; label: string; hint: string }[] = [
+  { id: 'all', label: 'Everything', hint: 'Every annotation in this review' },
+  { id: 'open', label: 'Open only', hint: 'What still needs work' },
+  { id: 'resolved', label: 'Resolved only', hint: 'What has been settled' },
+];
+
+export interface ExportCounts {
+  all: number;
+  open: number;
+  resolved: number;
+}
+
+/**
+ * Configures an annotation export before it runs (issue #547).
+ *
+ * <p>A wizard rather than a menu because the choices interact: the format
+ * decides what the fields even mean, and the scope decides how many rows there
+ * will be. Splitting them across two steps keeps each screen answerable at a
+ * glance instead of presenting eleven checkboxes and six formats at once.
+ *
+ * <p>Three things earn their place beyond what was asked for. The <em>scope</em>
+ * turns the export into a report ("just the open findings") instead of always a
+ * full dump. The <em>row count</em> is shown before the download, because an
+ * export is a one-shot action with no undo and no preview once it lands in the
+ * downloads folder. And the settings are <em>remembered</em>, since exporting a
+ * review is something people do repeatedly and reconfiguring every time is a
+ * tax on the frequent case.
+ */
+export function ExportWizard({
+  open,
+  onClose,
+  onExport,
+  counts,
+  exporting = false,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onExport: (settings: ExportSettings) => void;
+  /** Row counts per scope, so the wizard can say what the download will contain. */
+  counts?: ExportCounts;
+  exporting?: boolean;
+}) {
+  // The caller mounts this only while it is open, so the initialisers run on
+  // every open: first step, last configuration. A reset effect would do the
+  // same thing a render too late, and cascade.
+  const [step, setStep] = useState(0);
+  const [settings, setSettings] = useState<ExportSettings>(loadSettings);
+
+  const selected = useMemo(() => effectiveFields(settings.fields), [settings.fields]);
+  const rows = counts ? counts[settings.scope] : null;
+  const format = EXPORT_FORMATS.find((entry) => entry.id === settings.format);
+
+  const toggleField = (id: string) =>
+    setSettings((current) => ({
+      ...current,
+      fields: current.fields.includes(id)
+        ? current.fields.filter((field) => field !== id)
+        : [...current.fields, id],
+    }));
+
+  const setAllFields = (on: boolean) =>
+    setSettings((current) => ({
+      ...current,
+      fields: on ? EXPORT_FIELDS.map((field) => field.id) : [],
+    }));
+
+  const start = () => {
+    const chosen = { ...settings, fields: selected };
+    saveSettings(chosen);
+    onExport(chosen);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ pb: 1 }}>
+        <Typography
+          sx={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            color: 'primary.main',
+          }}
+        >
+          Export
+        </Typography>
+        <Typography component="span" sx={{ fontSize: 20, fontWeight: 800 }}>
+          {step === 0 ? 'What do you need?' : 'Which details?'}
+        </Typography>
+      </DialogTitle>
+
+      <Box sx={{ px: 3, pb: 1 }}>
+        <Stepper activeStep={step} sx={{ '& .MuiStepLabel-label': { fontSize: 13 } }}>
+          {STEPS.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+      </Box>
+
+      <DialogContent dividers>
+        {step === 0 ? (
+          <Stack spacing={3}>
+            <Box>
+              <SectionLabel>Format</SectionLabel>
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                  gap: 1,
+                  mt: 1,
+                }}
+              >
+                {EXPORT_FORMATS.map((entry) => {
+                  const active = entry.id === settings.format;
+                  return (
+                    <Box
+                      key={entry.id}
+                      component="button"
+                      type="button"
+                      disabled={entry.planned}
+                      aria-pressed={active}
+                      onClick={() => setSettings((c) => ({ ...c, format: entry.id }))}
+                      sx={{
+                        textAlign: 'left',
+                        p: 1.5,
+                        borderRadius: 2,
+                        border: '1px solid',
+                        borderColor: active ? 'primary.main' : 'divider',
+                        bgcolor: (t) =>
+                          active ? alpha(t.palette.primary.main, 0.06) : 'transparent',
+                        cursor: entry.planned ? 'not-allowed' : 'pointer',
+                        opacity: entry.planned ? 0.5 : 1,
+                        transition: 'border-color 150ms, background-color 150ms',
+                        '&:hover:not(:disabled)': { borderColor: 'primary.main' },
+                      }}
+                    >
+                      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center', mb: 0.25 }}>
+                        <Typography sx={{ fontSize: 14, fontWeight: 700 }}>
+                          {entry.label}
+                        </Typography>
+                        <Typography sx={{ fontSize: 11.5, color: 'text.disabled' }}>
+                          {entry.extension}
+                        </Typography>
+                        {entry.planned && <ToneBadge tone="neutral" label="Planned" />}
+                      </Stack>
+                      <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
+                        {entry.hint}
+                      </Typography>
+                    </Box>
+                  );
+                })}
+              </Box>
+            </Box>
+
+            <Box>
+              <SectionLabel>Which annotations</SectionLabel>
+              <Stack spacing={0.75} sx={{ mt: 1 }}>
+                {SCOPES.map((scope) => {
+                  const active = scope.id === settings.scope;
+                  return (
+                    <Box
+                      key={scope.id}
+                      component="button"
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => setSettings((c) => ({ ...c, scope: scope.id }))}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1.5,
+                        width: '100%',
+                        textAlign: 'left',
+                        px: 1.5,
+                        py: 1,
+                        borderRadius: 2,
+                        border: '1px solid',
+                        borderColor: active ? 'primary.main' : 'divider',
+                        bgcolor: (t) =>
+                          active ? alpha(t.palette.primary.main, 0.06) : 'transparent',
+                        cursor: 'pointer',
+                        '&:hover': { borderColor: 'primary.main' },
+                      }}
+                    >
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography sx={{ fontSize: 14, fontWeight: active ? 700 : 500 }}>
+                          {scope.label}
+                        </Typography>
+                        <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
+                          {scope.hint}
+                        </Typography>
+                      </Box>
+                      {counts && (
+                        <Typography sx={{ fontSize: 13, fontWeight: 700, color: 'text.secondary' }}>
+                          {counts[scope.id]}
+                        </Typography>
+                      )}
+                    </Box>
+                  );
+                })}
+              </Stack>
+            </Box>
+          </Stack>
+        ) : (
+          <Stack spacing={2}>
+            <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
+              <SectionLabel>Columns</SectionLabel>
+              <Stack direction="row" spacing={0.5}>
+                <Button size="small" onClick={() => setAllFields(true)}>
+                  All
+                </Button>
+                <Button size="small" onClick={() => setAllFields(false)}>
+                  None
+                </Button>
+              </Stack>
+            </Stack>
+
+            {FIELD_GROUPS.map((group) => (
+              <Box key={group}>
+                <Typography
+                  sx={{ fontSize: 11.5, fontWeight: 700, color: 'text.disabled', mb: 0.25 }}
+                >
+                  {group}
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                    columnGap: 2,
+                  }}
+                >
+                  {EXPORT_FIELDS.filter((field) => field.group === group).map((field) => (
+                    <FormControlLabel
+                      key={field.id}
+                      sx={{ m: 0 }}
+                      control={
+                        <Checkbox
+                          size="small"
+                          checked={selected.includes(field.id)}
+                          disabled={field.required}
+                          onChange={() => toggleField(field.id)}
+                        />
+                      }
+                      label={
+                        <Typography sx={{ fontSize: 13.5 }}>
+                          {field.label}
+                          {field.required && (
+                            <Typography
+                              component="span"
+                              sx={{ fontSize: 11.5, color: 'text.disabled', ml: 0.5 }}
+                            >
+                              (always)
+                            </Typography>
+                          )}
+                        </Typography>
+                      }
+                    />
+                  ))}
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+
+      {/* The commitment line: an export has no preview and no undo once it is in
+          the downloads folder, so what it will contain is stated before it runs. */}
+      <Box sx={{ px: 3, py: 1.25, bgcolor: (t) => t.qnop.surface2 }}>
+        <Typography sx={{ fontSize: 12.5, color: 'text.secondary' }}>
+          {format?.label} {format?.extension} · {selected.length} of {EXPORT_FIELDS.length} columns
+          {rows !== null && ` · ${rows} annotation${rows === 1 ? '' : 's'}`}
+        </Typography>
+      </Box>
+      <Divider />
+
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button onClick={onClose} disabled={exporting}>
+          Cancel
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        {step > 0 && (
+          <Button
+            startIcon={<ArrowLeft size={15} />}
+            onClick={() => setStep(0)}
+            disabled={exporting}
+          >
+            Back
+          </Button>
+        )}
+        {step === 0 ? (
+          <Button variant="contained" endIcon={<ArrowRight size={15} />} onClick={() => setStep(1)}>
+            Next
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            startIcon={
+              exporting ? <CircularProgress size={14} color="inherit" /> : <Download size={15} />
+            }
+            disabled={exporting || rows === 0}
+            onClick={start}
+          >
+            Export
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+      <Check size={13} />
+      <Typography sx={{ fontSize: 12.5, fontWeight: 700 }}>{children}</Typography>
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/export/exportModel.ts
+++ b/qnop-ui/src/components/reviews/export/exportModel.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * What the export wizard offers and remembers (issue #547) — the data behind the
+ * dialog, kept out of it so the choices are testable without rendering anything.
+ */
+
+export type ExportScope = 'all' | 'open' | 'resolved';
+
+export interface ExportFormat {
+  id: string;
+  label: string;
+  extension: string;
+  /** One line on the format card: why you would pick this one. */
+  hint: string;
+  /** Not yet implemented — shown so the wizard tells the truth about what is coming. */
+  planned?: boolean;
+}
+
+/**
+ * The formats the wizard shows. Planned ones are listed on purpose: a user who
+ * wonders whether Word exists gets an answer here instead of filing a request,
+ * and shipping one flips a flag (issues #635–#639).
+ */
+export const EXPORT_FORMATS: ExportFormat[] = [
+  {
+    id: 'xlsx',
+    label: 'Excel',
+    extension: '.xlsx',
+    hint: 'Sortable, filterable — for triage and reporting.',
+  },
+  { id: 'docx', label: 'Word', extension: '.docx', hint: 'A readable report.', planned: true },
+  {
+    id: 'md',
+    label: 'Markdown',
+    extension: '.md',
+    hint: 'For pull requests and wikis.',
+    planned: true,
+  },
+  { id: 'html', label: 'HTML', extension: '.html', hint: 'Opens anywhere.', planned: true },
+  { id: 'csv', label: 'CSV', extension: '.csv', hint: 'For other tools.', planned: true },
+  { id: 'pdf', label: 'PDF', extension: '.pdf', hint: 'For archiving.', planned: true },
+];
+
+export interface ExportField {
+  id: string;
+  label: string;
+  group: 'Identity' | 'Classification' | 'Content' | 'History';
+  /** Cannot be switched off — a sheet of rows with nothing to name them is useless. */
+  required?: boolean;
+}
+
+/** Mirrors `AnnotationExportColumn` on the server; ids must match, order need not. */
+export const EXPORT_FIELDS: ExportField[] = [
+  { id: 'taskKey', label: 'Task key (#)', group: 'Identity', required: true },
+  { id: 'page', label: 'Page', group: 'Identity' },
+  { id: 'author', label: 'Author', group: 'Identity' },
+  { id: 'status', label: 'Status', group: 'Classification' },
+  { id: 'type', label: 'Type', group: 'Classification' },
+  { id: 'priority', label: 'Priority', group: 'Classification' },
+  { id: 'placement', label: 'Placement state', group: 'Classification' },
+  { id: 'summary', label: 'Summary', group: 'Content' },
+  { id: 'comments', label: 'Comment count', group: 'Content' },
+  { id: 'created', label: 'Created', group: 'History' },
+  { id: 'updated', label: 'Updated', group: 'History' },
+];
+
+export const FIELD_GROUPS: ExportField['group'][] = [
+  'Identity',
+  'Classification',
+  'Content',
+  'History',
+];
+
+export interface ExportSettings {
+  format: string;
+  scope: ExportScope;
+  fields: string[];
+}
+
+/** Everything on, everything in — the state the wizard opens in the first time. */
+export function defaultSettings(): ExportSettings {
+  return { format: 'xlsx', scope: 'all', fields: EXPORT_FIELDS.map((field) => field.id) };
+}
+
+const STORAGE_KEY = 'qnop-export-settings';
+
+/**
+ * The last configuration, so a second export of the same review is one click.
+ *
+ * <p>Anything unrecognised falls back to the defaults rather than throwing: the
+ * field list will grow, and a stored selection from an older release must not
+ * leave the wizard in a state the user cannot fix.
+ */
+export function loadSettings(): ExportSettings {
+  const fallback = defaultSettings();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as Partial<ExportSettings>;
+    const known = new Set(EXPORT_FIELDS.map((field) => field.id));
+    const fields = (parsed.fields ?? []).filter((id) => known.has(id));
+    const shipped = EXPORT_FORMATS.find((f) => f.id === parsed.format && !f.planned);
+    return {
+      format: shipped ? shipped.id : fallback.format,
+      scope: (['all', 'open', 'resolved'] as const).includes(parsed.scope as ExportScope)
+        ? (parsed.scope as ExportScope)
+        : fallback.scope,
+      fields: fields.length > 0 ? fields : fallback.fields,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveSettings(settings: ExportSettings): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // Remembering the last export is a nicety; private-mode failures are fine.
+  }
+}
+
+/** Required fields are always in, whatever the checkbox state says. */
+export function effectiveFields(selected: string[]): string[] {
+  const required = EXPORT_FIELDS.filter((field) => field.required).map((field) => field.id);
+  return EXPORT_FIELDS.filter(
+    (field) => required.includes(field.id) || selected.includes(field.id),
+  ).map((field) => field.id);
+}
+
+/** How many annotations the current scope would export, given the board's counts. */
+export function scopeCount(
+  scope: ExportScope,
+  counts: { all: number; open: number; resolved: number },
+): number {
+  return counts[scope];
+}

--- a/qnop-ui/src/components/reviews/export/exportModel.ts
+++ b/qnop-ui/src/components/reviews/export/exportModel.ts
@@ -79,7 +79,7 @@ export const EXPORT_FIELDS: ExportField[] = [
   { id: 'priority', label: 'Priority', group: 'Classification' },
   { id: 'placement', label: 'Placement state', group: 'Classification' },
   { id: 'summary', label: 'Summary', group: 'Content' },
-  { id: 'comments', label: 'Comment count', group: 'Content' },
+  { id: 'replies', label: 'Replies', group: 'Content' },
   { id: 'created', label: 'Created', group: 'History' },
   { id: 'updated', label: 'Updated', group: 'History' },
 ];

--- a/qnop-ui/src/components/reviews/export/exportModel.ts
+++ b/qnop-ui/src/components/reviews/export/exportModel.ts
@@ -95,11 +95,18 @@ export interface ExportSettings {
   format: string;
   scope: ExportScope;
   fields: string[];
+  /** Adds a second sheet with the full text of every comment, one row each. */
+  includeComments: boolean;
 }
 
 /** Everything on, everything in — the state the wizard opens in the first time. */
 export function defaultSettings(): ExportSettings {
-  return { format: 'xlsx', scope: 'all', fields: EXPORT_FIELDS.map((field) => field.id) };
+  return {
+    format: 'xlsx',
+    scope: 'all',
+    fields: EXPORT_FIELDS.map((field) => field.id),
+    includeComments: true,
+  };
 }
 
 const STORAGE_KEY = 'qnop-export-settings';
@@ -126,6 +133,7 @@ export function loadSettings(): ExportSettings {
         ? (parsed.scope as ExportScope)
         : fallback.scope,
       fields: fields.length > 0 ? fields : fallback.fields,
+      includeComments: parsed.includeComments ?? fallback.includeComments,
     };
   } catch {
     return fallback;

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -378,7 +378,7 @@ export function AnnotationPanel({
             onNewDocumentNote && !readOnly && !reviewClosed ? (
               <ToolbarIconButton
                 label="Global annotation"
-                icon={<Plus size={15} />}
+                icon={Plus}
                 onClick={onNewDocumentNote}
               />
             ) : undefined

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -21,7 +21,6 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -39,6 +38,7 @@ import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { ExportAnnotationsButton } from '../ExportAnnotationsButton';
+import { ToolbarIconButton } from '../ToolbarIconButton';
 import { isUnseen } from '../newSince';
 import type { BuildPermalink } from '../useReviewPermalink';
 import { useConfirmPlacement } from '../../../api/hooks/useAnnotations';
@@ -369,7 +369,6 @@ export function AnnotationPanel({
                 documentId={documentId}
                 version={versionNumber ?? undefined}
                 onError={(message) => notify?.(message, 'error')}
-                compact
               />
             ) : undefined
           }
@@ -377,14 +376,11 @@ export function AnnotationPanel({
             // Raise a whole-document task without a selection (issue #395) — a quiet peer to the
             // text-selection gesture, offered while the latest version is open for review.
             onNewDocumentNote && !readOnly && !reviewClosed ? (
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<Plus size={15} />}
+              <ToolbarIconButton
+                label="Global annotation"
+                icon={<Plus size={15} />}
                 onClick={onNewDocumentNote}
-              >
-                Global annotation
-              </Button>
+              />
             ) : undefined
           }
         </Stack>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.tsx
@@ -38,6 +38,7 @@ import { useAuthStore } from '../../../stores/authStore';
 import type { Notify } from '../../admin/layout/useToast';
 import { SectionCard } from '../../admin/layout/SectionCard';
 import { ToneBadge } from '../../admin/ToneBadge';
+import { ExportAnnotationsButton } from '../ExportAnnotationsButton';
 import { isUnseen } from '../newSince';
 import type { BuildPermalink } from '../useReviewPermalink';
 import { useConfirmPlacement } from '../../../api/hooks/useAnnotations';
@@ -91,6 +92,11 @@ interface AnnotationPanelProps {
   readOnly?: boolean;
   /** The viewed version — the scope of placement outcomes and their confirmation (issue #326). */
   versionNumber?: number | null;
+  /**
+   * The review these annotations belong to. Only needed for the export action
+   * (issue #547) — the panel itself works off the annotations it is handed.
+   */
+  documentId?: string;
   /**
    * Arms re-attaching a lost placement (issue #457) — the page owns the
    * viewer, so it turns the next selection into the new anchor.
@@ -148,6 +154,7 @@ export function AnnotationPanel({
   mentionCandidates,
   readOnly = false,
   versionNumber = null,
+  documentId,
   onArmReattach,
   freeReattachEnabled = false,
   viewerIsAdmin = false,
@@ -354,6 +361,18 @@ export function AnnotationPanel({
               <ToneBadge tone="blue" label={`${newCount} new`} />
             </Box>
           )}
+          {
+            // Icon-only here: the panel header is narrow and already carries the
+            // count badge and the global-annotation action (issue #547).
+            documentId ? (
+              <ExportAnnotationsButton
+                documentId={documentId}
+                version={versionNumber ?? undefined}
+                onError={(message) => notify?.(message, 'error')}
+                compact
+              />
+            ) : undefined
+          }
           {
             // Raise a whole-document task without a selection (issue #395) — a quiet peer to the
             // text-selection gesture, offered while the latest version is open for review.

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -659,6 +659,7 @@ export function DocumentReviewPage() {
                 )}
               >
                 <AnnotationPanel
+                  documentId={documentId}
                   anonymous={document.anonymous ?? false}
                   threadParticipation={document.threadParticipation ?? 'OPEN'}
                   ownerId={document.ownerId}
@@ -701,6 +702,7 @@ export function DocumentReviewPage() {
             )}
           >
             <AnnotationPanel
+              documentId={documentId}
               anonymous={document.anonymous ?? false}
               threadParticipation={document.threadParticipation ?? 'OPEN'}
               ownerId={document.ownerId}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -29,6 +29,7 @@ import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
+import { AnnotationStatus } from '../../api/generated';
 import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useRecordVisit } from '../../api/hooks/useReviews';
@@ -104,6 +105,12 @@ export function ReviewTasksPage() {
     latestVersion >= 1 ? latestVersion : undefined,
   );
   const annotations = annotationsQuery.data?.annotations ?? [];
+  // What each export scope would contain — shown in the wizard before it runs.
+  const exportCounts = {
+    all: annotations.length,
+    open: annotations.filter((a) => a.status !== AnnotationStatus.Resolved).length,
+    resolved: annotations.filter((a) => a.status === AnnotationStatus.Resolved).length,
+  };
 
   const [view, setView] = useTasksViewMode();
   // The unseen-marker baseline (issue #307): the PREVIOUS visit, stamped once.
@@ -289,6 +296,7 @@ export function ReviewTasksPage() {
         <ExportAnnotationsButton
           documentId={documentId}
           version={latestVersion >= 1 ? latestVersion : undefined}
+          counts={exportCounts}
           onError={(message) => notify(message, 'error')}
         />
         {/* A document-scoped task (issue #395) needs no selection — offered while the review is

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -296,8 +296,7 @@ export function ReviewTasksPage() {
         {isOpenWorkflowState(document.workflowState) && latestVersion >= 1 && (
           <ToolbarIconButton
             label="Global annotation"
-            icon={<Plus size={16} />}
-            variant="contained"
+            icon={Plus}
             onClick={() => setNewTaskOpen(true)}
           />
         )}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -22,7 +22,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Divider from '@mui/material/Divider';
@@ -35,6 +34,7 @@ import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useRecordVisit } from '../../api/hooks/useReviews';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
 import { ExportAnnotationsButton } from '../../components/reviews/ExportAnnotationsButton';
+import { ToolbarIconButton } from '../../components/reviews/ToolbarIconButton';
 import { ReviewPageHeader } from '../../components/reviews/hub/ReviewPageHeader';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
@@ -294,15 +294,12 @@ export function ReviewTasksPage() {
         {/* A document-scoped task (issue #395) needs no selection — offered while the review is
             open and has a version to author against; the server refuses a closed review anyway. */}
         {isOpenWorkflowState(document.workflowState) && latestVersion >= 1 && (
-          <Button
+          <ToolbarIconButton
+            label="Global annotation"
+            icon={<Plus size={16} />}
             variant="contained"
-            size="small"
-            startIcon={<Plus size={16} />}
             onClick={() => setNewTaskOpen(true)}
-            sx={{ flexShrink: 0 }}
-          >
-            Global annotation
-          </Button>
+          />
         )}
       </Stack>
 

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -29,12 +29,12 @@ import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import { FileDown, LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
-import { downloadAnnotationExport } from '../../api/annotationExport';
+import { LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
 import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useRecordVisit } from '../../api/hooks/useReviews';
 import { AdminToast } from '../../components/admin/layout/AdminToast';
+import { ExportAnnotationsButton } from '../../components/reviews/ExportAnnotationsButton';
 import { ReviewPageHeader } from '../../components/reviews/hub/ReviewPageHeader';
 import { ReviewViewTabs } from '../../components/reviews/hub/ReviewViewTabs';
 import { useReviewDocumentId } from '../../components/reviews/reviewDocumentId';
@@ -129,20 +129,6 @@ export function ReviewTasksPage() {
   };
   const [openTaskId, setOpenTaskId] = useState<string | null>(null);
   const [newTaskOpen, setNewTaskOpen] = useState(false);
-  const [exporting, setExporting] = useState(false);
-
-  const onExport = async () => {
-    setExporting(true);
-    try {
-      await downloadAnnotationExport(documentId, latestVersion >= 1 ? latestVersion : undefined);
-    } catch {
-      // A failed download leaves nothing behind, so the page's own toast is the
-      // whole recovery story — the button stays available for another try.
-      notify('The export could not be generated. Please try again.', 'error');
-    } finally {
-      setExporting(false);
-    }
-  };
 
   // A new version uploaded from this tab lands on its Document view (issue #571).
   const goToNewVersion = (versionNumber: number) =>
@@ -282,7 +268,13 @@ export function ReviewTasksPage() {
           />
         ))}
         <Box sx={{ flex: 1 }} />
-        <Box sx={{ width: { xs: '100%', sm: 560, md: 720 } }}>
+        {/*
+          The search field takes what is left instead of a fixed 560/720: with a
+          fixed width the row's total outgrew the content area and the two
+          actions wrapped onto a line of their own. Now the filter bar absorbs
+          the slack and the actions stay pinned to the end of the row.
+        */}
+        <Box sx={{ flex: '1 1 260px', minWidth: 200, maxWidth: 720 }}>
           <PanelFilterBar
             filters={facets}
             onChange={setFacets}
@@ -294,17 +286,11 @@ export function ReviewTasksPage() {
         </Box>
         {/* Reporting hand-off (issue #547): the server builds the workbook, so the
             sheet carries exactly what this caller may see, anonymity included. */}
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={
-            exporting ? <CircularProgress size={14} color="inherit" /> : <FileDown size={16} />
-          }
-          disabled={exporting}
-          onClick={onExport}
-        >
-          Export to Excel
-        </Button>
+        <ExportAnnotationsButton
+          documentId={documentId}
+          version={latestVersion >= 1 ? latestVersion : undefined}
+          onError={(message) => notify(message, 'error')}
+        />
         {/* A document-scoped task (issue #395) needs no selection — offered while the review is
             open and has a version to author against; the server refuses a closed review anyway. */}
         {isOpenWorkflowState(document.workflowState) && latestVersion >= 1 && (
@@ -313,6 +299,7 @@ export function ReviewTasksPage() {
             size="small"
             startIcon={<Plus size={16} />}
             onClick={() => setNewTaskOpen(true)}
+            sx={{ flexShrink: 0 }}
           >
             Global annotation
           </Button>

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -29,7 +29,8 @@ import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import { LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
+import { FileDown, LayoutGrid, List as ListIcon, Plus } from 'lucide-react';
+import { downloadAnnotationExport } from '../../api/annotationExport';
 import { useAnnotations } from '../../api/hooks/useAnnotations';
 import { useDocument, useDocumentVersions } from '../../api/hooks/useDocuments';
 import { useRecordVisit } from '../../api/hooks/useReviews';
@@ -128,6 +129,20 @@ export function ReviewTasksPage() {
   };
   const [openTaskId, setOpenTaskId] = useState<string | null>(null);
   const [newTaskOpen, setNewTaskOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+
+  const onExport = async () => {
+    setExporting(true);
+    try {
+      await downloadAnnotationExport(documentId, latestVersion >= 1 ? latestVersion : undefined);
+    } catch {
+      // A failed download leaves nothing behind, so the page's own toast is the
+      // whole recovery story — the button stays available for another try.
+      notify('The export could not be generated. Please try again.', 'error');
+    } finally {
+      setExporting(false);
+    }
+  };
 
   // A new version uploaded from this tab lands on its Document view (issue #571).
   const goToNewVersion = (versionNumber: number) =>
@@ -277,6 +292,19 @@ export function ReviewTasksPage() {
             searchLabel="Search tasks"
           />
         </Box>
+        {/* Reporting hand-off (issue #547): the server builds the workbook, so the
+            sheet carries exactly what this caller may see, anonymity included. */}
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={
+            exporting ? <CircularProgress size={14} color="inherit" /> : <FileDown size={16} />
+          }
+          disabled={exporting}
+          onClick={onExport}
+        >
+          Export to Excel
+        </Button>
         {/* A document-scoped task (issue #395) needs no selection — offered while the review is
             open and has a version to author against; the server refuses a closed review anyway. */}
         {isOpenWorkflowState(document.workflowState) && latestVersion >= 1 && (


### PR DESCRIPTION
Closes #547.

A review's annotations can now leave qnop as an Excel workbook — for triage in a spreadsheet, for a status report, or simply to send to someone who does not have an account.

## What ships

**One authorized path.** The exporter reads through `AnnotationService.list` — the very source the Tasks workspace uses — rather than the repository. That is the point, not a convenience: the list already filters PRIVATE threads by visibility and resolves author names through `ReviewIdentityResolver` (ADR-0038). An anonymous review therefore cannot leak a real name into a spreadsheet by construction, instead of by remembering to.

**Reading order.** Rows come out top-to-bottom, page by page — new behaviour, because the annotation model is position-free (ADR-0009) and nothing else in qnop sorts this way. `AnnotationPosition` parses the opaque anchor and degrades to "unplaced, last" rather than throwing when it cannot.

**Task keys keep their whole-review numbering.** `T-7` stays `T-7` in an export narrowed to the open items — a key that renumbered per filter would be worthless for talking about a finding.

**Comment threads on a second sheet.** A thread has no fixed length, so it cannot be a column, and a whole conversation in one cell is neither sortable nor readable. The `Comments` sheet carries one row per comment (`#`, `Author`, `Written`, `Comment`), read through `listComments` so the visibility check and the pseudonyms come along for free. The owner keeps their real name — anonymity never covered them.

**An export wizard, not a menu.** Two steps: format & scope, then fields. It shows the row count before the download because an export has no preview and no undo once it is in the downloads folder, it remembers the last configuration, and it names the planned formats (#635–#639) instead of leaving people to file a request asking whether Word is coming.

**A toolbar primitive.** `ToolbarIconButton` gives the review actions one style with the label doing double duty as tooltip and `aria-label`, so the two tabs cannot drift apart again.

## Notable decisions

- **A plain controller**, deliberately outside `openapi.yaml`, mirroring the existing binary downloads (ADR-0028/0021). The frontend calls it through the shared axios instance — a bare `<a href>` carries no bearer token.
- **`Replies` counts answers, not the annotation.** The opening comment *is* the annotation, so an unanswered finding reads `0`.
- **The comment sheet is N+1 by construction.** Accepted, not batched: an export is rare and deliberate, and re-implementing the visibility rules to save the round trips would trade a bounded cost for an unbounded correctness risk.
- **Two columns from the original proposal were dropped** rather than duplicated: a board column is a pure derivation of two columns already present, and a position ordinal would equal the row number until the user re-sorts, at which point it lies.

ADR-0052 records all of this.

## Test plan

- [x] `./gradlew build` — full gate green (Spotless, ArchUnit, all tests)
- [x] 12 integration tests in `AnnotationExportIT`, reading the workbook back with POI: reading order, task-key numbering, field selection and its fixed column order, unknown fields ignored, scope narrowing, `Replies` = 0/2, header-only for an empty review, and — the ones that matter — a foreign user gets 404 rather than 403 (anti-enumeration), an anonymous review exports `Participant N`, and the comment sheet pseudonymises its authors too while the owner stays real
- [x] `AnnotationPositionTest` — anchor parsing, including malformed input
- [x] 1169 frontend tests, ESLint and Prettier clean
- [ ] Manual: export a review from both tabs, open the file in Excel, check the filter dropdowns and the second sheet

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
