### PR TITLE
feat(review): admins list and moderate every review (#563)

### DIFF
--- a/docs/adr/0038-per-review-privacy.md
+++ b/docs/adr/0038-per-review-privacy.md
@@ -68,6 +68,16 @@ Resolving identity on the server is the only way anonymity can be real, and it a
 - **Deriving the pseudonym token from the real author id** (e.g. a hash of `documentId:authorId`). Rejected: the participant roster exposes reviewer user ids, so such a token is confirmable by brute force over the roster — it must derive from the ordinal, whose mapping to real ids lives only server-side.
 - **A single "private review" flag** conflating anonymity and visibility. Rejected: they are independent choices (an anonymous but fully-open review, or a named but private one, are both sensible).
 
+## Amendment (2026-07-30, admins do not unmask — issue #563)
+
+Admins can now list and moderate reviews they are no part of. That reopened the obvious question: should the review surface show them the real names?
+
+**No.** An admin browsing a foreign anonymous review sees the same pseudonyms as everyone else; `ReviewIdentityResolver` deliberately takes no admin flag. Anonymity is a promise made to the participants when the review was created, and the person moderating is not the person it was made to.
+
+The unmasking path already exists and is the right one: the audit trail ([ADR-0042](0042-audit-trail-exposure.md)) resolves real actors for ADMIN and AUDITOR, and reading it is itself an auditable act. So the capability is not lost — it is moved to the surface that leaves a trace, instead of the one that does not.
+
+One thing does change for admins, and it is a correction rather than an exception. The overview's annotation counts are visibility-scoped, and under a `PRIVATE` thread policy that made a moderation row read "0 open" for a review full of open concerns — while `AnnotationService.canSeeThread` was letting the same admin read every one of those threads. The counts now follow what the admin can actually see. That is a wrong number being fixed, not a privacy boundary being moved.
+
 ## Relationships
 
-Extends [ADR-0011](0011-review-workflow-state-model.md) (review model & the `FINALIZED` invariant). Related issues: #403 (the original "Participant" placeholder), #410 (likes), #412 (permalinks).
+Extends [ADR-0011](0011-review-workflow-state-model.md) (review model & the `FINALIZED` invariant). Related issues: #403 (the original "Participant" placeholder), #410 (likes), #412 (permalinks), #563 (admin moderation).

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2831,6 +2831,30 @@ paths:
             type: string
             enum: [active, archived, all]
             default: active
+        - name: participation
+          in: query
+          required: false
+          description: |
+            Whose reviews to list (issue #563). `mine` (default) is the caller's
+            own — owned, joined directly, or joined through a team. `all` lists
+            **every** review for moderation and is **ADMIN-only**: any other
+            caller gets `403 FORBIDDEN`.
+
+            Separate from `scope`, which selects the retention slice; the two
+            combine freely.
+
+            Under `all`, rows the caller is not part of come back with
+            `participating: false`, and the annotation counts are the true totals
+            rather than the caller's slice — an admin already reads private
+            threads, so scoping the numbers would only under-report.
+
+            This listing is meant to be paged and searched on the **server**: a
+            moderation view that quietly stopped at the first page would be worse
+            than none, because seeing everything is the point.
+          schema:
+            type: string
+            enum: [mine, all]
+            default: mine
         - name: page
           in: query
           required: false
@@ -2892,7 +2916,8 @@ paths:
         - Documents
       summary: Add a review participant
       description: |
-        Owner-only. Exactly one of `userId` or `teamId` — a participant is a
+        The owner, or an admin moderating (issue #563). Exactly one of `userId`
+        or `teamId` — a participant is a
         user XOR a team. Adding the owner, a disabled principal, or an unknown
         principal is rejected with 400; adding a principal twice with 409.
       operationId: addParticipant
@@ -2920,7 +2945,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '403':
-          description: The caller is a participant but not the owner
+          description: The caller is a participant, but neither the owner nor an admin
           content:
             application/json:
               schema:
@@ -2944,7 +2969,7 @@ paths:
       tags:
         - Documents
       summary: Remove a review participant
-      description: Owner-only.
+      description: The owner, or an admin moderating (issue #563).
       operationId: removeParticipant
       security:
         - bearerAuth: []
@@ -2955,7 +2980,7 @@ paths:
         '204':
           description: The participant was removed.
         '403':
-          description: The caller is a participant but not the owner
+          description: The caller is a participant, but neither the owner nor an admin
           content:
             application/json:
               schema:
@@ -3227,10 +3252,10 @@ paths:
         - Documents
       summary: Update document metadata
       description: |
-        Owner-only. Currently patches the optional review due date (issue #295):
-        a supplied `dueAt` sets it, an explicit `null` clears it. Any value —
-        including the past — is accepted on edit so the owner can correct a
-        deadline after the fact.
+        The owner, or an admin moderating (issue #563). Currently patches the
+        optional review due date (issue #295): a supplied `dueAt` sets it, an
+        explicit `null` clears it. Any value — including the past — is accepted on
+        edit so the deadline can be corrected after the fact.
       operationId: updateDocument
       security:
         - bearerAuth: []
@@ -3250,7 +3275,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DocumentResponse'
         '403':
-          description: The caller is a participant but not the owner
+          description: The caller is a participant, but neither the owner nor an admin
           content:
             application/json:
               schema:
@@ -6582,6 +6607,13 @@ components:
             When the review was archived out of the active lists (issue #576), or
             null when not archived. The terminal workflowState is preserved, so
             the UI can read "Archived · was Finalized".
+        participating:
+          type: boolean
+          description: >-
+            Whether the caller owns or reviews this one (issue #563). Always true
+            in the default listing, where every row is theirs by construction;
+            under `participation=all` it marks the reviews an admin is moderating
+            from the outside.
       required:
         - id
         - title
@@ -7270,8 +7302,9 @@ components:
     DocumentUpdateRequest:
       type: object
       description: >-
-        Owner-only patch of a document's mutable metadata (issue #295). Every
-        supplied field replaces the stored value; an explicit `null` clears it.
+        Patch of a document's mutable metadata by its owner or an admin (issues
+        #295, #563). Every supplied field replaces the stored value; an explicit
+        `null` clears it.
       properties:
         dueAt:
           type: string

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2855,13 +2855,17 @@ paths:
             type: string
             enum: [mine, all]
             default: mine
-        - name: state
+        - name: lifecycle
           in: query
           required: false
           description: |
             The workflow slice, orthogonal to `scope` (issue #563). `any`
             (default), `open` for reviews the workflow has not closed, `closed`
             for FINALIZED/CANCELLED.
+
+            Named `lifecycle` rather than `state` because `workflowState` below
+            slices the same column more finely; two parameters called `state`
+            would be a trap.
 
             Applied by the server only under `participation=all`, where the
             listing is paged and a client-side facet would narrow one page while
@@ -2871,6 +2875,47 @@ paths:
             type: string
             enum: [any, open, closed]
             default: any
+        - name: workflowState
+          in: query
+          required: false
+          description: |
+            One specific workflow state (issue #563), e.g. `CHANGES_REQUESTED`.
+            Open string set, not an enum: an enterprise edition may extend the
+            state machine (ADR-0011/0035). `participation=all` only.
+          schema:
+            type: string
+        - name: due
+          in: query
+          required: false
+          description: |
+            The deadline slice (issue #563). `overdue` and `soon` speak about
+            LIVING deadlines — a closed or archived review is never overdue —
+            while `none` finds work nobody has put a clock on.
+            `participation=all` only.
+          schema:
+            type: string
+            enum: [any, overdue, soon, none]
+            default: any
+        - name: format
+          in: query
+          required: false
+          description: |
+            The document family of the review's LATEST version (issue #563) —
+            what the row's ribbon shows, so a review that started as a PDF and is
+            now Word counts as Word. `participation=all` only.
+          schema:
+            type: string
+            enum: [any, pdf, docx, md]
+            default: any
+        - name: ownerId
+          in: query
+          required: false
+          description: |
+            One specific owner (issue #563). Ownership is structurally public
+            (#413). `participation=all` only.
+          schema:
+            type: string
+            format: uuid
         - name: role
           in: query
           required: false
@@ -6655,6 +6700,18 @@ components:
         - participants
         - createdAt
         - updatedAt
+    ReviewOwnerOption:
+      type: object
+      description: One entry of the moderation listing's owner facet (issue #563).
+      properties:
+        id:
+          type: string
+          format: uuid
+        displayName:
+          type: string
+      required:
+        - id
+        - displayName
     ReviewFacetCounts:
       type: object
       description: |
@@ -6667,6 +6724,14 @@ components:
         rule the participant-scoped listing already follows — so a chip's number
         keeps predicting what clicking it shows.
       properties:
+        owners:
+          type: array
+          description: >-
+            Everyone who owns a review, across the workspace rather than the
+            current page — a dropdown built from twenty rows would look complete
+            and quietly not be. Capped; past that the search field is the tool.
+          items:
+            $ref: '#/components/schemas/ReviewOwnerOption'
         totalUnfiltered:
           type: integer
           format: int64
@@ -6703,6 +6768,7 @@ components:
           type: integer
           format: int64
       required:
+        - owners
         - totalUnfiltered
         - roleAny
         - roleOwner

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -2855,6 +2855,36 @@ paths:
             type: string
             enum: [mine, all]
             default: mine
+        - name: state
+          in: query
+          required: false
+          description: |
+            The workflow slice, orthogonal to `scope` (issue #563). `any`
+            (default), `open` for reviews the workflow has not closed, `closed`
+            for FINALIZED/CANCELLED.
+
+            Applied by the server only under `participation=all`, where the
+            listing is paged and a client-side facet would narrow one page while
+            appearing to describe the workspace. The participant-scoped listing
+            fetches its rows in one go and facets them in the browser.
+          schema:
+            type: string
+            enum: [any, open, closed]
+            default: any
+        - name: role
+          in: query
+          required: false
+          description: |
+            The caller's part in the review (issue #563): `any` (default),
+            `owner`, `reviewer` — on the roster directly or through a team — or
+            `observer` for the reviews they are no part of at all.
+
+            Applied by the server only under `participation=all`, for the same
+            reason as `state`.
+          schema:
+            type: string
+            enum: [any, owner, reviewer, observer]
+            default: any
         - name: page
           in: query
           required: false
@@ -6625,6 +6655,56 @@ components:
         - participants
         - createdAt
         - updatedAt
+    ReviewFacetCounts:
+      type: object
+      description: |
+        What each filter chip would show if clicked (issue #563). Present only
+        under `participation=all`, where the listing is paged: a count derived
+        from one page would describe that page while appearing to describe the
+        workspace.
+
+        Each group is counted against the OTHER group's current selection — the
+        rule the participant-scoped listing already follows — so a chip's number
+        keeps predicting what clicking it shows.
+      properties:
+        roleAny:
+          type: integer
+          format: int64
+        roleOwner:
+          type: integer
+          format: int64
+        roleReviewer:
+          type: integer
+          format: int64
+        roleObserver:
+          type: integer
+          format: int64
+          description: Reviews the caller is no part of — the moderation listing's own facet.
+        stateActive:
+          type: integer
+          format: int64
+        stateOpen:
+          type: integer
+          format: int64
+        stateClosed:
+          type: integer
+          format: int64
+        stateArchived:
+          type: integer
+          format: int64
+        stateAll:
+          type: integer
+          format: int64
+      required:
+        - roleAny
+        - roleOwner
+        - roleReviewer
+        - roleObserver
+        - stateActive
+        - stateOpen
+        - stateClosed
+        - stateArchived
+        - stateAll
     DocumentListResponse:
       type: object
       description: A page of the caller's documents.
@@ -6645,6 +6725,8 @@ components:
           type: integer
           format: int32
           description: Page size.
+        facets:
+          $ref: '#/components/schemas/ReviewFacetCounts'
       required:
         - items
         - total

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -6667,6 +6667,13 @@ components:
         rule the participant-scoped listing already follows — so a chip's number
         keeps predicting what clicking it shows.
       properties:
+        totalUnfiltered:
+          type: integer
+          format: int64
+          description: >-
+            Every review there is, ignoring the search and every facet. Tells
+            "the workspace is empty" apart from "this filter matched nothing" —
+            two states with very different messages.
         roleAny:
           type: integer
           format: int64
@@ -6696,6 +6703,7 @@ components:
           type: integer
           format: int64
       required:
+        - totalUnfiltered
         - roleAny
         - roleOwner
         - roleReviewer

--- a/qnop-app/src/main/java/io/qnop/web/DocumentUploadController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentUploadController.java
@@ -82,7 +82,8 @@ public class DocumentUploadController {
   public ResponseEntity<DocumentUploadResponse> addVersion(
       @PathVariable UUID documentId, @RequestParam("file") MultipartFile file) {
     UploadResult result =
-        ingest.addVersion(CurrentUser.requireUserId(), documentId, sourceOf(file));
+        ingest.addVersion(
+            CurrentUser.requireUserId(), CurrentUser.isAdmin(), documentId, sourceOf(file));
     return ResponseEntity.status(HttpStatus.CREATED).body(DocumentUploadResponse.of(result));
   }
 

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -94,13 +94,17 @@ public class DocumentsController implements DocumentsApi {
 
   @Override
   public ResponseEntity<DocumentListResponse> listDocuments(
-      String q, String sort, String scope, Integer page, Integer size) {
+      String q, String sort, String scope, String participation, Integer page, Integer size) {
     // The retention slice (issue #576): active (default) / archived / all.
     boolean includeArchived = "archived".equals(scope) || "all".equals(scope);
     boolean includeActive = !"archived".equals(scope);
+    // The moderation listing (issue #563); the service refuses it for non-admins.
+    boolean moderation = "all".equals(participation);
     DocumentOverviewService.DocumentPage result =
         overview.listVisible(
             CurrentUser.requireUserId(),
+            CurrentUser.isAdmin(),
+            moderation,
             q,
             sort,
             includeActive,
@@ -166,7 +170,8 @@ public class DocumentsController implements DocumentsApi {
         .createdAt(view.createdAt().atOffset(ZoneOffset.UTC))
         .updatedAt(view.updatedAt().atOffset(ZoneOffset.UTC))
         .dueAt(atUtc(view.dueAt()))
-        .archivedAt(atUtc(view.archivedAt()));
+        .archivedAt(atUtc(view.archivedAt()))
+        .participating(view.participating());
   }
 
   /** Nullable {@link Instant} → {@link OffsetDateTime} at UTC for the wire model (#295). */

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -37,6 +37,7 @@ import io.qnop.api.v1.model.ParticipantKind;
 import io.qnop.api.v1.model.ParticipantListResponse;
 import io.qnop.api.v1.model.ParticipantView;
 import io.qnop.api.v1.model.RenderedDocumentResponse;
+import io.qnop.api.v1.model.ReviewFacetCounts;
 import io.qnop.api.v1.model.ThreadParticipation;
 import io.qnop.api.v1.model.VersionDiffResponse;
 import io.qnop.api.v1.model.VisitResponse;
@@ -94,7 +95,14 @@ public class DocumentsController implements DocumentsApi {
 
   @Override
   public ResponseEntity<DocumentListResponse> listDocuments(
-      String q, String sort, String scope, String participation, Integer page, Integer size) {
+      String q,
+      String sort,
+      String scope,
+      String participation,
+      String state,
+      String role,
+      Integer page,
+      Integer size) {
     // The retention slice (issue #576): active (default) / archived / all.
     boolean includeArchived = "archived".equals(scope) || "all".equals(scope);
     boolean includeActive = !"archived".equals(scope);
@@ -107,6 +115,9 @@ public class DocumentsController implements DocumentsApi {
             moderation,
             q,
             sort,
+            scope,
+            state,
+            role,
             includeActive,
             includeArchived,
             page == null ? 0 : page,
@@ -116,7 +127,8 @@ public class DocumentsController implements DocumentsApi {
             .items(result.items().stream().map(DocumentsController::toSummary).toList())
             .total(result.total())
             .page(result.page())
-            .size(result.size()));
+            .size(result.size())
+            .facets(toFacets(result.facets())));
   }
 
   @Override
@@ -149,6 +161,22 @@ public class DocumentsController implements DocumentsApi {
     participants.remove(
         documentId, participantId, CurrentUser.requireUserId(), CurrentUser.isAdmin());
     return ResponseEntity.noContent().build();
+  }
+
+  /** The chip counts, or null outside the moderation listing (issue #563). */
+  private static ReviewFacetCounts toFacets(DocumentOverviewService.ReviewFacetCounts counts) {
+    return counts == null
+        ? null
+        : new ReviewFacetCounts()
+            .roleAny(counts.roleAny())
+            .roleOwner(counts.roleOwner())
+            .roleReviewer(counts.roleReviewer())
+            .roleObserver(counts.roleObserver())
+            .stateActive(counts.stateActive())
+            .stateOpen(counts.stateOpen())
+            .stateClosed(counts.stateClosed())
+            .stateArchived(counts.stateArchived())
+            .stateAll(counts.stateAll());
   }
 
   private static DocumentSummary toSummary(DocumentOverviewService.DocumentSummaryView view) {

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -38,6 +38,7 @@ import io.qnop.api.v1.model.ParticipantListResponse;
 import io.qnop.api.v1.model.ParticipantView;
 import io.qnop.api.v1.model.RenderedDocumentResponse;
 import io.qnop.api.v1.model.ReviewFacetCounts;
+import io.qnop.api.v1.model.ReviewOwnerOption;
 import io.qnop.api.v1.model.ThreadParticipation;
 import io.qnop.api.v1.model.VersionDiffResponse;
 import io.qnop.api.v1.model.VisitResponse;
@@ -99,7 +100,11 @@ public class DocumentsController implements DocumentsApi {
       String sort,
       String scope,
       String participation,
-      String state,
+      String lifecycle,
+      String workflowState,
+      String due,
+      String format,
+      UUID ownerId,
       String role,
       Integer page,
       Integer size) {
@@ -116,8 +121,12 @@ public class DocumentsController implements DocumentsApi {
             q,
             sort,
             scope,
-            state,
+            lifecycle,
             role,
+            workflowState,
+            due,
+            format,
+            ownerId,
             includeActive,
             includeArchived,
             page == null ? 0 : page,
@@ -168,6 +177,10 @@ public class DocumentsController implements DocumentsApi {
     return counts == null
         ? null
         : new ReviewFacetCounts()
+            .owners(
+                counts.owners().stream()
+                    .map(o -> new ReviewOwnerOption().id(o.id()).displayName(o.displayName()))
+                    .toList())
             .totalUnfiltered(counts.totalUnfiltered())
             .roleAny(counts.roleAny())
             .roleOwner(counts.roleOwner())

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -168,6 +168,7 @@ public class DocumentsController implements DocumentsApi {
     return counts == null
         ? null
         : new ReviewFacetCounts()
+            .totalUnfiltered(counts.totalUnfiltered())
             .roleAny(counts.roleAny())
             .roleOwner(counts.roleOwner())
             .roleReviewer(counts.roleReviewer())

--- a/qnop-app/src/test/java/io/qnop/review/AdminReviewModerationIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AdminReviewModerationIT.java
@@ -66,9 +66,17 @@ class AdminReviewModerationIT extends SeededIntegrationTest {
     return foreignReview(title, ThreadParticipation.OPEN);
   }
 
+  private UUID foreignReview(String title, WorkflowState state) {
+    return foreignReview(title, ThreadParticipation.OPEN, state);
+  }
+
   private UUID foreignReview(String title, ThreadParticipation threads) {
+    return foreignReview(title, threads, WorkflowState.IN_REVIEW);
+  }
+
+  private UUID foreignReview(String title, ThreadParticipation threads, WorkflowState state) {
     Document document = new Document(MEMBER_ID, title);
-    document.setWorkflowState(WorkflowState.IN_REVIEW);
+    document.setWorkflowState(state);
     document.setThreadParticipation(threads);
     UUID documentId = documents.save(document).getId();
     versions.save(
@@ -83,12 +91,14 @@ class AdminReviewModerationIT extends SeededIntegrationTest {
     return documentId;
   }
 
-  private String list(UUID actor, String participation) throws Exception {
+  private String list(UUID actor, String participation, String... params) throws Exception {
+    var request =
+        get("/api/v1/documents").param("participation", participation).param("size", "100");
+    for (int index = 0; index + 1 < params.length; index += 2) {
+      request = request.param(params[index], params[index + 1]);
+    }
     return mockMvc
-        .perform(
-            as(
-                get("/api/v1/documents").param("participation", participation).param("size", "100"),
-                actor))
+        .perform(as(request, actor))
         .andExpect(status().isOk())
         .andReturn()
         .getResponse()
@@ -199,6 +209,61 @@ class AdminReviewModerationIT extends SeededIntegrationTest {
     // And the reviewer now sees it in their own listing, which is the point of
     // being able to do it at all.
     assertThat(titles(list(MEMBER2_ID, "mine"))).contains("Reviewer added by an admin");
+  }
+
+  @Test
+  @DisplayName("the facets filter the workspace on the server, not the page on screen")
+  void facetsAreServerSide() throws Exception {
+    foreignReview("Closed foreign review", WorkflowState.FINALIZED);
+    foreignReview("Open foreign review");
+    Document own = new Document(ADMIN_ID, "The admins own open one");
+    own.setWorkflowState(WorkflowState.IN_REVIEW);
+    documents.save(own);
+
+    // The workflow slice is a predicate, orthogonal to the retention one.
+    String open = list(ADMIN_ID, "all", "state", "open");
+    assertThat(titles(open)).contains("Open foreign review", "The admins own open one");
+    assertThat(titles(open)).doesNotContain("Closed foreign review");
+
+    // And so is the caller's part in it — the facet that only this listing has.
+    String observed = list(ADMIN_ID, "all", "role", "observer");
+    assertThat(titles(observed)).contains("Open foreign review");
+    assertThat(titles(observed)).doesNotContain("The admins own open one");
+
+    String owned = list(ADMIN_ID, "all", "role", "owner");
+    assertThat(titles(owned)).containsOnly("The admins own open one");
+  }
+
+  @Test
+  @DisplayName("the chip counts describe the workspace, not the page")
+  void facetCountsSpanTheWorkspace() throws Exception {
+    for (int index = 0; index < 3; index++) {
+      foreignReview("Foreign review " + index);
+    }
+    Document own = new Document(ADMIN_ID, "Owned by the admin");
+    own.setWorkflowState(WorkflowState.IN_REVIEW);
+    documents.save(own);
+
+    // One row per page, so a count taken from the page would read 1 for
+    // everything — which is exactly the lie the server-side counts prevent.
+    String json =
+        mockMvc
+            .perform(
+                as(
+                    get("/api/v1/documents")
+                        .param("participation", "all")
+                        .param("size", "1")
+                        .param("q", "review "),
+                    ADMIN_ID))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    assertThat((Integer) JsonPath.read(json, "$.items.length()")).isEqualTo(1);
+    assertThat(((Number) JsonPath.read(json, "$.facets.roleObserver")).intValue()).isEqualTo(3);
+    assertThat(((Number) JsonPath.read(json, "$.facets.roleOwner")).intValue()).isZero();
+    assertThat(json).doesNotContain("Owned by the admin"); // the search excluded it
   }
 
   /** Raises one open annotation on version 1, authored by {@code author}. */

--- a/qnop-app/src/test/java/io/qnop/review/AdminReviewModerationIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AdminReviewModerationIT.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ThreadParticipation;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Admins list and moderate every review (issue #563).
+ *
+ * <p>The listing is the part with teeth: it is the one query in the product that deliberately drops
+ * the participation predicate, so what it returns — and to whom it refuses to return anything — is
+ * asserted per role rather than assumed.
+ */
+class AdminReviewModerationIT extends SeededIntegrationTest {
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  /** A review owned by MEMBER that nobody else is part of. */
+  private UUID foreignReview(String title) {
+    return foreignReview(title, ThreadParticipation.OPEN);
+  }
+
+  private UUID foreignReview(String title, ThreadParticipation threads) {
+    Document document = new Document(MEMBER_ID, title);
+    document.setWorkflowState(WorkflowState.IN_REVIEW);
+    document.setThreadParticipation(threads);
+    UUID documentId = documents.save(document).getId();
+    versions.save(
+        new DocumentVersion(
+            documentId,
+            1,
+            "sha256/aa/" + title.hashCode(),
+            "hash",
+            "application/pdf",
+            1L,
+            MEMBER_ID));
+    return documentId;
+  }
+
+  private String list(UUID actor, String participation) throws Exception {
+    return mockMvc
+        .perform(
+            as(
+                get("/api/v1/documents").param("participation", participation).param("size", "100"),
+                actor))
+        .andExpect(status().isOk())
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+  }
+
+  private static List<String> titles(String json) {
+    return JsonPath.read(json, "$.items[*].title");
+  }
+
+  /** One field of the row with the given title, as text. */
+  private static String field(String json, String title, String field) {
+    return JsonPath.read(json, "$.items[?(@.title == '" + title + "')]." + field).toString();
+  }
+
+  @Test
+  @DisplayName("the default listing stays the caller's own, for an admin as much as anyone")
+  void defaultListingIsUnchangedForAdmins() throws Exception {
+    foreignReview("Not the admins review");
+
+    // The point of the opt-in: an admin's own work must not be drowned out by
+    // every review in the workspace on every visit.
+    assertThat(titles(list(ADMIN_ID, "mine"))).doesNotContain("Not the admins review");
+    assertThat(titles(list(ADMIN_ID, "all"))).contains("Not the admins review");
+  }
+
+  @Test
+  @DisplayName("only an admin may ask for every review; everyone else is refused")
+  void moderationListingIsAdminOnly() throws Exception {
+    foreignReview("Someone elses review");
+
+    for (UUID actor : List.of(MEMBER2_ID, AUDITOR_ID, EXTERNAL_ID)) {
+      // 403 rather than 404: the listing is not a document whose existence could be
+      // probed, so hiding it would only obscure why the call failed. The AUDITOR is
+      // in this list deliberately — their organisation-wide view is the audit trail
+      // (ADR-0042), not the review list.
+      mockMvc
+          .perform(as(get("/api/v1/documents").param("participation", "all"), actor))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    assertThat(titles(list(MEMBER2_ID, "mine"))).doesNotContain("Someone elses review");
+  }
+
+  @Test
+  @DisplayName("reviews the admin is not part of are marked as such")
+  void foreignReviewsAreMarked() throws Exception {
+    foreignReview("Moderated from outside");
+    Document own = new Document(ADMIN_ID, "The admins own");
+    own.setWorkflowState(WorkflowState.IN_REVIEW);
+    documents.save(own);
+
+    String json = list(ADMIN_ID, "all");
+
+    assertThat(field(json, "Moderated from outside", "participating")).contains("false");
+    assertThat(field(json, "The admins own", "participating")).contains("true");
+  }
+
+  @Test
+  @DisplayName("the moderation listing counts private threads the admin can already read")
+  void countsAreNotUnderReported() throws Exception {
+    UUID documentId = foreignReview("Private threads", ThreadParticipation.PRIVATE);
+    annotate(documentId, MEMBER_ID);
+
+    // The admin reads PRIVATE threads (AnnotationService.canSeeThread), so a row
+    // showing "0 open" would be a wrong number rather than privacy.
+    assertThat(field(list(ADMIN_ID, "all"), "Private threads", "openAnnotationCount"))
+        .contains("1");
+    // A stranger's own listing is unaffected — they never see the review at all.
+    assertThat(titles(list(MEMBER2_ID, "mine"))).doesNotContain("Private threads");
+  }
+
+  @Test
+  @DisplayName("an admin edits the due date of a review they do not own")
+  void adminMayEditTheDueDate() throws Exception {
+    UUID documentId = foreignReview("Deadline moved by an admin");
+    String body = "{\"dueAt\":\"" + Instant.now().plus(14, ChronoUnit.DAYS).toString() + "\"}";
+
+    mockMvc
+        .perform(
+            as(patch("/api/v1/documents/" + documentId), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isOk());
+
+    // A non-participant without the admin role still cannot see it at all.
+    mockMvc
+        .perform(
+            as(patch("/api/v1/documents/" + documentId), MEMBER2_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("an admin adds a reviewer to a review they do not own")
+  void adminMayManageParticipants() throws Exception {
+    UUID documentId = foreignReview("Reviewer added by an admin");
+
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/participants"), ADMIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":\"" + MEMBER2_ID + "\"}"))
+        .andExpect(status().isCreated());
+
+    // And the reviewer now sees it in their own listing, which is the point of
+    // being able to do it at all.
+    assertThat(titles(list(MEMBER2_ID, "mine"))).contains("Reviewer added by an admin");
+  }
+
+  /** Raises one open annotation on version 1, authored by {@code author}. */
+  private void annotate(UUID documentId, UUID author) throws Exception {
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), author)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"versionNumber\":1,\"anchor\":{\"region\":{\"surfaceIndex\":0,"
+                        + "\"box\":{\"x\":0.1,\"y\":0.1,\"width\":0.3,\"height\":0.05}},"
+                        + "\"textQuote\":{\"quote\":\"the clause\"}},\"comment\":\"A concern\"}"))
+        .andExpect(status().isCreated());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/AdminReviewModerationIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AdminReviewModerationIT.java
@@ -221,7 +221,7 @@ class AdminReviewModerationIT extends SeededIntegrationTest {
     documents.save(own);
 
     // The workflow slice is a predicate, orthogonal to the retention one.
-    String open = list(ADMIN_ID, "all", "state", "open");
+    String open = list(ADMIN_ID, "all", "lifecycle", "open");
     assertThat(titles(open)).contains("Open foreign review", "The admins own open one");
     assertThat(titles(open)).doesNotContain("Closed foreign review");
 
@@ -264,6 +264,33 @@ class AdminReviewModerationIT extends SeededIntegrationTest {
     assertThat(((Number) JsonPath.read(json, "$.facets.roleObserver")).intValue()).isEqualTo(3);
     assertThat(((Number) JsonPath.read(json, "$.facets.roleOwner")).intValue()).isZero();
     assertThat(json).doesNotContain("Owned by the admin"); // the search excluded it
+  }
+
+  @Test
+  @DisplayName("the advanced filters narrow the workspace, and the owner facet spans it")
+  void advancedFiltersAreServerSide() throws Exception {
+    foreignReview("Cancelled elsewhere", WorkflowState.CANCELLED);
+    foreignReview("Still in review");
+
+    // One specific workflow state, not just open/closed.
+    String cancelled = list(ADMIN_ID, "all", "workflowState", "CANCELLED", "scope", "all");
+    assertThat(titles(cancelled)).contains("Cancelled elsewhere");
+    assertThat(titles(cancelled)).doesNotContain("Still in review");
+
+    // Owned by somebody: the facet offers owners from the whole workspace, so it
+    // can name people whose reviews are not on the current page.
+    String json = list(ADMIN_ID, "all");
+    assertThat(JsonPath.read(json, "$.facets.owners[*].id").toString())
+        .contains(MEMBER_ID.toString());
+
+    String byOwner = list(ADMIN_ID, "all", "ownerId", MEMBER_ID.toString(), "scope", "all");
+    assertThat(titles(byOwner)).contains("Still in review");
+
+    // A format nothing matches empties the page without emptying the workspace.
+    String markdown = list(ADMIN_ID, "all", "format", "md", "scope", "all");
+    assertThat(titles(markdown)).isEmpty();
+    assertThat(((Number) JsonPath.read(markdown, "$.facets.totalUnfiltered")).intValue())
+        .isGreaterThan(0);
   }
 
   /** Raises one open annotation on version 1, authored by {@code author}. */

--- a/qnop-core/src/main/java/io/qnop/repository/AnnotationRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/AnnotationRepository.java
@@ -60,17 +60,25 @@ public interface AnnotationRepository extends JpaRepository<Annotation, UUID> {
    * only the actor's own annotations (and, if they own the review, all of them) count — so the
    * reviews overview's totals follow the caller's visibility rather than over-counting hidden
    * threads. A document where the actor sees nothing is simply absent (the caller defaults to 0).
+   *
+   * <p>{@code admin} counts everything, because an admin already <em>reads</em> everything: {@code
+   * AnnotationService.canSeeThread} lets them into PRIVATE threads. Without the flag the moderation
+   * listing (issue #563) under-reports — a review with open concerns showing "0 open" — which is
+   * not privacy, just a wrong number.
    */
   @Query(
       "SELECT new io.qnop.repository.DocumentAnnotationCounts(a.documentId, COUNT(a),"
           + " SUM(CASE WHEN a.status = io.qnop.entity.AnnotationStatus.OPEN THEN 1 ELSE 0 END))"
           + " FROM Annotation a, Document d"
           + " WHERE a.documentId = d.id AND a.documentId IN :documentIds"
-          + " AND (d.threadParticipation <> io.qnop.entity.ThreadParticipation.PRIVATE"
+          + " AND (:admin = TRUE"
+          + " OR d.threadParticipation <> io.qnop.entity.ThreadParticipation.PRIVATE"
           + " OR d.ownerId = :actor OR a.authorId = :actor)"
           + " GROUP BY a.documentId")
   List<DocumentAnnotationCounts> countVisibleByDocumentIds(
-      @Param("documentIds") Collection<UUID> documentIds, @Param("actor") UUID actor);
+      @Param("documentIds") Collection<UUID> documentIds,
+      @Param("actor") UUID actor,
+      @Param("admin") boolean admin);
 
   /** Annotations the user raised in NON-anonymous reviews (ADR-0038, issue #473). */
   @Query(

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -128,6 +128,16 @@ public interface DocumentRepository
   List<Document> findTeamParticipationsVisibleTo(
       @Param("teamId") UUID teamId, @Param("actor") UUID actor);
 
+  /**
+   * Everyone who owns a review, for the moderation listing's owner facet (issue #563).
+   *
+   * <p>Across the whole workspace rather than the current page: a dropdown offering only the owners
+   * of the twenty rows on screen would look like the complete list and quietly not be one.
+   * Ownership is structurally public (#413), so this leaks nothing a row would not.
+   */
+  @Query("SELECT DISTINCT d.ownerId FROM Document d")
+  List<UUID> findDistinctOwnerIds(Pageable pageable);
+
   /** Reviews the user owns — ownership is structurally public, anonymous ones included (#473). */
   long countByOwnerId(UUID ownerId);
 

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -23,6 +23,7 @@ package io.qnop.repository;
 import io.qnop.entity.Document;
 import jakarta.persistence.LockModeType;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -82,6 +83,44 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
       @Param("includeActive") boolean includeActive,
       @Param("includeArchived") boolean includeArchived,
       Pageable pageable);
+
+  /**
+   * Every review, for an admin's moderation listing (issue #563).
+   *
+   * <p>A separate query rather than a flag on {@link #findVisibleTo}: a predicate that drops its
+   * own access clause when a boolean says so is the kind of construct that gets misread the next
+   * time someone touches it, and the thing being dropped here is the access rule. Two queries make
+   * the unscoped one impossible to reach by accident — the caller has to name it.
+   *
+   * <p>Callers must check the admin role themselves; this method asks nobody's permission.
+   */
+  @Query(
+      "SELECT d FROM Document d WHERE (:q IS NULL OR LOWER(d.title) LIKE :q)"
+          + " AND ((:includeActive = TRUE AND d.archivedAt IS NULL)"
+          + "   OR (:includeArchived = TRUE AND d.archivedAt IS NOT NULL))")
+  Page<Document> findAllForModeration(
+      @Param("q") String q,
+      @Param("includeActive") boolean includeActive,
+      @Param("includeArchived") boolean includeArchived,
+      Pageable pageable);
+
+  /**
+   * Which of the given reviews the actor is actually part of (issue #563).
+   *
+   * <p>So the moderation listing can mark the rest. The same three ways in as {@link
+   * #findVisibleTo} — owned, joined directly, joined through a team — because a row is only "not
+   * yours" if none of them applies; a reviewer who joined via their team is participating even
+   * though no row names them.
+   */
+  @Query(
+      "SELECT d.id FROM Document d WHERE d.id IN :documentIds"
+          + " AND (d.ownerId = :actor"
+          + " OR EXISTS (SELECT 1 FROM ReviewParticipant p"
+          + "   WHERE p.documentId = d.id AND p.userId = :actor)"
+          + " OR EXISTS (SELECT 1 FROM ReviewParticipant pt, TeamMembership m"
+          + "   WHERE pt.documentId = d.id AND pt.teamId = m.teamId AND m.userId = :actor))")
+  List<UUID> findParticipatingIds(
+      @Param("documentIds") Collection<UUID> documentIds, @Param("actor") UUID actor);
 
   /**
    * Reviews the given team participates in AND the actor may see (issue #586). The public team

--- a/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/DocumentRepository.java
@@ -30,12 +30,20 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-/** Data access for review aggregate roots (issue #244, ADR-0011). */
-public interface DocumentRepository extends JpaRepository<Document, UUID> {
+/**
+ * Data access for review aggregate roots (issue #244, ADR-0011).
+ *
+ * <p>Extends {@link JpaSpecificationExecutor} for the admin's moderation listing (issue #563),
+ * whose facets are independent dimensions the caller combines freely — built as a {@code
+ * Specification} rather than one query with a fistful of booleans.
+ */
+public interface DocumentRepository
+    extends JpaRepository<Document, UUID>, JpaSpecificationExecutor<Document> {
 
   /**
    * Loads a document under a {@code PESSIMISTIC_WRITE} row lock (issue #324): serializes the
@@ -79,26 +87,6 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
           + "   WHERE pt.documentId = d.id AND pt.teamId = m.teamId AND m.userId = :actor))")
   Page<Document> findVisibleTo(
       @Param("actor") UUID actor,
-      @Param("q") String q,
-      @Param("includeActive") boolean includeActive,
-      @Param("includeArchived") boolean includeArchived,
-      Pageable pageable);
-
-  /**
-   * Every review, for an admin's moderation listing (issue #563).
-   *
-   * <p>A separate query rather than a flag on {@link #findVisibleTo}: a predicate that drops its
-   * own access clause when a boolean says so is the kind of construct that gets misread the next
-   * time someone touches it, and the thing being dropped here is the access rule. Two queries make
-   * the unscoped one impossible to reach by accident — the caller has to name it.
-   *
-   * <p>Callers must check the admin role themselves; this method asks nobody's permission.
-   */
-  @Query(
-      "SELECT d FROM Document d WHERE (:q IS NULL OR LOWER(d.title) LIKE :q)"
-          + " AND ((:includeActive = TRUE AND d.archivedAt IS NULL)"
-          + "   OR (:includeArchived = TRUE AND d.archivedAt IS NOT NULL))")
-  Page<Document> findAllForModeration(
       @Param("q") String q,
       @Param("includeActive") boolean includeActive,
       @Param("includeArchived") boolean includeArchived,

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentIngestService.java
@@ -176,14 +176,21 @@ public class DocumentIngestService {
     return result;
   }
 
-  /** Appends the upload as the next version of {@code documentId}; owner-only. */
-  public UploadResult addVersion(UUID actor, UUID documentId, UploadSource upload) {
+  /**
+   * Appends the upload as the next version of {@code documentId} — the owner, or an admin
+   * moderating (issue #563).
+   *
+   * <p>The most consequential of the admin's moderation powers, and worth naming as such: a new
+   * version re-anchors every annotation and changes what everyone is reviewing. It is here because
+   * an owner can become unreachable mid-review; the audit trail records who actually did it.
+   */
+  public UploadResult addVersion(UUID actor, boolean admin, UUID documentId, UploadSource upload) {
     Document document =
         documents
             .findById(documentId)
             .orElseThrow(
                 () -> DocumentValidationException.notFound("no such document: " + documentId));
-    if (!document.getOwnerId().equals(actor)) {
+    if (!admin && !document.getOwnerId().equals(actor)) {
       // Anti-enumeration: a caller who cannot even see the document gets the same 404 as for an
       // unknown id; only a visible non-owner (participant/admin) learns the action is owner-only.
       if (!access.isVisible(documentId, actor, false)) {

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
@@ -32,12 +32,15 @@ import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.repository.UserDisplayName;
 import io.qnop.repository.UserRepository;
 import io.qnop.repository.UserSlug;
+import io.qnop.service.document.ReviewModerationFilter.Due;
+import io.qnop.service.document.ReviewModerationFilter.Facets;
+import io.qnop.service.document.ReviewModerationFilter.Lifecycle;
 import io.qnop.service.document.ReviewModerationFilter.Role;
 import io.qnop.service.document.ReviewModerationFilter.Scope;
-import io.qnop.service.document.ReviewModerationFilter.State;
 import io.qnop.service.document.ReviewParticipantService.ParticipantView;
 import io.qnop.service.review.ReviewIdentityResolver;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -98,6 +101,9 @@ public class DocumentOverviewService {
    * — a moderation list that silently stops at the first page would be worse than no list, because
    * "I can see everything" is exactly what a moderator relies on.
    */
+  /** How many owners the facet offers before the search field is the better tool. */
+  private static final int MAX_OWNER_OPTIONS = 100;
+
   @Transactional(readOnly = true)
   public DocumentPage listVisible(
       UUID actor,
@@ -106,8 +112,12 @@ public class DocumentOverviewService {
       String query,
       String sort,
       String scope,
-      String state,
+      String lifecycle,
       String role,
+      String workflowState,
+      String due,
+      String format,
+      UUID ownerId,
       boolean includeActive,
       boolean includeArchived,
       int page,
@@ -129,14 +139,19 @@ public class DocumentOverviewService {
     ReviewFacetCounts facets = null;
     Page<Document> result;
     if (moderation) {
-      Scope wantedScope = Scope.of(scope);
-      State wantedState = State.of(state);
-      Role wantedRole = Role.of(role);
-      result =
-          documents.findAll(
-              ReviewModerationFilter.of(actor, like, wantedScope, wantedState, wantedRole),
-              pageRequest);
-      facets = countFacets(actor, like, wantedScope, wantedState, wantedRole);
+      Instant now = Instant.now();
+      Facets wanted =
+          new Facets(
+              like,
+              Scope.of(scope),
+              Lifecycle.of(lifecycle),
+              Role.of(role),
+              blankToNull(workflowState),
+              Due.of(due),
+              blankToNull(format),
+              ownerId);
+      result = documents.findAll(ReviewModerationFilter.of(actor, wanted, now), pageRequest);
+      facets = countFacets(actor, wanted, now);
     } else {
       result = documents.findVisibleTo(actor, like, includeActive, includeArchived, pageRequest);
     }
@@ -246,21 +261,52 @@ public class DocumentOverviewService {
    * rows are reviews, and keeping each chip's number the result of the very predicate that chip
    * applies is what stops the two drifting apart.
    */
-  private ReviewFacetCounts countFacets(
-      UUID actor, String like, Scope scope, State state, Role role) {
+  private ReviewFacetCounts countFacets(UUID actor, Facets wanted, Instant now) {
+    Facets unfiltered =
+        new Facets(null, Scope.ALL, Lifecycle.ANY, Role.ANY, null, Due.ANY, null, null);
     return new ReviewFacetCounts(
         // Told apart from "this filter matched nothing", which is a different
         // message and must not show the first-run welcome.
-        documents.count(ReviewModerationFilter.of(actor, null, Scope.ALL, State.ANY, Role.ANY)),
-        documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.ANY)),
-        documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.OWNER)),
-        documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.REVIEWER)),
-        documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.OBSERVER)),
-        documents.count(ReviewModerationFilter.of(actor, like, Scope.ACTIVE, State.ANY, role)),
-        documents.count(ReviewModerationFilter.of(actor, like, Scope.ACTIVE, State.OPEN, role)),
-        documents.count(ReviewModerationFilter.of(actor, like, Scope.ACTIVE, State.CLOSED, role)),
-        documents.count(ReviewModerationFilter.of(actor, like, Scope.ARCHIVED, State.ANY, role)),
-        documents.count(ReviewModerationFilter.of(actor, like, Scope.ALL, State.ANY, role)));
+        documents.count(ReviewModerationFilter.of(actor, unfiltered, now)),
+        ownerOptions(),
+        count(actor, wanted.withRole(Role.ANY), now),
+        count(actor, wanted.withRole(Role.OWNER), now),
+        count(actor, wanted.withRole(Role.REVIEWER), now),
+        count(actor, wanted.withRole(Role.OBSERVER), now),
+        count(actor, wanted.withStatus(Scope.ACTIVE, Lifecycle.ANY), now),
+        count(actor, wanted.withStatus(Scope.ACTIVE, Lifecycle.OPEN), now),
+        count(actor, wanted.withStatus(Scope.ACTIVE, Lifecycle.CLOSED), now),
+        count(actor, wanted.withStatus(Scope.ARCHIVED, Lifecycle.ANY), now),
+        count(actor, wanted.withStatus(Scope.ALL, Lifecycle.ANY), now));
+  }
+
+  /**
+   * The owner facet's entries.
+   *
+   * <p>Capped: past a few dozen owners a dropdown stops being a way to find anything, and the
+   * search field is the better tool. The cap is generous enough that no ordinary workspace meets
+   * it.
+   */
+  private List<OwnerOption> ownerOptions() {
+    List<UUID> ids = documents.findDistinctOwnerIds(PageRequest.of(0, MAX_OWNER_OPTIONS));
+    if (ids.isEmpty()) {
+      return List.of();
+    }
+    Map<UUID, String> names =
+        users.findDisplayNamesByIdIn(ids).stream()
+            .collect(Collectors.toMap(UserDisplayName::id, UserDisplayName::displayName));
+    return ids.stream()
+        .map(id -> new OwnerOption(id, names.getOrDefault(id, "Unknown")))
+        .sorted(Comparator.comparing(OwnerOption::displayName, String.CASE_INSENSITIVE_ORDER))
+        .toList();
+  }
+
+  private long count(UUID actor, Facets facets, Instant now) {
+    return documents.count(ReviewModerationFilter.of(actor, facets, now));
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() || "any".equalsIgnoreCase(value) ? null : value;
   }
 
   private List<ParticipantView> rosterFor(
@@ -314,6 +360,9 @@ public class DocumentOverviewService {
        */
       boolean participating) {}
 
+  /** One entry of the owner facet (issue #563). */
+  public record OwnerOption(UUID id, String displayName) {}
+
   /** A page of the caller's documents; {@code facets} is set only when moderating (issue #563). */
   public record DocumentPage(
       List<DocumentSummaryView> items, long total, int page, int size, ReviewFacetCounts facets) {}
@@ -329,6 +378,8 @@ public class DocumentOverviewService {
   public record ReviewFacetCounts(
       /** Every review there is, ignoring search and facets — "is the workspace empty?" (#563). */
       long totalUnfiltered,
+      /** Everyone who owns a review, so the owner facet is not limited to the page. */
+      List<OwnerOption> owners,
       long roleAny,
       long roleOwner,
       long roleReviewer,

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
@@ -84,28 +84,45 @@ public class DocumentOverviewService {
     this.users = users;
   }
 
+  /**
+   * The reviews the caller may list.
+   *
+   * <p>{@code moderation} is the admin's cross-review listing (issue #563): every review, not just
+   * the caller's own participations. It is refused for anyone else here rather than in the
+   * controller, so the rule sits next to the query it guards.
+   *
+   * <p>Unlike the participant-scoped view, this one is meant to be paged and searched on the server
+   * — a moderation list that silently stops at the first page would be worse than no list, because
+   * "I can see everything" is exactly what a moderator relies on.
+   */
   @Transactional(readOnly = true)
   public DocumentPage listVisible(
       UUID actor,
+      boolean admin,
+      boolean moderation,
       String query,
       String sort,
       boolean includeActive,
       boolean includeArchived,
       int page,
       int size) {
+    if (moderation && !admin) {
+      // 403, not 404: the caller is authenticated and the listing exists — it is
+      // simply not theirs. Anti-enumeration does not apply, because this reveals
+      // nothing about any particular review.
+      throw DocumentValidationException.forbidden("only admins may list every review");
+    }
     String like =
         query == null || query.isBlank() ? null : "%" + query.trim().toLowerCase(Locale.ROOT) + "%";
     // The retention slice (issue #576): the caller picks any combination — the
     // overview's "All" facet spans active AND archived at once, the default
     // hides the records, the Archived view shows only them. Open/closed stays
     // a client-side facet over the result.
+    PageRequest pageRequest = PageRequest.of(page, size, parseSort(sort));
     Page<Document> result =
-        documents.findVisibleTo(
-            actor,
-            like,
-            includeActive,
-            includeArchived,
-            PageRequest.of(page, size, parseSort(sort)));
+        moderation
+            ? documents.findAllForModeration(like, includeActive, includeArchived, pageRequest)
+            : documents.findVisibleTo(actor, like, includeActive, includeArchived, pageRequest);
 
     List<UUID> ids = result.getContent().stream().map(Document::getId).toList();
     Map<UUID, Integer> maxVersions =
@@ -129,7 +146,7 @@ public class DocumentOverviewService {
     Map<UUID, DocumentAnnotationCounts> counts =
         ids.isEmpty()
             ? Map.of()
-            : annotations.countVisibleByDocumentIds(ids, actor).stream()
+            : annotations.countVisibleByDocumentIds(ids, actor, admin).stream()
                 .collect(
                     Collectors.toMap(DocumentAnnotationCounts::documentId, Function.identity()));
     // Owner names, batched (issue #469 polish): structurally public (#413).
@@ -160,6 +177,13 @@ public class DocumentOverviewService {
                 .filter(row -> row.slug() != null)
                 .collect(Collectors.toMap(UserSlug::id, UserSlug::slug));
 
+    // Only in moderation mode: everywhere else every row is the caller's by
+    // construction, so the extra query would answer a question nobody asked.
+    Set<UUID> participating =
+        moderation && !ids.isEmpty()
+            ? new HashSet<>(documents.findParticipatingIds(ids, actor))
+            : Set.copyOf(ids);
+
     List<DocumentSummaryView> items =
         result.getContent().stream()
             .map(
@@ -187,7 +211,8 @@ public class DocumentOverviewService {
                       document.getCreatedAt(),
                       document.getUpdatedAt(),
                       document.getDueAt(),
-                      document.getArchivedAt());
+                      document.getArchivedAt(),
+                      participating.contains(document.getId()));
                 })
             .toList();
     return new DocumentPage(items, result.getTotalElements(), page, size);
@@ -242,7 +267,11 @@ public class DocumentOverviewService {
       Instant createdAt,
       Instant updatedAt,
       Instant dueAt,
-      Instant archivedAt) {}
+      Instant archivedAt,
+      /**
+       * Whether the caller owns or reviews this one (issue #563); always true outside moderation.
+       */
+      boolean participating) {}
 
   /** A page of the caller's documents. */
   public record DocumentPage(List<DocumentSummaryView> items, long total, int page, int size) {}

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
@@ -32,6 +32,9 @@ import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.repository.UserDisplayName;
 import io.qnop.repository.UserRepository;
 import io.qnop.repository.UserSlug;
+import io.qnop.service.document.ReviewModerationFilter.Role;
+import io.qnop.service.document.ReviewModerationFilter.Scope;
+import io.qnop.service.document.ReviewModerationFilter.State;
 import io.qnop.service.document.ReviewParticipantService.ParticipantView;
 import io.qnop.service.review.ReviewIdentityResolver;
 import java.time.Instant;
@@ -102,6 +105,9 @@ public class DocumentOverviewService {
       boolean moderation,
       String query,
       String sort,
+      String scope,
+      String state,
+      String role,
       boolean includeActive,
       boolean includeArchived,
       int page,
@@ -116,13 +122,24 @@ public class DocumentOverviewService {
         query == null || query.isBlank() ? null : "%" + query.trim().toLowerCase(Locale.ROOT) + "%";
     // The retention slice (issue #576): the caller picks any combination — the
     // overview's "All" facet spans active AND archived at once, the default
-    // hides the records, the Archived view shows only them. Open/closed stays
-    // a client-side facet over the result.
+    // hides the records, the Archived view shows only them. In the participant-
+    // scoped view the finer slices stay client-side facets over the result; the
+    // moderation listing is paged, so they have to be predicates (issue #563).
     PageRequest pageRequest = PageRequest.of(page, size, parseSort(sort));
-    Page<Document> result =
-        moderation
-            ? documents.findAllForModeration(like, includeActive, includeArchived, pageRequest)
-            : documents.findVisibleTo(actor, like, includeActive, includeArchived, pageRequest);
+    ReviewFacetCounts facets = null;
+    Page<Document> result;
+    if (moderation) {
+      Scope wantedScope = Scope.of(scope);
+      State wantedState = State.of(state);
+      Role wantedRole = Role.of(role);
+      result =
+          documents.findAll(
+              ReviewModerationFilter.of(actor, like, wantedScope, wantedState, wantedRole),
+              pageRequest);
+      facets = countFacets(actor, like, wantedScope, wantedState, wantedRole);
+    } else {
+      result = documents.findVisibleTo(actor, like, includeActive, includeArchived, pageRequest);
+    }
 
     List<UUID> ids = result.getContent().stream().map(Document::getId).toList();
     Map<UUID, Integer> maxVersions =
@@ -215,13 +232,34 @@ public class DocumentOverviewService {
                       participating.contains(document.getId()));
                 })
             .toList();
-    return new DocumentPage(items, result.getTotalElements(), page, size);
+    return new DocumentPage(items, result.getTotalElements(), page, size, facets);
   }
 
   /**
    * The reviewer set for one summary card, anonymised (issue #422) when the review is anonymous and
    * the caller is not its owner — so the overview never leaks the roster of an anonymous review.
    */
+  /**
+   * The chip counts, each group counted against the other group's selection.
+   *
+   * <p>Nine counts rather than one grouped query: they are plain indexed counts over a table whose
+   * rows are reviews, and keeping each chip's number the result of the very predicate that chip
+   * applies is what stops the two drifting apart.
+   */
+  private ReviewFacetCounts countFacets(
+      UUID actor, String like, Scope scope, State state, Role role) {
+    return new ReviewFacetCounts(
+        documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.ANY)),
+        documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.OWNER)),
+        documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.REVIEWER)),
+        documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.OBSERVER)),
+        documents.count(ReviewModerationFilter.of(actor, like, Scope.ACTIVE, State.ANY, role)),
+        documents.count(ReviewModerationFilter.of(actor, like, Scope.ACTIVE, State.OPEN, role)),
+        documents.count(ReviewModerationFilter.of(actor, like, Scope.ACTIVE, State.CLOSED, role)),
+        documents.count(ReviewModerationFilter.of(actor, like, Scope.ARCHIVED, State.ANY, role)),
+        documents.count(ReviewModerationFilter.of(actor, like, Scope.ALL, State.ANY, role)));
+  }
+
   private List<ParticipantView> rosterFor(
       Document document, UUID actor, List<ParticipantProjection> rows, Map<UUID, String> slugById) {
     if (!document.isAnonymous() || document.getOwnerId().equals(actor)) {
@@ -273,6 +311,26 @@ public class DocumentOverviewService {
        */
       boolean participating) {}
 
-  /** A page of the caller's documents. */
-  public record DocumentPage(List<DocumentSummaryView> items, long total, int page, int size) {}
+  /** A page of the caller's documents; {@code facets} is set only when moderating (issue #563). */
+  public record DocumentPage(
+      List<DocumentSummaryView> items, long total, int page, int size, ReviewFacetCounts facets) {}
+
+  /**
+   * What each chip would show if clicked.
+   *
+   * <p>Counted on the server for the same reason the rows are paged there: a number derived from
+   * one page would describe that page while appearing to describe the workspace. Each group is
+   * counted against the OTHER group's current selection, which is the rule the participant-scoped
+   * view already follows — so a chip's number keeps predicting what clicking it shows.
+   */
+  public record ReviewFacetCounts(
+      long roleAny,
+      long roleOwner,
+      long roleReviewer,
+      long roleObserver,
+      long stateActive,
+      long stateOpen,
+      long stateClosed,
+      long stateArchived,
+      long stateAll) {}
 }

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentOverviewService.java
@@ -249,6 +249,9 @@ public class DocumentOverviewService {
   private ReviewFacetCounts countFacets(
       UUID actor, String like, Scope scope, State state, Role role) {
     return new ReviewFacetCounts(
+        // Told apart from "this filter matched nothing", which is a different
+        // message and must not show the first-run welcome.
+        documents.count(ReviewModerationFilter.of(actor, null, Scope.ALL, State.ANY, Role.ANY)),
         documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.ANY)),
         documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.OWNER)),
         documents.count(ReviewModerationFilter.of(actor, like, scope, state, Role.REVIEWER)),
@@ -324,6 +327,8 @@ public class DocumentOverviewService {
    * view already follows — so a chip's number keeps predicting what clicking it shows.
    */
   public record ReviewFacetCounts(
+      /** Every review there is, ignoring search and facets — "is the workspace empty?" (#563). */
+      long totalUnfiltered,
       long roleAny,
       long roleOwner,
       long roleReviewer,

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentUpdateService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentUpdateService.java
@@ -112,7 +112,9 @@ public class DocumentUpdateService {
         documents
             .findById(documentId)
             .orElseThrow(() -> DocumentValidationException.notFound("document " + documentId));
-    if (!document.getOwnerId().equals(actor)) {
+    if (!admin && !document.getOwnerId().equals(actor)) {
+      // Structural and low-consequence: it moves a deadline, not the content
+      // (issue #563).
       throw DocumentValidationException.notOwner("only the owner may edit the due date");
     }
     return document;

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentValidationException.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentValidationException.java
@@ -65,6 +65,16 @@ public class DocumentValidationException extends RuntimeException {
     return new DocumentValidationException(403, "NOT_OWNER", detail);
   }
 
+  /**
+   * An action reserved for admins (issue #563).
+   *
+   * <p>Distinct from {@link #notFound}: the cross-review listing is not a document whose existence
+   * could be probed, so hiding it behind a 404 would only obscure why the call failed.
+   */
+  public static DocumentValidationException forbidden(String detail) {
+    return new DocumentValidationException(403, "FORBIDDEN", detail);
+  }
+
   public static DocumentValidationException unsupportedType(String detail) {
     return new DocumentValidationException(415, "UNSUPPORTED_MEDIA_TYPE", detail);
   }

--- a/qnop-core/src/main/java/io/qnop/service/document/ReviewModerationFilter.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/ReviewModerationFilter.java
@@ -21,15 +21,19 @@
 package io.qnop.service.document;
 
 import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ReviewParticipant;
 import io.qnop.entity.TeamMembership;
 import io.qnop.entity.WorkflowState;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -62,18 +66,76 @@ final class ReviewModerationFilter {
     }
   }
 
-  /** The workflow slice, orthogonal to the retention one. */
-  enum State {
+  /**
+   * The workflow slice, orthogonal to the retention one.
+   *
+   * <p>Called <em>lifecycle</em> on the wire, not "state": the advanced filter has its own,
+   * finer-grained workflow-state parameter, and two things named `state` meaning different slices
+   * of the same column is a trap rather than a saving.
+   */
+  enum Lifecycle {
     ANY,
     OPEN,
     CLOSED;
 
-    static State of(String raw) {
+    static Lifecycle of(String raw) {
       return switch (raw == null ? "" : raw.toLowerCase(Locale.ROOT)) {
         case "open" -> OPEN;
         case "closed" -> CLOSED;
         default -> ANY;
       };
+    }
+  }
+
+  /** The due-date slice, mirroring the client's `matchesDue`. */
+  enum Due {
+    ANY,
+    OVERDUE,
+    SOON,
+    NONE;
+
+    static Due of(String raw) {
+      return switch (raw == null ? "" : raw.toLowerCase(Locale.ROOT)) {
+        case "overdue" -> OVERDUE;
+        case "soon" -> SOON;
+        case "none" -> NONE;
+        default -> ANY;
+      };
+    }
+  }
+
+  /** How far ahead "due soon" reaches, matching the client's window. */
+  private static final int DUE_SOON_DAYS = 7;
+
+  /** MIME families the format facet offers, in the DocumentIcon's language. */
+  private static final Map<String, List<String>> FORMATS =
+      Map.of(
+          "pdf", List.of("application/pdf"),
+          "docx",
+              List.of(
+                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                  "application/msword"),
+          "md", List.of("text/markdown"));
+
+  /** Everything the moderation listing can be narrowed by (issue #563). */
+  record Facets(
+      String like,
+      Scope scope,
+      Lifecycle lifecycle,
+      Role role,
+      String workflowState,
+      Due due,
+      String format,
+      UUID ownerId) {
+
+    /** The same filter with one dimension swapped — how a chip's own count is taken. */
+    Facets withRole(Role other) {
+      return new Facets(like, scope, lifecycle, other, workflowState, due, format, ownerId);
+    }
+
+    Facets withStatus(Scope otherScope, Lifecycle otherLifecycle) {
+      return new Facets(
+          like, otherScope, otherLifecycle, role, workflowState, due, format, ownerId);
     }
   }
 
@@ -107,12 +169,15 @@ final class ReviewModerationFilter {
   private static final List<String> CLOSED =
       List.of(WorkflowState.FINALIZED.name(), WorkflowState.CANCELLED.name());
 
-  static Specification<Document> of(UUID actor, String like, Scope scope, State state, Role role) {
+  static Specification<Document> of(UUID actor, Facets facets, Instant now) {
     return (root, query, cb) -> {
       List<Predicate> predicates = new ArrayList<>();
-      if (like != null) {
-        predicates.add(cb.like(cb.lower(root.get("title")), like));
+      if (facets.like() != null) {
+        predicates.add(cb.like(cb.lower(root.get("title")), facets.like()));
       }
+      Scope scope = facets.scope();
+      Lifecycle state = facets.lifecycle();
+      Role role = facets.role();
       switch (scope) {
         case ACTIVE -> predicates.add(cb.isNull(root.get("archivedAt")));
         case ARCHIVED -> predicates.add(cb.isNotNull(root.get("archivedAt")));
@@ -144,8 +209,66 @@ final class ReviewModerationFilter {
           // Whatever the caller's part is.
         }
       }
+      if (facets.workflowState() != null) {
+        predicates.add(cb.equal(root.get("workflowState"), facets.workflowState()));
+      }
+      if (facets.ownerId() != null) {
+        predicates.add(cb.equal(root.get("ownerId"), facets.ownerId()));
+      }
+      addDue(predicates, root, cb, facets.due(), now);
+      List<String> mimes = facets.format() == null ? null : FORMATS.get(facets.format());
+      if (mimes != null) {
+        // The LATEST version's type, which is what the row's ribbon shows — a
+        // review whose first version was a PDF and whose current one is Word is
+        // a Word review.
+        Subquery<UUID> latest = query.subquery(UUID.class);
+        Root<DocumentVersion> version = latest.from(DocumentVersion.class);
+        Subquery<Integer> maxNumber = latest.subquery(Integer.class);
+        Root<DocumentVersion> any = maxNumber.from(DocumentVersion.class);
+        maxNumber
+            .select(cb.max(any.get("versionNumber")))
+            .where(cb.equal(any.get("documentId"), root.get("id")));
+        latest
+            .select(version.get("id"))
+            .where(
+                cb.equal(version.get("documentId"), root.get("id")),
+                cb.equal(version.get("versionNumber"), maxNumber),
+                version.get("contentType").in(mimes));
+        predicates.add(cb.exists(latest));
+      }
       return cb.and(predicates.toArray(new Predicate[0]));
     };
+  }
+
+  /**
+   * The due-date slice.
+   *
+   * <p>Only living deadlines: a finalized or archived review is never "overdue", which is the same
+   * reading the client's `matchesDue` uses. `none` is the opposite question — work nobody has put a
+   * clock on — and applies whatever the state.
+   */
+  private static void addDue(
+      List<Predicate> predicates,
+      Root<Document> root,
+      jakarta.persistence.criteria.CriteriaBuilder cb,
+      Due due,
+      Instant now) {
+    if (due == Due.ANY) {
+      return;
+    }
+    if (due == Due.NONE) {
+      predicates.add(cb.isNull(root.get("dueAt")));
+      return;
+    }
+    predicates.add(cb.isNotNull(root.get("dueAt")));
+    predicates.add(cb.isNull(root.get("archivedAt")));
+    predicates.add(cb.not(root.get("workflowState").in(CLOSED)));
+    if (due == Due.OVERDUE) {
+      predicates.add(cb.lessThan(root.<Instant>get("dueAt"), now));
+    } else {
+      predicates.add(
+          cb.between(root.<Instant>get("dueAt"), now, now.plus(DUE_SOON_DAYS, ChronoUnit.DAYS)));
+    }
   }
 
   /** Whether the actor is on the roster, directly or through one of their teams. */

--- a/qnop-core/src/main/java/io/qnop/service/document/ReviewModerationFilter.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/ReviewModerationFilter.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.document;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.TeamMembership;
+import io.qnop.entity.WorkflowState;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * The facets of the admin's moderation listing, as a query (issue #563).
+ *
+ * <p>The participant-scoped overview fetches once and facets in the browser, which is honest while
+ * the rows are the caller's own. The moderation listing spans a whole workspace and is paged, so
+ * the same chips have to filter — and count — on the server. A chip that narrowed the current page
+ * while claiming to describe the workspace would be worse than no chip at all.
+ *
+ * <p>Built with the Criteria API rather than one JPQL query with a fistful of boolean parameters:
+ * the facets are independent dimensions, and a predicate assembled from what was actually asked for
+ * stays readable as they grow.
+ */
+final class ReviewModerationFilter {
+
+  /** The retention slice, matching the API's {@code scope}. */
+  enum Scope {
+    ACTIVE,
+    ARCHIVED,
+    ALL;
+
+    static Scope of(String raw) {
+      return switch (raw == null ? "" : raw.toLowerCase(Locale.ROOT)) {
+        case "archived" -> ARCHIVED;
+        case "all" -> ALL;
+        default -> ACTIVE;
+      };
+    }
+  }
+
+  /** The workflow slice, orthogonal to the retention one. */
+  enum State {
+    ANY,
+    OPEN,
+    CLOSED;
+
+    static State of(String raw) {
+      return switch (raw == null ? "" : raw.toLowerCase(Locale.ROOT)) {
+        case "open" -> OPEN;
+        case "closed" -> CLOSED;
+        default -> ANY;
+      };
+    }
+  }
+
+  /** The caller's part in the review. */
+  enum Role {
+    ANY,
+    OWNER,
+    REVIEWER,
+    OBSERVER;
+
+    static Role of(String raw) {
+      return switch (raw == null ? "" : raw.toLowerCase(Locale.ROOT)) {
+        case "owner" -> OWNER;
+        case "reviewer" -> REVIEWER;
+        case "observer" -> OBSERVER;
+        default -> ANY;
+      };
+    }
+  }
+
+  private ReviewModerationFilter() {}
+
+  /**
+   * The closed states, mirrored from {@link WorkflowState#isTerminal()}.
+   *
+   * <p>Names, not enum constants: the column is a plain string so an enterprise edition can extend
+   * the state machine (ADR-0011/0035). That also fixes what "open" means here — everything that is
+   * not one of these, so an unknown enterprise state counts as open, the same reading the client
+   * uses.
+   */
+  private static final List<String> CLOSED =
+      List.of(WorkflowState.FINALIZED.name(), WorkflowState.CANCELLED.name());
+
+  static Specification<Document> of(UUID actor, String like, Scope scope, State state, Role role) {
+    return (root, query, cb) -> {
+      List<Predicate> predicates = new ArrayList<>();
+      if (like != null) {
+        predicates.add(cb.like(cb.lower(root.get("title")), like));
+      }
+      switch (scope) {
+        case ACTIVE -> predicates.add(cb.isNull(root.get("archivedAt")));
+        case ARCHIVED -> predicates.add(cb.isNotNull(root.get("archivedAt")));
+        case ALL -> {
+          // Everything at once, records included.
+        }
+      }
+      switch (state) {
+        case OPEN -> predicates.add(cb.not(root.get("workflowState").in(CLOSED)));
+        case CLOSED -> predicates.add(root.get("workflowState").in(CLOSED));
+
+        case ANY -> {
+          // Every workflow state.
+        }
+      }
+      switch (role) {
+        case OWNER -> predicates.add(cb.equal(root.get("ownerId"), actor));
+        case REVIEWER ->
+            predicates.add(
+                cb.and(cb.notEqual(root.get("ownerId"), actor), reviewing(root, query, cb, actor)));
+        // "Not participating" is the moderation listing's own facet: neither owner
+        // nor on the roster, directly or through a team.
+        case OBSERVER ->
+            predicates.add(
+                cb.and(
+                    cb.notEqual(root.get("ownerId"), actor),
+                    cb.not(reviewing(root, query, cb, actor))));
+        case ANY -> {
+          // Whatever the caller's part is.
+        }
+      }
+      return cb.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+
+  /** Whether the actor is on the roster, directly or through one of their teams. */
+  private static Predicate reviewing(
+      Root<Document> root,
+      jakarta.persistence.criteria.CommonAbstractCriteria query,
+      jakarta.persistence.criteria.CriteriaBuilder cb,
+      UUID actor) {
+    Subquery<UUID> direct = query.subquery(UUID.class);
+    Root<ReviewParticipant> participant = direct.from(ReviewParticipant.class);
+    direct
+        .select(participant.get("id"))
+        .where(
+            cb.equal(participant.get("documentId"), root.get("id")),
+            cb.equal(participant.get("userId"), actor));
+
+    Subquery<UUID> viaTeam = query.subquery(UUID.class);
+    Root<ReviewParticipant> teamRow = viaTeam.from(ReviewParticipant.class);
+    Root<TeamMembership> membership = viaTeam.from(TeamMembership.class);
+    viaTeam
+        .select(teamRow.get("id"))
+        .where(
+            cb.equal(teamRow.get("documentId"), root.get("id")),
+            cb.equal(teamRow.get("teamId"), membership.get("teamId")),
+            cb.equal(membership.get("userId"), actor));
+
+    return cb.or(cb.exists(direct), cb.exists(viaTeam));
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/ReviewParticipantService.java
@@ -223,7 +223,10 @@ public class ReviewParticipantService {
         documents
             .findById(documentId)
             .orElseThrow(() -> DocumentValidationException.notFound("document " + documentId));
-    if (!document.getOwnerId().equals(actor)) {
+    if (!admin && !document.getOwnerId().equals(actor)) {
+      // Admins moderate (issue #563): taking someone off a review, or adding a
+      // reviewer, when the owner is unreachable. The audit trail records the real
+      // actor either way (ADR-0042).
       throw DocumentValidationException.notOwner("only the owner manages participants");
     }
     return document;

--- a/qnop-core/src/test/java/io/qnop/service/document/DocumentIngestServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/document/DocumentIngestServiceTest.java
@@ -404,7 +404,8 @@ class DocumentIngestServiceTest {
               });
       when(annotations.findByDocumentId(DOC)).thenReturn(List.of());
 
-      DocumentIngestService.UploadResult result = service.addVersion(OWNER, DOC, pdfUpload());
+      DocumentIngestService.UploadResult result =
+          service.addVersion(OWNER, false, DOC, pdfUpload());
 
       assertThat(result.versionNumber()).isEqualTo(3);
       assertThat(result.extractionStatus()).isEqualTo("PENDING");
@@ -418,7 +419,7 @@ class DocumentIngestServiceTest {
       service = newService();
       when(documents.findById(DOC)).thenReturn(Optional.empty());
 
-      assertRejected(() -> service.addVersion(OWNER, DOC, pdfUpload()), 404);
+      assertRejected(() -> service.addVersion(OWNER, false, DOC, pdfUpload()), 404);
     }
 
     @Test
@@ -428,8 +429,37 @@ class DocumentIngestServiceTest {
       when(documents.findById(DOC)).thenReturn(Optional.of(new Document(OWNER, "Contract")));
       when(access.isVisible(DOC, STRANGER, false)).thenReturn(true);
 
-      assertRejected(() -> service.addVersion(STRANGER, DOC, pdfUpload()), 403);
+      assertRejected(() -> service.addVersion(STRANGER, false, DOC, pdfUpload()), 403);
       verify(storage, never()).stage(any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("an admin may append a version to a review they do not own (#563)")
+    void adminMayAddVersion() {
+      service = newService();
+      when(documents.findById(DOC)).thenReturn(Optional.of(new Document(OWNER, "Contract")));
+      when(settings.getInteger(ApplicationSettingKey.UPLOAD_DOCUMENT_MAX_FILE_SIZE_MB))
+          .thenReturn(10);
+      StagedObject staged = new StagedObject("sha256/ab/key", "hash", 42L);
+      when(storage.stage(any(), eq(PDF_CONTENT_TYPE), anyLong())).thenReturn(staged);
+      when(versions.findTopByDocumentIdOrderByVersionNumberDesc(DOC))
+          .thenReturn(Optional.of(version(1)));
+      when(versions.save(any(DocumentVersion.class)))
+          .thenAnswer(
+              inv -> {
+                DocumentVersion saved = inv.getArgument(0);
+                setId(saved, UUID.randomUUID());
+                return saved;
+              });
+      when(annotations.findByDocumentId(DOC)).thenReturn(List.of());
+
+      // The most consequential moderation power (issue #563): it re-anchors every
+      // annotation. Deliberate, and audited with the real actor.
+      DocumentIngestService.UploadResult result =
+          service.addVersion(STRANGER, true, DOC, pdfUpload());
+
+      assertThat(result.versionNumber()).isEqualTo(2);
+      verify(storage).commit(staged.key());
     }
 
     @Test
@@ -439,7 +469,7 @@ class DocumentIngestServiceTest {
       when(documents.findById(DOC)).thenReturn(Optional.of(new Document(OWNER, "Contract")));
       when(access.isVisible(DOC, STRANGER, false)).thenReturn(false);
 
-      assertRejected(() -> service.addVersion(STRANGER, DOC, pdfUpload()), 404);
+      assertRejected(() -> service.addVersion(STRANGER, false, DOC, pdfUpload()), 404);
     }
   }
 

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewPurgeServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewPurgeServiceTest.java
@@ -155,7 +155,7 @@ class ReviewPurgeServiceTest {
     service.purgeOnce(false);
 
     verifyNoInteractions(auditEvents, storage);
-    verify(documents, never()).delete(any());
+    verify(documents, never()).delete(any(Document.class));
   }
 
   // --- the dry run ---------------------------------------------------------
@@ -174,7 +174,7 @@ class ReviewPurgeServiceTest {
 
     service.purgeOnce(true);
 
-    verify(documents, never()).delete(any());
+    verify(documents, never()).delete(any(Document.class));
     verify(storage, never()).delete(anyString());
     verifyNoInteractions(auditEvents);
   }
@@ -265,7 +265,7 @@ class ReviewPurgeServiceTest {
 
     service.purgeOnce(false);
 
-    verify(documents, never()).delete(any());
+    verify(documents, never()).delete(any(Document.class));
     verify(storage, never()).delete(anyString());
     verifyNoInteractions(auditEvents);
   }
@@ -282,7 +282,7 @@ class ReviewPurgeServiceTest {
 
     service.purgeOnce(false);
 
-    verify(documents, never()).delete(any());
+    verify(documents, never()).delete(any(Document.class));
   }
 
   @Test
@@ -295,7 +295,7 @@ class ReviewPurgeServiceTest {
 
     service.purgeOnce(false);
 
-    verify(documents, never()).delete(any());
+    verify(documents, never()).delete(any(Document.class));
     verifyNoInteractions(auditEvents);
   }
 

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -39,6 +39,12 @@ export interface ReviewListParams {
   sort?: string;
   /** When true, return only archived reviews (the "Archived" view); default excludes them (#576). */
   scope?: 'active' | 'archived' | 'all';
+  /**
+   * Whose reviews (issue #563). `all` is the ADMIN-only moderation listing and is
+   * refused with 403 for anyone else, so it is only ever requested from a surface
+   * that knows the caller's role.
+   */
+  participation?: 'mine' | 'all';
   page: number;
   size: number;
 }
@@ -61,6 +67,7 @@ export function useReviews(params: ReviewListParams) {
         q: params.q || undefined,
         sort: params.sort,
         scope: params.scope,
+        participation: params.participation,
         page: params.page,
         size: params.size,
       });

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -46,7 +46,15 @@ export interface ReviewListParams {
    */
   participation?: 'mine' | 'all';
   /** Workflow slice, server-applied while moderating (issue #563). */
-  state?: 'any' | 'open' | 'closed';
+  lifecycle?: 'any' | 'open' | 'closed';
+  /** One specific workflow state; open string set (ADR-0011/0035). */
+  workflowState?: string;
+  /** Deadline slice, server-applied while moderating. */
+  due?: 'any' | 'overdue' | 'soon' | 'none';
+  /** Document family of the latest version, server-applied while moderating. */
+  format?: 'any' | 'pdf' | 'docx' | 'md';
+  /** One specific owner, server-applied while moderating. */
+  ownerId?: string;
   /** The caller's part, server-applied while moderating (issue #563). */
   role?: 'any' | 'owner' | 'reviewer' | 'observer';
   page: number;
@@ -72,7 +80,11 @@ export function useReviews(params: ReviewListParams) {
         sort: params.sort,
         scope: params.scope,
         participation: params.participation,
-        state: params.state,
+        lifecycle: params.lifecycle,
+        workflowState: params.workflowState,
+        due: params.due,
+        format: params.format,
+        ownerId: params.ownerId,
         role: params.role,
         page: params.page,
         size: params.size,

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -45,6 +45,10 @@ export interface ReviewListParams {
    * that knows the caller's role.
    */
   participation?: 'mine' | 'all';
+  /** Workflow slice, server-applied while moderating (issue #563). */
+  state?: 'any' | 'open' | 'closed';
+  /** The caller's part, server-applied while moderating (issue #563). */
+  role?: 'any' | 'owner' | 'reviewer' | 'observer';
   page: number;
   size: number;
 }
@@ -68,6 +72,8 @@ export function useReviews(params: ReviewListParams) {
         sort: params.sort,
         scope: params.scope,
         participation: params.participation,
+        state: params.state,
+        role: params.role,
         page: params.page,
         size: params.size,
       });

--- a/qnop-ui/src/components/reviews/list/ReviewListParts.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewListParts.tsx
@@ -25,8 +25,9 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
-import { Eye, User } from 'lucide-react';
+import { Eye, ShieldCheck, User } from 'lucide-react';
 import type { ParticipantView } from '../../../api/generated';
+import type { ReviewRole } from './reviewListModel';
 import { ToneBadge } from '../../admin/ToneBadge';
 import { TeamHoverCard } from '../../people/TeamHoverCard';
 import { UserHoverCard } from '../../people/UserHoverCard';
@@ -37,16 +38,18 @@ import { tokens } from '../../../theme/tokens';
 
 /** Shared bits of the reviews overview: role badge, doc icon, progress, reviewer stack. */
 
-export function RoleBadge({ role }: { role: 'owner' | 'reviewer' }) {
-  return role === 'owner' ? (
-    <ToneBadge tone="blue" label="Owner" />
-  ) : (
-    <ToneBadge tone="neutral" label="Reviewer" />
-  );
+export function RoleBadge({ role }: { role: ReviewRole }) {
+  if (role === 'owner') return <ToneBadge tone="blue" label="Owner" />;
+  // The moderation listing (issue #563) shows reviews the admin has no part in;
+  // saying so plainly is what makes the row's context obvious.
+  if (role === 'observer') return <ToneBadge tone="amber" label="Not participating" />;
+  return <ToneBadge tone="neutral" label="Reviewer" />;
 }
 
-export function RoleIcon({ role }: { role: 'owner' | 'reviewer' }) {
-  return role === 'owner' ? <User size={12} aria-hidden /> : <Eye size={12} aria-hidden />;
+export function RoleIcon({ role }: { role: ReviewRole }) {
+  if (role === 'owner') return <User size={12} aria-hidden />;
+  if (role === 'observer') return <ShieldCheck size={12} aria-hidden />;
+  return <Eye size={12} aria-hidden />;
 }
 
 /** Known document MIME types and their ribbon label + tone (issue #509 follow-up). */

--- a/qnop-ui/src/components/reviews/list/reviewListModel.ts
+++ b/qnop-ui/src/components/reviews/list/reviewListModel.ts
@@ -22,7 +22,17 @@
 import type { DocumentSummary } from '../../../api/generated';
 
 /** The caller's role on a review — owner is structural (ADR-0011), everyone else reviews. */
-export function roleOf(review: DocumentSummary, userId: string | null): 'owner' | 'reviewer' {
+export type ReviewRole = 'owner' | 'reviewer' | 'observer';
+
+/**
+ * The caller's part in a review.
+ *
+ * <p>`observer` only occurs in an admin's moderation listing (issue #563), where
+ * rows appear that the caller has no part in at all. The server decides it —
+ * participation can come through a team, which the row itself does not show.
+ */
+export function roleOf(review: DocumentSummary, userId: string | null): ReviewRole {
+  if (review.participating === false) return 'observer';
   return review.ownerId === userId ? 'owner' : 'reviewer';
 }
 

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -512,7 +512,9 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
 
   it('marks the rows the admin has no part in', () => {
     useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
-    mockReviews({ data: { items: [foreign], total: 1, page: 0, size: 20 } });
+    mockReviews({
+      data: { items: [foreign], total: 1, page: 0, size: 20, facets: { ...FACETS, roleAny: 1 } },
+    });
 
     renderPage('/reviews?participation=all');
 
@@ -524,6 +526,7 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
   });
 
   const FACETS = {
+    totalUnfiltered: 57,
     roleAny: 57,
     roleOwner: 2,
     roleReviewer: 5,
@@ -600,9 +603,61 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
     expect(archived.state).toBe('any');
   });
 
+  it('says a filter matched nothing instead of greeting a full workspace as empty', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    // A filter combination with no hits, in a workspace holding 57 reviews.
+    mockReviews({
+      data: {
+        items: [],
+        total: 0,
+        page: 0,
+        size: 20,
+        // Nothing archived either, so the plain "no matches" line is the one
+        // under test rather than the archive-only variant (#578).
+        facets: { ...FACETS, roleAny: 0, stateActive: 0, stateArchived: 0, totalUnfiltered: 57 },
+      },
+    });
+
+    renderPage('/reviews?participation=all&role=observer');
+
+    expect(screen.getByText('No reviews match your filters.')).toBeInTheDocument();
+    expect(screen.queryByText(/Start your first review/i)).not.toBeInTheDocument();
+    // And the chips stay: without them there is no way to undo the filter that
+    // emptied the page.
+    expect(screen.getByText('Not participating (50)')).toBeInTheDocument();
+  });
+
+  it('still welcomes an admin whose workspace really is empty', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({
+      data: {
+        items: [],
+        total: 0,
+        page: 0,
+        size: 20,
+        facets: {
+          totalUnfiltered: 0,
+          roleAny: 0,
+          roleOwner: 0,
+          roleReviewer: 0,
+          roleObserver: 0,
+          stateActive: 0,
+          stateOpen: 0,
+          stateClosed: 0,
+          stateArchived: 0,
+          stateAll: 0,
+        },
+      },
+    });
+
+    renderPage('/reviews?participation=all');
+
+    expect(screen.getByText(/Start your first review/i)).toBeInTheDocument();
+  });
+
   it('says which slice of the workspace is on screen', () => {
     useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
-    mockReviews({ data: { items: [foreign], total: 57, page: 0, size: 20 } });
+    mockReviews({ data: { items: [foreign], total: 57, page: 0, size: 20, facets: FACETS } });
 
     renderPage('/reviews?participation=all');
 

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -523,15 +523,81 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
     expect(screen.queryByText('Reviewer')).not.toBeInTheDocument();
   });
 
-  it('hides the client-side facets while moderating', () => {
+  const FACETS = {
+    roleAny: 57,
+    roleOwner: 2,
+    roleReviewer: 5,
+    roleObserver: 50,
+    stateActive: 40,
+    stateOpen: 31,
+    stateClosed: 9,
+    stateArchived: 17,
+    stateAll: 57,
+  };
+
+  it('counts the chips from the whole workspace, not from the page on screen', () => {
     useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
-    mockReviews({ data: { items: [foreign], total: 1, page: 0, size: 20 } });
+    mockReviews({ data: { items: [foreign], total: 57, page: 0, size: 20, facets: FACETS } });
 
     renderPage('/reviews?participation=all');
 
-    // They would narrow the current page and read as the whole workspace.
-    expect(screen.queryByText('Owned by me')).not.toBeInTheDocument();
-    expect(screen.queryByText('Every state')).not.toBeInTheDocument();
+    // One row is on screen and the numbers describe 57 reviews, which is the
+    // whole point: a count taken from the page would describe the page while
+    // appearing to describe the workspace.
+    expect(screen.getByText('Owned by me (2)')).toBeInTheDocument();
+    expect(screen.getByText('Reviewing (5)')).toBeInTheDocument();
+    expect(screen.getByText('Every state (57)')).toBeInTheDocument();
+    expect(screen.getByText('Archived (17)')).toBeInTheDocument();
+  });
+
+  it('offers the not-participating facet, and only while moderating', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({ data: { items: [foreign], total: 57, page: 0, size: 20, facets: FACETS } });
+
+    renderPage('/reviews?participation=all');
+
+    expect(screen.getByText('Not participating (50)')).toBeInTheDocument();
+  });
+
+  it("has no not-participating facet in the caller's own listing", () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+
+    renderPage();
+
+    // There, every row is the caller's by construction — a facet that can never
+    // match is a control that only puzzles.
+    expect(screen.queryByText(/Not participating/)).not.toBeInTheDocument();
+  });
+
+  it('sends a chosen chip to the server rather than filtering the page', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({ data: { items: [foreign], total: 57, page: 0, size: 20, facets: FACETS } });
+
+    renderPage('/reviews?participation=all');
+    fireEvent.click(screen.getByText('Not participating (50)'));
+
+    const last = vi.mocked(useReviews).mock.calls.at(-1)![0];
+    expect(last.role).toBe('observer');
+    expect(last.participation).toBe('all');
+  });
+
+  it('splits the status chips into the retention and workflow slices', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({ data: { items: [foreign], total: 57, page: 0, size: 20, facets: FACETS } });
+
+    renderPage('/reviews?participation=all');
+    fireEvent.click(screen.getByText('Closed (9)'));
+
+    // 'Closed' means "not archived, and the workflow closed it" — two orthogonal
+    // parameters on the wire, the same rule the browser-side facet follows.
+    const closed = vi.mocked(useReviews).mock.calls.at(-1)![0];
+    expect(closed.scope).toBe('active');
+    expect(closed.state).toBe('closed');
+
+    fireEvent.click(screen.getByText('Archived (17)'));
+    const archived = vi.mocked(useReviews).mock.calls.at(-1)![0];
+    expect(archived.scope).toBe('archived');
+    expect(archived.state).toBe('any');
   });
 
   it('says which slice of the workspace is on screen', () => {

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -453,3 +453,85 @@ describe('ReviewsPage', () => {
     expect(screen.getByRole('option', { name: 'Due date' })).toBeInTheDocument();
   });
 });
+
+describe('ReviewsPage — the admin moderation listing (#563)', () => {
+  const foreign = summary({
+    id: 'doc-9',
+    title: 'A review nobody invited me to',
+    ownerId: OTHER,
+    ownerDisplayName: 'Someone Else',
+    workflowState: 'IN_REVIEW',
+    participating: false,
+  });
+
+  it('does not offer the switch to a member', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'MEMBER' });
+
+    renderPage();
+
+    // The API refuses them anyway; not showing the control keeps the UI from
+    // promising something the server will deny.
+    expect(screen.queryByTestId('participation-all')).not.toBeInTheDocument();
+  });
+
+  it('offers the switch to an admin', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+
+    renderPage();
+
+    expect(screen.getByTestId('participation-all')).toBeInTheDocument();
+  });
+
+  it("lists the caller's own reviews until the admin asks for all of them", () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    renderPage();
+
+    // Default off, so an admin's own work is not drowned out on every visit.
+    expect(vi.mocked(useReviews).mock.calls[0][0].participation).toBeUndefined();
+
+    fireEvent.click(screen.getByTestId('participation-all'));
+
+    const last = vi.mocked(useReviews).mock.calls.at(-1)![0];
+    expect(last.participation).toBe('all');
+    // Paged on the server, not sliced from one big fetch (issue #563): a
+    // moderation view that stopped at the first hundred would read as "that is
+    // everything".
+    expect(last.size).toBe(20);
+  });
+
+  it('marks the rows the admin has no part in', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({ data: { items: [foreign], total: 1, page: 0, size: 20 } });
+
+    renderPage('/reviews?participation=all');
+
+    expect(screen.getByText('A review nobody invited me to')).toBeInTheDocument();
+    expect(screen.getByText('Not participating')).toBeInTheDocument();
+    // Not "Reviewer": the admin is not on the roster, and saying so would be a
+    // small lie in exactly the view where the context matters.
+    expect(screen.queryByText('Reviewer')).not.toBeInTheDocument();
+  });
+
+  it('hides the client-side facets while moderating', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({ data: { items: [foreign], total: 1, page: 0, size: 20 } });
+
+    renderPage('/reviews?participation=all');
+
+    // They would narrow the current page and read as the whole workspace.
+    expect(screen.queryByText('Owned by me')).not.toBeInTheDocument();
+    expect(screen.queryByText('Every state')).not.toBeInTheDocument();
+  });
+
+  it('says which slice of the workspace is on screen', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({ data: { items: [foreign], total: 57, page: 0, size: 20 } });
+
+    renderPage('/reviews?participation=all');
+
+    // A moderator has to know whether this is everything or page one of three.
+    expect(screen.getByText(/1–20 of 57/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+  });
+});

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -482,6 +482,17 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
     expect(screen.getByTestId('participation-all')).toBeInTheDocument();
   });
 
+  it('still offers the switch to an admin who owns no reviews at all', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({ data: { items: [], total: 0, page: 0, size: 100 } });
+
+    renderPage();
+
+    // The switch lives in the filter row, which an empty list does not render —
+    // without this an admin who only administers could never reach the workspace.
+    expect(screen.getByTestId('participation-all')).toBeInTheDocument();
+  });
+
   it("lists the caller's own reviews until the admin asks for all of them", () => {
     useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
     renderPage();

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -526,6 +526,7 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
   });
 
   const FACETS = {
+    owners: [{ id: OTHER, displayName: 'Someone Else' }],
     totalUnfiltered: 57,
     roleAny: 57,
     roleOwner: 2,
@@ -595,12 +596,12 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
     // parameters on the wire, the same rule the browser-side facet follows.
     const closed = vi.mocked(useReviews).mock.calls.at(-1)![0];
     expect(closed.scope).toBe('active');
-    expect(closed.state).toBe('closed');
+    expect(closed.lifecycle).toBe('closed');
 
     fireEvent.click(screen.getByText('Archived (17)'));
     const archived = vi.mocked(useReviews).mock.calls.at(-1)![0];
     expect(archived.scope).toBe('archived');
-    expect(archived.state).toBe('any');
+    expect(archived.lifecycle).toBe('any');
   });
 
   it('says a filter matched nothing instead of greeting a full workspace as empty', () => {
@@ -653,6 +654,47 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
     renderPage('/reviews?participation=all');
 
     expect(screen.getByText(/Start your first review/i)).toBeInTheDocument();
+  });
+
+  it('sends the advanced filters to the server too', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({ data: { items: [foreign], total: 57, page: 0, size: 20, facets: FACETS } });
+
+    renderPage('/reviews?participation=all&due=overdue&format=docx&state=CHANGES_REQUESTED');
+
+    // Everything the filter button offers has to reach the query, or it would
+    // narrow the page while reading as the workspace — the same trap the chips
+    // had (issue #563).
+    const sent = vi.mocked(useReviews).mock.calls.at(-1)![0];
+    expect(sent.due).toBe('overdue');
+    expect(sent.format).toBe('docx');
+    expect(sent.workflowState).toBe('CHANGES_REQUESTED');
+  });
+
+  it('offers every owner in the workspace, not just the ones on this page', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+    mockReviews({
+      data: {
+        items: [foreign],
+        total: 57,
+        page: 0,
+        size: 20,
+        facets: {
+          ...FACETS,
+          owners: [
+            { id: OTHER, displayName: 'Someone Else' },
+            { id: 'owner-3', displayName: 'Nobody On This Page' },
+          ],
+        },
+      },
+    });
+
+    renderPage('/reviews?participation=all');
+    fireEvent.click(screen.getByRole('button', { name: 'Filter reviews' }));
+
+    // The page holds one row owned by one person; the facet still offers both,
+    // because it comes from the server.
+    expect(screen.getByText('Nobody On This Page')).toBeInTheDocument();
   });
 
   it('says which slice of the workspace is on screen', () => {

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -102,7 +102,7 @@ const SCOPE_OF_STATUS: Record<StatusFilter, 'active' | 'archived' | 'all'> = {
   archived: 'archived',
   all: 'all',
 };
-const STATE_OF_STATUS: Record<StatusFilter, 'any' | 'open' | 'closed'> = {
+const LIFECYCLE_OF_STATUS: Record<StatusFilter, 'any' | 'open' | 'closed'> = {
   active: 'any',
   open: 'open',
   closed: 'closed',
@@ -388,6 +388,11 @@ export function ReviewsPage() {
     setServerPage(0);
     setParam('role', next, 'all');
   };
+  /** The advanced menu's picks; same page reset as the chips. */
+  const setAdvancedParam = (key: string, next: string, fallback: string) => {
+    setServerPage(0);
+    setParam(key, next, fallback);
+  };
 
   const { data, isPending, isError, refetch } = useReviews(
     moderating
@@ -399,8 +404,12 @@ export function ReviewsPage() {
           // paged, so a browser-side facet would narrow one page while reading
           // as the whole workspace (issue #563).
           scope: SCOPE_OF_STATUS[statusFilter],
-          state: STATE_OF_STATUS[statusFilter],
+          lifecycle: LIFECYCLE_OF_STATUS[statusFilter],
           role: roleFilter === 'all' ? 'any' : roleFilter,
+          workflowState: stateFilter === 'any' ? undefined : stateFilter,
+          due: dueFilter,
+          format: formatFilter,
+          ownerId: ownerFilter ?? undefined,
           participation: 'all',
           q: debouncedQuery,
         }
@@ -525,14 +534,19 @@ export function ReviewsPage() {
     statusFilter !== 'all' &&
     statusCounts.archived > 0;
 
-  // The owner facet offers everyone who owns a loaded review, alphabetically.
-  const owners = (() => {
+  // While moderating the owners come from the server (issue #563): a list built
+  // from the twenty rows on screen would look complete and quietly not be.
+  const owners: [string, string][] = moderating
+    ? (facets?.owners ?? []).map((o) => [o.id, o.displayName])
+    : ownersFromRows();
+
+  function ownersFromRows(): [string, string][] {
     const byId = new Map<string, string>();
     for (const r of items) {
       if (r.ownerId && !byId.has(r.ownerId)) byId.set(r.ownerId, r.ownerDisplayName ?? 'Unknown');
     }
     return [...byId].sort((a, b) => a[1].localeCompare(b[1]));
-  })();
+  }
 
   const hasActiveFilters =
     query !== '' || roleFilter !== 'all' || statusFilter !== 'active' || advancedCount > 0;
@@ -640,17 +654,15 @@ export function ReviewsPage() {
             />
             {participationToggle}
             <Box sx={{ flex: 1 }} />
-            {!moderating && (
-              <ReviewFilterMenu
-                dueFilter={dueFilter}
-                formatFilter={formatFilter}
-                stateFilter={stateFilter}
-                ownerFilter={ownerFilter}
-                owners={owners}
-                activeCount={advancedCount}
-                onSet={setParam}
-              />
-            )}
+            <ReviewFilterMenu
+              dueFilter={dueFilter}
+              formatFilter={formatFilter}
+              stateFilter={stateFilter}
+              ownerFilter={ownerFilter}
+              owners={owners}
+              activeCount={advancedCount}
+              onSet={setAdvancedParam}
+            />
             <TextField
               select
               size="small"

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -19,7 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -49,7 +49,7 @@ import { roleOf } from '../../components/reviews/list/reviewListModel';
 import { ReviewCards } from '../../components/reviews/list/ReviewCards';
 import { ReviewsTable } from '../../components/reviews/list/ReviewsTable';
 import { ReviewsEmptyState } from './ReviewsEmptyState';
-import { useAuthStore } from '../../stores/authStore';
+import { selectIsAdmin, useAuthStore } from '../../stores/authStore';
 
 type RoleFilter = 'all' | 'owner' | 'reviewer';
 // Client facets over ONE scope=all fetch (issue #576 follow-up), so every chip
@@ -70,6 +70,19 @@ const VIEW_STORAGE_KEY = 'qnop-reviews-view';
 // stay consistent with what is on screen; server paging arrives when real
 // installations outgrow this (documented trade-off in #251).
 const FETCH_SIZE = 100;
+
+/**
+ * The moderation listing pages on the server (issue #563).
+ *
+ * <p>The participant-scoped view fetches once and facets in the browser, which is
+ * honest as long as the caller's own reviews fit in one page. Across a whole
+ * workspace they do not, and a moderation view that quietly stopped at the first
+ * hundred would be the worst kind of wrong: seeing everything is the point.
+ */
+const MODERATION_PAGE_SIZE = 20;
+
+/** Mirrors the admin lists' debounce — one query per typing pause. */
+const SEARCH_DEBOUNCE_MS = 300;
 
 function readStoredView(): ViewMode {
   try {
@@ -308,6 +321,7 @@ function ReviewFilterMenu({
 export function ReviewsPage() {
   const navigate = useNavigate();
   const userId = useAuthStore((s) => s.userId);
+  const isAdmin = useAuthStore(selectIsAdmin);
 
   // Every facet is URL-persisted (issue #576 follow-up) so any sliced view is
   // shareable and survives reloads. ONE scope=all fetch backs them all: the
@@ -330,20 +344,48 @@ export function ReviewsPage() {
   const formatFilter = parseParam(searchParams.get('format'), FORMAT_FILTERS, 'any');
   const stateFilter = parseParam(searchParams.get('state'), STATE_FILTERS, 'any');
   const ownerFilter = searchParams.get('owner');
+  // The admin's moderation listing (issue #563). Opt-in and URL-persisted like
+  // the rest, default off so an admin's own work is not drowned out.
+  const moderating = isAdmin && searchParams.get('participation') === 'all';
+  const [serverPage, setServerPage] = useState(0);
+  // Moderation searches the SERVER, so it waits for a pause in typing the way the
+  // admin lists do; the participant-scoped view keeps filtering as you type
+  // because it already holds its rows.
+  const [debouncedQuery, setDebouncedQuery] = useState('');
   const setStatusFilter = (next: StatusFilter) => setParam('status', next, 'active');
   const setRoleFilter = (next: RoleFilter) => setParam('role', next, 'all');
 
-  const { data, isPending, isError, refetch } = useReviews({
-    page: 0,
-    size: FETCH_SIZE,
-    sort: 'updatedAt,desc',
-    scope: 'all',
-  });
+  const { data, isPending, isError, refetch } = useReviews(
+    moderating
+      ? {
+          page: serverPage,
+          size: MODERATION_PAGE_SIZE,
+          sort: 'updatedAt,desc',
+          scope: 'all',
+          participation: 'all',
+          q: debouncedQuery,
+        }
+      : { page: 0, size: FETCH_SIZE, sort: 'updatedAt,desc', scope: 'all' },
+  );
 
   const [search, setSearch] = useState(searchParams.get('q') ?? '');
   const setSearchAndParam = (next: string) => {
     setSearch(next);
     setParam('q', next.trim(), '');
+  };
+  useEffect(() => {
+    if (!moderating) return;
+    const timer = setTimeout(() => {
+      setDebouncedQuery(search.trim());
+      setServerPage(0); // a new query starts at its own first page
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [search, moderating]);
+
+  const setModerating = (next: boolean) => {
+    setServerPage(0);
+    setDebouncedQuery(search.trim());
+    setParam('participation', next ? 'all' : 'mine', 'mine');
   };
   const [sortBy, setSortBy] = useState<SortBy>('updated');
   const [view, setView] = useState<ViewMode>(readStoredView);
@@ -390,10 +432,17 @@ export function ReviewsPage() {
     };
   })();
 
-  const visible = sortReviews(
-    searched.filter((r) => matchesRole(r, roleFilter, userId) && matchesStatus(r, statusFilter)),
-    sortBy,
-  );
+  // Moderation rows arrive already filtered and paged by the server, so the client
+  // facets are neither applied nor offered: applied, they would narrow one page
+  // and read as the whole workspace.
+  const visible = moderating
+    ? sortReviews(items, sortBy)
+    : sortReviews(
+        searched.filter(
+          (r) => matchesRole(r, roleFilter, userId) && matchesStatus(r, statusFilter),
+        ),
+        sortBy,
+      );
 
   // A workspace whose living work is all done holds nothing but records. Saying
   // "nothing matches your filters" there would be a dead end — no filter is set
@@ -448,9 +497,30 @@ export function ReviewsPage() {
     <Stack spacing={3}>
       <PageHeader
         title="Reviews"
-        description="Documents you own or review — pick one up where it stands."
+        description={
+          moderating
+            ? 'Every review in the workspace — you are moderating, not participating.'
+            : 'Documents you own or review — pick one up where it stands.'
+        }
         action={newReviewButton}
       />
+
+      {isAdmin && (
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={moderating ? 'all' : 'mine'}
+          onChange={(_e, next: string | null) => next && setModerating(next === 'all')}
+          aria-label="Which reviews"
+        >
+          <ToggleButton value="mine" data-testid="participation-mine">
+            My reviews
+          </ToggleButton>
+          <ToggleButton value="all" data-testid="participation-all">
+            All reviews
+          </ToggleButton>
+        </ToggleButtonGroup>
+      )}
 
       {isError && (
         // The branded failure shell (issue #611) instead of a bare alert -
@@ -491,15 +561,17 @@ export function ReviewsPage() {
               sx={{ width: { xs: '100%', md: 280 } }}
             />
             <Box sx={{ flex: 1 }} />
-            <ReviewFilterMenu
-              dueFilter={dueFilter}
-              formatFilter={formatFilter}
-              stateFilter={stateFilter}
-              ownerFilter={ownerFilter}
-              owners={owners}
-              activeCount={advancedCount}
-              onSet={setParam}
-            />
+            {!moderating && (
+              <ReviewFilterMenu
+                dueFilter={dueFilter}
+                formatFilter={formatFilter}
+                stateFilter={stateFilter}
+                ownerFilter={ownerFilter}
+                owners={owners}
+                activeCount={advancedCount}
+                onSet={setParam}
+              />
+            )}
             <TextField
               select
               size="small"
@@ -528,75 +600,77 @@ export function ReviewsPage() {
             </ToggleButtonGroup>
           </Stack>
 
-          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
-            <FilterChip
-              label="All"
-              hint="Every review you can see, whatever your part in it"
-              count={roleCounts.all}
-              selected={roleFilter === 'all'}
-              onClick={() => setRoleFilter('all')}
-            />
-            <FilterChip
-              label="Owned by me"
-              hint="Reviews you own and steer"
-              count={roleCounts.owner}
-              selected={roleFilter === 'owner'}
-              onClick={() => setRoleFilter('owner')}
-            />
-            <FilterChip
-              label="Reviewing"
-              hint="Reviews where you are on the reviewer roster"
-              count={roleCounts.reviewer}
-              selected={roleFilter === 'reviewer'}
-              onClick={() => setRoleFilter('reviewer')}
-            />
-            <Box sx={{ width: 8 }} />
-            <FilterChip
-              label="Active"
-              hint="All live work — every workflow state except archived records (the default)"
-              count={statusCounts.active}
-              selected={statusFilter === 'active'}
-              onClick={() => setStatusFilter('active')}
-            />
-            <FilterChip
-              label="Open"
-              hint="Live reviews the workflow has not closed yet"
-              count={statusCounts.open}
-              selected={statusFilter === 'open'}
-              onClick={() => setStatusFilter(statusFilter === 'open' ? 'active' : 'open')}
-            />
-            <FilterChip
-              label="Closed"
-              hint="Finalized or cancelled reviews that are not archived yet"
-              count={statusCounts.closed}
-              selected={statusFilter === 'closed'}
-              onClick={() => setStatusFilter(statusFilter === 'closed' ? 'active' : 'closed')}
-            />
-            <FilterChip
-              label="Archived"
-              hint="Only the records archived out of the active lists"
-              count={statusCounts.archived}
-              selected={statusFilter === 'archived'}
-              onClick={() => setStatusFilter(statusFilter === 'archived' ? 'active' : 'archived')}
-            />
-            <FilterChip
-              label="Every state"
-              hint="Everything at once — every workflow state, archived records included"
-              count={statusCounts.all}
-              selected={statusFilter === 'all'}
-              onClick={() => setStatusFilter(statusFilter === 'all' ? 'active' : 'all')}
-            />
-            {hasActiveFilters && (
-              <Chip
-                label="Clear filters"
-                size="small"
-                variant="outlined"
-                onDelete={clearFilters}
-                onClick={clearFilters}
-                sx={{ ml: 'auto' }}
+          {!moderating && (
+            <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+              <FilterChip
+                label="All"
+                hint="Every review you can see, whatever your part in it"
+                count={roleCounts.all}
+                selected={roleFilter === 'all'}
+                onClick={() => setRoleFilter('all')}
               />
-            )}
-          </Stack>
+              <FilterChip
+                label="Owned by me"
+                hint="Reviews you own and steer"
+                count={roleCounts.owner}
+                selected={roleFilter === 'owner'}
+                onClick={() => setRoleFilter('owner')}
+              />
+              <FilterChip
+                label="Reviewing"
+                hint="Reviews where you are on the reviewer roster"
+                count={roleCounts.reviewer}
+                selected={roleFilter === 'reviewer'}
+                onClick={() => setRoleFilter('reviewer')}
+              />
+              <Box sx={{ width: 8 }} />
+              <FilterChip
+                label="Active"
+                hint="All live work — every workflow state except archived records (the default)"
+                count={statusCounts.active}
+                selected={statusFilter === 'active'}
+                onClick={() => setStatusFilter('active')}
+              />
+              <FilterChip
+                label="Open"
+                hint="Live reviews the workflow has not closed yet"
+                count={statusCounts.open}
+                selected={statusFilter === 'open'}
+                onClick={() => setStatusFilter(statusFilter === 'open' ? 'active' : 'open')}
+              />
+              <FilterChip
+                label="Closed"
+                hint="Finalized or cancelled reviews that are not archived yet"
+                count={statusCounts.closed}
+                selected={statusFilter === 'closed'}
+                onClick={() => setStatusFilter(statusFilter === 'closed' ? 'active' : 'closed')}
+              />
+              <FilterChip
+                label="Archived"
+                hint="Only the records archived out of the active lists"
+                count={statusCounts.archived}
+                selected={statusFilter === 'archived'}
+                onClick={() => setStatusFilter(statusFilter === 'archived' ? 'active' : 'archived')}
+              />
+              <FilterChip
+                label="Every state"
+                hint="Everything at once — every workflow state, archived records included"
+                count={statusCounts.all}
+                selected={statusFilter === 'all'}
+                onClick={() => setStatusFilter(statusFilter === 'all' ? 'active' : 'all')}
+              />
+              {hasActiveFilters && (
+                <Chip
+                  label="Clear filters"
+                  size="small"
+                  variant="outlined"
+                  onDelete={clearFilters}
+                  onClick={clearFilters}
+                  sx={{ ml: 'auto' }}
+                />
+              )}
+            </Stack>
+          )}
 
           {visible.length === 0 ? (
             <Paper variant="outlined" sx={{ py: 6, px: 3, textAlign: 'center' }}>
@@ -624,6 +698,36 @@ export function ReviewsPage() {
             <ReviewsTable reviews={visible} userId={userId} onOpen={openReview} />
           ) : (
             <ReviewCards reviews={visible} userId={userId} onOpen={openReview} />
+          )}
+
+          {moderating && (data?.total ?? 0) > MODERATION_PAGE_SIZE && (
+            <Stack
+              direction="row"
+              spacing={2}
+              sx={{ alignItems: 'center', justifyContent: 'flex-end' }}
+            >
+              {/* Named counts, not just arrows: a moderator has to know whether
+                  they are looking at everything or at page one of twelve. */}
+              <Typography variant="body2" color="text.secondary">
+                {serverPage * MODERATION_PAGE_SIZE + 1}–
+                {Math.min((serverPage + 1) * MODERATION_PAGE_SIZE, data?.total ?? 0)} of{' '}
+                {data?.total ?? 0}
+              </Typography>
+              <Button
+                size="small"
+                disabled={serverPage === 0}
+                onClick={() => setServerPage((p) => Math.max(0, p - 1))}
+              >
+                Previous
+              </Button>
+              <Button
+                size="small"
+                disabled={(serverPage + 1) * MODERATION_PAGE_SIZE >= (data?.total ?? 0)}
+                onClick={() => setServerPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </Stack>
           )}
         </>
       )}

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -493,6 +493,25 @@ export function ReviewsPage() {
     </Button>
   );
 
+  // Rendered next to the search field, and again over the empty state — an admin
+  // with no reviews of their own must still be able to reach everyone else's.
+  const participationToggle = isAdmin ? (
+    <ToggleButtonGroup
+      exclusive
+      size="small"
+      value={moderating ? 'all' : 'mine'}
+      onChange={(_e, next: string | null) => next && setModerating(next === 'all')}
+      aria-label="Which reviews"
+    >
+      <ToggleButton value="mine" data-testid="participation-mine">
+        My reviews
+      </ToggleButton>
+      <ToggleButton value="all" data-testid="participation-all">
+        All reviews
+      </ToggleButton>
+    </ToggleButtonGroup>
+  ) : null;
+
   return (
     <Stack spacing={3}>
       <PageHeader
@@ -504,23 +523,6 @@ export function ReviewsPage() {
         }
         action={newReviewButton}
       />
-
-      {isAdmin && (
-        <ToggleButtonGroup
-          exclusive
-          size="small"
-          value={moderating ? 'all' : 'mine'}
-          onChange={(_e, next: string | null) => next && setModerating(next === 'all')}
-          aria-label="Which reviews"
-        >
-          <ToggleButton value="mine" data-testid="participation-mine">
-            My reviews
-          </ToggleButton>
-          <ToggleButton value="all" data-testid="participation-all">
-            All reviews
-          </ToggleButton>
-        </ToggleButtonGroup>
-      )}
 
       {isError && (
         // The branded failure shell (issue #611) instead of a bare alert -
@@ -544,7 +546,12 @@ export function ReviewsPage() {
       )}
 
       {data && items.length === 0 && (
-        <ReviewsEmptyState onNewReview={() => navigate('/reviews/new')} />
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+          {participationToggle}
+          <Box sx={{ alignSelf: 'stretch' }}>
+            <ReviewsEmptyState onNewReview={() => navigate('/reviews/new')} />
+          </Box>
+        </Stack>
       )}
 
       {data && items.length > 0 && (
@@ -560,6 +567,7 @@ export function ReviewsPage() {
               onValueChange={setSearchAndParam}
               sx={{ width: { xs: '100%', md: 280 } }}
             />
+            {participationToggle}
             <Box sx={{ flex: 1 }} />
             {!moderating && (
               <ReviewFilterMenu

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -450,6 +450,19 @@ export function ReviewsPage() {
   // group's filter, so a chip's number always predicts what clicking it shows.
   const searched = items.filter((r) => matchesSearch(r, query) && matchesAdvanced(r));
   const facets = data?.facets;
+  /**
+   * Whether there is nothing to show *at all*, as opposed to nothing matching.
+   *
+   * <p>The welcome state invites you to start your first review, which is only
+   * true of an empty workspace. In the participant-scoped view the fetched rows
+   * are unfiltered, so an empty page does mean that; the moderation listing is
+   * filtered by the server, so it has to ask (issue #563) — otherwise a filter
+   * combination with no hits greets a workspace full of reviews as a fresh
+   * install, and hides the very controls needed to undo it.
+   */
+  const nothingAtAll = moderating
+    ? (facets?.totalUnfiltered ?? 0) === 0
+    : (data?.items.length ?? 0) === 0;
   const roleCounts = (() => {
     if (moderating) {
       return {
@@ -603,7 +616,7 @@ export function ReviewsPage() {
         </Stack>
       )}
 
-      {data && items.length === 0 && (
+      {data && nothingAtAll && (
         <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
           {participationToggle}
           <Box sx={{ alignSelf: 'stretch' }}>
@@ -612,7 +625,7 @@ export function ReviewsPage() {
         </Stack>
       )}
 
-      {data && items.length > 0 && (
+      {data && !nothingAtAll && (
         <>
           <Stack
             direction={{ xs: 'column', md: 'row' }}

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -51,7 +51,11 @@ import { ReviewsTable } from '../../components/reviews/list/ReviewsTable';
 import { ReviewsEmptyState } from './ReviewsEmptyState';
 import { selectIsAdmin, useAuthStore } from '../../stores/authStore';
 
-type RoleFilter = 'all' | 'owner' | 'reviewer';
+/**
+ * `observer` — reviews the caller is no part of — exists only in the admin's
+ * moderation listing (issue #563), where such rows can appear at all.
+ */
+type RoleFilter = 'all' | 'owner' | 'reviewer' | 'observer';
 // Client facets over ONE scope=all fetch (issue #576 follow-up), so every chip
 // carries a count without a refetch. Archiving is a retention flag, not a
 // workflow state (#576): the default 'active' facet spans every workflow state
@@ -83,6 +87,28 @@ const MODERATION_PAGE_SIZE = 20;
 
 /** Mirrors the admin lists' debounce — one query per typing pause. */
 const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * The status chips split into the server's two orthogonal parameters.
+ *
+ * <p>`scope` is the retention slice and `state` the workflow one; the chips are
+ * the five combinations that mean something. Only the explicit facets cross the
+ * archive line, which is the same rule `matchesStatus` follows in the browser.
+ */
+const SCOPE_OF_STATUS: Record<StatusFilter, 'active' | 'archived' | 'all'> = {
+  active: 'active',
+  open: 'active',
+  closed: 'active',
+  archived: 'archived',
+  all: 'all',
+};
+const STATE_OF_STATUS: Record<StatusFilter, 'any' | 'open' | 'closed'> = {
+  active: 'any',
+  open: 'open',
+  closed: 'closed',
+  archived: 'any',
+  all: 'any',
+};
 
 function readStoredView(): ViewMode {
   try {
@@ -136,7 +162,7 @@ function matchesDue(review: DocumentSummary, filter: DueFilter, now: number): bo
 }
 
 const STATUS_FILTERS: readonly StatusFilter[] = ['active', 'all', 'open', 'closed', 'archived'];
-const ROLE_FILTERS: readonly RoleFilter[] = ['all', 'owner', 'reviewer'];
+const ROLE_FILTERS: readonly RoleFilter[] = ['all', 'owner', 'reviewer', 'observer'];
 const DUE_FILTERS: readonly DueFilter[] = ['any', 'overdue', 'soon', 'none'];
 // The fine-grained workflow facet (open string set, ADR-0011 — the known states).
 const STATE_FILTERS = [
@@ -352,8 +378,16 @@ export function ReviewsPage() {
   // admin lists do; the participant-scoped view keeps filtering as you type
   // because it already holds its rows.
   const [debouncedQuery, setDebouncedQuery] = useState('');
-  const setStatusFilter = (next: StatusFilter) => setParam('status', next, 'active');
-  const setRoleFilter = (next: RoleFilter) => setParam('role', next, 'all');
+  // A narrowed set starts at its own first page: keeping page 3 across a facet
+  // change lands the reader on an empty one and reads as "nothing matches".
+  const setStatusFilter = (next: StatusFilter) => {
+    setServerPage(0);
+    setParam('status', next, 'active');
+  };
+  const setRoleFilter = (next: RoleFilter) => {
+    setServerPage(0);
+    setParam('role', next, 'all');
+  };
 
   const { data, isPending, isError, refetch } = useReviews(
     moderating
@@ -361,7 +395,12 @@ export function ReviewsPage() {
           page: serverPage,
           size: MODERATION_PAGE_SIZE,
           sort: 'updatedAt,desc',
-          scope: 'all',
+          // The chips are predicates here, not client slices: the listing is
+          // paged, so a browser-side facet would narrow one page while reading
+          // as the whole workspace (issue #563).
+          scope: SCOPE_OF_STATUS[statusFilter],
+          state: STATE_OF_STATUS[statusFilter],
+          role: roleFilter === 'all' ? 'any' : roleFilter,
           participation: 'all',
           q: debouncedQuery,
         }
@@ -410,15 +449,34 @@ export function ReviewsPage() {
   // Faceted counts: each chip group is counted against the search + the OTHER
   // group's filter, so a chip's number always predicts what clicking it shows.
   const searched = items.filter((r) => matchesSearch(r, query) && matchesAdvanced(r));
+  const facets = data?.facets;
   const roleCounts = (() => {
+    if (moderating) {
+      return {
+        all: facets?.roleAny ?? 0,
+        owner: facets?.roleOwner ?? 0,
+        reviewer: facets?.roleReviewer ?? 0,
+        observer: facets?.roleObserver ?? 0,
+      };
+    }
     const base = searched.filter((r) => matchesStatus(r, statusFilter));
     return {
       all: base.length,
       owner: base.filter((r) => roleOf(r, userId) === 'owner').length,
       reviewer: base.filter((r) => roleOf(r, userId) === 'reviewer').length,
+      observer: 0,
     };
   })();
   const statusCounts = (() => {
+    if (moderating) {
+      return {
+        active: facets?.stateActive ?? 0,
+        all: facets?.stateAll ?? 0,
+        open: facets?.stateOpen ?? 0,
+        closed: facets?.stateClosed ?? 0,
+        archived: facets?.stateArchived ?? 0,
+      };
+    }
     const base = searched.filter((r) => matchesRole(r, roleFilter, userId));
     // Every count goes through the SAME predicate the list uses, so a chip's
     // number keeps predicting what clicking it shows — 'all' counts the archive
@@ -608,77 +666,86 @@ export function ReviewsPage() {
             </ToggleButtonGroup>
           </Stack>
 
-          {!moderating && (
-            <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+          <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+            <FilterChip
+              label="All"
+              hint="Every review you can see, whatever your part in it"
+              count={roleCounts.all}
+              selected={roleFilter === 'all'}
+              onClick={() => setRoleFilter('all')}
+            />
+            <FilterChip
+              label="Owned by me"
+              hint="Reviews you own and steer"
+              count={roleCounts.owner}
+              selected={roleFilter === 'owner'}
+              onClick={() => setRoleFilter('owner')}
+            />
+            <FilterChip
+              label="Reviewing"
+              hint="Reviews where you are on the reviewer roster"
+              count={roleCounts.reviewer}
+              selected={roleFilter === 'reviewer'}
+              onClick={() => setRoleFilter('reviewer')}
+            />
+            {moderating && (
+              // Only the moderation listing can hold reviews the caller has no part
+              // in, so the facet exists exactly where it can match (issue #563).
               <FilterChip
-                label="All"
-                hint="Every review you can see, whatever your part in it"
-                count={roleCounts.all}
-                selected={roleFilter === 'all'}
-                onClick={() => setRoleFilter('all')}
+                label="Not participating"
+                hint="Reviews you neither own nor review — what you are moderating from outside"
+                count={roleCounts.observer}
+                selected={roleFilter === 'observer'}
+                onClick={() => setRoleFilter(roleFilter === 'observer' ? 'all' : 'observer')}
               />
-              <FilterChip
-                label="Owned by me"
-                hint="Reviews you own and steer"
-                count={roleCounts.owner}
-                selected={roleFilter === 'owner'}
-                onClick={() => setRoleFilter('owner')}
+            )}
+            <Box sx={{ width: 8 }} />
+            <FilterChip
+              label="Active"
+              hint="All live work — every workflow state except archived records (the default)"
+              count={statusCounts.active}
+              selected={statusFilter === 'active'}
+              onClick={() => setStatusFilter('active')}
+            />
+            <FilterChip
+              label="Open"
+              hint="Live reviews the workflow has not closed yet"
+              count={statusCounts.open}
+              selected={statusFilter === 'open'}
+              onClick={() => setStatusFilter(statusFilter === 'open' ? 'active' : 'open')}
+            />
+            <FilterChip
+              label="Closed"
+              hint="Finalized or cancelled reviews that are not archived yet"
+              count={statusCounts.closed}
+              selected={statusFilter === 'closed'}
+              onClick={() => setStatusFilter(statusFilter === 'closed' ? 'active' : 'closed')}
+            />
+            <FilterChip
+              label="Archived"
+              hint="Only the records archived out of the active lists"
+              count={statusCounts.archived}
+              selected={statusFilter === 'archived'}
+              onClick={() => setStatusFilter(statusFilter === 'archived' ? 'active' : 'archived')}
+            />
+            <FilterChip
+              label="Every state"
+              hint="Everything at once — every workflow state, archived records included"
+              count={statusCounts.all}
+              selected={statusFilter === 'all'}
+              onClick={() => setStatusFilter(statusFilter === 'all' ? 'active' : 'all')}
+            />
+            {hasActiveFilters && (
+              <Chip
+                label="Clear filters"
+                size="small"
+                variant="outlined"
+                onDelete={clearFilters}
+                onClick={clearFilters}
+                sx={{ ml: 'auto' }}
               />
-              <FilterChip
-                label="Reviewing"
-                hint="Reviews where you are on the reviewer roster"
-                count={roleCounts.reviewer}
-                selected={roleFilter === 'reviewer'}
-                onClick={() => setRoleFilter('reviewer')}
-              />
-              <Box sx={{ width: 8 }} />
-              <FilterChip
-                label="Active"
-                hint="All live work — every workflow state except archived records (the default)"
-                count={statusCounts.active}
-                selected={statusFilter === 'active'}
-                onClick={() => setStatusFilter('active')}
-              />
-              <FilterChip
-                label="Open"
-                hint="Live reviews the workflow has not closed yet"
-                count={statusCounts.open}
-                selected={statusFilter === 'open'}
-                onClick={() => setStatusFilter(statusFilter === 'open' ? 'active' : 'open')}
-              />
-              <FilterChip
-                label="Closed"
-                hint="Finalized or cancelled reviews that are not archived yet"
-                count={statusCounts.closed}
-                selected={statusFilter === 'closed'}
-                onClick={() => setStatusFilter(statusFilter === 'closed' ? 'active' : 'closed')}
-              />
-              <FilterChip
-                label="Archived"
-                hint="Only the records archived out of the active lists"
-                count={statusCounts.archived}
-                selected={statusFilter === 'archived'}
-                onClick={() => setStatusFilter(statusFilter === 'archived' ? 'active' : 'archived')}
-              />
-              <FilterChip
-                label="Every state"
-                hint="Everything at once — every workflow state, archived records included"
-                count={statusCounts.all}
-                selected={statusFilter === 'all'}
-                onClick={() => setStatusFilter(statusFilter === 'all' ? 'active' : 'all')}
-              />
-              {hasActiveFilters && (
-                <Chip
-                  label="Clear filters"
-                  size="small"
-                  variant="outlined"
-                  onDelete={clearFilters}
-                  onClick={clearFilters}
-                  sx={{ ml: 'auto' }}
-                />
-              )}
-            </Stack>
-          )}
+            )}
+          </Stack>
 
           {visible.length === 0 ? (
             <Paper variant="outlined" sx={{ py: 6, px: 3, textAlign: 'center' }}>


### PR DESCRIPTION
Closes #563.

An admin could already open any review by link, but the overview was participant-scoped: reviews they were not part of were invisible unless somebody handed them a URL.

`GET /documents?participation=all` lists every review and is admin-only — **403** for anyone else, including AUDITOR, whose organisation-wide view is the audit trail rather than the review list. The default stays the caller's own participations, so an admin's own work is not drowned out on every visit.

### The moderation inventory was smaller than the issue assumed

Checked guard by guard rather than taken from the description: workflow transitions (#568), archive/unarchive, dismiss (#408) and re-position (#562) already honoured the admin flag, and annotation deletion does not exist at all. Genuinely owner-only were three, all now open to admins: **participant management**, **the due date**, and **appending a version**.

The last is the most consequential — it re-anchors every annotation and changes what everyone is reviewing — and is named as such where it lives. It was included on the maintainer's explicit call after I raised the concern.

### Anonymity: admins do not unmask

An admin browsing a foreign anonymous review sees the same pseudonyms as everyone else; `ReviewIdentityResolver` deliberately takes no admin flag. Anonymity is a promise made to the participants, and the person moderating is not the person it was made to. The unmasking path already exists and leaves a trace: the audit trail (ADR-0042). Recorded as an amendment to **ADR-0038**.

One number does change, as a correction rather than an exception: the overview's counts are visibility-scoped, and under a `PRIVATE` thread policy a moderation row read "0 open" for a review full of open concerns — while `canSeeThread` was letting the same admin read every one of those threads. Counts are now admin-aware.

### Everything that filters, filters on the server

The participant-scoped list fetches once and facets in the browser, which is honest while the rows are the caller's own. Across a workspace it is not, so the moderation listing pages and searches on the server — and so does every control over it:

- the status chips, split into the orthogonal `scope` (retention) and `lifecycle` (workflow) parameters;
- the role chips, plus **Not participating**, the facet only this listing can match;
- the advanced menu: due date, one specific workflow state, format, owner.

Their **counts** come from the server too, each the result of the very predicate its chip applies. Anything else and a chip's number would describe the page while appearing to describe the workspace — the rule the participant-scoped listing already follows, kept honest across paging. The owner dropdown likewise spans the workspace: built from twenty rows it would have looked complete and quietly not been.

### Two defects found while using it

- **A filter with no hits showed the first-run welcome** — "start your first review" — in a workspace full of them, and took the filter controls away with it, so there was no way left to undo the filter. The facets now carry `totalUnfiltered` to tell "empty workspace" from "nothing matched". My regression, from making the rows server-filtered.
- **A test that checked nothing**: it asserted the chips were hidden while moderating via `queryByText('Owned by me')`, which never matched — the label is `Owned by me (3)`. Replaced with real assertions.

### Measured, not assumed

`workflow_state` is a plain string column so an enterprise edition can extend the state machine (ADR-0011/0035) — the closed set is matched by name, which also fixes "open" as "not one of these", the reading the client uses for unknown states. And `JpaSpecificationExecutor` brings a second `delete` overload, which made untyped Mockito matchers in the purge tests ambiguous.

One rename in the contract: the open/closed slice is `lifecycle`, not `state`, because the advanced filter slices the same column more finely under `workflowState`.

## Test plan

- [x] `./gradlew build` — Spotless, ArchUnit, full suite
- [x] `pnpm lint` / `format:check` / `typecheck` / `test:run` (1218 tests)
- [x] `AdminReviewModerationIT` (9): visibility per role (admin/member/auditor/external), the marked rows, private-thread counts, due date and participants by an admin, server-side facets, chip counts at `size=1`, and a format with no hits that leaves `totalUnfiltered` positive
- [x] Frontend (12 new): the switch per role and with an empty own list, server paging, the badge, chip counts from the workspace, `Not participating`, chips and advanced filters reaching the query, the owner facet spanning the workspace, and both empty states
- [x] Filter row inspected in a browser at 1280

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)