### PR TITLE
feat(review): export review annotations to PDF (#639)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,18 @@ RUN ./gradlew --no-daemon -x test :qnop-app:bootJar \
 FROM eclipse-temurin:21.0.11_10-jre@sha256:273396ed5998598ed1091e8d72711c2d36980a0e65103859c55a4e977a41ffd3 AS runtime
 WORKDIR /app
 
+# LibreOffice, headless, for the PDF export (issue #639) — and for DOCX ingest
+# when that lands (ADR-0010). It is invoked as a subprocess and never linked, which
+# is the only way ADR-0007 permits a copyleft tool.
+#
+# `--no-install-recommends` plus the Writer-only package keeps this to what the
+# conversion actually needs; the full suite would be several times the size. A
+# deployment that drops it still runs — the server then reports PDF as
+# unavailable and the export wizard stops offering it.
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends libreoffice-writer-nogui fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
 # Run unprivileged.
 RUN groupadd --system qnop && useradd --system --gid qnop --home /app qnop
 

--- a/docs/adr/0052-annotation-export.md
+++ b/docs/adr/0052-annotation-export.md
@@ -96,6 +96,16 @@ In the spreadsheet the link cannot sit in the prose at all: Excel attaches a hyp
 
 The link must also be **absolute**, and that is a correctness requirement rather than a nicety: Word resolves a relative target against the document's own location, so `/api/v1/…` in a downloaded report becomes `file:///api/v1/…` and points at the reader's disk. The origin comes from `general.base_url`; where an operator has not set it, the origin the export was just downloaded from is used instead — unlike a notification mail, whose link is followed by someone who did not make the request, this link is read by the person who asked for the file. With neither available the file is named but not linked. OOXML *can* carry an OLE object, but POI exposes only `getAllEmbeddedParts()` for reading; writing one means hand-authored `w:object` XML, a package part, a relationship and an icon image, on schema types `poi-ooxml-lite` does not guarantee. Weighed against a report that would then mail binaries around, the link is the better answer: a reader with access is one click away, and a reader without at least knows the file exists — which the bare filename this replaces did not convey.
 
+### PDF is the Word report, converted — not drawn again
+
+The requirement was that the PDF look like the Word report. That settles the question the issue left open, because the report is no longer a text dump: a running header with the logo, outline levels, inline images, attachment rows with hyperlinks, and a discussion set with rules and small caps. Drawing that a second time on a PDF canvas means hand-writing line breaking, pagination and running headers — and then keeping two implementations in step forever. A second implementation matches a design only until the next change to either.
+
+So `PdfAnnotationRenderer` renders the DOCX and converts it. One design, one renderer; a change to the report reaches the PDF without anyone doing anything, because it *is* the report.
+
+The conversion runs **out-of-process** through LibreOffice — the only way ADR-0007 permits a copyleft tool, and the same call ADR-0010 already made for DOCX ingest, so this reuses an installation the roadmap had committed to rather than asking for a new one. It is invoked with `ProcessBuilder` rather than through a wrapper library: no Java dependency at all, and the licence boundary stays absolute. Two invocation details are load-bearing — a per-run user profile, because LibreOffice refuses to start against one already in use and concurrent exports would otherwise fail sporadically, and a deadline, because a hung office process would hold a request thread until restart.
+
+Whether a deployment can produce PDF is therefore a property of the **server**, not of the release. `GET /api/v1/config` reports `exportFormats`, the wizard offers only those, and a request for a format this server cannot make answers **503** with a named code — nothing broke and a retry will not help. Every developer machine is such a server, which is why the seam is an interface a test can fake.
+
 ### The filename is the user's, within limits
 
 The default is `<slug>-annotations.<ext>`, derived from the review's title, because a folder full of exports has to stay legible. It is only a default: a report going to a customer is rarely best named after an internal document title, so the wizard shows the name and lets it be replaced.
@@ -145,6 +155,7 @@ Headings use direct character formatting plus an OOXML outline level rather than
 - **2026-07-29** — extended for Word (#635): the model/renderer split, the `?format=` parameter, and the report layout. The remaining formats (#637, #639) are a renderer and an enum entry.
 - **2026-07-29** — the date convention, its timezone, the branding logo and the filename became per-export choices, all format-independent.
 - **2026-07-29** — inline images in annotations and comments are exported rather than stripped; other attachments are linked.
+- **2026-07-29** — PDF (#639) ships by converting the Word report out-of-process, and format availability becomes a server capability rather than a release constant.
 - **ADR-0021 / ADR-0015** — OpenAPI-first, and why this endpoint is the deliberate exception
 - **ADR-0004** — the layering that puts the workbook in the service and leaves the controller streaming
 - Issue **#547**

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4651,6 +4651,18 @@ components:
             Markdown support extends it once their extractors land.
           items:
             $ref: '#/components/schemas/SupportedFormat'
+        exportFormats:
+          type: array
+          description: |
+            The annotation-export formats this deployment can actually produce
+            (issue #639). Clients should offer only these. It is a server property
+            rather than a release constant: PDF is produced by converting the Word
+            report through an out-of-process office suite (ADR-0007/0010), and a
+            deployment without that installed reports `["xlsx", "docx"]`. Offering a
+            format absent here yields a download that fails.
+          items:
+            type: string
+            example: pdf
         branding:
           $ref: '#/components/schemas/ServerConfigBranding'
       required:

--- a/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/QnopApplication.java
@@ -21,6 +21,7 @@
 package io.qnop.bootstrap;
 
 import io.qnop.security.QnopProperties;
+import io.qnop.service.convert.OfficeConverterProperties;
 import io.qnop.service.http.HttpClientProperties;
 import io.qnop.service.review.ReanchoringProperties;
 import io.qnop.web.security.ratelimit.RateLimitProperties;
@@ -44,7 +45,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
   QnopProperties.class,
   RateLimitProperties.class,
   HttpClientProperties.class,
-  ReanchoringProperties.class
+  ReanchoringProperties.class,
+  OfficeConverterProperties.class
 })
 @EntityScan("io.qnop.entity")
 @EnableJpaRepositories("io.qnop.repository")

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -37,6 +37,8 @@ import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.branding.BrandingService;
 import io.qnop.service.branding.BrandingService.SlotStatus;
 import io.qnop.service.oidc.OidcProviderService;
+import io.qnop.service.review.AnnotationExportService;
+import io.qnop.service.review.export.AnnotationExportFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,15 +72,18 @@ public class ConfigController implements ServerConfigApi {
   private final ApplicationSettingsService settings;
   private final BrandingService branding;
   private final BuildProperties buildProperties;
+  private final AnnotationExportService exports;
 
   public ConfigController(
       OidcProviderService oidcProviders,
       ApplicationSettingsService settings,
       BrandingService branding,
+      AnnotationExportService exports,
       ObjectProvider<BuildProperties> buildProperties) {
     this.oidcProviders = oidcProviders;
     this.settings = settings;
     this.branding = branding;
+    this.exports = exports;
     this.buildProperties = buildProperties.getIfAvailable();
   }
 
@@ -106,6 +111,10 @@ public class ConfigController implements ServerConfigApi {
                         settings.getBoolean(
                             ApplicationSettingKey.REVIEW_FINALIZE_WITH_OPEN_ANNOTATIONS)))
             .upload(new ServerConfigUpload().maxDocumentSizeMb(DEFAULT_MAX_DOCUMENT_SIZE_MB))
+            // Only what this server can actually produce: PDF needs an office
+            // converter, and a client must not offer a download that would fail.
+            .exportFormats(
+                exports.availableFormats().stream().map(AnnotationExportFormat::getId).toList())
             // Report only the formats whose extractor actually ships, so a client never offers an
             // upload the ingest pipeline would reject with 415 (magic-byte sniffing, issue #345).
             // Today that is PDF; DOCX and Markdown are Community-scope and join this list once

--- a/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
@@ -28,6 +28,7 @@ import io.qnop.service.review.AnnotationNotFoundException;
 import io.qnop.service.review.DocumentNotFoundException;
 import io.qnop.service.review.NotDocumentOwnerException;
 import io.qnop.service.review.WorkflowTransitionException;
+import io.qnop.service.review.export.ExportFormatUnavailableException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -57,6 +58,14 @@ public class DocumentExceptionHandler {
       body.fieldErrors(List.of(new FieldError().field(ex.getField()).message(ex.getMessage())));
     }
     return ResponseEntity.status(ex.getStatus()).body(body);
+  }
+
+  @ExceptionHandler(ExportFormatUnavailableException.class)
+  ResponseEntity<ErrorResponse> exportFormatUnavailable(ExportFormatUnavailableException ex) {
+    // 503 rather than 500: nothing broke, and nothing will change on a retry —
+    // this deployment lacks the converter the format needs (issue #639).
+    return error(
+        HttpStatus.SERVICE_UNAVAILABLE.value(), "EXPORT_FORMAT_UNAVAILABLE", ex.getMessage());
   }
 
   @ExceptionHandler(DocumentNotFoundException.class)

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
@@ -555,12 +555,13 @@ class AnnotationExportIT extends SeededIntegrationTest {
     annotate(MEMBER_ID, 0, 0.1, 0.1, "Still exports");
 
     // Same reasoning as unknown fields: a client one release ahead should get a
-    // file it can open, not a 400.
+    // file it can open, not a 400. (PDF used to stand in for "unknown" here and no
+    // longer can — it is a format this server knows, and may even be able to make.)
     mockMvc
         .perform(
             as(
                 get("/api/v1/documents/" + documentId + "/annotations/export")
-                    .param("format", "pdf"),
+                    .param("format", "somethingNew"),
                 MEMBER_ID))
         .andExpect(status().isOk())
         .andExpect(
@@ -940,6 +941,44 @@ class AnnotationExportIT extends SeededIntegrationTest {
       assertThat(document.getAllPictures()).hasSize(1);
       assertThat(document.getParagraphs().stream().map(XWPFParagraph::getText).toList())
           .anySatisfy(line -> assertThat(line).contains("Schlusssatz."));
+    }
+  }
+
+  @Test
+  @DisplayName("PDF is offered only where the server can produce it, and refused clearly otherwise")
+  void pdfFollowsTheServersCapability() throws Exception {
+    seedDocument(false);
+    annotate(MEMBER_ID, 0, 0.1, 0.1, "A finding");
+
+    String config =
+        mockMvc
+            .perform(as(get("/api/v1/config"), MEMBER_ID))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    List<String> offered = com.jayway.jsonpath.JsonPath.read(config, "$.exportFormats");
+
+    // The two formats that only assemble bytes are always there.
+    assertThat(offered).contains("xlsx", "docx");
+
+    var request =
+        get("/api/v1/documents/" + documentId + "/annotations/export").param("format", "pdf");
+    if (offered.contains("pdf")) {
+      // An office converter is installed (CI images that ship one); the download works.
+      mockMvc
+          .perform(as(request, MEMBER_ID))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Content-Type", "application/pdf"));
+    } else {
+      // The common case on a developer machine. Nothing broke and a retry will not
+      // help, so it is 503 with a named code — never a 500.
+      mockMvc
+          .perform(as(request, MEMBER_ID))
+          .andExpect(status().isServiceUnavailable())
+          .andExpect(
+              org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath(
+                  "$.code", org.hamcrest.Matchers.is("EXPORT_FORMAT_UNAVAILABLE")));
     }
   }
 

--- a/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
@@ -32,6 +32,8 @@ import io.qnop.service.branding.BrandingService.BrandingSource;
 import io.qnop.service.branding.BrandingService.SlotStatus;
 import io.qnop.service.oidc.OidcProviderLoginView;
 import io.qnop.service.oidc.OidcProviderService;
+import io.qnop.service.review.AnnotationExportService;
+import io.qnop.service.review.export.AnnotationExportFormat;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -60,6 +62,7 @@ class ConfigControllerTest {
   @MockitoBean private OidcProviderService oidcProviders;
   @MockitoBean private ApplicationSettingsService settings;
   @MockitoBean private BrandingService branding;
+  @MockitoBean private AnnotationExportService exports;
 
   @BeforeEach
   void setUp() {
@@ -69,6 +72,10 @@ class ConfigControllerTest {
         .thenReturn(false);
     when(settings.getString(ApplicationSettingKey.GENERAL_DEFAULT_TIMEZONE))
         .thenReturn("Europe/Berlin");
+    // The two formats that need nothing installed; PDF depends on an office
+    // converter this deployment may not have (issue #639).
+    when(exports.availableFormats())
+        .thenReturn(List.of(AnnotationExportFormat.XLSX, AnnotationExportFormat.DOCX));
     // All slots on the factory default until something is uploaded.
     when(branding.statusAll())
         .thenReturn(

--- a/qnop-core/src/main/java/io/qnop/service/convert/LibreOfficeConverter.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/LibreOfficeConverter.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.convert;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converts through a LibreOffice subprocess (issue #639).
+ *
+ * <p>A subprocess and not a library, deliberately. LibreOffice is MPL/LGPL, and ADR-0007 allows
+ * copyleft tools only where nothing links against them; spawning the binary keeps that boundary
+ * absolute and costs qnop no new Java dependency at all. ADR-0010 made the same call for DOCX
+ * ingest, so this is one installation serving both.
+ *
+ * <p>Two details are not optional and are the usual reason a naive invocation fails in production.
+ * Each run gets its <em>own</em> user profile: LibreOffice refuses to start a second instance
+ * against a profile already in use, so without it two concurrent exports would fight and one would
+ * fail. And each run gets a deadline: a hung office process would otherwise hold a request thread
+ * until the server is restarted.
+ */
+@Component
+public class LibreOfficeConverter implements OfficeConverter {
+
+  private static final Logger log = LoggerFactory.getLogger(LibreOfficeConverter.class);
+
+  private final OfficeConverterProperties properties;
+
+  /**
+   * Whether the binary answered when first asked.
+   *
+   * <p>Cached for the process's lifetime: installing an office suite into a running container is
+   * not a thing that happens, and probing on every call would spawn a process per request just to
+   * decide whether to spawn a process.
+   */
+  private volatile Boolean available;
+
+  public LibreOfficeConverter(OfficeConverterProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public boolean isAvailable() {
+    Boolean cached = available;
+    if (cached != null) {
+      return cached;
+    }
+    synchronized (this) {
+      if (available == null) {
+        available = probe();
+      }
+      return available;
+    }
+  }
+
+  /** Asks the binary for its version — the cheapest question that proves it can actually run. */
+  private boolean probe() {
+    try {
+      Process process =
+          new ProcessBuilder(properties.binary(), "--version")
+              .redirectErrorStream(true)
+              .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+              .start();
+      boolean finished = process.waitFor(20, TimeUnit.SECONDS);
+      if (!finished) {
+        process.destroyForcibly();
+        log.warn("{} --version did not answer; PDF export stays unavailable", properties.binary());
+        return false;
+      }
+      boolean ok = process.exitValue() == 0;
+      log.info(
+          ok
+              ? "Office converter available ({}), PDF export enabled"
+              : "Office converter at {} exited non-zero; PDF export stays unavailable",
+          properties.binary());
+      return ok;
+    } catch (IOException e) {
+      // The overwhelmingly common case: no office suite on this machine. Expected
+      // on a developer laptop, so it is stated once at INFO, not warned about.
+      log.info(
+          "No office converter at '{}' — PDF export is unavailable on this server",
+          properties.binary());
+      return false;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
+  @Override
+  public byte[] toPdf(byte[] source, String sourceExtension) {
+    if (!isAvailable()) {
+      throw new OfficeConversionException(
+          "no office converter is installed on this server (looked for '"
+              + properties.binary()
+              + "')");
+    }
+    Path workspace = null;
+    try {
+      workspace = Files.createTempDirectory("qnop-convert-");
+      Path input = workspace.resolve("document." + sourceExtension);
+      Files.write(input, source);
+      run(workspace, input);
+
+      Path output = workspace.resolve("document.pdf");
+      if (!Files.exists(output)) {
+        throw new OfficeConversionException(
+            "the converter reported success but produced no PDF for " + input.getFileName());
+      }
+      return Files.readAllBytes(output);
+    } catch (IOException e) {
+      throw new OfficeConversionException("could not convert a document to PDF", e);
+    } finally {
+      deleteRecursively(workspace);
+    }
+  }
+
+  private void run(Path workspace, Path input) throws IOException {
+    List<String> command =
+        List.of(
+            properties.binary(),
+            "--headless",
+            "--norestore",
+            "--invisible",
+            // Its own profile per run: LibreOffice will not start against a profile
+            // another instance holds, so a shared one turns concurrent exports into
+            // sporadic failures.
+            "-env:UserInstallation=file://" + workspace.resolve("profile"),
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            workspace.toString(),
+            input.toString());
+
+    Process process =
+        new ProcessBuilder(command)
+            .redirectErrorStream(true)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .start();
+    try {
+      if (!process.waitFor(properties.timeout().toMillis(), TimeUnit.MILLISECONDS)) {
+        process.destroyForcibly();
+        throw new OfficeConversionException(
+            "the converter did not finish within " + properties.timeout());
+      }
+      if (process.exitValue() != 0) {
+        throw new OfficeConversionException(
+            "the converter exited with status " + process.exitValue());
+      }
+    } catch (InterruptedException e) {
+      process.destroyForcibly();
+      Thread.currentThread().interrupt();
+      throw new OfficeConversionException("interrupted while converting a document", e);
+    }
+  }
+
+  /** Best-effort cleanup: a leftover temp directory must not fail a conversion that succeeded. */
+  private static void deleteRecursively(Path directory) {
+    if (directory == null) {
+      return;
+    }
+    try (var paths = Files.walk(directory)) {
+      paths.sorted(Comparator.reverseOrder()).forEach(LibreOfficeConverter::deleteQuietly);
+    } catch (IOException e) {
+      log.warn("Could not clean up the conversion workspace {}", directory, e);
+    }
+  }
+
+  private static void deleteQuietly(Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException e) {
+      log.debug("Could not delete {}", path, e);
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/convert/OfficeConversionException.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/OfficeConversionException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.convert;
+
+/**
+ * A document could not be converted — an environment or infrastructure failure, not a user error.
+ */
+public class OfficeConversionException extends RuntimeException {
+
+  public OfficeConversionException(String message) {
+    super(message);
+  }
+
+  public OfficeConversionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverter.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.convert;
+
+/**
+ * Renders an office document to PDF (issue #639).
+ *
+ * <p>An interface with one implementation today, because the implementation is a
+ * <em>subprocess</em> and everything that depends on it needs a seam it can fake: an office suite
+ * is not something a test, a developer machine or a CI runner can be assumed to have.
+ *
+ * <p>Out-of-process is not an implementation detail either. The conversion tools that do this well
+ * are copyleft, and ADR-0007 permits them only as separate processes — never linked into the AGPL
+ * core or the commercial add-ons. ADR-0010 already settled the same question for DOCX ingest; this
+ * is that decision reused rather than a second one.
+ */
+public interface OfficeConverter {
+
+  /**
+   * Whether a converter is actually installed and answering.
+   *
+   * <p>Callers are expected to ask before offering a feature that depends on it. A server without
+   * the binary is a normal state — every developer machine is one — and it should read as "PDF is
+   * not available here", never as an error at download time.
+   */
+  boolean isAvailable();
+
+  /**
+   * Converts a document to PDF.
+   *
+   * @param source the document's bytes
+   * @param sourceExtension the extension the source needs on disk, without a dot ({@code docx})
+   * @throws OfficeConversionException if no converter is installed, it fails, or it takes too long
+   */
+  byte[] toPdf(byte[] source, String sourceExtension);
+}

--- a/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverterProperties.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverterProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.convert;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Tunables for the out-of-process office converter (issue #639), overridable via {@code
+ * qnop.office.*} or the matching {@code QNOP_OFFICE_*} environment variables.
+ *
+ * @param binary the executable to invoke; a bare name is resolved on {@code PATH} ({@code soffice})
+ * @param timeout how long one conversion may take before the process is killed (60s). A cold
+ *     LibreOffice needs a second or two; a minute means it has hung, and an export must not hold a
+ *     request thread indefinitely because of it.
+ */
+@ConfigurationProperties(prefix = "qnop.office")
+public record OfficeConverterProperties(String binary, Duration timeout) {
+
+  public OfficeConverterProperties {
+    binary = binary == null || binary.isBlank() ? "soffice" : binary.strip();
+    timeout = timeout == null ? Duration.ofSeconds(60) : timeout;
+  }
+
+  /** The documented defaults — for direct construction in tests and non-Spring callers. */
+  public static OfficeConverterProperties defaults() {
+    return new OfficeConverterProperties(null, null);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/AnnotationExportService.java
@@ -35,9 +35,11 @@ import io.qnop.service.review.export.AnnotationExportModel;
 import io.qnop.service.review.export.AnnotationExportRenderer;
 import io.qnop.service.review.export.ExportAttachmentResolver;
 import io.qnop.service.review.export.ExportDateFormat;
+import io.qnop.service.review.export.ExportFormatUnavailableException;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -159,12 +161,32 @@ public class AnnotationExportService {
           documentId, new IllegalStateException("no renderer for format " + format.getId()));
     }
 
+    if (!renderer.isAvailable()) {
+      // Said plainly rather than as a subprocess failure three layers down: this
+      // server cannot produce the format, and the wizard should not have offered it.
+      throw new ExportFormatUnavailableException(format.getId());
+    }
+
     AnnotationExportModel model = model(documentId, versionNumber, request, actor, admin);
     try {
       return new Export(renderer.render(model), model.documentTitle(), format);
     } catch (IOException e) {
       throw new AnnotationExportException(documentId, e);
     }
+  }
+
+  /**
+   * The formats this deployment can actually produce, in declaration order.
+   *
+   * <p>Published through {@code GET /api/v1/config} so a client offers only what it can get. Not a
+   * constant: one format needs an external converter, and whether that is installed is a property
+   * of the server, not of the release.
+   */
+  public List<AnnotationExportFormat> availableFormats() {
+    return Arrays.stream(AnnotationExportFormat.values())
+        .filter(renderers::containsKey)
+        .filter(format -> renderers.get(format).isAvailable())
+        .toList();
   }
 
   /** The authorized read, the ordering and the task keys — everything a renderer must not redo. */

--- a/qnop-core/src/main/java/io/qnop/service/review/export/AnnotationExportFormat.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/AnnotationExportFormat.java
@@ -36,7 +36,8 @@ public enum AnnotationExportFormat {
       "docx",
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       ".docx",
-      true);
+      true),
+  PDF("pdf", "application/pdf", ".pdf", true);
 
   /** What a request that names no format gets — the format that shipped first. */
   public static final AnnotationExportFormat DEFAULT = XLSX;

--- a/qnop-core/src/main/java/io/qnop/service/review/export/AnnotationExportRenderer.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/AnnotationExportRenderer.java
@@ -38,6 +38,17 @@ public interface AnnotationExportRenderer {
   AnnotationExportFormat format();
 
   /**
+   * Whether this server can actually produce the format right now.
+   *
+   * <p>Almost always yes — a renderer that only assembles bytes has nothing to be unavailable. It
+   * is a question at all because one format converts through an external process (issue #639), and
+   * a deployment without that installed must not be offered a download it cannot deliver.
+   */
+  default boolean isAvailable() {
+    return true;
+  }
+
+  /**
    * Renders the whole model.
    *
    * @throws java.io.IOException when the underlying document library fails to assemble the file

--- a/qnop-core/src/main/java/io/qnop/service/review/export/ExportFormatUnavailableException.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/ExportFormatUnavailableException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review.export;
+
+/**
+ * The requested format cannot be produced by this deployment (issue #639).
+ *
+ * <p>Its own type, and not an export failure, because the two deserve different answers. A failure
+ * means something broke and retrying might work; this means the server was never able to and never
+ * will be until an operator installs something. `GET /api/v1/config` says so in advance, so a
+ * client that asks anyway is either out of date or hand-written — and both are better served by
+ * "this server does not do that" than by a 500.
+ */
+public class ExportFormatUnavailableException extends RuntimeException {
+
+  public ExportFormatUnavailableException(String format) {
+    super(format + " export is not available on this server");
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/export/PdfAnnotationRenderer.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/PdfAnnotationRenderer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review.export;
+
+import io.qnop.service.convert.OfficeConverter;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renders the export as PDF by rendering the Word report and converting it (issue #639).
+ *
+ * <p>The alternative was to draw the report a second time on a PDF canvas. It was rejected on the
+ * requirement itself: the PDF is meant to <em>look like</em> the Word report, and a second
+ * implementation matches a design only until the next change to either. Everything the report has
+ * grown — the running header, the outline levels, the inline images, the attachment links, the
+ * discussion's rules — would have to be re-derived by hand, and then kept in step by hand forever.
+ *
+ * <p>Converting means there is one design and one renderer. A change to the report appears in the
+ * PDF without anyone doing anything, because it <em>is</em> the report.
+ *
+ * <p>The cost is an office suite in the deployment, out-of-process (ADR-0007/0010) — a dependency
+ * the DOCX ingest roadmap already commits to, so this reuses an installation rather than asking for
+ * one. Where it is absent {@link #isAvailable()} says so and the format is never offered.
+ */
+@Component
+public class PdfAnnotationRenderer implements AnnotationExportRenderer {
+
+  private final DocxAnnotationRenderer word;
+  private final OfficeConverter converter;
+
+  public PdfAnnotationRenderer(DocxAnnotationRenderer word, OfficeConverter converter) {
+    this.word = word;
+    this.converter = converter;
+  }
+
+  @Override
+  public AnnotationExportFormat format() {
+    return AnnotationExportFormat.PDF;
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return converter.isAvailable();
+  }
+
+  @Override
+  public byte[] render(AnnotationExportModel model) throws IOException {
+    return converter.toPdf(word.render(model), "docx");
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/export/PdfAnnotationRendererTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/export/PdfAnnotationRendererTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.service.convert.OfficeConversionException;
+import io.qnop.service.convert.OfficeConverter;
+import io.qnop.service.review.AnnotationPosition;
+import io.qnop.service.review.AnnotationService.AnnotationView;
+import java.io.ByteArrayInputStream;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The PDF renderer (issue #639).
+ *
+ * <p>It converts through a subprocess, which no test may assume exists — so the converter is faked
+ * here and what is asserted is the contract around it: that the Word report is what gets converted,
+ * and that an absent converter is reported as absence rather than as a failure.
+ */
+class PdfAnnotationRendererTest {
+
+  private static final Instant WHEN = Instant.parse("2026-03-04T10:15:30Z");
+
+  /** Records what it was handed and returns something recognisable. */
+  private static final class FakeConverter implements OfficeConverter {
+    private final boolean available;
+    byte[] received;
+    String receivedExtension;
+
+    FakeConverter(boolean available) {
+      this.available = available;
+    }
+
+    @Override
+    public boolean isAvailable() {
+      return available;
+    }
+
+    @Override
+    public byte[] toPdf(byte[] source, String sourceExtension) {
+      if (!available) {
+        throw new OfficeConversionException("no converter");
+      }
+      received = source;
+      receivedExtension = sourceExtension;
+      return "%PDF-1.7 converted".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    }
+  }
+
+  private static AnnotationExportModel model() {
+    AnnotationView view =
+        new AnnotationView(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            null,
+            "Mia Member",
+            "OPEN",
+            "COMMENT",
+            "NORMAL",
+            "{}",
+            "ANCHORED",
+            "The indemnity clause is too broad",
+            1,
+            null,
+            List.of(),
+            WHEN,
+            WHEN);
+    return new AnnotationExportModel(
+        "Vendor agreement",
+        3,
+        List.of(
+            new AnnotationExportModel.Row(
+                "T-1",
+                view,
+                new AnnotationPosition(true, 0, 0.1, 0.1, 0),
+                List.of(),
+                view.firstComment())),
+        AnnotationExportColumn.all(),
+        false,
+        null,
+        ExportDateFormat.ISO,
+        ZoneOffset.UTC,
+        Map.of(),
+        Map.of());
+  }
+
+  @Test
+  @DisplayName("converts the Word report rather than drawing a second one")
+  void convertsTheWordReport() throws Exception {
+    FakeConverter converter = new FakeConverter(true);
+    PdfAnnotationRenderer renderer =
+        new PdfAnnotationRenderer(new DocxAnnotationRenderer(), converter);
+
+    byte[] pdf = renderer.render(model());
+
+    assertThat(new String(pdf, java.nio.charset.StandardCharsets.UTF_8)).startsWith("%PDF");
+    assertThat(converter.receivedExtension).isEqualTo("docx");
+    // What went in is the report itself — which is the whole point: one design,
+    // one renderer, and a change to the report reaches the PDF for free.
+    try (XWPFDocument document = new XWPFDocument(new ByteArrayInputStream(converter.received))) {
+      assertThat(document.getParagraphs().stream().map(p -> p.getText()).toList())
+          .contains("Vendor agreement", "The indemnity clause is too broad");
+    }
+  }
+
+  @Test
+  @DisplayName("reports absence when no converter is installed, instead of failing late")
+  void reportsAbsence() {
+    PdfAnnotationRenderer renderer =
+        new PdfAnnotationRenderer(new DocxAnnotationRenderer(), new FakeConverter(false));
+
+    // A developer machine is the normal case here, and "PDF is not offered" is a
+    // very different thing from "your download broke".
+    assertThat(renderer.isAvailable()).isFalse();
+    assertThatThrownBy(() -> renderer.render(model()))
+        .isInstanceOf(OfficeConversionException.class);
+  }
+
+  @Test
+  @DisplayName("a renderer that only assembles bytes is always available")
+  void otherRenderersAreAlwaysAvailable() {
+    assertThat(new DocxAnnotationRenderer().isAvailable()).isTrue();
+    assertThat(new XlsxAnnotationRenderer().isAvailable()).isTrue();
+  }
+}

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
@@ -185,8 +185,8 @@ describe('ExportAnnotationsButton', () => {
     renderButton();
     await openWizard(user);
 
-    // Answering "is PDF coming?" in the wizard beats a support request.
-    expect(screen.getByRole('button', { name: /PDF/ })).toBeDisabled();
+    // Answering "is HTML coming?" in the wizard beats a support request.
+    expect(screen.getByRole('button', { name: /^HTML/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /Excel/ })).toBeEnabled();
   });
 
@@ -195,7 +195,7 @@ describe('ExportAnnotationsButton', () => {
     renderButton();
     await openWizard(user);
 
-    await user.click(screen.getByRole('button', { name: /Word/ }));
+    await user.click(screen.getByRole('button', { name: /^Word/ }));
     await user.click(screen.getByRole('button', { name: /Next/ }));
     await user.click(screen.getByRole('button', { name: /^Export$/ }));
 
@@ -211,7 +211,7 @@ describe('ExportAnnotationsButton', () => {
     // A spreadsheet has columns; a report does not, and calling them columns
     // there would describe a file the user is not about to get.
     expect(screen.getByText(/of 11 columns/)).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: /Word/ }));
+    await user.click(screen.getByRole('button', { name: /^Word/ }));
     expect(screen.getByText(/of 11 details/)).toBeInTheDocument();
   });
 

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
@@ -22,6 +22,7 @@
 import { useState } from 'react';
 import { Download } from 'lucide-react';
 import { downloadAnnotationExport } from '../../api/annotationExport';
+import { useConfig } from '../../api/hooks/useConfig';
 import { useDocument } from '../../api/hooks/useDocuments';
 import { ToolbarIconButton } from './ToolbarIconButton';
 import { ExportWizard, type ExportCounts } from './export/ExportWizard';
@@ -56,6 +57,9 @@ export function ExportAnnotationsButton({
   // already loaded this document — so it comes from the cache rather than
   // becoming a prop that two call sites have to remember to pass.
   const documentQuery = useDocument(documentId);
+  // Which formats this deployment can actually produce (#639): PDF needs an
+  // office converter, and offering one the server lacks yields a failed download.
+  const configQuery = useConfig();
 
   const run = async (settings: ExportSettings, fileName: string) => {
     setExporting(true);
@@ -96,6 +100,7 @@ export function ExportAnnotationsButton({
           onClose={() => setOpen(false)}
           onExport={run}
           documentTitle={documentQuery.data?.title}
+          offeredFormats={configQuery.data?.exportFormats}
           counts={counts}
           exporting={exporting}
         />

--- a/qnop-ui/src/components/reviews/export/ExportWizard.tsx
+++ b/qnop-ui/src/components/reviews/export/ExportWizard.tsx
@@ -56,6 +56,7 @@ import {
   EXPORT_FIELDS,
   EXPORT_FORMATS,
   defaultFileName,
+  isFormatAvailable,
   FIELD_GROUPS,
   effectiveFields,
   loadSettings,
@@ -114,6 +115,7 @@ export function ExportWizard({
   onExport,
   counts,
   documentTitle,
+  offeredFormats,
   exporting = false,
 }: {
   open: boolean;
@@ -121,6 +123,8 @@ export function ExportWizard({
   onExport: (settings: ExportSettings, fileName: string) => void;
   /** The review's title, which the prefilled filename is derived from. */
   documentTitle?: string | null;
+  /** Formats this server can actually produce; undefined means "assume all shipped ones". */
+  offeredFormats?: string[];
   /** Row counts per scope, so the wizard can say what the download will contain. */
   counts?: ExportCounts;
   exporting?: boolean;
@@ -234,12 +238,13 @@ export function ExportWizard({
                 >
                   {EXPORT_FORMATS.map((entry) => {
                     const active = entry.id === settings.format;
+                    const available = isFormatAvailable(entry, offeredFormats);
                     return (
                       <Box
                         key={entry.id}
                         component="button"
                         type="button"
-                        disabled={entry.planned}
+                        disabled={!available}
                         aria-pressed={active}
                         onClick={() => setSettings((c) => ({ ...c, format: entry.id }))}
                         sx={{
@@ -268,6 +273,9 @@ export function ExportWizard({
                             {entry.extension}
                           </Typography>
                           {entry.planned && <ToneBadge tone="neutral" label="Planned" />}
+                          {!entry.planned && !available && (
+                            <ToneBadge tone="neutral" label="Unavailable" />
+                          )}
                         </Stack>
                         <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
                           {entry.hint}

--- a/qnop-ui/src/components/reviews/export/exportModel.test.ts
+++ b/qnop-ui/src/components/reviews/export/exportModel.test.ts
@@ -24,6 +24,7 @@ import {
   EXPORT_DATE_FORMATS,
   EXPORT_FORMATS,
   defaultSettings,
+  isFormatAvailable,
   effectiveFields,
   loadSettings,
   saveSettings,
@@ -47,6 +48,20 @@ describe('exportModel', () => {
     // them as "planned" would be promising work nobody intends to do.
     const ids = EXPORT_FORMATS.map((format) => format.id);
     expect(ids).toEqual(['xlsx', 'docx', 'html', 'pdf']);
+  });
+
+  it("treats availability as the server's answer, not the release's", () => {
+    const byId = Object.fromEntries(EXPORT_FORMATS.map((format) => [format.id, format]));
+
+    // A planned format is never available, whatever the server lists.
+    expect(isFormatAvailable(byId.html, ['xlsx', 'docx', 'pdf', 'html'])).toBe(false);
+    // A shipped one follows the server: PDF needs an office converter (#639).
+    expect(isFormatAvailable(byId.pdf, ['xlsx', 'docx'])).toBe(false);
+    expect(isFormatAvailable(byId.pdf, ['xlsx', 'docx', 'pdf'])).toBe(true);
+    // Silence is not a refusal — an older server, or a config request still in
+    // flight, must not take a working format away.
+    expect(isFormatAvailable(byId.pdf, undefined)).toBe(true);
+    expect(isFormatAvailable(byId.pdf, [])).toBe(true);
   });
 
   it('starts with everything included', () => {

--- a/qnop-ui/src/components/reviews/export/exportModel.ts
+++ b/qnop-ui/src/components/reviews/export/exportModel.ts
@@ -84,7 +84,7 @@ export const EXPORT_FORMATS: ExportFormat[] = [
     hint: 'A readable report — for meetings and sign-off.',
     fieldNoun: 'details',
     commentsHint:
-      'Every reply in full, indented under the annotation it answers. In an anonymous review the authors stay pseudonymous here too.',
+      'The full discussion under each annotation — every reply, with who wrote it and when. In an anonymous review the authors stay pseudonymous here too.',
   },
   {
     id: 'html',
@@ -101,10 +101,10 @@ export const EXPORT_FORMATS: ExportFormat[] = [
     supportsLogo: true,
     fieldNoun: 'details',
     commentsHint:
-      'Every reply in full, indented under the annotation it answers. In an anonymous review the authors stay pseudonymous here too.',
+      'The full discussion under each annotation — every reply, with who wrote it and when. In an anonymous review the authors stay pseudonymous here too.',
     label: 'PDF',
     extension: '.pdf',
-    hint: 'The Word report, fixed — for archiving and sign-off.',
+    hint: 'Looks the same everywhere — for printing and archiving.',
   },
 ];
 

--- a/qnop-ui/src/components/reviews/export/exportModel.ts
+++ b/qnop-ui/src/components/reviews/export/exportModel.ts
@@ -54,11 +54,16 @@ export interface ExportFormat {
 
 /**
  * The formats the wizard shows. Planned ones are listed on purpose: a user who
- * wonders whether Word exists gets an answer here instead of filing a request,
- * and shipping one flips a flag (issues #637, #639). CSV and Markdown were
+ * wonders whether HTML is coming gets an answer here instead of filing a
+ * request, and shipping one flips a flag (issue #637). CSV and Markdown were
  * dropped (#636/#638): CSV is a strictly worse Excel for this data — no typed
  * dates, nowhere to put the comment threads — and Markdown duplicates what the
  * review UI already shows.
+ *
+ * <p>`planned` is a property of the release. Whether a shipped format can
+ * actually be produced is a property of the *server* — PDF converts through an
+ * out-of-process office suite (#639), which a given deployment may not have —
+ * and that answer comes from `ServerConfig.exportFormats`, not from here.
  */
 export const EXPORT_FORMATS: ExportFormat[] = [
   {
@@ -94,12 +99,12 @@ export const EXPORT_FORMATS: ExportFormat[] = [
   {
     id: 'pdf',
     supportsLogo: true,
-    fieldNoun: 'sections',
-    commentsHint: 'Comment threads are included.',
+    fieldNoun: 'details',
+    commentsHint:
+      'Every reply in full, indented under the annotation it answers. In an anonymous review the authors stay pseudonymous here too.',
     label: 'PDF',
     extension: '.pdf',
-    hint: 'For archiving.',
-    planned: true,
+    hint: 'The Word report, fixed — for archiving and sign-off.',
   },
 ];
 
@@ -177,6 +182,19 @@ export interface ExportSettings {
  *   chain (profile → operator default → UTC). Passed in rather than resolved
  *   here, so the wizard and the rest of the app can never disagree about it.
  */
+/**
+ * Whether the server can actually produce a format.
+ *
+ * <p>A format the release ships is not automatically one this deployment can
+ * make. When the server says nothing — an older build, or a request that has not
+ * landed yet — everything shipped is assumed available, so a missing field never
+ * takes a working format away.
+ */
+export function isFormatAvailable(format: ExportFormat, offered: string[] | undefined): boolean {
+  if (format.planned) return false;
+  return offered === undefined || offered.length === 0 || offered.includes(format.id);
+}
+
 export function defaultSettings(timezone: string = FALLBACK_TIME_ZONE): ExportSettings {
   return {
     format: 'xlsx',


### PR DESCRIPTION
Closes #639.

## The decision the issue turned on

#639 deliberately left open *how* the PDF is produced, and listed three candidates. The requirement settled it: **the PDF should look like the Word report** (#635).

That report is no longer a text dump — a running header with the logo, outline levels, inline images, attachment rows with hyperlinks, and a discussion set with hairline rules and small caps. Drawing it a second time on a PDFBox canvas means hand-writing line breaking, pagination and running headers, and then keeping two implementations in step forever. A second implementation matches a design only until the next change to either.

So `PdfAnnotationRenderer` renders the Word report and converts it. **One design, one renderer** — a change to the report reaches the PDF without anyone doing anything, because it *is* the report. The renderer itself is one line; everything else in this PR is the operational surface that line implies.

## Conversion

Out-of-process through LibreOffice — the only way ADR-0007 permits a copyleft tool, and the same call **ADR-0010 already made** for DOCX ingest, so this reuses an installation the roadmap had committed to rather than asking for a new one.

Invoked with `ProcessBuilder` rather than through a wrapper library: no new Java dependency at all, and the licence boundary stays absolute. Two invocation details are load-bearing and are the usual reason a naive call fails in production:

- **A user profile per run.** LibreOffice refuses to start against a profile another instance holds, so a shared one turns concurrent exports into sporadic failures.
- **A deadline.** A hung office process would otherwise hold a request thread until the server is restarted.

`libreoffice-writer-nogui` goes into the runtime image — the Writer package rather than the full suite, which would be several times the size.

## Availability is a server property, not a release constant

A deployment that drops the package still runs; every developer machine is such a deployment. So:

- `GET /api/v1/config` reports `exportFormats` — what this server can actually produce.
- The wizard offers only those, and shows the rest as **Unavailable · "Not configured on this server."** rather than silently greying them out, so it does not read as a bug.
- A request for a format this server cannot make answers **503** with `EXPORT_FORMAT_UNAVAILABLE`. Not 500: nothing broke, and a retry will not help.

The converter is an interface precisely so a test can fake it — no test, CI runner or laptop may be assumed to have an office suite.

## Test plan

- [x] `./gradlew build` — full gate green
- [x] 3 renderer unit tests against a fake converter: that the *Word report* is what gets converted, that an absent converter reads as absence rather than failure, and that byte-assembling renderers are always available
- [x] An integration test that adapts to the server it runs on — asserts the download and its `application/pdf` where a converter exists, and the 503 with its named code where it does not
- [x] 1190 frontend tests, ESLint and Prettier clean
- [ ] Manual: open the PDF and compare it against the Word report side by side

## Note

LibreOffice is not installed on the machine this was written on, so the integration test exercised the *unavailable* branch here. The conversion fidelity itself is unverified and wants a look in the container.

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
