### PR TITLE
feat(export): export a review as one self-contained HTML page (#637)

### DIFF
--- a/docs/adr/0052-annotation-export.md
+++ b/docs/adr/0052-annotation-export.md
@@ -94,13 +94,13 @@ Pinning it against cell changes needed a second detour. `ClientAnchor.setAnchorT
 
 ### Four formats, not six
 
-CSV and Markdown were dropped (#636/#638) after Word shipped. CSV is a strictly worse Excel for this data — no typed dates, and nowhere to put the comment threads that need a second sheet — and Markdown duplicates what the review UI already renders. Excel and Word cover the two things an export is actually for: a grid to filter and a document to read; HTML (#637) and PDF (#639) remain because they answer "opens anywhere" and "archive this", which neither shipped format does.
+CSV and Markdown were dropped (#636/#638) after Word shipped. CSV is a strictly worse Excel for this data — no typed dates, and nowhere to put the comment threads that need a second sheet — and Markdown duplicates what the review UI already renders. Excel and Word cover the two things an export is actually for: a grid to filter and a document to read; HTML (#637) and PDF (#639) earn their place by answering "opens anywhere" and "archive this", which neither of those does. All four now ship, so the wizard no longer carries a notion of a planned format.
 
 ### Inline images travel with the text
 
 Comment bodies are Markdown, and a screenshot pasted into a review is frequently the substance of the comment. The original flattening stripped image references along with the rest of the markup, so those comments exported as a sentence pointing at nothing.
 
-Bodies are now *split* rather than stripped (`ExportSegment`), and each format decides: Word embeds the picture where the author put it, the spreadsheet writes `[screenshot.png]` in the cell. A floating picture in a filterable grid would be worse than none — the first sort detaches it from its row — but silence was the bug.
+Bodies are now *parsed* rather than stripped, and an image arrives as a block of its own, so each format decides: Word embeds the picture where the author put it, the spreadsheet writes `[screenshot.png]` in the cell. A floating picture in a filterable grid would be worse than none — the first sort detaches it from its row — but silence was the bug.
 
 The bytes arrive through the model, resolved by `ExportImageResolver`, for the same reason the logo does: a renderer that could read an attachment could read one its caller may not see. Two rules bound that resolver, and both are tested. Only this app's own attachment URLs are followed — otherwise an export becomes a fetcher for whatever URL someone typed into a comment, which is server-side request forgery with a review as the delivery vehicle. And every lookup is scoped to the document being exported, so a comment naming another review's attachment resolves to nothing instead of to a file the reader cannot otherwise open.
 
@@ -121,6 +121,18 @@ So `PdfAnnotationRenderer` renders the DOCX and converts it. One design, one ren
 The conversion runs **out-of-process** through LibreOffice — the only way ADR-0007 permits a copyleft tool, and the same call ADR-0010 already made for DOCX ingest, so this reuses an installation the roadmap had committed to rather than asking for a new one. It is invoked with `ProcessBuilder` rather than through a wrapper library: no Java dependency at all, and the licence boundary stays absolute. Two invocation details are load-bearing — a per-run user profile, because LibreOffice refuses to start against one already in use and concurrent exports would otherwise fail sporadically, and a deadline, because a hung office process would hold a request thread until restart.
 
 Whether a deployment can produce PDF is therefore a property of the **server**, not of the release. `GET /api/v1/config` reports `exportFormats`, the wizard offers only those, and a request for a format this server cannot make answers **503** with a named code — nothing broke and a retry will not help. Every developer machine is such a server, which is why the seam is an interface a test can fake.
+
+### HTML is one file, and escapes by construction
+
+The HTML report (#637) is a **single file with no external reference**: the stylesheet and the script are inlined, the branding logo and every screenshot are `data:` URIs. That is the whole reason the format exists — it is the one that opens on a machine with no Office suite, from a mail attachment, on a train. A stylesheet from a CDN or an image left as a URL would make the report depend on the reader's network, and would quietly report back to this server when and where it was read. The integration test asserts the absence, not the presence: no `src="http`, no `<link>`.
+
+The report is assembled from review titles, comment bodies and filenames — all user-written — into a document a browser *executes*. One missed interpolation is stored XSS that travels by e-mail, so escaping is not something a call site may remember to do. `HtmlWriter` makes it structural: `text` and `attr` are the only ways content enters the document and both always escape; raw markup has a single entrance that takes compile-time constants — the scaffolding, the stylesheet, the script. A user string cannot reach it, because a user string is never a constant. That is defence in depth over the parse-level rule above, which already drops `HtmlBlock`/`HtmlInline` before any renderer sees them: the payload a commenter wrote comes out as visible prose, which is exactly right — the reader sees it, the browser does not run it.
+
+**No data is interpolated into the script.** Escaping for HTML is not escaping for JavaScript, and a comment containing `</script>` would end the block early whatever the escaping. The script only reads the DOM and writes `hidden` and `open`, so the question does not arise. It follows that the report is complete without it: the markup carries every finding and every reply, and a mail client that refuses inline script costs the reader the filter, never the content. An empty review ships no script at all — there is nothing to filter.
+
+Images are inlined against a **budget** (8 MB of source bytes, before base64 adds its third). Past it an image degrades to `[name]`, the same marker the spreadsheet uses. A review of thirty screenshots would otherwise produce a file no mail server will carry, which is a worse failure than a missing picture in a report that still says one was there.
+
+HTML does not copy the Word layout, and should not: it is the only format read in a browser, so it gets what a browser is good at — a text filter, status chips, expand-all across the discussions — and a print stylesheet that drops those controls and keeps a finding from breaking across pages. It is light-only and uses system fonts: this artifact is printed and filed, a document that guesses at the reader's theme guesses wrong on paper, and embedding a webface would add megabytes to a file meant to travel as an attachment.
 
 ### The filename is the user's, within limits
 
@@ -173,6 +185,7 @@ Headings use direct character formatting plus an OOXML outline level rather than
 - **2026-07-29** — inline images in annotations and comments are exported rather than stripped; other attachments are linked.
 - **2026-07-29** — PDF (#639) ships by converting the Word report out-of-process, and format availability becomes a server capability rather than a release constant.
 - **2026-07-30** — comment markdown is parsed once with commonmark and rendered by each format instead of being flattened away (#637).
+- **2026-07-30** — HTML (#637) ships as a single self-contained page; all four formats are now implemented.
 - **ADR-0021 / ADR-0015** — OpenAPI-first, and why this endpoint is the deliberate exception
 - **ADR-0004** — the layering that puts the workbook in the service and leaves the controller streaming
 - Issue **#547**

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationExportIT.java
@@ -993,4 +993,72 @@ class AnnotationExportIT extends SeededIntegrationTest {
     assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("#");
     assertThat(sheet.getLastRowNum()).isZero();
   }
+
+  /** Downloads the HTML report and returns the page as text. */
+  private String downloadHtml(UUID actor, String... params) throws Exception {
+    var request =
+        get("/api/v1/documents/" + documentId + "/annotations/export").param("format", "html");
+    for (int index = 0; index + 1 < params.length; index += 2) {
+      request = request.param(params[index], params[index + 1]);
+    }
+    return mockMvc
+        .perform(as(request, actor))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Content-Type", "text/html;charset=UTF-8"))
+        .andExpect(
+            header().string("Content-Disposition", org.hamcrest.Matchers.containsString(".html")))
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+  }
+
+  @Test
+  @DisplayName("the HTML report is one file that fetches nothing, logo and screenshots included")
+  void htmlIsSelfContained() throws Exception {
+    seedDocument(false);
+    String url = uploadImage(MEMBER_ID, "screenshot.png");
+    createAnnotationReturningId(MEMBER_ID, 0, 0.1, 0.1, "A finding ![screenshot.png](" + url + ")");
+
+    String page = downloadHtml(MEMBER_ID);
+
+    // The whole chain, which only an IT covers: the bundled SVG default is
+    // rasterized by the branding service, the screenshot comes back out of object
+    // storage, and both end up inside the file as data URIs. A single external
+    // reference would break the promise the format makes — opens anywhere, and
+    // tells nobody when it was read.
+    assertThat(page).doesNotContain("src=\"http", "src=\"/api/", "<link ");
+    assertThat(page.split("src=\"data:image/", -1)).hasSize(3);
+    assertThat(page).contains("A finding", "Vendor agreement");
+  }
+
+  @Test
+  @DisplayName("an anonymous review's HTML report names no foreign author (ADR-0038)")
+  void htmlRespectsAnonymity() throws Exception {
+    seedDocument(true);
+    String annotationId = createAnnotationReturningId(AUDITOR_ID, 0, 0.1, 0.1, "Opened by a peer");
+    reply(annotationId, AUDITOR_ID, "And answered by the same peer");
+
+    // The renderer never sees a repository, so this can only come out right if
+    // the service pseudonymised before handing over the model — the point of
+    // ADR-0052's split, checked on the format most easily forwarded by mail.
+    String page = downloadHtml(MEMBER2_ID, "comments", "true");
+
+    assertThat(page).contains("Participant", "Opened by a peer", "And answered by the same peer");
+    assertThat(page).doesNotContain("Avery Auditor");
+  }
+
+  @Test
+  @DisplayName("a user who cannot see the review cannot export it as HTML either")
+  void htmlIsRefusedToForeignUsers() throws Exception {
+    seedDocument(false);
+    annotate(MEMBER_ID, 0, 0.1, 0.1, "Not for outsiders");
+
+    mockMvc
+        .perform(
+            as(
+                get("/api/v1/documents/" + documentId + "/annotations/export")
+                    .param("format", "html"),
+                EXTERNAL_ID))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/qnop-core/src/main/java/io/qnop/service/review/export/AnnotationExportFormat.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/AnnotationExportFormat.java
@@ -27,8 +27,8 @@ import java.util.Locale;
  * The file formats an annotation export can produce (issues #547, #635).
  *
  * <p>One place that knows an id, its media type and its extension, so the controller, the filename
- * helper and the renderer lookup cannot drift apart. The remaining formats (#637, #639) are entries
- * here plus a renderer, nothing else.
+ * helper and the renderer lookup cannot drift apart. A further format is an entry here plus a
+ * renderer, nothing else.
  */
 public enum AnnotationExportFormat {
   XLSX("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx", true),
@@ -37,6 +37,7 @@ public enum AnnotationExportFormat {
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       ".docx",
       true),
+  HTML("html", "text/html;charset=UTF-8", ".html", true),
   PDF("pdf", "application/pdf", ".pdf", true);
 
   /** What a request that names no format gets — the format that shipped first. */

--- a/qnop-core/src/main/java/io/qnop/service/review/export/HtmlAnnotationRenderer.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/HtmlAnnotationRenderer.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review.export;
+
+import io.qnop.service.review.AnnotationService.AnnotationView;
+import io.qnop.service.review.AnnotationService.CommentView;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Renders the export as one self-contained HTML file (issue #637).
+ *
+ * <p>One file and nothing else: the stylesheet and the script are inlined, images travel as {@code
+ * data:} URIs, and no font is fetched. It has to open from a mail attachment on a train — an
+ * external reference would break that promise and, incidentally, tell someone when the report was
+ * read.
+ *
+ * <p>It is also the only export that can be <em>interactive</em>, which is the reason it exists
+ * beside the PDF: a reader facing eighty findings can filter them. The script does that and nothing
+ * more, and the document is complete without it — a client that refuses inline script costs the
+ * filter, never the findings.
+ *
+ * <p><strong>Every user string is escaped by construction</strong> ({@link HtmlWriter}), raw markup
+ * comes only from compile-time constants, and markup a commenter wrote was already dropped at the
+ * parse (ADR-0052). Those three together are why a review cannot be turned into a document that
+ * runs code on whoever opens it.
+ */
+@Component
+public class HtmlAnnotationRenderer implements AnnotationExportRenderer {
+
+  /**
+   * How many bytes of image this format will inline.
+   *
+   * <p>Base64 adds a third, so the resolver's budget would become a file no mail server accepts.
+   * Beyond this an image degrades to its name, which is what an unresolvable one already does.
+   */
+  private static final int IMAGE_BUDGET_BYTES = 8 * 1024 * 1024;
+
+  @Override
+  public AnnotationExportFormat format() {
+    return AnnotationExportFormat.HTML;
+  }
+
+  @Override
+  public byte[] render(AnnotationExportModel model) {
+    HtmlWriter html = new HtmlWriter();
+    Budget budget = new Budget(IMAGE_BUDGET_BYTES);
+
+    html.raw("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">")
+        .raw("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">")
+        .raw("<title>");
+    html.text(model.documentTitle() + " — annotations");
+    html.raw("</title><style>").raw(HtmlReportStyle.CSS).raw("</style></head><body>");
+    html.raw("<main class=\"sheet\">");
+
+    writeMasthead(html, model, budget);
+    if (model.rows().isEmpty()) {
+      html.raw("<p class=\"empty\">This review has no annotations.</p>");
+    } else {
+      writeControls(html, model);
+      for (AnnotationExportModel.Row row : model.rows()) {
+        writeFinding(html, model, row, budget);
+      }
+    }
+
+    html.raw("</main>");
+    if (!model.rows().isEmpty()) {
+      html.raw("<script>").raw(HtmlReportStyle.JS).raw("</script>");
+    }
+    html.raw("</body></html>");
+    return html.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  private void writeMasthead(HtmlWriter html, AnnotationExportModel model, Budget budget) {
+    html.raw("<header class=\"masthead\"><div>");
+    html.raw("<h1>").text(model.documentTitle()).raw("</h1>");
+    html.raw("<p class=\"sub\">");
+    List<String> parts = new ArrayList<>();
+    parts.add("Annotation report");
+    if (model.versionNumber() != null) {
+      parts.add("version " + model.versionNumber());
+    }
+    parts.add(model.rows().size() + (model.rows().size() == 1 ? " annotation" : " annotations"));
+    html.text(String.join(" · ", parts));
+    html.raw("</p></div>");
+    if (model.hasLogo() && budget.take(model.logoPng().length)) {
+      html.raw("<img").attr("src", dataUri("image/png", model.logoPng())).attr("alt", "").raw(">");
+    }
+    html.raw("</header>");
+  }
+
+  /**
+   * The filter bar.
+   *
+   * <p>Rendered as real form controls with no handlers attached in markup — the script wires them
+   * up. Without it they simply do nothing, which is why the findings below are never hidden by
+   * default.
+   */
+  private void writeControls(HtmlWriter html, AnnotationExportModel model) {
+    html.raw("<div class=\"controls\">");
+    html.raw("<input id=\"q\" type=\"search\"")
+        .attr("placeholder", "Search these findings…")
+        .attr("aria-label", "Search findings")
+        .raw(">");
+    html.raw("<button type=\"button\" data-status=\"all\" aria-pressed=\"true\">All</button>");
+    html.raw("<button type=\"button\" data-status=\"Open\" aria-pressed=\"false\">Open</button>");
+    html.raw(
+        "<button type=\"button\" data-status=\"Resolved\" aria-pressed=\"false\">Resolved</button>");
+    html.raw("<button type=\"button\" id=\"expand\" aria-pressed=\"false\">Discussions</button>");
+    html.raw("<span class=\"count\" id=\"count\">");
+    html.text(model.rows().size() + " of " + model.rows().size());
+    html.raw("</span></div>");
+  }
+
+  private void writeFinding(
+      HtmlWriter html, AnnotationExportModel model, AnnotationExportModel.Row row, Budget budget) {
+    AnnotationView view = row.view();
+    html.raw("<article class=\"finding\"")
+        .attr("data-status", ExportText.humanize(view.status()))
+        .raw(">");
+
+    html.raw("<div class=\"key\"><h2>");
+    html.text(headingText(model, row));
+    html.raw("</h2></div>");
+
+    html.raw("<p class=\"facts\">");
+    for (String fact : facts(model, row)) {
+      html.raw("<span>").text(fact).raw("</span>");
+    }
+    html.raw("</p>");
+
+    if (model.has(AnnotationExportColumn.SUMMARY)) {
+      html.raw("<div class=\"body\">");
+      writeBlocks(html, model, ExportMarkdown.parse(row.openingComment()), budget);
+      html.raw("</div>");
+    }
+
+    writeThread(html, model, row, budget);
+    html.raw("</article>");
+  }
+
+  private void writeThread(
+      HtmlWriter html, AnnotationExportModel model, AnnotationExportModel.Row row, Budget budget) {
+    List<CommentView> replies = row.replyComments();
+    if (replies.isEmpty()) {
+      return;
+    }
+    String finder = row.view().authorDisplayName();
+    html.raw("<details class=\"thread\"><summary>");
+    html.text("Discussion · " + replies.size() + (replies.size() == 1 ? " reply" : " replies"));
+    html.raw("</summary>");
+    for (CommentView comment : replies) {
+      boolean byFinder = finder != null && finder.equals(comment.authorDisplayName());
+      html.raw(byFinder ? "<div class=\"turn by-author\">" : "<div class=\"turn\">");
+      html.raw("<div><span class=\"who\">");
+      html.text(
+          comment.authorDisplayName() == null || comment.authorDisplayName().isBlank()
+              ? "Unknown"
+              : comment.authorDisplayName());
+      html.raw("</span><span class=\"when\">");
+      html.text(model.formatTimestamp(comment.createdAt()));
+      html.raw("</span></div><div class=\"body\">");
+      writeBlocks(html, model, ExportMarkdown.parse(comment.body()), budget);
+      html.raw("</div></div>");
+    }
+    html.raw("</details>");
+  }
+
+  /** The shared blocks as elements; consecutive list items and table rows are grouped. */
+  private void writeBlocks(
+      HtmlWriter html, AnnotationExportModel model, List<ExportBlock> blocks, Budget budget) {
+    int quoted = 0;
+    for (int index = 0; index < blocks.size(); index++) {
+      ExportBlock block = blocks.get(index);
+      quoted = adjustQuote(html, quoted, block.quoteDepth());
+
+      if (block instanceof ExportBlock.ListItem) {
+        index = writeList(html, blocks, index) - 1;
+        continue;
+      }
+      if (block instanceof ExportBlock.TableRow) {
+        index = writeTable(html, blocks, index) - 1;
+        continue;
+      }
+      switch (block) {
+        case ExportBlock.Paragraph paragraph -> {
+          html.raw("<p>");
+          writeSpans(html, paragraph.spans());
+          html.raw("</p>");
+        }
+        case ExportBlock.Heading heading -> {
+          // Never above h3: h1 is the review and h2 the finding, and a commenter's
+          // heading is neither.
+          String tag = "h" + Math.min(6, 2 + Math.max(1, heading.level()));
+          html.open(tag);
+          writeSpans(html, heading.spans());
+          html.close(tag);
+        }
+        case ExportBlock.Code code -> {
+          html.raw("<pre><code>").text(code.text().stripTrailing()).raw("</code></pre>");
+        }
+        case ExportBlock.Image image -> writeImage(html, model, image, budget);
+        case ExportBlock.Attachment file -> writeAttachment(html, model, file);
+        case ExportBlock.Divider ignored -> html.raw("<hr>");
+        case ExportBlock.ListItem ignored -> {}
+        case ExportBlock.TableRow ignored -> {}
+      }
+    }
+    adjustQuote(html, quoted, 0);
+  }
+
+  /** Opens or closes blockquotes so the nesting matches the block's depth. */
+  private int adjustQuote(HtmlWriter html, int current, int wanted) {
+    for (int depth = current; depth < wanted; depth++) {
+      html.raw("<blockquote>");
+    }
+    for (int depth = current; depth > wanted; depth--) {
+      html.raw("</blockquote>");
+    }
+    return wanted;
+  }
+
+  /** A run of list items as one list; returns the index after the run. */
+  private int writeList(HtmlWriter html, List<ExportBlock> blocks, int from) {
+    ExportBlock.ListItem first = (ExportBlock.ListItem) blocks.get(from);
+    boolean ordered = !first.marker().equals("•");
+    String tag = ordered ? "ol" : "ul";
+    html.open(tag);
+    int index = from;
+    while (index < blocks.size() && blocks.get(index) instanceof ExportBlock.ListItem item) {
+      html.raw("<li>");
+      writeSpans(html, item.spans());
+      html.raw("</li>");
+      index++;
+    }
+    html.close(tag);
+    return index;
+  }
+
+  /** A run of table rows as one table; returns the index after the run. */
+  private int writeTable(HtmlWriter html, List<ExportBlock> blocks, int from) {
+    html.raw("<table>");
+    int index = from;
+    while (index < blocks.size() && blocks.get(index) instanceof ExportBlock.TableRow row) {
+      html.raw("<tr>");
+      String cell = row.header() ? "th" : "td";
+      for (List<ExportSpan> spans : row.cells()) {
+        html.open(cell);
+        writeSpans(html, spans);
+        html.close(cell);
+      }
+      html.raw("</tr>");
+      index++;
+    }
+    html.raw("</table>");
+    return index;
+  }
+
+  private void writeSpans(HtmlWriter html, List<ExportSpan> spans) {
+    for (ExportSpan span : spans) {
+      switch (span) {
+        case ExportSpan.Break ignored -> html.raw("<br>");
+        case ExportSpan.Link link -> {
+          if (ExportMarkdown.isSafeHref(link.href())) {
+            html.raw("<a").attr("href", link.href()).attr("rel", "noopener noreferrer").raw(">");
+            writeSpans(html, link.spans());
+            html.raw("</a>");
+          } else {
+            // A javascript: or data: target keeps its words and loses its link.
+            writeSpans(html, link.spans());
+          }
+        }
+        case ExportSpan.Text text -> {
+          List<String> tags = new ArrayList<>();
+          if (text.has(ExportSpan.Style.BOLD)) {
+            tags.add("strong");
+          }
+          if (text.has(ExportSpan.Style.ITALIC)) {
+            tags.add("em");
+          }
+          if (text.has(ExportSpan.Style.STRIKETHROUGH)) {
+            tags.add("s");
+          }
+          if (text.has(ExportSpan.Style.CODE)) {
+            tags.add("code");
+          }
+          tags.forEach(tag -> html.open(tag));
+          html.text(text.value());
+          for (int index = tags.size() - 1; index >= 0; index--) {
+            html.close(tags.get(index));
+          }
+        }
+      }
+    }
+  }
+
+  private void writeImage(
+      HtmlWriter html, AnnotationExportModel model, ExportBlock.Image image, Budget budget) {
+    ExportImage resolved = model.image(image.url());
+    String alt = image.alt() == null || image.alt().isBlank() ? "image" : image.alt();
+    if (resolved == null || !resolved.hasContent() || !budget.take(resolved.content().length)) {
+      html.raw("<p class=\"file\">").text("[" + alt + "]").raw("</p>");
+      return;
+    }
+    html.raw("<img")
+        .attr("src", dataUri(resolved.contentType(), resolved.content()))
+        .attr("alt", alt)
+        .raw(">");
+  }
+
+  private void writeAttachment(
+      HtmlWriter html, AnnotationExportModel model, ExportBlock.Attachment file) {
+    ExportAttachment resolved = model.attachment(file.url());
+    String label =
+        resolved != null && resolved.fileName() != null && !resolved.fileName().isBlank()
+            ? resolved.fileName()
+            : (file.label() == null || file.label().isBlank() ? "attachment" : file.label());
+
+    html.raw("<p class=\"file\">📎 ");
+    boolean linkable =
+        resolved != null && resolved.href() != null && ExportMarkdown.isSafeHref(resolved.href());
+    if (linkable) {
+      html.raw("<a").attr("href", resolved.href()).attr("rel", "noopener noreferrer").raw(">");
+      html.text(label);
+      html.raw("</a><span class=\"meta\">").text(resolved.describe()).raw("</span>");
+    } else {
+      html.text(label);
+    }
+    html.raw("</p>");
+  }
+
+  /** {@code T-3 · Page 2}, the same shorthand every other format uses. */
+  private String headingText(AnnotationExportModel model, AnnotationExportModel.Row row) {
+    StringBuilder text = new StringBuilder();
+    if (model.has(AnnotationExportColumn.TASK_KEY)) {
+      text.append(row.taskKey());
+    }
+    if (model.has(AnnotationExportColumn.PAGE) && row.page() != null) {
+      if (!text.isEmpty()) {
+        text.append(" · ");
+      }
+      text.append("Page ").append(row.page());
+    }
+    return text.isEmpty() ? "Annotation" : text.toString();
+  }
+
+  private List<String> facts(AnnotationExportModel model, AnnotationExportModel.Row row) {
+    AnnotationView view = row.view();
+    List<String> facts = new ArrayList<>();
+    add(facts, model, AnnotationExportColumn.STATUS, "Status", ExportText.humanize(view.status()));
+    add(facts, model, AnnotationExportColumn.TYPE, "Type", ExportText.humanize(view.type()));
+    add(
+        facts,
+        model,
+        AnnotationExportColumn.PRIORITY,
+        "Priority",
+        ExportText.humanize(view.priority()));
+    add(facts, model, AnnotationExportColumn.AUTHOR, "Author", view.authorDisplayName());
+    add(
+        facts,
+        model,
+        AnnotationExportColumn.PLACEMENT,
+        "Placement",
+        ExportText.humanize(view.placementStatus()));
+    add(facts, model, AnnotationExportColumn.REPLIES, "Replies", String.valueOf(row.replies()));
+    add(
+        facts,
+        model,
+        AnnotationExportColumn.CREATED,
+        "Created",
+        model.formatTimestamp(view.createdAt()));
+    add(
+        facts,
+        model,
+        AnnotationExportColumn.UPDATED,
+        "Updated",
+        model.formatTimestamp(view.updatedAt()));
+    return facts;
+  }
+
+  private static void add(
+      List<String> facts,
+      AnnotationExportModel model,
+      AnnotationExportColumn column,
+      String label,
+      String value) {
+    if (model.has(column) && value != null && !value.isBlank()) {
+      facts.add(label + ": " + value);
+    }
+  }
+
+  private static String dataUri(String contentType, byte[] content) {
+    return "data:"
+        + (contentType == null || contentType.isBlank() ? "image/png" : contentType)
+        + ";base64,"
+        + Base64.getEncoder().encodeToString(content);
+  }
+
+  /** What is left of the inlining allowance. */
+  private static final class Budget {
+    private int remaining;
+
+    Budget(int bytes) {
+      this.remaining = bytes;
+    }
+
+    boolean take(int bytes) {
+      if (bytes > remaining) {
+        return false;
+      }
+      remaining -= bytes;
+      return true;
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/export/HtmlReportStyle.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/HtmlReportStyle.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review.export;
+
+/**
+ * The HTML report's stylesheet and script, inlined (issue #637).
+ *
+ * <p>Constants rather than resource files, and that is the point: everything {@link HtmlWriter#raw}
+ * accepts has to be a literal, so a user string can never take this path. It also keeps the promise
+ * the format makes — one file, no fetches — visible in one place.
+ *
+ * <p>System fonts only. Embedding a webface would add megabytes to a document meant to travel as a
+ * mail attachment, and the report's typography does not depend on one.
+ *
+ * <p>Light only, deliberately: this artifact is printed and filed, and a document that guesses at
+ * the reader's theme guesses wrong on paper.
+ */
+final class HtmlReportStyle {
+
+  private HtmlReportStyle() {}
+
+  static final String CSS =
+      """
+      *,*::before,*::after{box-sizing:border-box}
+      body{margin:0;background:#f4f5f7;color:#111827;
+        font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+      .sheet{max-width:60rem;margin:0 auto;padding:2.5rem 1.5rem 5rem}
+      .masthead{display:flex;flex-wrap:wrap;align-items:flex-start;
+        justify-content:space-between;gap:1rem 2rem;
+        padding-bottom:1.25rem;border-bottom:2px solid #111827}
+      /* An operator's logo is whatever they uploaded: without a width bound a wide
+         one pushes the whole page sideways on a phone. */
+      .masthead img{max-height:44px;max-width:100%;width:auto}
+      h1{margin:0;font-size:1.9rem;line-height:1.2;letter-spacing:-.02em}
+      .sub{margin:.35rem 0 0;color:#6b7280;font-size:.875rem}
+      .controls{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center;margin:1.5rem 0 .5rem}
+      .controls input{flex:1 1 16rem;min-width:12rem;padding:.5rem .7rem;font:inherit;
+        border:1px solid #d1d5db;border-radius:.5rem;background:#fff}
+      .controls button{padding:.45rem .8rem;font:inherit;font-size:.85rem;cursor:pointer;
+        border:1px solid #d1d5db;border-radius:999px;background:#fff;color:#374151}
+      .controls button[aria-pressed=true]{background:#1f3a8a;border-color:#1f3a8a;color:#fff}
+      .count{color:#6b7280;font-size:.85rem}
+      .finding{background:#fff;border:1px solid #e5e7eb;border-radius:.75rem;
+        padding:1.25rem 1.5rem;margin:1rem 0;box-shadow:0 1px 2px rgba(17,24,39,.04)}
+      .finding[hidden]{display:none}
+      .key{display:flex;align-items:baseline;gap:.6rem;flex-wrap:wrap}
+      .key h2{margin:0;font-size:1.05rem;color:#1f3a8a;letter-spacing:-.01em}
+      /* Flex, because the facts are written without whitespace between them and
+         inline boxes cannot break where there is none — a timestamp split across
+         two lines reads as two facts, and nowrap alone would push the line out of
+         the card. The separator trails its fact so a wrap never starts a line
+         with a lone dot. */
+      .facts{display:flex;flex-wrap:wrap;column-gap:.5rem;row-gap:.15rem;
+        margin:.35rem 0 .9rem;color:#6b7280;font-size:.8125rem}
+      .facts span{white-space:nowrap}
+      .facts span:not(:last-child)::after{content:"·";margin-left:.5rem;color:#d1d5db}
+      .body>*:first-child{margin-top:0}
+      .body>*:last-child{margin-bottom:0}
+      .body p{margin:.6rem 0}
+      .body h3,.body h4,.body h5{margin:1rem 0 .4rem;font-size:1rem}
+      .body ul,.body ol{margin:.5rem 0;padding-left:1.4rem}
+      .body blockquote{margin:.7rem 0;padding-left:.9rem;border-left:2px solid #c7d2e4;color:#374151}
+      .body pre{margin:.7rem 0;padding:.7rem .9rem;overflow-x:auto;background:#f8fafc;
+        border:1px solid #e5e7eb;border-radius:.4rem}
+      .body code,.body pre{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+        font-size:.86em}
+      .body img{max-width:100%;height:auto;border:1px solid #e5e7eb;border-radius:.4rem;margin:.6rem 0}
+      .body table{border-collapse:collapse;margin:.7rem 0;font-size:.9em}
+      .body th,.body td{border:1px solid #e5e7eb;padding:.35rem .6rem;text-align:left}
+      .body th{background:#f8fafc}
+      .file{display:inline-flex;align-items:baseline;gap:.4rem;margin:.35rem 0;
+        font-size:.9rem;color:#1d4ed8}
+      .file .meta{color:#6b7280;font-size:.8125rem}
+      a{color:#1d4ed8}
+      .thread{margin-top:1rem;border-top:1px solid #e5e7eb;padding-top:.5rem}
+      .thread>summary{cursor:pointer;list-style:none;padding:.4rem 0;
+        font-size:.75rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#6b7280}
+      .thread>summary::-webkit-details-marker{display:none}
+      .thread>summary::before{content:"▸";display:inline-block;width:1em;color:#9ca3af}
+      .thread[open]>summary::before{content:"▾"}
+      .turn{padding:.6rem 0 .6rem 1rem;border-left:2px solid #c7d2e4}
+      .turn.by-author{border-left-color:#1f3a8a;border-left-width:3px}
+      .turn .who{font-size:.8125rem;font-weight:700;color:#111827}
+      .turn.by-author .who{color:#1f3a8a}
+      .turn .when{font-size:.8125rem;color:#6b7280;margin-left:.6rem}
+      .empty{padding:3rem 0;text-align:center;color:#6b7280}
+      @media print{
+        body{background:#fff}
+        .sheet{max-width:none;padding:0}
+        .controls{display:none}
+        .finding{break-inside:avoid;page-break-inside:avoid;
+          border:0;border-bottom:1px solid #e5e7eb;border-radius:0;box-shadow:none;padding:1rem 0}
+        .thread[open]>summary,.thread>summary{color:#6b7280}
+        a{color:inherit;text-decoration:underline}
+      }
+      """;
+
+  /**
+   * Filtering and expand-all, and nothing else.
+   *
+   * <p>It reads from the DOM and writes only {@code hidden} and {@code open} — no data is
+   * interpolated into it, because escaping for HTML is not escaping for JavaScript and a body
+   * containing {@code </script>} would end the block early. Keeping the script free of content
+   * makes that impossible rather than merely unlikely.
+   *
+   * <p>The report is complete without it. A mail client that refuses inline script costs the reader
+   * the filter, never the findings — which is why the markup carries everything and the script only
+   * hides parts of it.
+   */
+  static final String JS =
+      """
+      (function () {
+        var q = document.getElementById('q');
+        var count = document.getElementById('count');
+        // Scoped to the bar: the findings carry data-status too, and a selector
+        // that swept them up would turn any click on a card into a filter.
+        var chips = Array.prototype.slice.call(
+          document.querySelectorAll('.controls button[data-status]'));
+        var findings = Array.prototype.slice.call(document.querySelectorAll('.finding'));
+        var status = 'all';
+        function apply() {
+          var needle = (q.value || '').toLowerCase();
+          var shown = 0;
+          findings.forEach(function (el) {
+            var okStatus = status === 'all' || el.getAttribute('data-status') === status;
+            var okText = !needle || (el.textContent || '').toLowerCase().indexOf(needle) !== -1;
+            var show = okStatus && okText;
+            el.hidden = !show;
+            if (show) shown++;
+          });
+          count.textContent = shown + ' of ' + findings.length;
+        }
+        q.addEventListener('input', apply);
+        chips.forEach(function (chip) {
+          chip.addEventListener('click', function () {
+            status = chip.getAttribute('data-status');
+            chips.forEach(function (other) {
+              other.setAttribute('aria-pressed', String(other === chip));
+            });
+            apply();
+          });
+        });
+        var toggle = document.getElementById('expand');
+        if (toggle) {
+          toggle.addEventListener('click', function () {
+            var threads = document.querySelectorAll('details.thread');
+            var open = toggle.getAttribute('aria-pressed') !== 'true';
+            Array.prototype.forEach.call(threads, function (t) { t.open = open; });
+            toggle.setAttribute('aria-pressed', String(open));
+          });
+        }
+        apply();
+      })();
+      """;
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/export/HtmlWriter.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/HtmlWriter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review.export;
+
+/**
+ * Builds the HTML export, escaping by construction (issue #637).
+ *
+ * <p>The export is a document a browser executes, assembled from review titles, comment text and
+ * filenames — all of it written by users. Getting one interpolation wrong turns it into stored XSS
+ * that travels by e-mail, so escaping cannot be something a caller remembers to do.
+ *
+ * <p>Hence the shape of this class: {@link #text} and {@link #attr} are the <em>only</em> ways
+ * content enters the document, and both always escape. Raw markup has one entrance, {@link #raw},
+ * and it takes a compile-time constant — the stylesheet, the script, a tag this class itself emits.
+ * A user string cannot reach it, because a user string is never a constant.
+ */
+final class HtmlWriter {
+
+  private final StringBuilder out = new StringBuilder(8192);
+
+  /**
+   * Appends markup verbatim.
+   *
+   * <p>For the document's own scaffolding only. Every call site passes a literal; none passes
+   * anything derived from the model.
+   */
+  HtmlWriter raw(String markup) {
+    out.append(markup);
+    return this;
+  }
+
+  /** Appends text, escaped. The only way content becomes part of the document. */
+  HtmlWriter text(String value) {
+    return raw(escape(value));
+  }
+
+  /** Opens a tag with an optional class. */
+  HtmlWriter open(String tag, String className) {
+    raw("<").raw(tag);
+    if (className != null) {
+      raw(" class=\"").raw(escape(className)).raw("\"");
+    }
+    return raw(">");
+  }
+
+  HtmlWriter open(String tag) {
+    return open(tag, null);
+  }
+
+  HtmlWriter close(String tag) {
+    return raw("</").raw(tag).raw(">");
+  }
+
+  /** An attribute, escaped for a double-quoted value. */
+  HtmlWriter attr(String name, String value) {
+    return raw(" ").raw(name).raw("=\"").raw(escape(value)).raw("\"");
+  }
+
+  @Override
+  public String toString() {
+    return out.toString();
+  }
+
+  /**
+   * Escapes for both text and quoted-attribute contexts.
+   *
+   * <p>All five, including both quote characters: an attribute value is where a single missing
+   * escape lets an author close the attribute and add another one. {@code &} goes first, or the
+   * escapes would escape each other.
+   */
+  static String escape(String value) {
+    if (value == null || value.isEmpty()) {
+      return "";
+    }
+    StringBuilder escaped = new StringBuilder(value.length() + 16);
+    for (int index = 0; index < value.length(); index++) {
+      char character = value.charAt(index);
+      switch (character) {
+        case '&' -> escaped.append("&amp;");
+        case '<' -> escaped.append("&lt;");
+        case '>' -> escaped.append("&gt;");
+        case '"' -> escaped.append("&quot;");
+        case '\'' -> escaped.append("&#39;");
+        default -> escaped.append(character);
+      }
+    }
+    return escaped.toString();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/export/HtmlAnnotationRendererTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/export/HtmlAnnotationRendererTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.service.review.AnnotationPosition;
+import io.qnop.service.review.AnnotationService.AnnotationView;
+import io.qnop.service.review.AnnotationService.CommentView;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** The self-contained HTML report (issue #637). */
+class HtmlAnnotationRendererTest {
+
+  private final HtmlAnnotationRenderer renderer = new HtmlAnnotationRenderer();
+
+  private static final Instant WHEN = Instant.parse("2026-03-04T10:15:30Z");
+
+  private static AnnotationView view(String title, String body, String author) {
+    return new AnnotationView(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        null,
+        author,
+        "OPEN",
+        "COMMENT",
+        "NORMAL",
+        "{}",
+        "ANCHORED",
+        body,
+        1,
+        null,
+        List.of(),
+        WHEN,
+        WHEN);
+  }
+
+  private static CommentView comment(String author, String body) {
+    return new CommentView(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        null,
+        author,
+        body,
+        List.of(),
+        WHEN);
+  }
+
+  private static String render(HtmlAnnotationRenderer renderer, AnnotationExportModel model) {
+    return new String(renderer.render(model), StandardCharsets.UTF_8);
+  }
+
+  private static AnnotationExportModel model(String title, String body) {
+    return model(title, body, List.of(), Map.of(), Map.of(), null);
+  }
+
+  private static AnnotationExportModel model(
+      String title,
+      String body,
+      List<CommentView> thread,
+      Map<String, ExportImage> images,
+      Map<String, ExportAttachment> files,
+      byte[] logo) {
+    AnnotationView view = view(title, body, "Mia Member");
+    return new AnnotationExportModel(
+        title,
+        3,
+        List.of(
+            new AnnotationExportModel.Row(
+                "T-1", view, new AnnotationPosition(true, 0, 0.1, 0.1, 0), thread, body)),
+        AnnotationExportColumn.all(),
+        true,
+        logo,
+        ExportDateFormat.ISO,
+        ZoneOffset.UTC,
+        images,
+        files);
+  }
+
+  private static byte[] png(int width, int height) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ImageIO.write(new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB), "png", out);
+    return out.toByteArray();
+  }
+
+  @Test
+  @DisplayName("the file references nothing outside itself")
+  void isSelfContained() throws Exception {
+    String html =
+        render(
+            renderer,
+            model(
+                "Vendor agreement",
+                "See ![shot.png](/api/v1/documents/d/attachments/a)",
+                List.of(),
+                Map.of(
+                    "/api/v1/documents/d/attachments/a",
+                    new ExportImage("shot.png", png(20, 10), "image/png")),
+                Map.of(),
+                png(40, 20)));
+
+    // It has to open from a mail attachment on a train. Any external reference
+    // would break that — and would say when the report was read.
+    assertThat(html).doesNotContain("<link ");
+    assertThat(html).doesNotContain("src=\"http", "src='http");
+    assertThat(html).doesNotContain("@import", "url(http");
+    // The stylesheet, the script and both images are all in the file.
+    assertThat(html).contains("<style>", "<script>");
+    assertThat(html).contains("src=\"data:image/png;base64,");
+  }
+
+  @Test
+  @DisplayName("a script a commenter wrote is not in the document, escaped or otherwise")
+  void refusesInjectedMarkup() {
+    String attack = "Before <script>alert(1)</script> and <img src=x onerror=alert(2)> after";
+
+    String html = render(renderer, model("Vendor agreement", attack));
+
+    // The tags are dropped at the parse, so nothing a commenter wrote can become
+    // markup. What sat between them is prose and stays visible as prose — the
+    // reader sees the payload, the browser never runs it.
+    assertThat(html).doesNotContain("<script>alert", "onerror");
+    assertThat(html).contains("Before", "alert(1)", "after");
+    // The only script element in the file is the one this renderer put there.
+    assertThat(html.split("<script").length - 1).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("a hostile review title cannot break out of the markup around it")
+  void escapesTitles() {
+    String html = render(renderer, model("\"><img src=x onerror=alert(1)>", "A finding"));
+
+    assertThat(html).doesNotContain("<img src=x");
+    assertThat(html).contains("&quot;&gt;&lt;img");
+  }
+
+  @Test
+  @DisplayName("a javascript: link keeps its words and loses its target")
+  void refusesUnsafeLinks() {
+    String html =
+        render(renderer, model("Vendor agreement", "See [click me](javascript:alert(1))"));
+
+    assertThat(html).doesNotContain("href=\"javascript");
+    assertThat(html).contains("click me");
+  }
+
+  @Test
+  @DisplayName("markdown becomes real elements")
+  void rendersMarkdown() {
+    String html =
+        render(
+            renderer,
+            model(
+                "Vendor agreement",
+                """
+                ## Finding
+
+                A **bold** and *italic* claim.
+
+                - first
+                - second
+
+                > quoted
+
+                | A | B |
+                | - | - |
+                | 1 | 2 |
+                """));
+
+    assertThat(html).contains("<strong>bold</strong>", "<em>italic</em>");
+    assertThat(html).contains("<ul><li>first</li><li>second</li></ul>");
+    assertThat(html).contains("<blockquote>");
+    assertThat(html).contains("<table>", "<th>A</th>", "<td>1</td>");
+    // A commenter's heading never rises to h1 or h2 — those are the review and
+    // the finding.
+    assertThat(html).contains("<h4>Finding</h4>");
+  }
+
+  @Test
+  @DisplayName("the discussion is a details block that is complete without the script")
+  void rendersThread() {
+    String html =
+        render(
+            renderer,
+            model(
+                "Vendor agreement",
+                "The finding",
+                List.of(comment("Mia Member", "The finding"), comment("Participant 2", "Disagree")),
+                Map.of(),
+                Map.of(),
+                null));
+
+    assertThat(html).contains("<details class=\"thread\">", "Discussion · 1 reply");
+    // The reply's text is in the markup, not fetched or built by the script: a
+    // client that refuses inline script costs the filter, never the findings.
+    assertThat(html).contains("Disagree");
+    // The opening comment is the annotation, not a reply.
+    assertThat(html.split("The finding").length - 1).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("the filter chips are addressed through the bar, not by carrying a status")
+  void scopesTheChipSelector() {
+    String html = render(renderer, model("Vendor agreement", "A finding"));
+
+    // The findings carry data-status too — it is what the filter matches on — so
+    // an unscoped selector makes every card a filter button, and one click on a
+    // card hides every other finding. Caught in a browser, not by a unit test,
+    // which is why the selector is asserted here.
+    assertThat(html).contains("<article class=\"finding\" data-status=");
+    assertThat(html).contains("querySelectorAll('.controls button[data-status]')");
+  }
+
+  @Test
+  @DisplayName("an empty review is a valid page that says so, and ships no script")
+  void handlesEmptyReview() {
+    AnnotationExportModel empty =
+        new AnnotationExportModel(
+            "Vendor agreement",
+            3,
+            List.of(),
+            AnnotationExportColumn.all(),
+            false,
+            null,
+            ExportDateFormat.ISO,
+            ZoneOffset.UTC,
+            Map.of(),
+            Map.of());
+
+    String html = render(renderer, empty);
+
+    assertThat(html).startsWith("<!doctype html>").endsWith("</body></html>");
+    assertThat(html).contains("This review has no annotations.");
+    // Nothing to filter, so nothing to run.
+    assertThat(html).doesNotContain("<script>");
+  }
+
+  @Test
+  @DisplayName("an image too large to inline degrades to its name")
+  void degradesOversizedImages() throws Exception {
+    // The budget is what keeps a review of screenshots from becoming a file no
+    // mail server will carry — base64 adds a third on top.
+    byte[] huge = new byte[9 * 1024 * 1024];
+    String url = "/api/v1/documents/d/attachments/a";
+
+    String html =
+        render(
+            renderer,
+            model(
+                "Vendor agreement",
+                "![big.png](" + url + ")",
+                List.of(),
+                Map.of(url, new ExportImage("big.png", huge, "image/png")),
+                Map.of(),
+                null));
+
+    assertThat(html).doesNotContain("base64");
+    assertThat(html).contains("[big.png]");
+  }
+}

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.test.tsx
@@ -180,14 +180,19 @@ describe('ExportAnnotationsButton', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
-  it('names the planned formats without offering them', async () => {
+  it('exports HTML like any other format', async () => {
     const user = userEvent.setup();
     renderButton();
     await openWizard(user);
 
-    // Answering "is HTML coming?" in the wizard beats a support request.
-    expect(screen.getByRole('button', { name: /^HTML/ })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /Excel/ })).toBeEnabled();
+    // It shipped in #637; nothing about it is conditional on the server the way
+    // PDF's converter is.
+    await user.click(screen.getByRole('button', { name: /^HTML/ }));
+    await user.click(screen.getByRole('button', { name: /Next/ }));
+    await user.click(screen.getByRole('button', { name: /^Export$/ }));
+
+    await waitFor(() => expect(downloadAnnotationExport).toHaveBeenCalled());
+    expect(vi.mocked(downloadAnnotationExport).mock.calls[0][2]?.format).toBe('html');
   });
 
   it('exports the chosen format', async () => {

--- a/qnop-ui/src/components/reviews/export/ExportWizard.tsx
+++ b/qnop-ui/src/components/reviews/export/ExportWizard.tsx
@@ -255,8 +255,8 @@ export function ExportWizard({
                           borderColor: active ? 'primary.main' : 'divider',
                           bgcolor: (t) =>
                             active ? alpha(t.palette.primary.main, 0.06) : 'transparent',
-                          cursor: entry.planned ? 'not-allowed' : 'pointer',
-                          opacity: entry.planned ? 0.5 : 1,
+                          cursor: available ? 'pointer' : 'not-allowed',
+                          opacity: available ? 1 : 0.5,
                           transition: 'border-color 150ms, background-color 150ms',
                           '&:hover:not(:disabled)': { borderColor: 'primary.main' },
                         }}
@@ -272,10 +272,7 @@ export function ExportWizard({
                           <Typography sx={{ fontSize: 11.5, color: 'text.disabled' }}>
                             {entry.extension}
                           </Typography>
-                          {entry.planned && <ToneBadge tone="neutral" label="Planned" />}
-                          {!entry.planned && !available && (
-                            <ToneBadge tone="neutral" label="Unavailable" />
-                          )}
+                          {!available && <ToneBadge tone="neutral" label="Unavailable" />}
                         </Stack>
                         <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
                           {entry.hint}

--- a/qnop-ui/src/components/reviews/export/exportModel.test.ts
+++ b/qnop-ui/src/components/reviews/export/exportModel.test.ts
@@ -45,17 +45,16 @@ describe('exportModel', () => {
 
   it('offers only the formats that are still on the roadmap', () => {
     // CSV and Markdown were dropped (#636/#638) — a wizard that still listed
-    // them as "planned" would be promising work nobody intends to do.
+    // them would be promising work nobody intends to do.
     const ids = EXPORT_FORMATS.map((format) => format.id);
     expect(ids).toEqual(['xlsx', 'docx', 'html', 'pdf']);
   });
 
-  it("treats availability as the server's answer, not the release's", () => {
+  it('leaves availability to the server', () => {
     const byId = Object.fromEntries(EXPORT_FORMATS.map((format) => [format.id, format]));
 
-    // A planned format is never available, whatever the server lists.
-    expect(isFormatAvailable(byId.html, ['xlsx', 'docx', 'pdf', 'html'])).toBe(false);
-    // A shipped one follows the server: PDF needs an office converter (#639).
+    // Every format ships; whether one can be produced is the deployment's
+    // answer: PDF needs an office converter (#639).
     expect(isFormatAvailable(byId.pdf, ['xlsx', 'docx'])).toBe(false);
     expect(isFormatAvailable(byId.pdf, ['xlsx', 'docx', 'pdf'])).toBe(true);
     // Silence is not a refusal — an older server, or a config request still in

--- a/qnop-ui/src/components/reviews/export/exportModel.ts
+++ b/qnop-ui/src/components/reviews/export/exportModel.ts
@@ -48,22 +48,18 @@ export interface ExportFormat {
    * would be a control that silently does nothing.
    */
   supportsLogo: boolean;
-  /** Not yet implemented — shown so the wizard tells the truth about what is coming. */
-  planned?: boolean;
 }
 
 /**
- * The formats the wizard shows. Planned ones are listed on purpose: a user who
- * wonders whether HTML is coming gets an answer here instead of filing a
- * request, and shipping one flips a flag (issue #637). CSV and Markdown were
- * dropped (#636/#638): CSV is a strictly worse Excel for this data — no typed
- * dates, nowhere to put the comment threads — and Markdown duplicates what the
- * review UI already shows.
+ * The formats the wizard shows — all of them shipped, since HTML landed (#637).
+ * CSV and Markdown were dropped (#636/#638): CSV is a strictly worse Excel for
+ * this data — no typed dates, nowhere to put the comment threads — and Markdown
+ * duplicates what the review UI already shows.
  *
- * <p>`planned` is a property of the release. Whether a shipped format can
- * actually be produced is a property of the *server* — PDF converts through an
- * out-of-process office suite (#639), which a given deployment may not have —
- * and that answer comes from `ServerConfig.exportFormats`, not from here.
+ * <p>Listing a format here does not mean this deployment can produce it: PDF
+ * converts through an out-of-process office suite (#639), which a given
+ * installation may not have. That answer comes from `ServerConfig.exportFormats`,
+ * not from here.
  */
 export const EXPORT_FORMATS: ExportFormat[] = [
   {
@@ -89,12 +85,12 @@ export const EXPORT_FORMATS: ExportFormat[] = [
   {
     id: 'html',
     supportsLogo: true,
-    fieldNoun: 'sections',
-    commentsHint: 'Comment threads are included.',
+    fieldNoun: 'details',
+    commentsHint:
+      'The full discussion under each annotation — every reply, with who wrote it and when. In an anonymous review the authors stay pseudonymous here too.',
     label: 'HTML',
     extension: '.html',
-    hint: 'Opens anywhere.',
-    planned: true,
+    hint: 'One self-contained page — searchable in any browser, no attachments to open.',
   },
   {
     id: 'pdf',
@@ -187,11 +183,10 @@ export interface ExportSettings {
  *
  * <p>A format the release ships is not automatically one this deployment can
  * make. When the server says nothing — an older build, or a request that has not
- * landed yet — everything shipped is assumed available, so a missing field never
- * takes a working format away.
+ * landed yet — everything is assumed available, so a missing field never takes a
+ * working format away.
  */
 export function isFormatAvailable(format: ExportFormat, offered: string[] | undefined): boolean {
-  if (format.planned) return false;
   return offered === undefined || offered.length === 0 || offered.includes(format.id);
 }
 
@@ -224,9 +219,9 @@ export function loadSettings(timezone?: string): ExportSettings {
     const parsed = JSON.parse(raw) as Partial<ExportSettings>;
     const known = new Set(EXPORT_FIELDS.map((field) => field.id));
     const fields = (parsed.fields ?? []).filter((id) => known.has(id));
-    const shipped = EXPORT_FORMATS.find((f) => f.id === parsed.format && !f.planned);
+    const format = EXPORT_FORMATS.find((entry) => entry.id === parsed.format);
     return {
-      format: shipped ? shipped.id : fallback.format,
+      format: format ? format.id : fallback.format,
       scope: (['all', 'open', 'resolved'] as const).includes(parsed.scope as ExportScope)
         ? (parsed.scope as ExportScope)
         : fallback.scope,


### PR DESCRIPTION
Closes #637.

The last of the four export formats. The HTML report is **one file with no external reference**: the stylesheet and the script are inlined, the branding logo and every screenshot travel as `data:` URIs. That is the point of the format — it opens from a mail attachment on a machine with no Office suite, and it never reports back when or where it was read. The integration test asserts the *absence*: no `src="http`, no `<link>`.

It is also the only export that can be interactive, which is why it earns its place beside the PDF: a text filter, status chips, expand-all across the discussions. HTML does not copy the Word layout — it gets what a browser is good at, plus a print stylesheet that drops the controls and keeps a finding from breaking across pages.

### Safety

Escaping is structural, not remembered. `HtmlWriter.text`/`attr` are the only ways content enters the document and both always escape; raw markup has a single entrance that takes compile-time constants. A user string cannot reach it, because a user string is never a constant. On top of that, markup a commenter wrote was already dropped at the parse (#645), so the payload comes out as visible prose — the reader sees it, the browser does not run it.

**No data is interpolated into the script.** Escaping for HTML is not escaping for JavaScript, and a comment containing `</script>` would end the block early whatever the escaping. The script only reads the DOM and writes `hidden` and `open`, so the report is complete without it: a client that refuses inline script costs the filter, never the findings. An empty review ships no script at all.

Images inline against an 8 MB budget (base64 adds a third on top) and degrade to `[name]` past it, so a review of thirty screenshots stays mailable.

### Two defects the browser found, not the tests

The renderer was rendered to a sample and looked at in a browser before this was committed. Two real bugs surfaced:

1. `querySelectorAll('[data-status]')` matched the **finding cards**, not just the filter chips — a click anywhere on a card set the status filter and hid every other finding. Scoped to `.controls button[data-status]`, with a regression test that says why.
2. The facts line broke mid-timestamp; `white-space: nowrap` alone then pushed the line out of the card, because the spans are written without whitespace and inline boxes cannot break where there is none. Now a wrapping flex row. Measuring that also caught the masthead logo having no `max-width`, which pushed the page sideways at 390 px.

### Also

- The format is offered in the wizard; with all four shipped, the `planned` flag and its UI branches are gone.
- ADR-0052 gains an HTML section and a stale `ExportSegment` reference is corrected.

## Test plan

- [x] `./gradlew build` — Spotless, ArchUnit, full suite
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test:run` (1190 tests)
- [x] 9 renderer unit tests: self-containment, the four attack cases, markdown → real elements, thread, empty review, oversized image
- [x] 3 integration tests: the whole chain (SVG branding → raster → data URI, attachment out of object storage → data URI), ADR-0038 anonymity, refusal to a user who cannot see the review
- [x] Rendered sample inspected in a browser at 1200 px and 390 px: no horizontal overflow, filter and expand-all behave, print sheet present

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)