### PR TITLE
feat(review): admins delete a review permanently; owners archive (#421)

### DIFF
--- a/docs/adr/0050-purging-archived-reviews.md
+++ b/docs/adr/0050-purging-archived-reviews.md
@@ -36,6 +36,19 @@ This is the first and only code path in qnop that destroys user data with no rec
 - **Neutral.** A concurrent upload can re-reference a key between the check and the delete. Accepted rather than locked away: `StorageService.stage` verifies a dedup hit and re-uploads from the buffered bytes when the object is missing (#575), so the race self-heals instead of yielding a key that points at nothing. Locking the whole content-addressed namespace to close a window this narrow is not worth the contention.
 - **Negative / deferred.** The `job` queue (ADR-0033) carries document ids inside its jsonb `payload` and has **no** FK to `document`, so a purge cannot be blocked by it — but it also leaves any queued job for a purged review behind. A review archived ≥180 days has no in-flight extraction work in practice, so this is an accepted gap rather than a solved problem; the worker fails and dead-letters if it ever happens. There is also no **manual** "purge now" for owners or admins: #576 shipped manual archive/unarchive because archiving is reversible, and a one-click irreversible destructor deserves its own confirmation UX. Finally, a purge is invisible to participants by design — no notification; the review was archived long ago, and purging is an operator-level lifecycle event.
 
+## Amendment (2026-07-31, who may delete — issue #421)
+
+The open question from #421 is settled: **the owner archives, only an admin deletes.**
+
+Archiving is reversible and hides a review from the active lists; it is the owner's call, because it takes nothing away. Deleting destroys other people's annotations and discussions along with the document, and a review is not the owner's alone merely because they created it. `DELETE /documents/{id}` is therefore ADMIN-only — 403 for a caller who can see the review, 404 for one who cannot, the same anti-enumeration split the rest of the document API uses.
+
+This adds a second way into the destruction this ADR already describes, and it shares the implementation rather than repeating it: `ReviewDeletionService` owns the aggregate delete and the storage release, and the retention sweep calls it with its own eligibility check. A second delete path is exactly the kind of duplicate where one of the two eventually forgets to release the objects and nobody notices for months.
+
+Two deliberate differences from the sweep:
+
+- **Any state, archived or not.** The sweep exists to enforce retention and therefore only ever sees archived reviews. A manual deletion usually targets a review that should never have existed — most often still a draft — and routing that through cancel and archive would be friction rather than safety, because archiving requires a closed review. What guards it is the role plus a confirmation that makes the admin type the review's title.
+- **An actor, not the system.** The sweep's `review.purged` event has no actor; a manual `review.deleted` carries the real one. Both are SYSTEM-scoped for the same reason: per-document audit rows cascade away with the document, so a run- or review-level record is the only surviving answer to "where did that review go?" — which is why it carries the title and not just the id.
+
 ## Alternatives considered
 
 - **Purge as a workflow state (`PURGED`) rather than a deletion.** Rejected — it is soft deletion under another name and delivers none of the point: the rows and the storage objects stay, so the retention policy still never frees anything.
@@ -43,4 +56,6 @@ This is the first and only code path in qnop that destroys user data with no rec
 - **Reference-count storage objects** (a counter on `storage_object`). Rejected as premature: the two `IN`-clause queries answer the same question against the actual referrers, cannot drift from them, and reuse code ADR-0044 already needed. A counter would add a write to every upload path to save two reads on a nightly sweep.
 - **One transaction for the whole run.** Rejected: a failure after 199 of 200 reviews would roll back all of them while their storage objects are already deleted — the worst of both orderings.
 - **Keeping ADR-0045's gate transaction and using `REQUIRES_NEW` per review.** Rejected: the outer transaction would stay open for the whole run holding a connection, and `StorageService.delete` (a `@Transactional` bean) would join *it* rather than commit per object — so registry rows would commit at the end of the run while objects vanished immediately. The `selfTransactional` opt-out states the intent instead of working around the wrapper.
+- **Letting the owner delete their own review** (#421). Rejected: a review holds other people's annotations and discussions, so the owner deleting it destroys work that was never theirs alone. They keep `archive`, which is reversible, and `CANCELLED`, which ends a review without removing it.
+- **Requiring an admin to archive before deleting.** Rejected: archiving demands a closed review, so removing an obvious mistake would take three steps. The safety belongs in the confirmation, not in a detour.
 - **Purging by `closed_at` instead of `archived_at`.** Rejected: it would let a review skip the archive stage entirely if both windows elapsed before a sweep ran. Chaining the purge to `archived_at` guarantees a review is always archived first, so the archive window is a real grace period.

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -3363,6 +3363,50 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+    delete:
+      tags:
+        - Documents
+      summary: Delete a review permanently
+      description: |
+        **ADMIN only** (issue #421). Destroys the review and everything it owns
+        — versions, annotations, discussions, participants, attachments and its
+        own audit trail — and releases the object-storage blobs that nothing else
+        references. There is no undo and no recycle bin.
+
+        The owner's tool is `archive`, which is reversible and hides the review
+        from the active lists; the retention sweep (ADR-0050) removes archived
+        reviews on its own schedule. This endpoint is the same destruction, aimed
+        at one review and running now.
+
+        Any workflow state, archived or not: a review created by mistake is
+        usually still a draft, and routing its removal through cancel and archive
+        would be friction rather than safety. Clients are expected to confirm
+        explicitly instead.
+
+        One SYSTEM-scoped `review.deleted` audit event survives, naming the real
+        actor and the review's title — the per-review events die with it.
+      operationId: deleteDocument
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/DocumentIdParam'
+      responses:
+        '204':
+          description: The review and everything it owned are gone.
+        '403':
+          description: The caller can see the review but is not an admin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Unknown document, or the caller cannot see it at all
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /documents/by-slug/{slug}:
     get:
       tags:

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -7163,6 +7163,10 @@ components:
         What happened (issue #538). Mirrors the review event/mail-template
         vocabulary; `MENTION` outranks the `COMMENT_ADDED`/`ANNOTATION_CREATED`
         it is contained in, so a mentioned follower gets one notification.
+
+        `REVIEW_DELETED` (issue #421) is the one type whose review no longer
+        exists: it carries no `documentId` and no action to follow, and its
+        `documentTitle` is the deleted review's name rather than a link to it.
       enum:
         - PARTICIPANT_ADDED
         - ANNOTATION_CREATED
@@ -7171,6 +7175,7 @@ components:
         - MENTION
         - VERSION_UPLOADED
         - WORKFLOW_CHANGED
+        - REVIEW_DELETED
       example: COMMENT_ADDED
     NotificationSummary:
       type: object

--- a/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentsController.java
@@ -50,6 +50,7 @@ import io.qnop.service.document.DocumentOverviewService;
 import io.qnop.service.document.DocumentUpdateService;
 import io.qnop.service.document.ReviewParticipantService;
 import io.qnop.service.review.ReviewArchiveService;
+import io.qnop.service.review.ReviewDeletionService;
 import io.qnop.service.review.ReviewVisitService;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -76,6 +77,7 @@ public class DocumentsController implements DocumentsApi {
   private final DocumentUpdateService updates;
   private final ReviewVisitService visits;
   private final ReviewArchiveService archive;
+  private final ReviewDeletionService deletions;
 
   public DocumentsController(
       DocumentAccessService documents,
@@ -84,7 +86,8 @@ public class DocumentsController implements DocumentsApi {
       ReviewParticipantService participants,
       DocumentUpdateService updates,
       ReviewVisitService visits,
-      ReviewArchiveService archive) {
+      ReviewArchiveService archive,
+      ReviewDeletionService deletions) {
     this.documents = documents;
     this.diffs = diffs;
     this.overview = overview;
@@ -92,6 +95,7 @@ public class DocumentsController implements DocumentsApi {
     this.updates = updates;
     this.visits = visits;
     this.archive = archive;
+    this.deletions = deletions;
   }
 
   @Override
@@ -191,6 +195,12 @@ public class DocumentsController implements DocumentsApi {
             .stateClosed(counts.stateClosed())
             .stateArchived(counts.stateArchived())
             .stateAll(counts.stateAll());
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteDocument(UUID documentId) {
+    deletions.delete(documentId, CurrentUser.requireUserId(), CurrentUser.isAdmin());
+    return ResponseEntity.noContent().build();
   }
 
   private static DocumentSummary toSummary(DocumentOverviewService.DocumentSummaryView view) {

--- a/qnop-app/src/test/java/io/qnop/review/ReviewDeletionIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewDeletionIT.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.AnnotationRepository;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.service.review.ReviewDeletionService;
+import io.qnop.service.storage.StorageService;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * Deleting a review permanently (issue #421): admin-only, and it really does take everything.
+ *
+ * <p>The owner's tool is `archive`, which is reversible; this is the other end of that decision, so
+ * the tests are as much about who is refused as about what is destroyed.
+ */
+class ReviewDeletionIT extends SeededIntegrationTest {
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private AnnotationRepository annotations;
+  @Autowired private ReviewParticipantRepository participants;
+  @Autowired private AuditEventRepository auditEvents;
+  @Autowired private StorageService storage;
+
+  private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
+    return builder.header("Authorization", "Bearer " + token(user));
+  }
+
+  /** A review owned by MEMBER, reviewed by MEMBER2, with one version at {@code storageKey}. */
+  private UUID review(String title, String storageKey) {
+    Document document = new Document(MEMBER_ID, title);
+    document.setWorkflowState(WorkflowState.IN_REVIEW);
+    UUID documentId = documents.save(document).getId();
+    versions.save(
+        new DocumentVersion(documentId, 1, storageKey, "hash", "application/pdf", 4L, MEMBER_ID));
+    participants.save(ReviewParticipant.forUser(documentId, MEMBER2_ID));
+    return documentId;
+  }
+
+  /** Stores a real object so the release can be observed rather than assumed. */
+  private String storeObject(String content) {
+    var staged =
+        storage.stage(
+            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), "application/pdf");
+    storage.commit(staged.key());
+    return staged.key();
+  }
+
+  @Test
+  @DisplayName("an admin deletes a review, and everything it owned goes with it")
+  void adminDeletesTheWholeAggregate() throws Exception {
+    String key = storeObject("only this review holds these bytes");
+    UUID documentId = review("Deleted by an admin", key);
+    annotate(documentId, MEMBER_ID);
+
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + documentId), ADMIN_ID))
+        .andExpect(status().isNoContent());
+
+    assertThat(documents.findById(documentId)).isEmpty();
+    assertThat(versions.findByDocumentIdOrderByVersionNumberAsc(documentId)).isEmpty();
+    assertThat(annotations.findByDocumentId(documentId)).isEmpty();
+    assertThat(participants.findByDocumentId(documentId)).isEmpty();
+    // The blob is gone too, not merely unreferenced — an orphan nobody reclaims
+    // would defeat the point of deleting.
+    assertThat(storage.get(key)).isEmpty();
+
+    // Even the review itself is gone from the admin's own listing.
+    mockMvc
+        .perform(as(get("/api/v1/documents/" + documentId), ADMIN_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("nobody but an admin may delete — not even the owner")
+  void deletionIsAdminOnly() throws Exception {
+    UUID documentId = review("Not the owners to destroy", storeObject("kept"));
+
+    // The owner's tool is archive, which is reversible. Deleting takes other
+    // people's annotations with it, so it is not theirs alone to decide.
+    for (UUID actor : List.of(MEMBER_ID, MEMBER2_ID)) {
+      mockMvc
+          .perform(as(delete("/api/v1/documents/" + documentId), actor))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    // Someone who cannot see it at all learns nothing further: 404, not 403.
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + documentId), EXTERNAL_ID))
+        .andExpect(status().isNotFound());
+
+    assertThat(documents.findById(documentId)).isPresent();
+  }
+
+  @Test
+  @DisplayName("a blob two reviews share survives the deletion of one of them")
+  void sharedStorageIsKept() throws Exception {
+    // Storage keys are content-addressed, so uploading the same file twice yields
+    // ONE object. Deleting one review must not empty the other — the check that is
+    // easiest to lose when this code moves.
+    String shared = storeObject("the very same bytes in two reviews");
+    UUID first = review("First review of the same file", shared);
+    UUID second = review("Second review of the same file", shared);
+
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + first), ADMIN_ID))
+        .andExpect(status().isNoContent());
+
+    assertThat(documents.findById(first)).isEmpty();
+    assertThat(documents.findById(second)).isPresent();
+    assertThat(storage.get(shared)).isPresent();
+  }
+
+  @Test
+  @DisplayName("a record of the deletion outlives the review it describes")
+  void theAuditTrailRemembers() throws Exception {
+    UUID documentId = review("Gone but audited", storeObject("audited"));
+
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + documentId), ADMIN_ID))
+        .andExpect(status().isNoContent());
+
+    // The review's own audit rows cascade away with it, so this SYSTEM-scoped one
+    // is the only surviving answer to "where did that review go?" — hence the
+    // title, and the real actor.
+    assertThat(auditEvents.findAll())
+        .filteredOn(
+            event -> ReviewDeletionService.AUDIT_REVIEW_DELETED.equals(event.getEventType()))
+        .isNotEmpty()
+        .anySatisfy(
+            event -> {
+              assertThat(event.getActorId()).isEqualTo(ADMIN_ID);
+              assertThat(event.getDetail()).contains("Gone but audited");
+              assertThat(event.getDetail()).contains(documentId.toString());
+            });
+  }
+
+  @Test
+  @DisplayName("a draft can be deleted without cancelling and archiving it first")
+  void anyStateMayGo() throws Exception {
+    Document draft = new Document(MEMBER_ID, "Created by mistake");
+    draft.setWorkflowState(WorkflowState.DRAFT);
+    UUID documentId = documents.save(draft).getId();
+
+    // The usual case for deleting at all is a review that should never have
+    // existed; routing it through cancel and archive would be friction, not safety.
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + documentId), ADMIN_ID))
+        .andExpect(status().isNoContent());
+
+    assertThat(documents.findById(documentId)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("deleting the same review twice is a 404, not a server error")
+  void secondDeleteIsNotFound() throws Exception {
+    UUID documentId = review("Deleted once", storeObject("once"));
+
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + documentId), ADMIN_ID))
+        .andExpect(status().isNoContent());
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + documentId), ADMIN_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  /** Raises one annotation on version 1, so the cascade has something to take. */
+  private void annotate(UUID documentId, UUID author) throws Exception {
+    mockMvc
+        .perform(
+            as(post("/api/v1/documents/" + documentId + "/annotations"), author)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"versionNumber\":1,\"anchor\":{\"region\":{\"surfaceIndex\":0,"
+                        + "\"box\":{\"x\":0.1,\"y\":0.1,\"width\":0.3,\"height\":0.05}},"
+                        + "\"textQuote\":{\"quote\":\"the clause\"}},\"comment\":\"A concern\"}"))
+        .andExpect(status().isCreated());
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/ReviewDeletionIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewDeletionIT.java
@@ -29,12 +29,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.qnop.entity.Document;
 import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.Notification;
+import io.qnop.entity.NotificationType;
 import io.qnop.entity.ReviewParticipant;
 import io.qnop.entity.WorkflowState;
 import io.qnop.repository.AnnotationRepository;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.NotificationRepository;
 import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.service.review.ReviewDeletionService;
 import io.qnop.service.storage.StorageService;
@@ -62,6 +65,7 @@ class ReviewDeletionIT extends SeededIntegrationTest {
   @Autowired private AnnotationRepository annotations;
   @Autowired private ReviewParticipantRepository participants;
   @Autowired private AuditEventRepository auditEvents;
+  @Autowired private NotificationRepository notifications;
   @Autowired private StorageService storage;
 
   private MockHttpServletRequestBuilder as(MockHttpServletRequestBuilder builder, UUID user) {
@@ -205,6 +209,58 @@ class ReviewDeletionIT extends SeededIntegrationTest {
     mockMvc
         .perform(as(delete("/api/v1/documents/" + documentId), ADMIN_ID))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("the owner is told their review is gone, and the notice outlives it")
+  void theOwnerIsNotified() throws Exception {
+    UUID documentId = review("Deleted out from under its owner", storeObject("notified"));
+
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + documentId), ADMIN_ID))
+        .andExpect(status().isNoContent());
+
+    List<Notification> mine =
+        notifications.findAll().stream()
+            .filter(n -> MEMBER_ID.equals(n.getRecipientId()))
+            .filter(n -> n.getType() == NotificationType.REVIEW_DELETED)
+            .toList();
+
+    assertThat(mine).hasSize(1);
+    // No documentId, deliberately: that column cascades with the document, so a
+    // row naming the deleted review would have been deleted in the same
+    // statement. The title rides along instead.
+    assertThat(mine.getFirst().getDocumentId()).isNull();
+    assertThat(mine.getFirst().getExcerpt()).isEqualTo("Deleted out from under its owner");
+
+    // And the inbox says which review, rather than the "no longer available to
+    // you" tombstone every other document-less notification gets.
+    mockMvc
+        .perform(as(get("/api/v1/notifications"), MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.items[?(@.type == 'REVIEW_DELETED')].documentTitle")
+                .value(org.hamcrest.Matchers.hasItem("Deleted out from under its owner")))
+        // Nothing to open: the client hides the link rather than offering a 404.
+        .andExpect(
+            jsonPath("$.items[?(@.type == 'REVIEW_DELETED')].accessible")
+                .value(org.hamcrest.Matchers.hasItem(false)));
+  }
+
+  @Test
+  @DisplayName("an admin deleting their own review is not notified about it")
+  void noSelfNotification() throws Exception {
+    Document own = new Document(ADMIN_ID, "The admins own mistake");
+    own.setWorkflowState(WorkflowState.DRAFT);
+    UUID documentId = documents.save(own).getId();
+
+    mockMvc
+        .perform(as(delete("/api/v1/documents/" + documentId), ADMIN_ID))
+        .andExpect(status().isNoContent());
+
+    assertThat(notifications.findAll())
+        .filteredOn(n -> n.getType() == NotificationType.REVIEW_DELETED)
+        .isEmpty();
   }
 
   /** Raises one annotation on version 1, so the cascade has something to take. */

--- a/qnop-core/src/main/java/io/qnop/entity/NotificationType.java
+++ b/qnop-core/src/main/java/io/qnop/entity/NotificationType.java
@@ -36,5 +36,18 @@ public enum NotificationType {
   ANNOTATION_DECIDED,
   COMMENT_ADDED,
   VERSION_UPLOADED,
-  WORKFLOW_CHANGED
+  WORKFLOW_CHANGED,
+  /**
+   * A review was deleted permanently by an admin (issue #421).
+   *
+   * <p>Last, and outside the ranking that matters above: it never competes with another candidate,
+   * because the event it comes from concerns exactly one recipient and no other event can fire for
+   * a review that no longer exists.
+   *
+   * <p>The only type whose notification carries no {@code documentId} — that column cascades with
+   * the document, so a row pointing at the deleted review would be deleted along with it. The
+   * review's title travels in {@code excerpt} instead, which is why this one renders without
+   * loading anything.
+   */
+  REVIEW_DELETED
 }

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -262,6 +262,33 @@ public enum MailTemplateKey {
       "oldState",
       "newState",
       "actionUrl"),
+  REVIEW_DELETED(
+      "review.deleted",
+      "Review deleted",
+      "“{{documentTitle}}” was deleted",
+      """
+      Hi {{recipientName}},
+
+      Your review "{{documentTitle}}" ({{siteName}}) was permanently deleted by an administrator.
+
+      Everything in it is gone: every version, annotation and discussion. This cannot be undone.
+
+      If you were not expecting this, ask your administrator — the deletion is recorded in the audit trail.
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Review deleted</h1>
+      <p style="margin:0 0 14px;">Hi {{recipientName}},</p>
+      <p style="margin:0 0 14px;">Your review <strong style="color:#18191f;">&#8220;{{documentTitle}}&#8221;</strong> was permanently deleted by an administrator.</p>
+      <p style="margin:0 0 14px;">Everything in it is gone &#8212; every version, annotation and discussion. This cannot be undone.</p>
+      <p style="margin:0;color:#9a9ea8;font-size:13px;">If you were not expecting this, ask your administrator; the deletion is recorded in the audit trail.</p>
+      """,
+      // No call to action: there is nothing left to open, and a button leading to
+      // a 404 would be worse than none (issue #421).
+      null,
+      "“{{documentTitle}}” was permanently deleted.",
+      "siteName",
+      "recipientName",
+      "documentTitle"),
   REVIEW_VERSION_UPLOADED(
       "review.version_uploaded",
       "New document version",

--- a/qnop-core/src/main/java/io/qnop/service/notification/NotificationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/NotificationService.java
@@ -22,6 +22,7 @@ package io.qnop.service.notification;
 
 import io.qnop.entity.Document;
 import io.qnop.entity.Notification;
+import io.qnop.entity.NotificationType;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.NotificationRepository;
 import io.qnop.service.document.DocumentAccessService;
@@ -131,6 +132,12 @@ public class NotificationService {
   // --- rendering -----------------------------------------------------------
 
   private NotificationView render(Notification notification, RenderContext context) {
+    if (notification.getType() == NotificationType.REVIEW_DELETED) {
+      // Self-describing by necessity (issue #421): there is no review left to
+      // load, and tombstoning it would replace the one thing the owner needs —
+      // which review went — with "no longer available to you".
+      return deletedReview(notification);
+    }
     UUID documentId = notification.getDocumentId();
     boolean accessible = documentId != null && context.isVisible(documentId, access);
     Document document = accessible ? context.document(documentId, documents) : null;
@@ -152,6 +159,39 @@ public class NotificationService {
         actionPath(notification, document),
         actionLabel(notification),
         true,
+        notification.getReadAt(),
+        notification.getCreatedAt());
+  }
+
+  /**
+   * A review an admin destroyed: everything it says travels on the row itself (issue #421).
+   *
+   * <p>The admin is not named. Actor names elsewhere resolve through the review's identity rules
+   * (ADR-0038), and there is no review left to resolve against; naming them anyway would be a
+   * privacy decision made by accident. The audit trail holds the real actor for anyone entitled to
+   * it.
+   */
+  private NotificationView deletedReview(Notification notification) {
+    String title = notification.getExcerpt() == null ? "a review" : notification.getExcerpt();
+    return new NotificationView(
+        notification.getId(),
+        notification.getType().name(),
+        "A review was deleted",
+        "“" + title + "” was permanently deleted by an administrator.",
+        // No preview: there is no comment or annotation text to quote.
+        null,
+        null,
+        null,
+        // No id — the row never had one — but the name, which is the whole point
+        // of the notice.
+        null,
+        title,
+        // No path and no label either: there is nothing left to open, and a link
+        // that 404s would be worse than none. `accessible` false says exactly
+        // that to the client.
+        null,
+        null,
+        false,
         notification.getReadAt(),
         notification.getCreatedAt());
   }
@@ -187,6 +227,9 @@ public class NotificationService {
       case COMMENT_ADDED -> actorName + " replied";
       case VERSION_UPLOADED -> "New version uploaded";
       case WORKFLOW_CHANGED -> "The review moved to " + humanState(notification.getToState());
+      // Rendered by deletedReview before this is reached; listed so the switch
+      // stays exhaustive and a new type cannot slip past the compiler.
+      case REVIEW_DELETED -> "A review was deleted";
     };
   }
 
@@ -213,6 +256,9 @@ public class NotificationService {
               + " to "
               + humanState(notification.getToState())
               + ".";
+      // Rendered by deletedReview before this is reached; listed so a new type
+      // cannot slip past the compiler.
+      case REVIEW_DELETED -> review + " was permanently deleted by an administrator.";
     };
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewDeletionService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewDeletionService.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.review;
+
+import io.qnop.entity.AuditEvent;
+import io.qnop.entity.Document;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.repository.DocumentAttachmentRepository;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.service.document.DocumentAccessService;
+import io.qnop.service.document.DocumentValidationException;
+import io.qnop.service.storage.StorageService;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Destroying a review, for good (issue #421).
+ *
+ * <p>Two callers, one implementation: the retention sweep ({@link ReviewPurgeService}) and an admin
+ * deleting one review by hand. A second delete path would be the kind of duplicate where one of the
+ * two eventually forgets to release the storage objects, and nobody notices for months.
+ *
+ * <p><strong>Who may.</strong> The owner archives — reversible, and theirs to decide. Only an admin
+ * deletes. A review carries other people's annotations and discussions, so removing it destroys
+ * work that was never the owner's alone.
+ *
+ * <p><strong>Order matters.</strong> The storage keys are read before the rows are, because
+ * afterwards there is nothing left to read them from; the objects go only once the aggregate delete
+ * has committed, so the document's own rows can no longer make a key look shared.
+ */
+@Service
+public class ReviewDeletionService {
+
+  /**
+   * Audit event for one review deleted by hand.
+   *
+   * <p>SYSTEM-scoped despite having an actor: per-document events die with the document (the {@code
+   * audit_event.document_id} FK cascades), so this is the only surviving answer to "where did that
+   * review go?" — which is why it carries the title, not just the id.
+   */
+  public static final String AUDIT_REVIEW_DELETED = "review.deleted";
+
+  private static final Logger log = LoggerFactory.getLogger(ReviewDeletionService.class);
+
+  private final DocumentRepository documents;
+  private final DocumentVersionRepository versions;
+  private final DocumentAttachmentRepository attachments;
+  private final AuditEventRepository auditEvents;
+  private final DocumentAccessService access;
+  private final StorageService storage;
+  private final TransactionTemplate tx;
+
+  public ReviewDeletionService(
+      DocumentRepository documents,
+      DocumentVersionRepository versions,
+      DocumentAttachmentRepository attachments,
+      AuditEventRepository auditEvents,
+      DocumentAccessService access,
+      StorageService storage,
+      PlatformTransactionManager transactionManager) {
+    this.documents = documents;
+    this.versions = versions;
+    this.attachments = attachments;
+    this.auditEvents = auditEvents;
+    this.access = access;
+    this.storage = storage;
+    this.tx = new TransactionTemplate(transactionManager);
+  }
+
+  /**
+   * Deletes one review immediately, at an admin's request.
+   *
+   * <p>Any state: a review created by mistake is most often still a draft, and making its removal a
+   * three-step detour through cancel and archive would be friction rather than safety. What guards
+   * this is the role and the client's confirmation, not a longer path.
+   *
+   * @throws DocumentValidationException 404 when the caller cannot see it at all, 403 when they can
+   *     but are not an admin
+   */
+  public DeletedReview delete(UUID documentId, UUID actorId, boolean admin) {
+    if (!admin) {
+      // Anti-enumeration: a caller who cannot even see the review learns nothing
+      // beyond "no such review"; a participant learns that deleting is not theirs.
+      if (!access.isVisible(documentId, actorId, false)) {
+        throw DocumentValidationException.notFound("no such document: " + documentId);
+      }
+      throw DocumentValidationException.forbidden("only admins may delete a review");
+    }
+
+    DeletedAggregate deleted = deleteAggregate(documentId, document -> true);
+    if (deleted == null) {
+      throw DocumentValidationException.notFound("no such document: " + documentId);
+    }
+    int objects = deleteUnreferencedObjects(deleted.storageKeys());
+    audit(documentId, deleted.title(), actorId, objects);
+    log.info(
+        "Review {} ({}) deleted by {}; {} storage object(s) released.",
+        documentId,
+        deleted.title(),
+        actorId,
+        objects);
+    return new DeletedReview(documentId, deleted.title(), objects);
+  }
+
+  /**
+   * Deletes one review's DB aggregate in its own transaction, or returns {@code null} when {@code
+   * stillEligible} says it should be left alone.
+   *
+   * <p>The document is re-read and re-checked inside that transaction rather than trusted from
+   * whatever the caller saw earlier: deleting is irreversible, and the sweep in particular reads
+   * its batch in an earlier transaction during which an admin may have unarchived something.
+   *
+   * <p>The keys are collected first, because after the delete the rows that name them are gone.
+   */
+  DeletedAggregate deleteAggregate(UUID documentId, Predicate<Document> stillEligible) {
+    return tx.execute(
+        status -> {
+          Document document = documents.findById(documentId).orElse(null);
+          if (document == null || !stillEligible.test(document)) {
+            return null;
+          }
+          Set<String> referenced = new LinkedHashSet<>();
+          referenced.addAll(versions.findStorageKeysByDocumentId(documentId));
+          referenced.addAll(attachments.findStorageKeysByDocumentId(documentId));
+          // The schema cascades the whole aggregate (versions, annotations, placements, comments,
+          // reactions, mentions, participants, visits, attachments, version diffs and the
+          // per-document audit trail) — see DocumentReviewSchemaIT.
+          documents.delete(document);
+          return new DeletedAggregate(document.getTitle(), referenced);
+        });
+  }
+
+  /**
+   * Deletes each key that no surviving row references, and returns how many went.
+   *
+   * <p>Keys are content-addressed, so two reviews holding the same file hold the same object. This
+   * check is what keeps deleting one of them from emptying the other; both reference sources are
+   * queried once over the whole key set, never once per key.
+   */
+  int deleteUnreferencedObjects(Set<String> candidateKeys) {
+    if (candidateKeys.isEmpty()) {
+      return 0;
+    }
+    Set<String> stillReferenced =
+        tx.execute(
+            status -> {
+              Set<String> referenced = new LinkedHashSet<>();
+              versions.findVersionRefsByStorageKeyIn(candidateKeys).stream()
+                  .map(ref -> ref.storageKey())
+                  .forEach(referenced::add);
+              // A converted version is rendered from a second object (issue #343),
+              // and the projection names the key that matched.
+              versions.findVersionRefsByRenditionKeyIn(candidateKeys).stream()
+                  .map(ref -> ref.storageKey())
+                  .forEach(referenced::add);
+              attachments.findAttachmentRefsByStorageKeyIn(candidateKeys).stream()
+                  .map(ref -> ref.storageKey())
+                  .forEach(referenced::add);
+              return referenced;
+            });
+    Set<String> shared = stillReferenced == null ? Set.of() : stillReferenced;
+    int deleted = 0;
+    for (String key : candidateKeys) {
+      if (shared.contains(key)) {
+        log.debug("Keeping storage object {} — still referenced by a surviving document.", key);
+        continue;
+      }
+      // Own transaction (StorageService.delete is @Transactional and we hold none), so the object
+      // and its registry row go together, now — not at the end of the run.
+      storage.delete(key);
+      deleted++;
+    }
+    return deleted;
+  }
+
+  private void audit(UUID documentId, String title, UUID actorId, int objectsDeleted) {
+    String detail =
+        "{\"documentId\":\""
+            + documentId
+            + "\",\"title\":\""
+            + escape(title)
+            + "\",\"storageObjects\":"
+            + objectsDeleted
+            + "}";
+    tx.executeWithoutResult(
+        status -> auditEvents.save(AuditEvent.system(AUDIT_REVIEW_DELETED, actorId, detail)));
+  }
+
+  /** Minimal JSON string escaping for a user-supplied title. */
+  private static String escape(String value) {
+    return value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  /** What one deletion destroyed, for the caller's response and log line. */
+  public record DeletedReview(UUID documentId, String title, int storageObjectsDeleted) {}
+
+  /** The aggregate's title and the storage keys it referenced, read before it was deleted. */
+  record DeletedAggregate(String title, Set<String> storageKeys) {}
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewDeletionService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewDeletionService.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -74,6 +75,7 @@ public class ReviewDeletionService {
   private final AuditEventRepository auditEvents;
   private final DocumentAccessService access;
   private final StorageService storage;
+  private final ApplicationEventPublisher events;
   private final TransactionTemplate tx;
 
   public ReviewDeletionService(
@@ -83,6 +85,7 @@ public class ReviewDeletionService {
       AuditEventRepository auditEvents,
       DocumentAccessService access,
       StorageService storage,
+      ApplicationEventPublisher events,
       PlatformTransactionManager transactionManager) {
     this.documents = documents;
     this.versions = versions;
@@ -90,6 +93,7 @@ public class ReviewDeletionService {
     this.auditEvents = auditEvents;
     this.access = access;
     this.storage = storage;
+    this.events = events;
     this.tx = new TransactionTemplate(transactionManager);
   }
 
@@ -119,6 +123,17 @@ public class ReviewDeletionService {
     }
     int objects = deleteUnreferencedObjects(deleted.storageKeys());
     audit(documentId, deleted.title(), actorId, objects);
+    // Inside a transaction, and that is not decoration: the notification listener
+    // is @TransactionalEventListener(AFTER_COMMIT), and an event published outside
+    // a transaction is dropped without a word. The aggregate delete has already
+    // committed by now, so this one exists purely to give the event a commit to
+    // ride on. It carries what the review was, because nothing can be looked up
+    // any more (issue #421).
+    tx.executeWithoutResult(
+        status ->
+            events.publishEvent(
+                new ReviewEvent.ReviewDeleted(
+                    documentId, actorId, deleted.ownerId(), deleted.title())));
     log.info(
         "Review {} ({}) deleted by {}; {} storage object(s) released.",
         documentId,
@@ -148,11 +163,12 @@ public class ReviewDeletionService {
           Set<String> referenced = new LinkedHashSet<>();
           referenced.addAll(versions.findStorageKeysByDocumentId(documentId));
           referenced.addAll(attachments.findStorageKeysByDocumentId(documentId));
+          UUID ownerId = document.getOwnerId();
           // The schema cascades the whole aggregate (versions, annotations, placements, comments,
           // reactions, mentions, participants, visits, attachments, version diffs and the
           // per-document audit trail) — see DocumentReviewSchemaIT.
           documents.delete(document);
-          return new DeletedAggregate(document.getTitle(), referenced);
+          return new DeletedAggregate(document.getTitle(), ownerId, referenced);
         });
   }
 
@@ -220,6 +236,6 @@ public class ReviewDeletionService {
   /** What one deletion destroyed, for the caller's response and log line. */
   public record DeletedReview(UUID documentId, String title, int storageObjectsDeleted) {}
 
-  /** The aggregate's title and the storage keys it referenced, read before it was deleted. */
-  record DeletedAggregate(String title, Set<String> storageKeys) {}
+  /** What the aggregate was, read before it was deleted — nothing can be looked up afterwards. */
+  record DeletedAggregate(String title, UUID ownerId, Set<String> storageKeys) {}
 }

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewEvent.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewEvent.java
@@ -70,4 +70,14 @@ public sealed interface ReviewEvent {
   record WorkflowChanged(
       UUID documentId, UUID actorId, String fromState, String toState, boolean manual)
       implements ReviewEvent {}
+
+  /**
+   * An admin destroyed the review (issue #421).
+   *
+   * <p>The one event whose subject no longer exists by the time anyone hears it. Every other event
+   * names a document the listener then loads; this one has to carry what that load would have
+   * provided — who owned it and what it was called — because there is nothing left to ask.
+   */
+  record ReviewDeleted(UUID documentId, UUID actorId, UUID ownerId, String title)
+      implements ReviewEvent {}
 }

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewNotificationService.java
@@ -151,6 +151,11 @@ public class ReviewNotificationService {
 
   /** The event's intents, grouped per recipient and ranked most-specific first. */
   private Map<UUID, List<ReviewNotificationIntent>> resolve(ReviewEvent event) {
+    if (event instanceof ReviewEvent.ReviewDeleted deleted) {
+      // Before the lookup, deliberately: the review is gone, which is the whole
+      // message (issue #421).
+      return byRecipient(reviewDeleted(deleted));
+    }
     Optional<Document> loaded = documents.findById(event.documentId());
     if (loaded.isEmpty()) {
       return Map.of(); // deleted between commit and dispatch — nothing to say
@@ -174,7 +179,44 @@ public class ReviewNotificationService {
           case ReviewEvent.CommentAdded comment -> commentAdded(document, comment);
           case ReviewEvent.VersionUploaded uploaded -> versionUploaded(document, uploaded);
           case ReviewEvent.WorkflowChanged changed -> workflowChanged(document, changed);
+          // Handled above, before the document lookup that this branch depends on.
+          case ReviewEvent.ReviewDeleted ignored -> List.of();
         };
+    return byRecipient(intents);
+  }
+
+  /**
+   * Tells the owner their review was destroyed.
+   *
+   * <p>Only the owner: everyone else's stake in a review is the discussion, and there is no
+   * discussion left to point them at. The owner is the one person who has to know the thing they
+   * started is gone.
+   *
+   * <p>The intent carries no {@code documentId} on purpose — {@code notification.document_id}
+   * cascades with the document, so a row naming the deleted review would be deleted in the same
+   * statement. The title travels as the excerpt instead.
+   */
+  private List<ReviewNotificationIntent> reviewDeleted(ReviewEvent.ReviewDeleted event) {
+    if (event.ownerId() == null || event.ownerId().equals(event.actorId())) {
+      // An admin deleting their own review already knows.
+      return List.of();
+    }
+    return users
+        .findById(event.ownerId())
+        .<List<ReviewNotificationIntent>>map(
+            owner ->
+                List.of(
+                    ReviewNotificationIntent.to(
+                            owner, NotificationType.REVIEW_DELETED, MailTemplateKey.REVIEW_DELETED)
+                        .actor(event.actorId())
+                        .excerpt(event.title())
+                        .var("documentTitle", event.title())
+                        .build()))
+        .orElseGet(List::of);
+  }
+
+  private Map<UUID, List<ReviewNotificationIntent>> byRecipient(
+      List<ReviewNotificationIntent> intents) {
     return intents.stream()
         .collect(
             Collectors.groupingBy(

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewPurgeService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewPurgeService.java
@@ -30,7 +30,6 @@ import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.scheduler.SchedulerJobCatalog;
 import io.qnop.service.scheduler.SchedulerService;
-import io.qnop.service.storage.StorageService;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -112,7 +111,7 @@ public class ReviewPurgeService {
   private final DocumentAttachmentRepository attachments;
   private final AuditEventRepository auditEvents;
   private final ApplicationSettingsService settings;
-  private final StorageService storage;
+  private final ReviewDeletionService deletions;
   private final TransactionTemplate tx;
 
   public ReviewPurgeService(
@@ -122,7 +121,7 @@ public class ReviewPurgeService {
       DocumentAttachmentRepository attachments,
       AuditEventRepository auditEvents,
       ApplicationSettingsService settings,
-      StorageService storage,
+      ReviewDeletionService deletions,
       PlatformTransactionManager transactionManager) {
     this.scheduler = scheduler;
     this.documents = documents;
@@ -130,7 +129,7 @@ public class ReviewPurgeService {
     this.attachments = attachments;
     this.auditEvents = auditEvents;
     this.settings = settings;
-    this.storage = storage;
+    this.deletions = deletions;
     this.tx = new TransactionTemplate(transactionManager);
   }
 
@@ -171,13 +170,13 @@ public class ReviewPurgeService {
     int objectsDeleted = 0;
     for (UUID documentId : eligible) {
       // One transaction per review: an interrupted run leaves whole reviews, never fragments.
-      PurgedAggregate result = purgeAggregate(documentId, cutoff);
+      ReviewDeletionService.DeletedAggregate result = purgeAggregate(documentId, cutoff);
       if (result == null) {
         continue; // no longer eligible — unarchived or already gone since the batch was read
       }
       // Only now — the aggregate delete has committed, so the document's own rows can no longer
       // make a key look shared.
-      objectsDeleted += deleteUnreferenced(result.storageKeys());
+      objectsDeleted += deletions.deleteUnreferencedObjects(result.storageKeys());
       purged.add(new PurgedReview(documentId, result.title()));
     }
 
@@ -202,64 +201,12 @@ public class ReviewPurgeService {
    * Purging is irreversible, so the eligibility decision is made in the same transaction as the
    * delete. The keys are read before the delete, because afterwards the rows are gone.
    */
-  private PurgedAggregate purgeAggregate(UUID documentId, Instant cutoff) {
-    return tx.execute(
-        status -> {
-          Document document = documents.findById(documentId).orElse(null);
-          if (document == null
-              || document.getArchivedAt() == null
-              || !document.getArchivedAt().isBefore(cutoff)) {
-            return null;
-          }
-          Set<String> referenced = new LinkedHashSet<>();
-          referenced.addAll(versions.findStorageKeysByDocumentId(documentId));
-          referenced.addAll(attachments.findStorageKeysByDocumentId(documentId));
-          // The schema cascades the whole aggregate (versions, annotations, placements, comments,
-          // reactions, mentions, participants, visits, attachments, version diffs and the
-          // per-document audit trail) — see DocumentReviewSchemaIT.
-          documents.delete(document);
-          return new PurgedAggregate(document.getTitle(), referenced);
-        });
-  }
-
-  /**
-   * Deletes each key that no surviving row references, and returns how many went. Both reference
-   * checks are one query over the whole key set, not one per key.
-   */
-  private int deleteUnreferenced(Set<String> candidateKeys) {
-    if (candidateKeys.isEmpty()) {
-      return 0;
-    }
-    Set<String> stillReferenced =
-        tx.execute(
-            status -> {
-              Set<String> referenced = new LinkedHashSet<>();
-              versions.findVersionRefsByStorageKeyIn(candidateKeys).stream()
-                  .map(ref -> ref.storageKey())
-                  .forEach(referenced::add);
-              // Renditions are referenced too (issue #343), and the projection names
-              // the key that matched — so a shared conversion is not deleted.
-              versions.findVersionRefsByRenditionKeyIn(candidateKeys).stream()
-                  .map(ref -> ref.storageKey())
-                  .forEach(referenced::add);
-              attachments.findAttachmentRefsByStorageKeyIn(candidateKeys).stream()
-                  .map(ref -> ref.storageKey())
-                  .forEach(referenced::add);
-              return referenced;
-            });
-    Set<String> shared = stillReferenced == null ? Set.of() : stillReferenced;
-    int deleted = 0;
-    for (String key : candidateKeys) {
-      if (shared.contains(key)) {
-        log.debug("Keeping storage object {} — still referenced by a surviving document.", key);
-        continue;
-      }
-      // Own transaction (StorageService.delete is @Transactional and we hold none), so the object
-      // and its registry row go together, now — not at the end of the run.
-      storage.delete(key);
-      deleted++;
-    }
-    return deleted;
+  private ReviewDeletionService.DeletedAggregate purgeAggregate(UUID documentId, Instant cutoff) {
+    // Shared with the admin's manual delete (issue #421): one implementation, so
+    // the storage release cannot drift apart between the two ways in.
+    return deletions.deleteAggregate(
+        documentId,
+        document -> document.getArchivedAt() != null && document.getArchivedAt().isBefore(cutoff));
   }
 
   /**
@@ -380,5 +327,4 @@ public class ReviewPurgeService {
   private record DryRunReport(long reviews, int storageObjects) {}
 
   /** What one committed aggregate delete leaves the caller to finish: the title and the keys. */
-  private record PurgedAggregate(String title, Set<String> storageKeys) {}
 }

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewPurgeServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewPurgeServiceTest.java
@@ -94,6 +94,18 @@ class ReviewPurgeServiceTest {
   @BeforeEach
   void setUp() {
     when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+    // The real deletion service over the same mocks (issue #421): the sweep
+    // delegates to it, so the assertions below still watch the storage calls the
+    // sweep is responsible for.
+    ReviewDeletionService deletions =
+        new ReviewDeletionService(
+            documents,
+            versions,
+            attachments,
+            auditEvents,
+            org.mockito.Mockito.mock(io.qnop.service.document.DocumentAccessService.class),
+            storage,
+            transactionManager);
     service =
         new ReviewPurgeService(
             scheduler,
@@ -102,7 +114,7 @@ class ReviewPurgeServiceTest {
             attachments,
             auditEvents,
             settings,
-            storage,
+            deletions,
             transactionManager);
     when(settings.getInteger(ApplicationSettingKey.REVIEW_PURGE_ARCHIVED_AFTER_DAYS))
         .thenReturn(180);

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewPurgeServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewPurgeServiceTest.java
@@ -105,6 +105,7 @@ class ReviewPurgeServiceTest {
             auditEvents,
             org.mockito.Mockito.mock(io.qnop.service.document.DocumentAccessService.class),
             storage,
+            org.mockito.Mockito.mock(org.springframework.context.ApplicationEventPublisher.class),
             transactionManager);
     service =
         new ReviewPurgeService(

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -222,6 +222,25 @@ export function useArchiveReview(documentId: string) {
   return { archive, unarchive };
 }
 
+/**
+ * Deleting a review for good (issue #421) — ADMIN only, and there is no undo.
+ *
+ * <p>Invalidates the lists rather than patching them: after this the review is
+ * not stale, it is gone, and every cached page that mentioned it is wrong.
+ */
+export function useDeleteReview(documentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      await documentsApi.deleteDocument({ documentId });
+    },
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: documentKeys.detail(documentId) });
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+    },
+  });
+}
+
 export interface UploadResult {
   documentId: string;
   versionNumber: number;

--- a/qnop-ui/src/components/notifications/NotificationTypeIcon.tsx
+++ b/qnop-ui/src/components/notifications/NotificationTypeIcon.tsx
@@ -26,6 +26,7 @@ import {
   GitBranch,
   MessageSquare,
   MessageSquarePlus,
+  Trash2,
   UserPlus,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
@@ -43,6 +44,7 @@ const ICONS: Record<NotificationType, LucideIcon> = {
   [NotificationType.CommentAdded]: MessageSquare,
   [NotificationType.VersionUploaded]: FileUp,
   [NotificationType.WorkflowChanged]: GitBranch,
+  [NotificationType.ReviewDeleted]: Trash2,
 };
 
 export function NotificationTypeIcon({

--- a/qnop-ui/src/components/notifications/notificationMeta.ts
+++ b/qnop-ui/src/components/notifications/notificationMeta.ts
@@ -39,6 +39,7 @@ const LABELS: Record<NotificationType, string> = {
   [NotificationType.CommentAdded]: 'Reply',
   [NotificationType.VersionUploaded]: 'New version',
   [NotificationType.WorkflowChanged]: 'Workflow',
+  [NotificationType.ReviewDeleted]: 'Review deleted',
 };
 
 /** Index into the brand's avatar ramp — see `tokens.ts`. */
@@ -50,6 +51,9 @@ const TONE_INDEX: Record<NotificationType, number> = {
   [NotificationType.CommentAdded]: 6, // mid blue — the conversation continues
   [NotificationType.VersionUploaded]: 3, // amber — the document itself moved
   [NotificationType.WorkflowChanged]: 7, // slate — a state change, not a person
+  // Red, the only one: everything else in this inbox reports work moving along,
+  // and this reports work that is gone (issue #421).
+  [NotificationType.ReviewDeleted]: 4,
 };
 
 export function notificationLabel(type: NotificationType): string {

--- a/qnop-ui/src/components/reviews/DeleteReviewDialog.test.tsx
+++ b/qnop-ui/src/components/reviews/DeleteReviewDialog.test.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { buildTheme } from '../../theme/theme';
+import { DeleteReviewDialog } from './DeleteReviewDialog';
+import { documentsApi } from '../../api/config';
+
+vi.mock('../../api/config', () => ({
+  documentsApi: { deleteDocument: vi.fn() },
+  axiosInstance: { get: vi.fn(), post: vi.fn() },
+}));
+
+const DOC_ID = '3f6f6f6f-0000-0000-0000-000000000001';
+const TITLE = 'Vendor agreement 2026';
+
+const onClose = vi.fn();
+const onDeleted = vi.fn();
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={buildTheme('light')}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderDialog(open = true) {
+  return render(
+    <DeleteReviewDialog
+      documentId={DOC_ID}
+      title={TITLE}
+      open={open}
+      onClose={onClose}
+      versionCount={3}
+      annotationCount={12}
+      onDeleted={onDeleted}
+    />,
+    { wrapper },
+  );
+}
+
+const deleteButton = () => screen.getByRole('button', { name: /Delete permanently/ });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DeleteReviewDialog', () => {
+  it('refuses to arm until the title is typed exactly', () => {
+    renderDialog();
+
+    // A confirm button alone would not survive an admin working down a list of
+    // look-alike reviews; there is no undo behind this one (issue #421).
+    expect(deleteButton()).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('delete-confirm-input'), {
+      target: { value: 'Vendor agreement' },
+    });
+    expect(deleteButton()).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('delete-confirm-input'), { target: { value: TITLE } });
+    expect(deleteButton()).toBeEnabled();
+  });
+
+  it('says what the deletion takes, in numbers', () => {
+    renderDialog();
+
+    // "This cannot be undone" is a warning; "3 versions and 12 annotations" is
+    // information the reader can weigh.
+    expect(screen.getByText(/3 versions and 12 annotations/)).toBeInTheDocument();
+    expect(screen.getByText(/cannot be undone/)).toBeInTheDocument();
+  });
+
+  it('names archiving as the reversible alternative', () => {
+    renderDialog();
+
+    // The owner's tool. Offering it here is what keeps deletion from being used
+    // as a tidy-up for something that only needed hiding.
+    expect(screen.getByText(/use Archive/)).toBeInTheDocument();
+  });
+
+  it('deletes once confirmed and reports back', async () => {
+    vi.mocked(documentsApi.deleteDocument).mockResolvedValue({ data: undefined } as never);
+    renderDialog();
+
+    fireEvent.change(screen.getByTestId('delete-confirm-input'), { target: { value: TITLE } });
+    fireEvent.click(deleteButton());
+
+    await waitFor(() => expect(onDeleted).toHaveBeenCalled());
+    expect(documentsApi.deleteDocument).toHaveBeenCalledWith({ documentId: DOC_ID });
+  });
+
+  it('keeps the dialog open when the server refuses', async () => {
+    vi.mocked(documentsApi.deleteDocument).mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 403, data: { code: 'FORBIDDEN', detail: 'only admins may delete' } },
+    });
+    renderDialog();
+
+    fireEvent.change(screen.getByTestId('delete-confirm-input'), { target: { value: TITLE } });
+    fireEvent.click(deleteButton());
+
+    // The shared helper deliberately does not surface raw server detail; what
+    // matters here is that the dialog stays put with the typed confirmation
+    // intact, so the reader can see what failed and retry.
+    expect(await screen.findByText(/could not be deleted/)).toBeInTheDocument();
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
+  it('forgets what was typed when it is reopened', () => {
+    const { rerender } = renderDialog();
+    fireEvent.change(screen.getByTestId('delete-confirm-input'), { target: { value: TITLE } });
+    expect(deleteButton()).toBeEnabled();
+
+    rerender(
+      <DeleteReviewDialog
+        documentId={DOC_ID}
+        title={TITLE}
+        open={false}
+        onClose={onClose}
+        onDeleted={onDeleted}
+      />,
+    );
+    rerender(
+      <DeleteReviewDialog
+        documentId={DOC_ID}
+        title={TITLE}
+        open
+        onClose={onClose}
+        onDeleted={onDeleted}
+      />,
+    );
+
+    // Otherwise an abandoned attempt leaves the next review one click from gone.
+    expect(deleteButton()).toBeDisabled();
+  });
+});

--- a/qnop-ui/src/components/reviews/DeleteReviewDialog.tsx
+++ b/qnop-ui/src/components/reviews/DeleteReviewDialog.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { Trash2 } from 'lucide-react';
+import { useDeleteReview } from '../../api/hooks/useReviews';
+import { apiErrorMessage } from '../../utils/apiError';
+
+interface DeleteReviewDialogProps {
+  documentId: string;
+  title: string;
+  open: boolean;
+  onClose: () => void;
+  /** What the deletion will take with it, so the reader can weigh it. */
+  versionCount?: number;
+  annotationCount?: number;
+  onDeleted: () => void;
+}
+
+/** Plural-aware "3 versions" / "1 version". */
+function count(value: number, noun: string): string {
+  return `${value} ${noun}${value === 1 ? '' : 's'}`;
+}
+
+/**
+ * Confirming the deletion of a review (issue #421).
+ *
+ * <p>The title has to be typed. That is heavier than a confirm button on purpose: this destroys
+ * other people's annotations and discussions along with the document, there is no undo and no
+ * recycle bin, and the admins who can do it are the same people working through a list of
+ * look-alike reviews. A misclick has to be impossible, not merely unlikely.
+ *
+ * <p>It also says what goes, in numbers. "This cannot be undone" is a warning; "3 versions and 12
+ * annotations" is information.
+ */
+export function DeleteReviewDialog({
+  documentId,
+  title,
+  open,
+  onClose,
+  versionCount,
+  annotationCount,
+  onDeleted,
+}: DeleteReviewDialogProps) {
+  const [typed, setTyped] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [wasOpen, setWasOpen] = useState(open);
+  const remove = useDeleteReview(documentId);
+
+  // Reset the draft each time it opens, so a previous attempt's typing can never
+  // arm the button for a different review.
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setTyped('');
+      setError(null);
+    }
+  }
+
+  const confirmed = typed.trim() === title.trim();
+  const pending = remove.isPending;
+
+  const scope = [
+    versionCount === undefined ? null : count(versionCount, 'version'),
+    annotationCount === undefined ? null : count(annotationCount, 'annotation'),
+  ].filter(Boolean);
+
+  const handleDelete = () => {
+    remove.mutate(undefined, {
+      onSuccess: onDeleted,
+      onError: (deleteError) =>
+        setError(apiErrorMessage(deleteError, 'The review could not be deleted.')),
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={pending ? undefined : onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Delete this review?</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2}>
+          <Typography variant="body2" color="text.secondary">
+            <strong>{title}</strong>
+            {scope.length > 0 && <> and its {scope.join(' and ')}</>} will be removed permanently,
+            for everyone. This cannot be undone.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            To archive it instead — reversible, and it keeps the record — close this and use
+            Archive.
+          </Typography>
+          <TextField
+            label="Type the review title to confirm"
+            value={typed}
+            onChange={(event) => setTyped(event.target.value)}
+            disabled={pending}
+            autoComplete="off"
+            fullWidth
+            size="small"
+            slotProps={{ htmlInput: { 'data-testid': 'delete-confirm-input' } }}
+          />
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={pending} color="inherit">
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          startIcon={<Trash2 size={16} />}
+          disabled={!confirmed || pending}
+          onClick={handleDelete}
+        >
+          {pending ? 'Deleting…' : 'Delete permanently'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/reviews/DeleteReviewsDialog.tsx
+++ b/qnop-ui/src/components/reviews/DeleteReviewsDialog.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import LinearProgress from '@mui/material/LinearProgress';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { Trash2 } from 'lucide-react';
+import { documentsApi } from '../../api/config';
+import { useQueryClient } from '@tanstack/react-query';
+import { documentKeys } from '../../api/hooks/useDocuments';
+import { reviewKeys } from '../../api/hooks/useReviews';
+import { apiErrorMessage } from '../../utils/apiError';
+
+/** What the caller must type to arm the button. */
+export const BULK_DELETE_PHRASE = 'delete';
+
+export interface DeletableReview {
+  id: string;
+  title: string;
+}
+
+interface DeleteReviewsDialogProps {
+  reviews: DeletableReview[];
+  open: boolean;
+  onClose: () => void;
+  /** Called with how many actually went, so the caller can report and re-select. */
+  onDeleted: (deletedIds: string[]) => void;
+}
+
+/**
+ * Confirming the deletion of several reviews at once (issue #421).
+ *
+ * <p>The single-review dialog has the admin type that review's title. Typing a dozen titles would
+ * be theatre, so this one names every review it will destroy and asks for one deliberate word. The
+ * list is the part that matters: a selection made across a filtered, paged listing is easy to
+ * misjudge, and seeing the titles is what catches the row that should not be there.
+ *
+ * <p>There is no bulk endpoint behind it. Each review is deleted on its own, so one refusal — a
+ * review someone removed in the meantime, a permission that changed — costs that review and not the
+ * rest, and the dialog can say exactly which ones survived.
+ */
+export function DeleteReviewsDialog({
+  reviews,
+  open,
+  onClose,
+  onDeleted,
+}: DeleteReviewsDialogProps) {
+  const queryClient = useQueryClient();
+  const [typed, setTyped] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState(0);
+  const [failures, setFailures] = useState<string[]>([]);
+  const [wasOpen, setWasOpen] = useState(open);
+
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setTyped('');
+      setBusy(false);
+      setDone(0);
+      setFailures([]);
+    }
+  }
+
+  const confirmed = typed.trim().toLowerCase() === BULK_DELETE_PHRASE;
+
+  const handleDelete = async () => {
+    setBusy(true);
+    setFailures([]);
+    const deleted: string[] = [];
+    const failed: string[] = [];
+    for (const review of reviews) {
+      try {
+        await documentsApi.deleteDocument({ documentId: review.id });
+        deleted.push(review.id);
+      } catch (error) {
+        failed.push(`${review.title}: ${apiErrorMessage(error, 'could not be deleted')}`);
+      }
+      setDone((count) => count + 1);
+    }
+    // One invalidation at the end rather than per review: the list would
+    // otherwise refetch a dozen times while the dialog is still working.
+    deleted.forEach((id) => queryClient.removeQueries({ queryKey: documentKeys.detail(id) }));
+    queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+    setBusy(false);
+    if (failed.length > 0) {
+      // Kept open on a partial failure: closing would report success for a job
+      // that was only mostly done.
+      setFailures(failed);
+      onDeleted(deleted);
+      return;
+    }
+    onDeleted(deleted);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={busy ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        Delete {reviews.length} review{reviews.length === 1 ? '' : 's'}?
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={2}>
+          <Typography variant="body2" color="text.secondary">
+            These will be removed permanently, for everyone — every version, annotation and
+            discussion in them. This cannot be undone. To keep the record instead, close this and
+            archive them.
+          </Typography>
+
+          <Paper variant="outlined" sx={{ maxHeight: 220, overflowY: 'auto' }}>
+            <List dense disablePadding data-testid="bulk-delete-list">
+              {reviews.map((review) => (
+                <ListItem key={review.id} divider>
+                  <ListItemText
+                    primary={review.title}
+                    slotProps={{ primary: { variant: 'body2', noWrap: true } }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Paper>
+
+          <TextField
+            label={`Type "${BULK_DELETE_PHRASE}" to confirm`}
+            value={typed}
+            onChange={(event) => setTyped(event.target.value)}
+            disabled={busy}
+            autoComplete="off"
+            fullWidth
+            size="small"
+            slotProps={{ htmlInput: { 'data-testid': 'bulk-delete-confirm-input' } }}
+          />
+
+          {busy && (
+            <Stack spacing={0.75}>
+              <LinearProgress
+                variant="determinate"
+                value={Math.round((done / reviews.length) * 100)}
+              />
+              <Typography variant="caption" color="text.secondary">
+                Deleting… {done} of {reviews.length}
+              </Typography>
+            </Stack>
+          )}
+
+          {failures.length > 0 && (
+            <Alert severity="error">
+              {/* Named, not counted: "3 failed" leaves the reader to work out which. */}
+              <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                {failures.length} of {reviews.length} could not be deleted
+              </Typography>
+              {failures.map((failure) => (
+                <Typography key={failure} variant="caption" component="div">
+                  {failure}
+                </Typography>
+              ))}
+            </Alert>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={busy} color="inherit">
+          {failures.length > 0 ? 'Close' : 'Cancel'}
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          startIcon={<Trash2 size={16} />}
+          disabled={!confirmed || busy || reviews.length === 0}
+          onClick={handleDelete}
+        >
+          {busy ? 'Deleting…' : `Delete ${reviews.length} permanently`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.test.tsx
@@ -110,6 +110,7 @@ function renderHub({
   return render(
     <ReviewHubHead
       documentId={DOC_ID}
+      title="NDA Acme Corp"
       ownerId={isOwner ? ME : 'owner-far-away'}
       isOwner={isOwner}
       ownUserId={ME}
@@ -120,6 +121,7 @@ function renderHub({
       archivedAt={archivedAt}
       notify={notify}
       onVersionUploaded={onVersionUploaded}
+      onDeleted={vi.fn()}
     />,
     { wrapper },
   );

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -30,7 +30,7 @@ import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { Archive, CalendarClock, ChevronDown, Upload, UserPlus } from 'lucide-react';
+import { Archive, CalendarClock, ChevronDown, Trash2, Upload, UserPlus } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus, ParticipantKind } from '../../../api/generated';
 import { useConfig } from '../../../api/hooks/useConfig';
@@ -40,7 +40,7 @@ import {
   useTransitionWorkflow,
   useWorkflow,
 } from '../../../api/hooks/useReviews';
-import { useAuthStore } from '../../../stores/authStore';
+import { selectIsAdmin, useAuthStore } from '../../../stores/authStore';
 import { ConfirmDialog } from '../../admin/ConfirmDialog';
 import type { Notify } from '../../admin/layout/useToast';
 import { UserHoverCard } from '../../people/UserHoverCard';
@@ -53,6 +53,7 @@ import { isOpenWorkflowState, workflowLabel } from '../workflowMeta';
 import { acceptedUploads } from '../wizard/wizardModel';
 import { apiErrorCode, apiErrorMessage } from '../../../utils/apiError';
 import { DueDateDialog } from './DueDateDialog';
+import { DeleteReviewDialog } from '../DeleteReviewDialog';
 import { NewVersionDialog } from './NewVersionDialog';
 import { ParticipantsDialog } from './ParticipantsDialog';
 
@@ -67,6 +68,8 @@ const TRANSITION_CONFLICTS: Record<string, string> = {
 
 interface ReviewHubHeadProps {
   documentId: string;
+  /** The review's title — typed back by the admin to confirm a deletion (issue #421). */
+  title: string;
   /** The document owner — shown prominently in the header (issue #403). */
   ownerId: string;
   /** The owner's profile slug (issue #486) — structurally public (#472). */
@@ -87,6 +90,8 @@ interface ReviewHubHeadProps {
   notify: Notify;
   /** Called with the new version number after a successful re-upload. */
   onVersionUploaded: (versionNumber: number) => void;
+  /** Called once the review has been deleted; there is nothing left to show (issue #421). */
+  onDeleted: () => void;
 }
 
 /**
@@ -97,6 +102,7 @@ interface ReviewHubHeadProps {
  */
 export function ReviewHubHead({
   documentId,
+  title,
   ownerId,
   ownerSlug,
   ownerDisplayName,
@@ -109,14 +115,17 @@ export function ReviewHubHead({
   archivedAt,
   notify,
   onVersionUploaded,
+  onDeleted,
 }: ReviewHubHeadProps) {
   const theme = useTheme();
   const [participantsOpen, setParticipantsOpen] = useState(false);
   const [newVersionOpen, setNewVersionOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const [dueDateOpen, setDueDateOpen] = useState(false);
   const [workflowMenuAnchor, setWorkflowMenuAnchor] = useState<HTMLElement | null>(null);
   const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
 
+  const isAdmin = useAuthStore(selectIsAdmin);
   const { data: config } = useConfig();
   const participantsQuery = useParticipants(documentId);
   const workflowQuery = useWorkflow(documentId);
@@ -394,6 +403,20 @@ export function ReviewHubHead({
         </Button>
       )}
 
+      {isAdmin && (
+        // Deleting is the admin's alone (issue #421): the owner's tool beside it
+        // is Archive, which is reversible and keeps the record.
+        <Button
+          size="small"
+          variant="outlined"
+          color="error"
+          startIcon={<Trash2 size={14} />}
+          onClick={() => setDeleteOpen(true)}
+        >
+          Delete
+        </Button>
+      )}
+
       {isOwner && (
         <>
           <Button
@@ -406,6 +429,15 @@ export function ReviewHubHead({
           </Button>
         </>
       )}
+
+      <DeleteReviewDialog
+        documentId={documentId}
+        title={title}
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        annotationCount={annotations.length}
+        onDeleted={onDeleted}
+      />
 
       <NewVersionDialog
         documentId={documentId}

--- a/qnop-ui/src/components/reviews/hub/ReviewPageHeader.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewPageHeader.tsx
@@ -39,6 +39,8 @@ interface ReviewPageHeaderProps {
   notify: Notify;
   /** Where to go after a successful new-version upload — the page decides. */
   onVersionUploaded: (versionNumber: number) => void;
+  /** Called once the review has been deleted — the page has nothing left to show (#421). */
+  onDeleted: () => void;
 }
 
 /**
@@ -54,6 +56,7 @@ export function ReviewPageHeader({
   annotations,
   notify,
   onVersionUploaded,
+  onDeleted,
 }: ReviewPageHeaderProps) {
   const documentId = useReviewDocumentId();
   const userId = useAuthStore((s) => s.userId);
@@ -76,6 +79,7 @@ export function ReviewPageHeader({
       action={
         <ReviewHubHead
           documentId={documentId}
+          title={document.title}
           ownerId={document.ownerId}
           ownerSlug={document.ownerSlug}
           ownerDisplayName={document.ownerDisplayName}
@@ -88,6 +92,7 @@ export function ReviewPageHeader({
           archivedAt={document.archivedAt ?? null}
           notify={notify}
           onVersionUploaded={onVersionUploaded}
+          onDeleted={onDeleted}
         />
       }
     />

--- a/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
@@ -29,7 +29,9 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
-import { ChevronRight } from 'lucide-react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { ChevronRight, Trash2 } from 'lucide-react';
 import type { DocumentSummary } from '../../../api/generated';
 import { useFormatters } from '../../../hooks/useFormatters';
 import { DueDateLabel } from '../DueDateLabel';
@@ -44,10 +46,15 @@ interface ReviewsTableProps {
   reviews: DocumentSummary[];
   userId: string | null;
   onOpen: (documentId: string) => void;
+  /**
+   * Offers a per-row delete (issue #421). Set only in the admin's moderation
+   * listing, which is where the reviews nobody wants are actually found.
+   */
+  onDelete?: (review: DocumentSummary) => void;
 }
 
 /** The overview's table view (prototype `reviews.jsx`): dense, scannable rows. */
-export function ReviewsTable({ reviews, userId, onOpen }: ReviewsTableProps) {
+export function ReviewsTable({ reviews, userId, onOpen, onDelete }: ReviewsTableProps) {
   const theme = useTheme();
   const { formatRelative } = useFormatters();
   return (
@@ -169,7 +176,23 @@ export function ReviewsTable({ reviews, userId, onOpen }: ReviewsTableProps) {
                       {formatRelative(review.updatedAt)}
                     </Typography>
                   </TableCell>
-                  <TableCell align="right" sx={{ color: 'text.secondary' }}>
+                  <TableCell align="right" sx={{ color: 'text.secondary', whiteSpace: 'nowrap' }}>
+                    {onDelete && (
+                      <Tooltip title="Delete permanently">
+                        <IconButton
+                          size="small"
+                          color="error"
+                          aria-label={`Delete ${review.title}`}
+                          onClick={(event) => {
+                            // The row itself opens the review; this must not.
+                            event.stopPropagation();
+                            onDelete(review);
+                          }}
+                        >
+                          <Trash2 size={15} />
+                        </IconButton>
+                      </Tooltip>
+                    )}
                     <ChevronRight size={16} aria-hidden />
                   </TableCell>
                 </TableRow>

--- a/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
@@ -29,6 +29,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
+import Checkbox from '@mui/material/Checkbox';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { ChevronRight, Trash2 } from 'lucide-react';
@@ -47,22 +48,52 @@ interface ReviewsTableProps {
   userId: string | null;
   onOpen: (documentId: string) => void;
   /**
-   * Offers a per-row delete (issue #421). Set only in the admin's moderation
-   * listing, which is where the reviews nobody wants are actually found.
+   * Offers a per-row delete (issue #421). Set only for admins, the only role that
+   * may destroy a review.
    */
   onDelete?: (review: DocumentSummary) => void;
+  /**
+   * Turns on row selection for bulk actions (issue #421). Absent means no
+   * checkbox column at all, rather than a disabled one nobody can use.
+   */
+  selectedIds?: ReadonlySet<string>;
+  onToggleSelected?: (documentId: string) => void;
+  onToggleAll?: () => void;
 }
 
 /** The overview's table view (prototype `reviews.jsx`): dense, scannable rows. */
-export function ReviewsTable({ reviews, userId, onOpen, onDelete }: ReviewsTableProps) {
+export function ReviewsTable({
+  reviews,
+  userId,
+  onOpen,
+  onDelete,
+  selectedIds,
+  onToggleSelected,
+  onToggleAll,
+}: ReviewsTableProps) {
   const theme = useTheme();
   const { formatRelative } = useFormatters();
+  const selectable = selectedIds !== undefined && onToggleSelected !== undefined;
+  const selectedHere = selectable ? reviews.filter((r) => selectedIds.has(r.id)).length : 0;
   return (
     <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
       <Box sx={{ overflowX: 'auto' }}>
         <Table size="small" sx={{ minWidth: 720 }}>
           <TableHead>
             <TableRow sx={{ bgcolor: theme.qnop.surface2 }}>
+              {selectable && (
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    size="small"
+                    // Indeterminate says "some of these", which is the honest state
+                    // when a page is partly selected.
+                    checked={selectedHere > 0 && selectedHere === reviews.length}
+                    indeterminate={selectedHere > 0 && selectedHere < reviews.length}
+                    onChange={onToggleAll}
+                    slotProps={{ input: { 'aria-label': 'Select every review on this page' } }}
+                  />
+                </TableCell>
+              )}
               {[
                 'Document',
                 'Role',
@@ -99,8 +130,21 @@ export function ReviewsTable({ reviews, userId, onOpen, onDelete }: ReviewsTable
                   hover
                   onClick={() => onOpen(review.slug ?? review.id)}
                   data-testid={`review-row-${review.id}`}
+                  selected={selectable && selectedIds.has(review.id)}
                   sx={{ cursor: 'pointer', '&:last-child td': { borderBottom: 0 } }}
                 >
+                  {selectable && (
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        size="small"
+                        checked={selectedIds.has(review.id)}
+                        // The row opens the review; ticking it must not.
+                        onClick={(event) => event.stopPropagation()}
+                        onChange={() => onToggleSelected(review.id)}
+                        slotProps={{ input: { 'aria-label': `Select ${review.title}` } }}
+                      />
+                    </TableCell>
+                  )}
                   <TableCell sx={{ py: 1.5 }}>
                     <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
                       <DocumentIcon contentType={review.contentType} />

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -113,6 +113,7 @@ export function DocumentReviewPage() {
   // The raw segment may be a slug (issue #411) — sibling links keep it, while
   // all data access below uses the canonical id resolved by the route gate.
   const { documentId: routeSegment = '' } = useParams();
+  const navigate = useNavigate();
   const documentId = useReviewDocumentId();
   const [searchParams, setSearchParams] = useSearchParams();
   const { toast, notify, clear } = useToast();
@@ -480,6 +481,7 @@ export function DocumentReviewPage() {
         annotations={annotations}
         notify={notify}
         onVersionUploaded={handleVersionChange}
+        onDeleted={() => navigate('/reviews')}
       />
       <ReviewViewTabs
         documentId={routeSegment}

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.tsx
@@ -233,6 +233,7 @@ export function ReviewTasksPage() {
         document={document}
         annotations={annotations}
         notify={notify}
+        onDeleted={() => navigate('/reviews')}
         onVersionUploaded={goToNewVersion}
       />
       <ReviewViewTabs

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -22,6 +22,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import type { DocumentSummary } from '../../api/generated';
 import { ParticipantKind } from '../../api/generated';
@@ -106,16 +107,21 @@ function mockReviews(value: Queryish) {
 }
 
 function renderPage(entry = '/reviews') {
+  // The page lives inside one in the app; the dialogs it opens use the cache to
+  // invalidate the lists after a deletion (issue #421).
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <ThemeProvider theme={buildTheme('light')}>
-      <MemoryRouter initialEntries={[entry]}>
-        <Routes>
-          <Route path="/reviews" element={<ReviewsPage />} />
-          <Route path="/reviews/new" element={<div data-testid="new-review-probe" />} />
-          <Route path="/reviews/:documentId" element={<div data-testid="detail-probe" />} />
-        </Routes>
-      </MemoryRouter>
-    </ThemeProvider>,
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <MemoryRouter initialEntries={[entry]}>
+          <Routes>
+            <Route path="/reviews" element={<ReviewsPage />} />
+            <Route path="/reviews/new" element={<div data-testid="new-review-probe" />} />
+            <Route path="/reviews/:documentId" element={<div data-testid="detail-probe" />} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
   );
 }
 
@@ -695,6 +701,60 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
     // The page holds one row owned by one person; the facet still offers both,
     // because it comes from the server.
     expect(screen.getByText('Nobody On This Page')).toBeInTheDocument();
+  });
+
+  it('selects rows and offers to delete them together', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+
+    renderPage();
+
+    // No selection, no bar: an empty toolbar taking up room says nothing.
+    expect(screen.queryByTestId('bulk-actions')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select NDA Acme Corp' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Architecture handbook' }));
+
+    const bar = screen.getByTestId('bulk-actions');
+    expect(within(bar).getByText('2 selected')).toBeInTheDocument();
+    expect(within(bar).getByRole('button', { name: /Delete selected \(2\)/ })).toBeEnabled();
+  });
+
+  it('names every review the bulk delete would take', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+
+    renderPage();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select NDA Acme Corp' }));
+    fireEvent.click(screen.getByRole('button', { name: /Delete selected/ }));
+
+    // A selection made across a filtered listing is easy to misjudge; the titles
+    // are what catch the row that should not be there (issue #421).
+    const list = screen.getByTestId('bulk-delete-list');
+    expect(within(list).getByText('NDA Acme Corp')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete 1 permanently/ })).toBeDisabled();
+  });
+
+  it('selects and clears every row on the page at once', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'ADMIN' });
+
+    renderPage();
+    const all = screen.getByRole('checkbox', { name: 'Select every review on this page' });
+    fireEvent.click(all);
+    // Three of the four fixtures are live work; the archived one is not shown by
+    // default, so "every row on this page" means exactly what is on screen.
+    expect(within(screen.getByTestId('bulk-actions')).getByText('3 selected')).toBeInTheDocument();
+
+    fireEvent.click(all);
+    expect(screen.queryByTestId('bulk-actions')).not.toBeInTheDocument();
+  });
+
+  it('offers no selection to someone who may not delete', () => {
+    useAuthStore.setState({ userId: ME, isAuthenticated: true, role: 'MEMBER' });
+
+    renderPage();
+
+    // Deleting is admin-only, so a checkbox column would promise something the
+    // server refuses.
+    expect(screen.queryByRole('checkbox', { name: /^Select / })).not.toBeInTheDocument();
   });
 
   it('says which slice of the workspace is on screen', () => {

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -35,8 +35,9 @@ import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
+import { alpha } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import { LayoutGrid, ListFilter, Plus, Rows3 } from 'lucide-react';
+import { LayoutGrid, ListFilter, Plus, Rows3, Trash2 } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router';
 import type { DocumentSummary } from '../../api/generated';
 import { useReviews } from '../../api/hooks/useReviews';
@@ -49,6 +50,7 @@ import { roleOf } from '../../components/reviews/list/reviewListModel';
 import { ReviewCards } from '../../components/reviews/list/ReviewCards';
 import { ReviewsTable } from '../../components/reviews/list/ReviewsTable';
 import { DeleteReviewDialog } from '../../components/reviews/DeleteReviewDialog';
+import { DeleteReviewsDialog } from '../../components/reviews/DeleteReviewsDialog';
 import { ReviewsEmptyState } from './ReviewsEmptyState';
 import { selectIsAdmin, useAuthStore } from '../../stores/authStore';
 
@@ -376,6 +378,10 @@ export function ReviewsPage() {
   const moderating = isAdmin && searchParams.get('participation') === 'all';
   const [serverPage, setServerPage] = useState(0);
   const [pendingDelete, setPendingDelete] = useState<DocumentSummary | null>(null);
+  // Selection for bulk deletion (issue #421). Admin-only, because deleting is;
+  // by id rather than by row, so it survives a re-render or a refetch.
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set());
+  const [bulkOpen, setBulkOpen] = useState(false);
   // Moderation searches the SERVER, so it waits for a pause in typing the way the
   // admin lists do; the participant-scoped view keeps filtering as you type
   // because it already holds its rows.
@@ -553,6 +559,30 @@ export function ReviewsPage() {
   const hasActiveFilters =
     query !== '' || roleFilter !== 'all' || statusFilter !== 'active' || advancedCount > 0;
 
+  const toggleSelected = (documentId: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (!next.delete(documentId)) {
+        next.add(documentId);
+      }
+      return next;
+    });
+  };
+
+  /** Selects every row currently shown, or clears them if they all already are. */
+  const toggleAllOnPage = () => {
+    setSelectedIds((current) => {
+      const shown = visible.map((review) => review.id);
+      const allSelected = shown.length > 0 && shown.every((id) => current.has(id));
+      const next = new Set(current);
+      shown.forEach((id) => (allSelected ? next.delete(id) : next.add(id)));
+      return next;
+    });
+  };
+
+  /** The selected rows that are actually on screen, in the order they appear. */
+  const selectedReviews = visible.filter((review) => selectedIds.has(review.id));
+
   const changeView = (next: ViewMode | null) => {
     if (!next) return;
     setView(next);
@@ -632,6 +662,23 @@ export function ReviewsPage() {
         </Stack>
       )}
 
+      {bulkOpen && (
+        <DeleteReviewsDialog
+          reviews={selectedReviews.map((review) => ({ id: review.id, title: review.title }))}
+          open
+          onClose={() => setBulkOpen(false)}
+          onDeleted={(deletedIds) => {
+            // Only the ones that actually went: a partial failure leaves the rest
+            // selected, so the retry is one click rather than a fresh hunt.
+            setSelectedIds((current) => {
+              const next = new Set(current);
+              deletedIds.forEach((id) => next.delete(id));
+              return next;
+            });
+          }}
+        />
+      )}
+
       {pendingDelete && (
         <DeleteReviewDialog
           documentId={pendingDelete.id}
@@ -704,6 +751,42 @@ export function ReviewsPage() {
               </ToggleButton>
             </ToggleButtonGroup>
           </Stack>
+
+          {selectedReviews.length > 0 && (
+            // Replaces the facet row while a selection is live: the chips would
+            // change what is on screen underneath a selection made against it.
+            <Stack
+              direction="row"
+              spacing={1.5}
+              data-testid="bulk-actions"
+              sx={{
+                alignItems: 'center',
+                px: 2,
+                py: 1,
+                borderRadius: 1.5,
+                bgcolor: (t) => alpha(t.palette.primary.main, 0.06),
+                border: '1px solid',
+                borderColor: 'primary.main',
+              }}
+            >
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {selectedReviews.length} selected
+              </Typography>
+              <Button size="small" color="inherit" onClick={() => setSelectedIds(new Set())}>
+                Clear
+              </Button>
+              <Box sx={{ flex: 1 }} />
+              <Button
+                size="small"
+                variant="outlined"
+                color="error"
+                startIcon={<Trash2 size={15} />}
+                onClick={() => setBulkOpen(true)}
+              >
+                Delete selected ({selectedReviews.length})
+              </Button>
+            </Stack>
+          )}
 
           <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
             <FilterChip
@@ -813,9 +896,12 @@ export function ReviewsPage() {
               reviews={visible}
               userId={userId}
               onOpen={openReview}
-              // Only while moderating: deleting is the admin's, and this listing
-              // is where the abandoned reviews are found (issues #421/#563).
-              onDelete={moderating ? setPendingDelete : undefined}
+              // Admin-only, in both listings: deleting is theirs wherever they
+              // find the review (issues #421/#563).
+              onDelete={isAdmin ? setPendingDelete : undefined}
+              selectedIds={isAdmin ? selectedIds : undefined}
+              onToggleSelected={isAdmin ? toggleSelected : undefined}
+              onToggleAll={isAdmin ? toggleAllOnPage : undefined}
             />
           ) : (
             <ReviewCards reviews={visible} userId={userId} onOpen={openReview} />

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -48,6 +48,7 @@ import { isOpenWorkflowState, workflowLabel } from '../../components/reviews/wor
 import { roleOf } from '../../components/reviews/list/reviewListModel';
 import { ReviewCards } from '../../components/reviews/list/ReviewCards';
 import { ReviewsTable } from '../../components/reviews/list/ReviewsTable';
+import { DeleteReviewDialog } from '../../components/reviews/DeleteReviewDialog';
 import { ReviewsEmptyState } from './ReviewsEmptyState';
 import { selectIsAdmin, useAuthStore } from '../../stores/authStore';
 
@@ -374,6 +375,7 @@ export function ReviewsPage() {
   // the rest, default off so an admin's own work is not drowned out.
   const moderating = isAdmin && searchParams.get('participation') === 'all';
   const [serverPage, setServerPage] = useState(0);
+  const [pendingDelete, setPendingDelete] = useState<DocumentSummary | null>(null);
   // Moderation searches the SERVER, so it waits for a pause in typing the way the
   // admin lists do; the participant-scoped view keeps filtering as you type
   // because it already holds its rows.
@@ -630,6 +632,18 @@ export function ReviewsPage() {
         </Stack>
       )}
 
+      {pendingDelete && (
+        <DeleteReviewDialog
+          documentId={pendingDelete.id}
+          title={pendingDelete.title}
+          open
+          onClose={() => setPendingDelete(null)}
+          versionCount={pendingDelete.latestVersionNumber}
+          annotationCount={pendingDelete.annotationCount}
+          onDeleted={() => setPendingDelete(null)}
+        />
+      )}
+
       {data && nothingAtAll && (
         <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
           {participationToggle}
@@ -795,7 +809,14 @@ export function ReviewsPage() {
               )}
             </Paper>
           ) : view === 'table' ? (
-            <ReviewsTable reviews={visible} userId={userId} onOpen={openReview} />
+            <ReviewsTable
+              reviews={visible}
+              userId={userId}
+              onOpen={openReview}
+              // Only while moderating: deleting is the admin's, and this listing
+              // is where the abandoned reviews are found (issues #421/#563).
+              onDelete={moderating ? setPendingDelete : undefined}
+            />
           ) : (
             <ReviewCards reviews={visible} userId={userId} onOpen={openReview} />
           )}

--- a/qnop-ui/src/pages/reviews/ReviewsPage.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.tsx
@@ -619,6 +619,9 @@ export function ReviewsPage() {
       value={moderating ? 'all' : 'mine'}
       onChange={(_e, next: string | null) => next && setModerating(next === 'all')}
       aria-label="Which reviews"
+      // Two words per button, never two lines: wrapped labels read as a broken
+      // control, and this row gets crowded once a selection joins it.
+      sx={{ flexShrink: 0, '& .MuiToggleButton-root': { whiteSpace: 'nowrap' } }}
     >
       <ToggleButton value="mine" data-testid="participation-mine">
         My reviews
@@ -705,15 +708,66 @@ export function ReviewsPage() {
           <Stack
             direction={{ xs: 'column', md: 'row' }}
             spacing={2}
-            sx={{ alignItems: { md: 'center' } }}
+            // Wraps rather than squeezes: with a selection live there are five
+            // controls in this row, and past a certain width something has to
+            // give. A second line costs nothing; a search field crushed to its
+            // magnifier is no longer a search field.
+            sx={{ alignItems: { md: 'center' }, flexWrap: 'wrap', rowGap: 2 }}
           >
             <ClearableSearchField
               placeholder="Search by title or owner…"
               value={search}
               onValueChange={setSearchAndParam}
-              sx={{ width: { xs: '100%', md: 280 } }}
+              sx={{ width: { xs: '100%', md: 280 }, minWidth: { md: 220 } }}
             />
             {participationToggle}
+
+            {selectedReviews.length > 0 && (
+              // Inline with the toolbar rather than a band of its own: the
+              // selection is a mode of this list, not a separate announcement,
+              // and it reads at the same scale as the controls beside it. The
+              // tinted rule keeps the three parts one unit as the row grows.
+              <Stack
+                direction="row"
+                spacing={1}
+                data-testid="bulk-actions"
+                sx={{
+                  alignItems: 'center',
+                  // The action must stay legible; the neighbours give way first.
+                  flexShrink: 0,
+                  pl: 1.25,
+                  pr: 0.5,
+                  py: 0.25,
+                  borderRadius: 1.5,
+                  bgcolor: (t) => alpha(t.palette.primary.main, 0.07),
+                  border: '1px solid',
+                  borderColor: (t) => alpha(t.palette.primary.main, 0.35),
+                }}
+              >
+                <Typography variant="body2" sx={{ fontWeight: 600, whiteSpace: 'nowrap' }}>
+                  {selectedReviews.length} selected
+                </Typography>
+                <Button
+                  size="small"
+                  color="inherit"
+                  sx={{ minWidth: 0 }}
+                  onClick={() => setSelectedIds(new Set())}
+                >
+                  Clear
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  startIcon={<Trash2 size={15} />}
+                  sx={{ whiteSpace: 'nowrap' }}
+                  onClick={() => setBulkOpen(true)}
+                >
+                  Delete selected ({selectedReviews.length})
+                </Button>
+              </Stack>
+            )}
+
             <Box sx={{ flex: 1 }} />
             <ReviewFilterMenu
               dueFilter={dueFilter}
@@ -730,7 +784,9 @@ export function ReviewsPage() {
               label="Sort"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as SortBy)}
-              sx={{ width: 180 }}
+              // A label truncated to "Re…" is not a control anyone can read; the
+              // search field is the one element that shrinks without cost.
+              sx={{ width: 180, flexShrink: 0 }}
             >
               <MenuItem value="updated">Recently updated</MenuItem>
               <MenuItem value="name">Name</MenuItem>
@@ -751,42 +807,6 @@ export function ReviewsPage() {
               </ToggleButton>
             </ToggleButtonGroup>
           </Stack>
-
-          {selectedReviews.length > 0 && (
-            // Replaces the facet row while a selection is live: the chips would
-            // change what is on screen underneath a selection made against it.
-            <Stack
-              direction="row"
-              spacing={1.5}
-              data-testid="bulk-actions"
-              sx={{
-                alignItems: 'center',
-                px: 2,
-                py: 1,
-                borderRadius: 1.5,
-                bgcolor: (t) => alpha(t.palette.primary.main, 0.06),
-                border: '1px solid',
-                borderColor: 'primary.main',
-              }}
-            >
-              <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                {selectedReviews.length} selected
-              </Typography>
-              <Button size="small" color="inherit" onClick={() => setSelectedIds(new Set())}>
-                Clear
-              </Button>
-              <Box sx={{ flex: 1 }} />
-              <Button
-                size="small"
-                variant="outlined"
-                color="error"
-                startIcon={<Trash2 size={15} />}
-                onClick={() => setBulkOpen(true)}
-              >
-                Delete selected ({selectedReviews.length})
-              </Button>
-            </Stack>
-          )}
 
           <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1 }}>
             <FilterChip

--- a/qnop-ui/src/pages/reviews/VersionComparePage.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.tsx
@@ -166,6 +166,7 @@ export function VersionComparePage() {
         document={document_}
         annotations={annotations}
         notify={notify}
+        onDeleted={() => navigate('/reviews')}
         onVersionUploaded={(versionNumber) =>
           // A new version uploaded from this tab lands on its Document view (issue #571).
           navigate(`/reviews/${routeSegment}?version=${versionNumber}`)


### PR DESCRIPTION
Closes #421.

The open question is settled: **the owner archives, only an admin deletes.**

Archiving is reversible and takes nothing away, so it is the owner's call. Deleting destroys other people's annotations and discussions along with the document, and a review is not the owner's alone merely because they created it. `DELETE /documents/{id}` is ADMIN-only — 403 for a caller who can see the review, 404 for one who cannot.

Half of it was already true: there was no delete endpoint at all, so owners could never delete anything. What was missing is an immediate, targeted deletion; until now an admin had to archive and wait out the retention window, or turn that window down for everyone.

### The destruction is not new code

The retention sweep (ADR-0050) already did it correctly — cascade over the whole aggregate, storage keys collected before the rows are gone, and only objects nothing else references released. That is now `ReviewDeletionService`, called by both. A second delete path is the kind of duplicate where one of the two eventually forgets the storage release and nobody notices for months.

Any workflow state, archived or not: the usual reason to delete is a review that should never have existed, most often still a draft, and archiving requires a closed one — so the detour would be friction rather than safety.

### Confirmation carries the weight

Single review: the admin types its title, and the dialog says what goes in numbers and names Archive as the reversible alternative. Bulk: the dialog names **every** review it would destroy and asks for one deliberate word — typing a dozen titles would be theatre, and the list is what catches the row that should not be there.

The overview offers row selection to admins with the actions inline in the toolbar. There is no bulk endpoint: each review goes on its own, so one refusal costs that review and not the rest, the dialog names which ones survived, and the page keeps them selected so the retry is one click.

### The owner is told

An in-app notification and an e-mail — the gap the maintainer spotted while testing. This notification is unlike every other one, and the schema is why: `notification.document_id` cascades with the document (the purge depends on it and the migration says not to weaken it), so a row naming the deleted review would be deleted in the same statement. It carries no documentId, keeps the title in `excerpt`, and renders without loading anything. Without a branch in the renderer it would have come out as the "a review you no longer have access to" tombstone — hiding the one fact the owner needs.

The admin is not named: actor names elsewhere resolve through the review's identity rules (ADR-0038), and there is no review left to resolve against. The audit trail holds the real actor for anyone entitled to it.

### One silent failure, caught while building

The notification listener is `@TransactionalEventListener(AFTER_COMMIT)` and nothing sets `fallbackExecution`, so an event published outside a transaction is dropped without a word — which the first version did. It now runs in a transaction that exists purely to give the event a commit to ride on, and an IT asserts the row actually lands.

Three toolbar defects came from looking at the row at 900px rather than reasoning about it: a wrapping toggle, a sort label truncated to "Re…", and then a search field crushed to its magnifier. The row wraps now instead of squeezing.

ADR-0050 records the decision and both deliberate differences from the sweep: any state, and a real actor on the surviving audit event.

## Test plan

- [x] `./gradlew build` — Spotless, ArchUnit, full suite
- [x] `pnpm lint` / `format:check` / `typecheck` / `test:run` (1228 tests)
- [x] `ReviewDeletionIT` (8): the whole cascade including the blob, admin-only with the owner refused, **a blob two reviews share surviving the deletion of one**, the surviving audit record, a draft deleted without archiving first, a second delete answering 404, the owner's notification, and no self-notification
- [x] Frontend: 6 dialog tests, 4 selection tests, plus the exhaustive notification-type maps the compiler and an existing test enforced
- [x] Toolbar and both dialogs inspected in a browser at 1280 and 900

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)