### PR TITLE
feat(review): upload a new version through a dropzone dialog (#652)

### DIFF
--- a/qnop-ui/src/components/reviews/hub/NewVersionDialog.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/NewVersionDialog.test.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { buildTheme } from '../../../theme/theme';
+import { acceptedUploads } from '../wizard/wizardModel';
+import { NewVersionDialog } from './NewVersionDialog';
+import { axiosInstance } from '../../../api/config';
+
+vi.mock('../../../api/config', () => ({
+  axiosInstance: { post: vi.fn() },
+  documentsApi: {},
+}));
+
+const DOC_ID = '3f6f6f6f-0000-0000-0000-000000000001';
+
+const notify = vi.fn();
+const onClose = vi.fn();
+const onUploaded = vi.fn();
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderDialog(open = true) {
+  return render(
+    <NewVersionDialog
+      documentId={DOC_ID}
+      open={open}
+      onClose={onClose}
+      maxSizeMb={50}
+      accepted={acceptedUploads(['PDF', 'DOCX'])}
+      notify={notify}
+      onUploaded={onUploaded}
+    />,
+    { wrapper },
+  );
+}
+
+const pdf = () => new File(['%PDF-1.4'], 'contract-v2.pdf', { type: 'application/pdf' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('NewVersionDialog', () => {
+  it('says what a new version does to the annotations already on the review', () => {
+    renderDialog();
+
+    // The old button said nothing about this at all, and re-anchoring (ADR-0009)
+    // is the part a reader would want to know before replacing the document.
+    expect(screen.getByText(/re-anchored to the new document/)).toBeInTheDocument();
+  });
+
+  it('accepts a dropped file, which the old file-chooser button could not', () => {
+    renderDialog();
+
+    fireEvent.drop(screen.getByTestId('new-version-dropzone'), {
+      dataTransfer: { files: [pdf()] },
+    });
+
+    expect(screen.getByText('contract-v2.pdf')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Upload version/ })).toBeEnabled();
+  });
+
+  it('offers Word only where the server takes it', () => {
+    renderDialog();
+
+    // Same rule as the wizard (issue #343): the dropzone must not invite an upload
+    // the server would refuse with 415.
+    expect(screen.getByTestId('new-version-dropzone-input')).toHaveAttribute(
+      'accept',
+      expect.stringContaining('.docx'),
+    );
+    expect(screen.getByText(/PDF or Word/)).toBeInTheDocument();
+  });
+
+  it('keeps the dialog and the chosen file when the upload fails', async () => {
+    vi.mocked(axiosInstance.post).mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 500, data: {} },
+    });
+    renderDialog();
+
+    fireEvent.change(screen.getByTestId('new-version-dropzone-input'), {
+      target: { files: [pdf()] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Upload version/ }));
+
+    // Closing on failure would throw away the file and make the reader find it
+    // again, so the error is shown where the retry is.
+    expect(await screen.findByText(/could not be uploaded/)).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText('contract-v2.pdf')).toBeInTheDocument();
+  });
+
+  it('reports progress while the bytes travel', async () => {
+    // The hook reports upload progress and the old button discarded it; a 50 MB
+    // document over a slow link looked identical to a hang.
+    let reportProgress: ((event: { loaded: number; total: number }) => void) | undefined;
+    vi.mocked(axiosInstance.post).mockImplementation((_url, _body, config) => {
+      reportProgress = (config as { onUploadProgress?: typeof reportProgress })?.onUploadProgress;
+      return new Promise(() => {}); // never settles: the upload stays in flight
+    });
+    renderDialog();
+
+    fireEvent.change(screen.getByTestId('new-version-dropzone-input'), {
+      target: { files: [pdf()] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Upload version/ }));
+
+    await waitFor(() => expect(reportProgress).toBeDefined());
+    reportProgress?.({ loaded: 40, total: 100 });
+
+    expect(await screen.findByText(/Uploading… 40%/)).toBeInTheDocument();
+    // Nothing is dismissible mid-flight — closing would leave a request with
+    // nowhere to report back to.
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('starts clean when reopened after a cancelled attempt', () => {
+    const { rerender } = renderDialog();
+
+    fireEvent.change(screen.getByTestId('new-version-dropzone-input'), {
+      target: { files: [pdf()] },
+    });
+    expect(screen.getByText('contract-v2.pdf')).toBeInTheDocument();
+
+    rerender(
+      <NewVersionDialog
+        documentId={DOC_ID}
+        open={false}
+        onClose={onClose}
+        maxSizeMb={50}
+        accepted={acceptedUploads(['PDF'])}
+        notify={notify}
+        onUploaded={onUploaded}
+      />,
+    );
+    rerender(
+      <NewVersionDialog
+        documentId={DOC_ID}
+        open={true}
+        onClose={onClose}
+        maxSizeMb={50}
+        accepted={acceptedUploads(['PDF'])}
+        notify={notify}
+        onUploaded={onUploaded}
+      />,
+    );
+
+    // A file left over from an abandoned attempt would be uploaded by the next
+    // person who opens this and presses the button without looking.
+    expect(screen.queryByText('contract-v2.pdf')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Upload version/ })).toBeDisabled();
+  });
+});

--- a/qnop-ui/src/components/reviews/hub/NewVersionDialog.tsx
+++ b/qnop-ui/src/components/reviews/hub/NewVersionDialog.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import LinearProgress from '@mui/material/LinearProgress';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { Upload } from 'lucide-react';
+import { useUploadVersion } from '../../../api/hooks/useReviews';
+import { apiErrorMessage } from '../../../utils/apiError';
+import type { ToastSeverity } from '../../admin/layout/useToast';
+import { DocumentDropzone } from '../upload/DocumentDropzone';
+import { validateDocumentFile, type AcceptedUploads } from '../wizard/wizardModel';
+
+interface NewVersionDialogProps {
+  documentId: string;
+  open: boolean;
+  onClose: () => void;
+  maxSizeMb: number;
+  accepted: AcceptedUploads;
+  notify: (message: string, severity?: ToastSeverity) => void;
+  onUploaded: (versionNumber: number) => void;
+}
+
+/**
+ * Uploading a new version of the document under review (issue #652).
+ *
+ * <p>The same dropzone the wizard uses, because it is the same act: this is not a
+ * lesser back-door for replacing a document, and it used to feel like one — a
+ * button wired straight to the OS file chooser, with the upload starting the
+ * instant a file was picked.
+ *
+ * <p>Two things that needs. A new version becomes the version everyone reviews,
+ * so there is now a moment between choosing and sending in which the wrong file
+ * can be noticed. And it re-anchors every existing annotation (ADR-0009), which
+ * the old button never said out loud.
+ *
+ * <p>Mirrors {@link ParticipantsDialog} and {@link DueDateDialog} as the review
+ * hub's owner affordances.
+ */
+export function NewVersionDialog({
+  documentId,
+  open,
+  onClose,
+  maxSizeMb,
+  accepted,
+  notify,
+  onUploaded,
+}: NewVersionDialogProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [wasOpen, setWasOpen] = useState(open);
+  const upload = useUploadVersion(documentId);
+
+  // Reset the draft each time the dialog opens — the recommended "adjust state
+  // during render" pattern rather than an effect, as DueDateDialog does.
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setFile(null);
+      setError(null);
+      setProgress(0);
+    }
+  }
+
+  const pending = upload.isPending;
+
+  const handleFilePicked = (picked: File) => {
+    const rejection = validateDocumentFile(picked, maxSizeMb, accepted);
+    // A rejected file is still shown as the error, not silently ignored: the
+    // reader needs to know which pick was refused.
+    setError(rejection);
+    setFile(rejection ? null : picked);
+  };
+
+  const handleUpload = () => {
+    if (!file) return;
+    setProgress(0);
+    upload.mutate(
+      { file, onProgress: setProgress },
+      {
+        onSuccess: (result) => {
+          notify(`Version ${result.versionNumber} uploaded.`);
+          onUploaded(result.versionNumber);
+          onClose();
+        },
+        onError: (uploadError) => {
+          setError(apiErrorMessage(uploadError, 'The new version could not be uploaded.'));
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      // Not dismissible mid-upload: closing would leave a request in flight with
+      // nothing left to report where it went.
+      onClose={pending ? undefined : onClose}
+      fullWidth
+      maxWidth="sm"
+    >
+      <DialogTitle>Upload a new version</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2.5}>
+          <Typography variant="body2" color="text.secondary">
+            It becomes the version everyone reviews. Existing annotations are carried over and
+            re-anchored to the new document; any that no longer fit are flagged for you to place
+            again.
+          </Typography>
+
+          <DocumentDropzone
+            file={file}
+            error={error}
+            maxSizeMb={maxSizeMb}
+            accepted={accepted}
+            onFilePicked={handleFilePicked}
+            onFileCleared={() => {
+              setFile(null);
+              setError(null);
+            }}
+            disabled={pending}
+            variant="stage"
+            testId="new-version-dropzone"
+          />
+
+          {pending && (
+            <Stack spacing={0.75}>
+              {/* Determinate, because the upload reports its bytes — a spinner on a
+                  50 MB document over a slow link is indistinguishable from a hang. */}
+              <LinearProgress
+                variant={progress > 0 && progress < 1 ? 'determinate' : 'indeterminate'}
+                value={Math.round(progress * 100)}
+                aria-label="Upload progress"
+              />
+              <Typography variant="caption" color="text.secondary">
+                {progress >= 1
+                  ? 'Processing the document…'
+                  : `Uploading… ${Math.round(progress * 100)}%`}
+              </Typography>
+            </Stack>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={pending} color="inherit">
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<Upload size={16} />}
+          onClick={handleUpload}
+          disabled={!file || pending}
+        >
+          {pending ? 'Uploading…' : 'Upload version'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
@@ -313,29 +313,43 @@ describe('ReviewHubHead — workflow transitions', () => {
 });
 
 describe('ReviewHubHead — new version upload', () => {
-  it('uploads a PDF and reports the new version', async () => {
+  /** Opens the dialog and returns its file input. */
+  function openDialog() {
+    fireEvent.click(screen.getByRole('button', { name: /New version/ }));
+    return screen.getByTestId('new-version-dropzone-input');
+  }
+
+  it('uploads only once the owner confirms the file they picked', async () => {
     vi.mocked(axiosInstance.post).mockResolvedValue({
       data: { documentId: DOC_ID, versionNumber: 3, extractionStatus: 'PENDING' },
     });
     renderHub();
 
     const file = new File(['%PDF-1.4'], 'v3.pdf', { type: 'application/pdf' });
-    fireEvent.change(screen.getByTestId('version-file-input'), { target: { files: [file] } });
+    fireEvent.change(openDialog(), { target: { files: [file] } });
+
+    // Picking is not sending (issue #652): a new version becomes the version
+    // everyone reviews, so there is a moment to notice the wrong file.
+    expect(axiosInstance.post).not.toHaveBeenCalled();
+    expect(await screen.findByText('v3.pdf')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Upload version/ }));
 
     await waitFor(() => expect(onVersionUploaded).toHaveBeenCalledWith(3));
     expect(vi.mocked(axiosInstance.post).mock.calls[0][0]).toBe(`/documents/${DOC_ID}/versions`);
     expect(notify).toHaveBeenCalledWith('Version 3 uploaded.');
   });
 
-  it('rejects a non-PDF without calling the API', async () => {
+  it('rejects an unsupported file in the dialog, without calling the API', async () => {
     renderHub();
 
     const file = new File(['x'], 'notes.txt', { type: 'text/plain' });
-    fireEvent.change(screen.getByTestId('version-file-input'), { target: { files: [file] } });
+    fireEvent.change(openDialog(), { target: { files: [file] } });
 
-    await waitFor(() =>
-      expect(notify).toHaveBeenCalledWith('Only PDF documents are supported.', 'error'),
-    );
+    // The refusal belongs next to the dropzone that refused it, not in a toast
+    // that outlives the dialog.
+    expect(await screen.findByText('Only PDF documents are supported.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Upload version/ })).toBeDisabled();
     expect(axiosInstance.post).not.toHaveBeenCalled();
   });
 
@@ -344,7 +358,6 @@ describe('ReviewHubHead — new version upload', () => {
 
     await screen.findByTestId('participants-button');
     expect(screen.queryByRole('button', { name: /New version/ })).not.toBeInTheDocument();
-    expect(screen.queryByTestId('version-file-input')).not.toBeInTheDocument();
   });
 });
 

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Button from '@mui/material/Button';
@@ -38,7 +38,6 @@ import {
   useArchiveReview,
   useParticipants,
   useTransitionWorkflow,
-  useUploadVersion,
   useWorkflow,
 } from '../../../api/hooks/useReviews';
 import { useAuthStore } from '../../../stores/authStore';
@@ -51,9 +50,10 @@ import { TeamAvatar } from '../../shell/TeamAvatar';
 import { DueDateLabel } from '../DueDateLabel';
 import { ProgressBar } from '../list/ReviewListParts';
 import { isOpenWorkflowState, workflowLabel } from '../workflowMeta';
-import { acceptedUploads, validateDocumentFile } from '../wizard/wizardModel';
+import { acceptedUploads } from '../wizard/wizardModel';
 import { apiErrorCode, apiErrorMessage } from '../../../utils/apiError';
 import { DueDateDialog } from './DueDateDialog';
+import { NewVersionDialog } from './NewVersionDialog';
 import { ParticipantsDialog } from './ParticipantsDialog';
 
 const FALLBACK_MAX_SIZE_MB = 50;
@@ -111,8 +111,8 @@ export function ReviewHubHead({
   onVersionUploaded,
 }: ReviewHubHeadProps) {
   const theme = useTheme();
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [participantsOpen, setParticipantsOpen] = useState(false);
+  const [newVersionOpen, setNewVersionOpen] = useState(false);
   const [dueDateOpen, setDueDateOpen] = useState(false);
   const [workflowMenuAnchor, setWorkflowMenuAnchor] = useState<HTMLElement | null>(null);
   const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
@@ -125,7 +125,6 @@ export function ReviewHubHead({
   // A closed review (FINALIZED/CANCELLED) can be archived out of the active lists,
   // or restored if already archived (issue #576) — owner action.
   const isClosed = !isOpenWorkflowState(workflowState);
-  const uploadVersion = useUploadVersion(documentId);
 
   const participants = participantsQuery.data?.participants ?? [];
   const ownDisplayName = useAuthStore((state) => state.displayName);
@@ -172,25 +171,6 @@ export function ReviewHubHead({
           'error',
         ),
     });
-  };
-
-  const handleFilePicked = (file: File) => {
-    const error = validateDocumentFile(file, maxSizeMb, accepted);
-    if (error) {
-      notify(error, 'error');
-      return;
-    }
-    uploadVersion.mutate(
-      { file },
-      {
-        onSuccess: (result) => {
-          notify(`Version ${result.versionNumber} uploaded.`);
-          onVersionUploaded(result.versionNumber);
-        },
-        onError: (uploadError) =>
-          notify(apiErrorMessage(uploadError, 'The new version could not be uploaded.'), 'error'),
-      },
-    );
   };
 
   const shown = participants.slice(0, MAX_STACK_AVATARS);
@@ -420,25 +400,22 @@ export function ReviewHubHead({
             size="small"
             variant="outlined"
             startIcon={<Upload size={14} />}
-            disabled={uploadVersion.isPending}
-            onClick={() => fileInputRef.current?.click()}
+            onClick={() => setNewVersionOpen(true)}
           >
-            {uploadVersion.isPending ? 'Uploading…' : 'New version'}
+            New version
           </Button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={accepted.accept}
-            hidden
-            data-testid="version-file-input"
-            onChange={(e) => {
-              const picked = e.target.files?.[0];
-              if (picked) handleFilePicked(picked);
-              e.target.value = '';
-            }}
-          />
         </>
       )}
+
+      <NewVersionDialog
+        documentId={documentId}
+        open={newVersionOpen}
+        onClose={() => setNewVersionOpen(false)}
+        maxSizeMb={maxSizeMb}
+        accepted={accepted}
+        notify={notify}
+        onUploaded={onVersionUploaded}
+      />
 
       <ParticipantsDialog
         documentId={documentId}

--- a/qnop-ui/src/components/reviews/upload/DocumentDropzone.tsx
+++ b/qnop-ui/src/components/reviews/upload/DocumentDropzone.tsx
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useRef, useState } from 'react';
+import type { DragEvent, ReactNode } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
+import { FileText, Upload, X } from 'lucide-react';
+import { formatFileSize, type AcceptedUploads } from '../wizard/wizardModel';
+
+interface DocumentDropzoneProps {
+  file: File | null;
+  /** Validation error from the last pick, if any. */
+  error?: string | null;
+  maxSizeMb: number;
+  /** Which formats this server takes, and how to name them (issue #343). */
+  accepted: AcceptedUploads;
+  onFilePicked: (file: File) => void;
+  onFileCleared: () => void;
+  /** Locks the control while its file is being uploaded. */
+  disabled?: boolean;
+  /**
+   * How much of the surface this control is.
+   *
+   * <p>`inline` (the wizard): the frame is the empty state, and a chosen file
+   * collapses to a compact row so the fields below move up to meet it.
+   *
+   * <p>`stage` (the dialog): the control *is* the content, so the frame stays and
+   * the chosen file is confirmed inside it. Collapsing there would drop ~200px out
+   * of the dialog and make it jump as it re-centres; merely padding the gap would
+   * leave the file floating in dead space. Keeping the frame also keeps it a drop
+   * target, so a second file replaces the first.
+   */
+  variant?: 'inline' | 'stage';
+  /** Distinguishes the two mounts for tests; the wizard and the dialog differ. */
+  testId?: string;
+}
+
+/**
+ * Choosing a document: a drop target, and then the document that was chosen.
+ *
+ * <p>Shared on purpose (issue #652). Starting a review and uploading a new version
+ * into one are the same act, and they used to look like different products — the
+ * wizard had this, the review hub had a bare file chooser. One component rather
+ * than two copies is what keeps them from drifting the next time either is
+ * touched.
+ *
+ * <p>The picked file is shown rather than sent: the caller decides when it goes,
+ * so there is a moment in which the wrong file can be noticed.
+ */
+export function DocumentDropzone({
+  file,
+  error,
+  maxSizeMb,
+  accepted,
+  onFilePicked,
+  onFileCleared,
+  disabled = false,
+  variant = 'inline',
+  testId = 'document-dropzone',
+}: DocumentDropzoneProps) {
+  const theme = useTheme();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const staged = variant === 'stage';
+
+  const openPicker = () => {
+    if (!disabled) inputRef.current?.click();
+  };
+
+  const handleDrop = (event: DragEvent) => {
+    event.preventDefault();
+    setIsDragOver(false);
+    if (disabled) return;
+    const dropped = event.dataTransfer.files[0];
+    if (dropped) onFilePicked(dropped);
+  };
+
+  /** The dashed drop target, whatever it currently holds. */
+  const frame = (children: ReactNode) => (
+    <Box
+      data-testid={testId}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-label={file ? 'Choose a different document' : 'Choose a document'}
+      aria-disabled={disabled || undefined}
+      onClick={openPicker}
+      onKeyDown={(event) => {
+        // A div that behaves like a button has to answer the keyboard like one.
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          openPicker();
+        }
+      }}
+      onDragOver={(event) => {
+        event.preventDefault();
+        if (!disabled) setIsDragOver(true);
+      }}
+      onDragLeave={() => setIsDragOver(false)}
+      onDrop={handleDrop}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: staged ? 260 : undefined,
+        border: '2px dashed',
+        borderColor: isDragOver ? theme.qnop.brand.blue : theme.palette.divider,
+        borderRadius: 3,
+        px: 3,
+        py: staged ? 4 : 7,
+        textAlign: 'center',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.6 : 1,
+        bgcolor: isDragOver ? theme.palette.primary.light : 'transparent',
+        transition: 'border-color 160ms ease, background-color 160ms ease',
+        '&:focus-visible': {
+          outline: `2px solid ${theme.qnop.brand.blue}`,
+          outlineOffset: 2,
+        },
+      }}
+    >
+      {children}
+    </Box>
+  );
+
+  const prompt = (
+    <>
+      <Box
+        sx={{
+          width: 60,
+          height: 60,
+          borderRadius: 3.5,
+          bgcolor: theme.palette.primary.light,
+          color: theme.qnop.brand.blue,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          mb: 2,
+        }}
+      >
+        <Upload size={26} aria-hidden />
+      </Box>
+      <Typography sx={{ fontWeight: 600, fontSize: 18, mb: 0.5 }}>
+        Drop your document here or choose a file
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {accepted.label} · max. {maxSizeMb} MB
+      </Typography>
+      <Button variant="contained" startIcon={<Upload size={16} />} disabled={disabled}>
+        Choose file
+      </Button>
+    </>
+  );
+
+  /** The chosen file, filling the frame it was dropped into. */
+  const confirmation = file && (
+    <>
+      <Box
+        sx={{
+          width: 60,
+          height: 60,
+          borderRadius: 3.5,
+          bgcolor: theme.qnop.brand.blue,
+          color: '#fff',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          mb: 2,
+        }}
+      >
+        <FileText size={26} aria-hidden />
+      </Box>
+      <Typography sx={{ fontWeight: 600, fontSize: 17, mb: 0.25, wordBreak: 'break-all' }}>
+        {file.name}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {formatFileSize(file.size)}
+      </Typography>
+      <Button
+        variant="outlined"
+        size="small"
+        disabled={disabled}
+        onClick={(event) => {
+          // The frame itself opens the picker; this clears the choice instead.
+          event.stopPropagation();
+          onFileCleared();
+        }}
+      >
+        Choose a different file
+      </Button>
+    </>
+  );
+
+  /** The compact row the wizard collapses to, so its fields move up to meet it. */
+  const row = file && (
+    <Stack
+      direction="row"
+      spacing={1.75}
+      sx={{ alignItems: 'center', p: 2, borderRadius: 2, bgcolor: theme.qnop.surface2 }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          borderRadius: 2,
+          bgcolor: theme.qnop.brand.blue,
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <FileText size={20} aria-hidden />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
+          {file.name}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {formatFileSize(file.size)}
+        </Typography>
+      </Box>
+      <Tooltip title="Remove file">
+        <span>
+          <IconButton
+            size="small"
+            onClick={onFileCleared}
+            aria-label="Remove file"
+            disabled={disabled}
+          >
+            <X size={16} />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Stack>
+  );
+
+  return (
+    <Stack spacing={2}>
+      {file && !staged ? row : frame(file ? confirmation : prompt)}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accepted.accept}
+        hidden
+        data-testid={`${testId}-input`}
+        onChange={(event) => {
+          const picked = event.target.files?.[0];
+          if (picked) onFilePicked(picked);
+          event.target.value = '';
+        }}
+      />
+
+      {error && <Alert severity="error">{error}</Alert>}
+    </Stack>
+  );
+}

--- a/qnop-ui/src/components/reviews/wizard/DocumentStep.tsx
+++ b/qnop-ui/src/components/reviews/wizard/DocumentStep.tsx
@@ -19,19 +19,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useRef, useState } from 'react';
-import type { DragEvent } from 'react';
-import Alert from '@mui/material/Alert';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
-import Tooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/material/styles';
-import { FileText, Upload, X } from 'lucide-react';
-import { formatFileSize, type AcceptedUploads } from './wizardModel';
+import { DocumentDropzone } from '../upload/DocumentDropzone';
+import { type AcceptedUploads } from './wizardModel';
 
 interface DocumentStepProps {
   file: File | null;
@@ -65,122 +56,17 @@ export function DocumentStep({
   onTitleChange,
   onSlugChange,
 }: DocumentStepProps) {
-  const theme = useTheme();
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [isDragOver, setIsDragOver] = useState(false);
-
-  const handleDrop = (event: DragEvent) => {
-    event.preventDefault();
-    setIsDragOver(false);
-    const dropped = event.dataTransfer.files[0];
-    if (dropped) onFilePicked(dropped);
-  };
-
   return (
     <Stack spacing={2.5}>
-      {!file ? (
-        <Box
-          data-testid="wizard-dropzone"
-          onClick={() => inputRef.current?.click()}
-          onDragOver={(e) => {
-            e.preventDefault();
-            setIsDragOver(true);
-          }}
-          onDragLeave={() => setIsDragOver(false)}
-          onDrop={handleDrop}
-          sx={{
-            border: '2px dashed',
-            borderColor: isDragOver ? theme.qnop.brand.blue : theme.palette.divider,
-            borderRadius: 3,
-            px: 3,
-            py: 7,
-            textAlign: 'center',
-            cursor: 'pointer',
-            bgcolor: isDragOver ? theme.palette.primary.light : 'transparent',
-            transition: 'border-color 160ms ease, background-color 160ms ease',
-          }}
-        >
-          <Box
-            sx={{
-              width: 60,
-              height: 60,
-              borderRadius: 3.5,
-              bgcolor: theme.palette.primary.light,
-              color: theme.qnop.brand.blue,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              mb: 2,
-            }}
-          >
-            <Upload size={26} aria-hidden />
-          </Box>
-          <Typography sx={{ fontWeight: 600, fontSize: 18, mb: 0.5 }}>
-            Drop your document here or choose a file
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {accepted.label} · max. {maxSizeMb} MB
-          </Typography>
-          <Button variant="contained" startIcon={<Upload size={16} />}>
-            Choose file
-          </Button>
-        </Box>
-      ) : (
-        <Stack
-          direction="row"
-          spacing={1.75}
-          sx={{
-            alignItems: 'center',
-            p: 2,
-            borderRadius: 2,
-            bgcolor: theme.qnop.surface2,
-          }}
-        >
-          <Box
-            sx={{
-              width: 44,
-              height: 44,
-              borderRadius: 2,
-              bgcolor: theme.qnop.brand.blue,
-              color: '#fff',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              flexShrink: 0,
-            }}
-          >
-            <FileText size={20} aria-hidden />
-          </Box>
-          <Box sx={{ flex: 1, minWidth: 0 }}>
-            <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>
-              {file.name}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              {formatFileSize(file.size)}
-            </Typography>
-          </Box>
-          <Tooltip title="Remove file">
-            <IconButton size="small" onClick={onFileCleared} aria-label="Remove file">
-              <X size={16} />
-            </IconButton>
-          </Tooltip>
-        </Stack>
-      )}
-
-      <input
-        ref={inputRef}
-        type="file"
-        accept={accepted.accept}
-        hidden
-        data-testid="wizard-file-input"
-        onChange={(e) => {
-          const picked = e.target.files?.[0];
-          if (picked) onFilePicked(picked);
-          e.target.value = '';
-        }}
+      <DocumentDropzone
+        file={file}
+        error={fileError}
+        maxSizeMb={maxSizeMb}
+        accepted={accepted}
+        onFilePicked={onFilePicked}
+        onFileCleared={onFileCleared}
+        testId="wizard-dropzone"
       />
-
-      {fileError && <Alert severity="error">{fileError}</Alert>}
 
       <TextField
         label="Review title"

--- a/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
@@ -71,7 +71,7 @@ function renderPage() {
 
 function pickPdf(name = 'NDA Acme Corp.pdf') {
   const file = new File(['%PDF-1.4'], name, { type: 'application/pdf' });
-  fireEvent.change(screen.getByTestId('wizard-file-input'), { target: { files: [file] } });
+  fireEvent.change(screen.getByTestId('wizard-dropzone-input'), { target: { files: [file] } });
   return file;
 }
 
@@ -125,7 +125,7 @@ describe('NewReviewPage — step 1', () => {
     renderPage();
 
     const file = new File(['hi'], 'notes.docx', { type: 'application/msword' });
-    fireEvent.change(screen.getByTestId('wizard-file-input'), { target: { files: [file] } });
+    fireEvent.change(screen.getByTestId('wizard-dropzone-input'), { target: { files: [file] } });
 
     expect(screen.getByText('Only PDF documents are supported.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Next/ })).toBeDisabled();


### PR DESCRIPTION
Closes #652.

**New version** wired straight to a hidden file input: one click opened the OS chooser, and picking a file uploaded it immediately. Starting a review got the wizard's dropzone. The same act looked like two different products depending on where you did it.

The wizard's dropzone is now a shared component, and **New version** opens a dialog carrying it. Sharing rather than copying is the point — two copies of the styling would drift the first time either was touched, which is the complaint this fixes.

### What the old path could not do

- **Drag and drop**, the usual way a file arrives.
- **A moment before it is live.** Picking is no longer sending, so the wrong file can be noticed — a new version becomes the version everyone reviews.
- **Real progress.** `useUploadVersion` already reported it and the button discarded it; a large document over a slow link was indistinguishable from a hang.

The dialog also says what the button never did: a new version re-anchors every existing annotation, and any that no longer fit are flagged to be placed again (ADR-0009). That claim was checked against `PlacementStatus.ORPHANED` before it was written, not assumed.

### Two variants, because the surfaces differ

`inline` (the wizard) collapses to a compact row when a file is picked, so the fields below move up to meet it — unchanged behaviour.

`stage` (the dialog) keeps the frame and confirms the file inside it. Two earlier attempts were built and looked at first:

1. Letting it collapse dropped ~200px out of the dialog and made it jump as it re-centred — the same complaint raised about the export wizard.
2. Padding the gap to a fixed height stopped the jump but left the file floating in dead space, which read worse than the jump.

Keeping the frame also keeps it a drop target, so a second file replaces the first. Measured: the dialog is 451px tall in both states.

### Screens

| | |
|---|---|
| Empty | dashed frame, `PDF or Word · max. 50 MB` from `ServerConfig.supportedFormats` (#343) |
| Chosen | same frame, document mark in brand blue, name, size, *Choose a different file* |
| Uploading | determinate progress bar, dialog not dismissible mid-flight |

At 390px there is no horizontal overflow and long filenames wrap.

## Test plan

- [x] `pnpm lint` / `pnpm format:check` / `pnpm typecheck` / `pnpm test:run` (1203 tests)
- [x] `NewVersionDialog.test.tsx` — the re-anchoring note, a dropped file, Word offered only where the server takes it, the dialog and the file surviving a failed upload, progress reported mid-flight with Cancel disabled, and a clean slate when reopened after an abandoned attempt
- [x] `ReviewHubHead.test.tsx` — picking is not sending; an unsupported file is refused next to the dropzone that refused it, not in a toast that outlives the dialog
- [x] Rendered in a browser at 1280 and 390 and inspected in every state; both discarded designs were looked at before this one was kept

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)