### PR TITLE
feat(observability): a diagnostic context, a logging policy, and verbose DEBUG tracing (#659)

### DIFF
--- a/docs/adr/0054-logging-and-diagnostic-context.md
+++ b/docs/adr/0054-logging-and-diagnostic-context.md
@@ -57,6 +57,18 @@ Object storage keeps throwing `StorageException` with the key rather than loggin
 
 Levels mean something: `ERROR` needs a human tonight; `WARN` is a failure the system handled but somebody should see; `INFO` is a business event worth reconstructing later; `DEBUG` is for chasing one specific problem and is off in production.
 
+### DEBUG is verbose, and one aspect rather than a thousand lines
+
+`MethodTraceAspect` traces every public method of an `@Service` bean: the call with its arguments, the return with its shape and duration, and the frame an exception left through. Written by hand this would be a log statement in several hundred methods, drifting from the first refactor onwards; a pointcut cannot drift.
+
+Scoped to the `@Service` stereotype rather than to the package, and not by preference — `@ConfigurationProperties` records live in `io.qnop.service` too, a record is final, and matching one makes Spring try to CGLIB-subclass it. That fails at startup, which is how it was found.
+
+Its loggers are named `io.qnop.trace.<SimpleName>`, so tracing switches independently of `io.qnop`: everything at once, or one class when a single flow is in question. The layers underneath — Hibernate SQL, Spring Security, Spring web, transactions — each have their own property and are off by default, because each alone can turn one request into dozens of lines.
+
+**Raising the level must not start writing personal data.** Arguments are therefore described, not printed: ids, numbers, booleans, enums and timestamps as themselves; a `String` as its length; anything else as its type and size. The cost is real — a job name is hidden along with a review title — and it is accepted because no shape rule separates them: `review-purge` and `max-mustermann` are the same string to a regex. `MethodTraceAspectIT` traces `getProfileBySlug` for exactly that reason: a slug is derived from a display name, so an aspect that printed arguments would leak one the moment DEBUG went on.
+
+The MDC's `path` follows the same rule: the matched route template (`/api/v1/documents/{documentId}`), not the URI a caller typed. It says as much about where a request went, groups the lines that belong together, and cannot carry the slug. Only an unmatched request falls back to the raw path — a 404 that cannot be identified is not worth logging, and a path matching nothing is a probe rather than one of our users.
+
 ## Consequences
 
 - A support report can be answered from a request id, across the async work it triggered.
@@ -68,7 +80,9 @@ Levels mean something: `ERROR` needs a human tonight; `WARN` is a failure the sy
 ## Alternatives considered
 
 - **JSON everywhere, including locally.** Rejected: one format is tidier, but a developer reading JSON on a terminal reads less, and the point of this work is that failures get read.
-- **Logging every service method's entry and exit.** Rejected: it is the literal reading of "comprehensive coverage" and produces a log in which the one relevant line is unfindable.
+- **Logging every service method's entry and exit at INFO.** Rejected: it is the literal reading of "comprehensive coverage" and produces a log in which the one relevant line is unfindable. The same tracing at DEBUG, switchable per class, is useful precisely because it is off by default.
+- **Hand-written DEBUG lines instead of the aspect.** Rejected: several hundred edits, each one a thing to forget in the next refactor, and every one of them an opportunity to pass an argument that should not be logged.
+- **Printing argument values at DEBUG**, on the grounds that DEBUG is a developer's level. Rejected: the file it writes to has the same absence of access control as any other, and "we only turn it on when something is wrong" describes exactly the moment when the most data flows through.
 - **Logging no ids at all**, the strictest privacy reading. Rejected: it satisfies any audit and makes the logs useless for the purpose they are being built for. Pseudonymous ids with the resolution behind access control is the proportionate answer.
 - **An ArchUnit rule for the privacy check.** Rejected as unable to express it — see above. The source scan is cruder and actually detects the thing.
 - **Micrometer tracing with propagated trace ids.** Deferred, not rejected: it is the right answer once there is a second service to trace into. Today the request id does the same job without the dependency, and `X-Request-Id` is honoured on the way in so an edge proxy can already stitch calls together.

--- a/docs/adr/0054-logging-and-diagnostic-context.md
+++ b/docs/adr/0054-logging-and-diagnostic-context.md
@@ -37,6 +37,18 @@ Client IP addresses are not logged either. They are personal data, and "reconstr
 
 `LogPrivacyTest` enforces this by scanning the sources for log calls whose arguments reach a user-entered accessor. Deliberately a source scan and not an ArchUnit rule: ArchUnit sees that a class calls `getTitle()` and that it calls `Logger.info()`, never that the first is an argument to the second — the data flow is invisible in the dependency model.
 
+**The scan is a net, not a proof.** It was written against accessors and therefore did not see `MailService` logging its recipient, because the address was already in a local named `to` — found by reading the code, not by the guard. Unambiguous identifier names are now checked too (`email`, `displayName`, `fileName`, …); `to` is deliberately absent, because a version diff legitimately logs a `from`/`to` pair of numbers. A name-shaped check cannot be complete, so review still matters.
+
+### Failures are logged where the context still exists
+
+An exception nobody handled used to leave the dispatcher, unwind the filter chain — which clears the MDC in its `finally` — and only then reach the servlet container, which wrote the stack trace. The single most important line in the system therefore arrived correlated to nothing. `UnhandledExceptionHandler` catches it inside the chain, logs it at `ERROR` with the trace, and returns the standard envelope with a generic message; internals are for the log, not the caller.
+
+It is ordered `LOWEST_PRECEDENCE` because `Exception` matches everything: at default precedence it would shadow the specific handlers and turn every 403 and 404 into a 500. What Spring Security and Spring MVC own — `AccessDeniedException`, `AuthenticationException`, anything implementing Spring's `ErrorResponse` — is rethrown rather than swallowed.
+
+The same reasoning applies out-of-process: the office converter discarded its own output, so a failed DOCX conversion reported an exit status and nothing about what LibreOffice objected to. Its output is now captured (bounded, drained on its own thread so a chatty converter cannot deadlock on a full pipe) and logged when the conversion fails.
+
+Object storage keeps throwing `StorageException` with the key rather than logging and rethrowing: log-and-throw duplicates every failure, and the handler above now records it with the request context attached.
+
 ### What is logged, and what is not
 
 **Logged:** authentication outcomes and token-rotation rejections; permission denials; job start, completion with duration, and failure; external I/O (object storage, SMTP, the office converter); state transitions and destructive acts; and every `catch` that discards a genuine failure.

--- a/docs/adr/0054-logging-and-diagnostic-context.md
+++ b/docs/adr/0054-logging-and-diagnostic-context.md
@@ -1,0 +1,66 @@
+# ADR-0054: Logging and the diagnostic context
+
+- **Status:** Accepted
+- **Date:** 2026-07-31
+- **Deciders:** qnop core team; bigpuritz, devtank42 (with Claude)
+
+## Context
+
+A user reports that something failed yesterday afternoon. Before this decision there was no way to find their request: no request id, no user attribution, and nothing tying an async job back to what caused it. Measured on `main` at the time: 98 log statements across 35 files out of 187 service classes, **no** logging configuration at all, and **zero** MDC usage.
+
+Two facts made this worse than the numbers suggest. Boot's default console pattern prints no MDC, so populating one without touching the format would have been invisible work. And personal data was already in the logs — `ReviewDeletionService` wrote the review *title*, which is user content and routinely carries a name.
+
+Logs are also the one place in this system with no access control, no retention policy and no subject-access route. Whatever lands there is outside every mechanism the rest of the product uses to protect it.
+
+## Decision
+
+### The context carries ids, and the pattern prints them
+
+`LogContext` owns the MDC keys: `requestId`, `userId`, `method`, `path`, `documentId`, `jobId`, `jobType`. `logging.pattern.correlation` renders the three that earn their width on every line; the rest are there for structured output.
+
+Values are set at the **edges**, not sprinkled through the code:
+
+- `RequestLogContextFilter` mints the request id, before Spring Security so a rejected login still has one, and returns it as `X-Request-Id` so a user can quote a number.
+- `UserLogContextFilter` adds the caller, after Security so there is one to add. Two filters rather than one, because no single filter can be on both sides of authentication.
+- `DocumentLogContextInterceptor` adds the review from the parsed URI template — one place covering every `/documents/{documentId}/…` route, including the ones added later.
+- The job poller and `JobService` scope `jobId` and `jobType`, because async work has no request behind it and would otherwise log unattributed.
+
+### Output is text by default and structured on demand
+
+`logging.structured.format.console` is empty for a developer at a terminal and set to `ecs` (or `logstash`/`gelf`) in a deployment, where every line becomes one JSON object with the MDC as fields. Boot ships this; no encoder dependency enters the build.
+
+### No personal data. Ever.
+
+Ids yes; names, e-mail addresses, review titles, annotation text, file names and slugs no. A UUID is still personal data, but it is pseudonymous: resolving it requires database access someone has to be entitled to, and a leaked log file does not read as a list of people. Free text offers none of that, because whatever a user typed is whatever a user typed.
+
+Client IP addresses are not logged either. They are personal data, and "reconstruct this failure" does not need them.
+
+`LogPrivacyTest` enforces this by scanning the sources for log calls whose arguments reach a user-entered accessor. Deliberately a source scan and not an ArchUnit rule: ArchUnit sees that a class calls `getTitle()` and that it calls `Logger.info()`, never that the first is an argument to the second — the data flow is invisible in the dependency model.
+
+### What is logged, and what is not
+
+**Logged:** authentication outcomes and token-rotation rejections; permission denials; job start, completion with duration, and failure; external I/O (object storage, SMTP, the office converter); state transitions and destructive acts; and every `catch` that discards a genuine failure.
+
+**Not logged:** ordinary reads, mappers, getters, validation that merely returns a message to the caller, and per-tick chatter from pollers. A poller that says "nothing to do" every five seconds costs more attention than it repays.
+
+Levels mean something: `ERROR` needs a human tonight; `WARN` is a failure the system handled but somebody should see; `INFO` is a business event worth reconstructing later; `DEBUG` is for chasing one specific problem and is off in production.
+
+## Consequences
+
+- A support report can be answered from a request id, across the async work it triggered.
+- Structured output is a property change, not a code change.
+- The privacy rule is enforced continuously rather than reviewed occasionally, and it fails with the file and the offending expression named.
+- Log volume stays proportional because the policy says what stays silent, not only what does not.
+- **Thread pools are the sharp edge.** A context left behind attributes the next request — a different person — to whoever came before, which is a false record in the very file someone later reads as evidence. Hence `LogContext.Scope` restoring rather than clearing, the filter wiping the whole MDC in `finally`, and tests that assert both.
+
+## Alternatives considered
+
+- **JSON everywhere, including locally.** Rejected: one format is tidier, but a developer reading JSON on a terminal reads less, and the point of this work is that failures get read.
+- **Logging every service method's entry and exit.** Rejected: it is the literal reading of "comprehensive coverage" and produces a log in which the one relevant line is unfindable.
+- **Logging no ids at all**, the strictest privacy reading. Rejected: it satisfies any audit and makes the logs useless for the purpose they are being built for. Pseudonymous ids with the resolution behind access control is the proportionate answer.
+- **An ArchUnit rule for the privacy check.** Rejected as unable to express it — see above. The source scan is cruder and actually detects the thing.
+- **Micrometer tracing with propagated trace ids.** Deferred, not rejected: it is the right answer once there is a second service to trace into. Today the request id does the same job without the dependency, and `X-Request-Id` is honoured on the way in so an edge proxy can already stitch calls together.
+
+## Relationships
+
+Completes the observability picture of [ADR-0037](0037-observability-actuator-health-and-prometheus.md) (health, metrics — logging was decided nowhere). The privacy rule shares its reasoning with [ADR-0038](0038-per-review-privacy.md) (identities are resolved server-side, never assumed safe to expose) and with [ADR-0042](0042-audit-trail-exposure.md), which is the place where who-did-what *is* recorded with names, behind access control — a log file is not that place. Related issue: #659.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,6 +83,14 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 # auto-configured at runtime, so it is a runtime-only dependency (no compile-time symbols).
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+# AOP, for the one aspect that traces the service layer at DEBUG (issue #659, ADR-0054).
+# Writing that by hand would mean a log line in every method, drifting from the first
+# refactor onwards; one pointcut cannot drift.
+#
+# The weaver directly rather than a starter: Spring Boot 4 dropped
+# spring-boot-starter-aop, and its AopAutoConfiguration keys off org.aspectj.weaver.Advice
+# being on the classpath. spring-aop itself already arrives with spring-context.
+aspectjweaver = { module = "org.aspectj:aspectjweaver" }
 liquibase-core = { module = "org.liquibase:liquibase-core" }
 # Spring Boot 4 split LiquibaseAutoConfiguration out of spring-boot-autoconfigure
 # into this dedicated module; without it on the classpath Liquibase never runs.

--- a/qnop-app/src/main/java/io/qnop/web/AuthController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AuthController.java
@@ -37,6 +37,8 @@ import io.qnop.web.security.RefreshTokenCookieFactory;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -57,6 +59,8 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @RestController
 public class AuthController implements AuthApi {
+
+  private static final Logger log = LoggerFactory.getLogger(AuthController.class);
 
   private static final String TOKEN_TYPE = "Bearer";
 
@@ -84,11 +88,19 @@ public class AuthController implements AuthApi {
 
   @Override
   public ResponseEntity<TokenResponse> login(LoginRequest request) {
+    // Never the identifier that was tried (issue #659): it is an e-mail address
+    // or a username, and a failed login writes it into a file with no access
+    // control. The request id ties the attempt to its rate-limit and audit rows.
     UUID userId =
         authService
             .authenticate(request.getUsernameOrEmail(), request.getPassword())
             .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials"));
+                () -> {
+                  log.info("Login rejected: invalid credentials");
+                  return new ResponseStatusException(
+                      HttpStatus.UNAUTHORIZED, "Invalid credentials");
+                });
+    log.info("Login succeeded for {}", userId);
     return issueSession(userId);
   }
 
@@ -99,8 +111,14 @@ public class AuthController implements AuthApi {
     }
     RotationResult result = refreshTokenService.rotate(refreshCookie);
     if (result instanceof RotationResult.Success success) {
+      log.debug("Refresh token rotated for {}", success.userId());
       return issueSession(success.userId(), success.token());
     }
+    // A presented token that is not valid is either replayed or forged, and both
+    // are worth seeing: a burst of them is the shape of a stolen cookie
+    // (ADR-0026). WARN, because unlike a mistyped password this should not happen
+    // in normal use.
+    log.warn("Refresh rejected: the presented token was reused or unknown");
     // Reused or Unknown: clear the cookie and reject. The two are indistinguishable to the client.
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
         .header(HttpHeaders.SET_COOKIE, cookieFactory.clear().toString())

--- a/qnop-app/src/main/java/io/qnop/web/CurrentUser.java
+++ b/qnop-app/src/main/java/io/qnop/web/CurrentUser.java
@@ -48,6 +48,25 @@ public final class CurrentUser {
     }
   }
 
+  /**
+   * The caller's id, or null when there is none (issue #659).
+   *
+   * <p>For the log context, which runs on anonymous traffic too — health probes, the login form,
+   * the branding assets — and must not turn "nobody is signed in" into a rejected request.
+   */
+  public static UUID optionalUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String name = authentication == null ? null : authentication.getName();
+    if (name == null) {
+      return null;
+    }
+    try {
+      return UUID.fromString(name);
+    } catch (IllegalArgumentException e) {
+      return null; // a machine principal is not a user
+    }
+  }
+
   /** Whether the caller carries the global {@code ROLE_ADMIN} authority (issue #245). */
   public static boolean isAdmin() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
@@ -31,6 +31,8 @@ import io.qnop.service.review.WorkflowTransitionException;
 import io.qnop.service.review.export.ExportFormatUnavailableException;
 import java.time.OffsetDateTime;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -44,6 +46,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  */
 @RestControllerAdvice
 public class DocumentExceptionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(DocumentExceptionHandler.class);
 
   @ExceptionHandler(DocumentValidationException.class)
   public ResponseEntity<ErrorResponse> onDocumentError(DocumentValidationException ex) {
@@ -80,12 +84,17 @@ public class DocumentExceptionHandler {
 
   @ExceptionHandler(NotDocumentOwnerException.class)
   public ResponseEntity<ErrorResponse> onNotOwner(NotDocumentOwnerException ex) {
+    // A denial is worth a line: it is either somebody probing, or a permission bug
+    // reported as "it says I am not allowed". The caller and the review come from
+    // the diagnostic context, so the message adds only what it refused.
+    log.info("Denied: not the review owner");
     return error(HttpStatus.FORBIDDEN.value(), "NOT_DOCUMENT_OWNER", ex.getMessage());
   }
 
   @ExceptionHandler(AnnotationActionForbiddenException.class)
   public ResponseEntity<ErrorResponse> onAnnotationActionForbidden(
       AnnotationActionForbiddenException ex) {
+    log.info("Denied: annotation action not permitted for this caller");
     return error(HttpStatus.FORBIDDEN.value(), "ANNOTATION_ACTION_FORBIDDEN", ex.getMessage());
   }
 

--- a/qnop-app/src/main/java/io/qnop/web/DocumentLogContextInterceptor.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentLogContextInterceptor.java
@@ -63,6 +63,14 @@ public class DocumentLogContextInterceptor implements HandlerInterceptor, WebMvc
   @Override
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
+    // The route, not the URI a caller typed. "/api/v1/users/{slug}" says as much about
+    // where a request went, groups lines that belong together, and cannot carry the
+    // display name a slug is derived from — the same reason a slug is refused below.
+    Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+    if (pattern != null) {
+      MDC.put(LogContext.PATH, pattern.toString());
+    }
+
     Object variables = request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
     if (!(variables instanceof Map<?, ?> parsed)) {
       return true;

--- a/qnop-app/src/main/java/io/qnop/web/DocumentLogContextInterceptor.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentLogContextInterceptor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.observability.LogContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Puts the review being acted on into the log context (issue #659, ADR-0054).
+ *
+ * <p>Here rather than in thirty controller methods: by the time a handler runs, Spring has already
+ * parsed the URI template, so one interceptor covers every {@code /documents/{documentId}/…} route
+ * — including the ones added next year, which is the part a per-method call could not promise.
+ *
+ * <p>It reads the parsed template variable rather than the raw path, so a client cannot inject
+ * anything: a value that is not a UUID is dropped instead of logged.
+ *
+ * <p>The request filter clears the whole MDC afterwards, so this deliberately does not implement
+ * {@code afterCompletion} — two places removing the same key is one place too many to reason about.
+ */
+@Component
+public class DocumentLogContextInterceptor implements HandlerInterceptor, WebMvcConfigurer {
+
+  /**
+   * Registers itself.
+   *
+   * <p>Rather than having {@code ApiPathConfig} depend on it: that class is about path mapping, and
+   * a web slice test importing it should not have to know that logging exists.
+   */
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(this);
+  }
+
+  private static final String DOCUMENT_ID = "documentId";
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    Object variables = request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+    if (!(variables instanceof Map<?, ?> parsed)) {
+      return true;
+    }
+    Object documentId = parsed.get(DOCUMENT_ID);
+    if (documentId != null && isUuid(documentId.toString())) {
+      MDC.put(LogContext.DOCUMENT_ID, documentId.toString());
+    }
+    return true;
+  }
+
+  /**
+   * Only a UUID goes in.
+   *
+   * <p>The same path also accepts a slug (issue #411), and a slug is user-chosen text — it would be
+   * personal data in a log line, and it would be attacker-controlled content in a field operators
+   * read as fact.
+   */
+  private static boolean isUuid(String value) {
+    try {
+      java.util.UUID.fromString(value);
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/RequestLogContextFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/RequestLogContextFilter.java
@@ -27,11 +27,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
 
 /**
  * Gives every request an identity in the logs (issue #659, ADR-0054).
@@ -55,6 +58,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
 public class RequestLogContextFilter extends OncePerRequestFilter {
 
+  private static final Logger log = LoggerFactory.getLogger(RequestLogContextFilter.class);
+
   static final String REQUEST_ID_HEADER = "X-Request-Id";
 
   /** Short enough to read out over the phone, long enough not to collide within a day's logs. */
@@ -67,15 +72,43 @@ public class RequestLogContextFilter extends OncePerRequestFilter {
     String requestId = requestIdOf(request);
     MDC.put(LogContext.REQUEST_ID, requestId);
     MDC.put(LogContext.METHOD, request.getMethod());
-    // The path only — never the query string, which carries search terms and other
-    // things a user typed.
-    MDC.put(LogContext.PATH, request.getRequestURI());
     response.setHeader(REQUEST_ID_HEADER, requestId);
+    // The path is deliberately NOT set here. At this point only the raw URI exists, and
+    // it carries whatever the caller put in it — a profile slug is a display name. The
+    // interceptor sets the matched route template instead, once Spring has parsed it.
+    long started = System.nanoTime();
     try {
       chain.doFilter(request, response);
     } finally {
+      logCompletion(request, response, started);
       MDC.clear();
     }
+  }
+
+  /**
+   * One line per request at DEBUG: what came in, what went out, how long it took.
+   *
+   * <p>Cheap to leave in and the first thing worth having when a flow is under investigation — a
+   * 404 nobody expected, or a call that was slow rather than broken.
+   *
+   * <p>The route template is preferred over the raw URI for the reason above. An unmatched request
+   * has no template, and there the raw path is logged: a 404 you cannot identify is not worth
+   * logging at all, and a path that matched nothing is junk or a probe rather than one of our
+   * users' names.
+   */
+  private void logCompletion(
+      HttpServletRequest request, HttpServletResponse response, long startedNanos) {
+    if (!log.isDebugEnabled()) {
+      return;
+    }
+    Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+    String route = pattern != null ? pattern.toString() : request.getRequestURI() + " (unmatched)";
+    log.debug(
+        "{} {} -> {} [{} ms]",
+        request.getMethod(),
+        route,
+        response.getStatus(),
+        (System.nanoTime() - startedNanos) / 1_000_000);
   }
 
   /**

--- a/qnop-app/src/main/java/io/qnop/web/RequestLogContextFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/RequestLogContextFilter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.observability.LogContext;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Gives every request an identity in the logs (issue #659, ADR-0054).
+ *
+ * <p>Without this a report of "it failed yesterday afternoon" has nothing to search by. The request
+ * id is minted here and returned in {@code X-Request-Id}, so a user can quote the number from a
+ * failure and an operator can pull the whole request — and, through the document scope, the async
+ * work it set off.
+ *
+ * <p>Ordered ahead of Spring Security so that authentication failures are logged with a request id
+ * too; the user id is therefore read <em>after</em> the chain has run its authentication, which is
+ * why it is set inside the filter rather than at entry.
+ *
+ * <p><strong>The finally block is the point of this class.</strong> Tomcat pools threads: a context
+ * left behind attributes the next request — a different person — to whoever came before. That is a
+ * false record in the log someone later reads as evidence, so the context is cleared
+ * unconditionally and the whole MDC is wiped rather than the keys this filter happens to know
+ * about.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+public class RequestLogContextFilter extends OncePerRequestFilter {
+
+  static final String REQUEST_ID_HEADER = "X-Request-Id";
+
+  /** Short enough to read out over the phone, long enough not to collide within a day's logs. */
+  private static final int REQUEST_ID_LENGTH = 12;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    String requestId = requestIdOf(request);
+    MDC.put(LogContext.REQUEST_ID, requestId);
+    MDC.put(LogContext.METHOD, request.getMethod());
+    // The path only — never the query string, which carries search terms and other
+    // things a user typed.
+    MDC.put(LogContext.PATH, request.getRequestURI());
+    response.setHeader(REQUEST_ID_HEADER, requestId);
+    try {
+      chain.doFilter(request, response);
+    } finally {
+      MDC.clear();
+    }
+  }
+
+  /**
+   * An inbound id is honoured so a reverse proxy or a client can stitch a call across services;
+   * anything unreasonable is replaced rather than trusted, because this value ends up in log files
+   * and must not carry newlines or a caller's free text.
+   */
+  private static String requestIdOf(HttpServletRequest request) {
+    String inbound = request.getHeader(REQUEST_ID_HEADER);
+    if (inbound != null && !inbound.isBlank() && inbound.length() <= 64 && isSafe(inbound)) {
+      return inbound;
+    }
+    return UUID.randomUUID().toString().replace("-", "").substring(0, REQUEST_ID_LENGTH);
+  }
+
+  private static boolean isSafe(String value) {
+    for (int index = 0; index < value.length(); index++) {
+      char character = value.charAt(index);
+      boolean allowed =
+          Character.isLetterOrDigit(character) || character == '-' || character == '_';
+      if (!allowed) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/UnhandledExceptionHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/UnhandledExceptionHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.api.v1.model.ErrorResponse;
+import java.time.OffsetDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * The last resort: nothing else handled it, so it gets logged before it becomes a 500 (issue #659,
+ * ADR-0054).
+ *
+ * <p>Without this, an unexpected failure — object storage unreachable, a constraint nobody
+ * anticipated — surfaced to the servlet container, which logs it <em>after</em> the filter chain
+ * has unwound. By then {@link RequestLogContextFilter} has cleared the context, so the one line
+ * that matters most arrived without a request id, a user or a review. Handling it here keeps it
+ * inside the filter chain, where the context still exists.
+ *
+ * <p><strong>Ordered last, deliberately.</strong> Spring picks the first advice with a matching
+ * handler, and {@code Exception} matches everything: at default precedence this class would shadow
+ * the specific handlers in {@link DocumentExceptionHandler} and turn every 403 and 404 into a 500.
+ *
+ * <p>What Spring and Spring Security own is rethrown rather than swallowed, for the same reason:
+ * {@code AccessDeniedException} becomes a 403 in the security filter chain, and Spring MVC's own
+ * exceptions already carry the status they mean.
+ */
+@RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class UnhandledExceptionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(UnhandledExceptionHandler.class);
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> onUnexpected(Exception ex) throws Exception {
+    if (ex instanceof AccessDeniedException
+        || ex instanceof AuthenticationException
+        || ex instanceof org.springframework.web.ErrorResponse) {
+      throw ex;
+    }
+
+    // The stack trace is the point. The message is not repeated to the client: it
+    // routinely names internals, and a caller who cannot fix it does not need them.
+    log.error("Unhandled {} while serving the request", ex.getClass().getSimpleName(), ex);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(
+            new ErrorResponse()
+                .code("INTERNAL_ERROR")
+                .message("The request could not be completed.")
+                .timestamp(OffsetDateTime.now()));
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/UserLogContextFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/UserLogContextFilter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.observability.LogContext;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Names the caller in the logs (issue #659, ADR-0054).
+ *
+ * <p>Separate from {@link RequestLogContextFilter}, and ordered <em>after</em> Spring Security
+ * rather than merged with it: the request id has to exist before authentication runs, because a
+ * rejected login is precisely the request someone wants to trace, while the user id can only exist
+ * after it. One filter could not be on both sides of that line.
+ *
+ * <p>The id and nothing else. A display name or an address in a log file is a copy of personal data
+ * in a place with no access control and no retention policy; the id resolves in the database, by
+ * someone entitled to do it.
+ */
+@Component
+@Order(0)
+public class UserLogContextFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    UUID userId = CurrentUser.optionalUserId();
+    // Anonymous traffic simply has no user — the scope leaves the key absent
+    // rather than printing "null" on every login and health probe.
+    try (LogContext.Scope ignored = LogContext.scope(LogContext.USER_ID, userId)) {
+      chain.doFilter(request, response);
+    }
+  }
+}

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -6,6 +6,34 @@
 # single .env drives both the DB container and the app. Defaults target the local
 # docker-compose Postgres; production may override with the standard
 # SPRING_DATASOURCE_* keys.
+# Logging (issue #659, ADR-0054). Two things are configured here and nothing else
+# is: what identifies a line, and in which shape it is written.
+#
+# `pattern.correlation` is the slot Boot's default console pattern already leaves
+# for diagnostic context, so the rest of the layout stays Boot's. Without it the
+# MDC would be populated and invisible — the default pattern prints none of it.
+# Blank values render as empty fields, which is why the keys are the three that
+# earn their width on every line; method and path are in the MDC for structured
+# output but not in the console layout, where the message usually names them.
+#
+# `structured.format.console` is empty by default, i.e. human-readable text for a
+# developer at a terminal. Set QNOP_LOG_FORMAT=ecs (or logstash / gelf) in a
+# deployment and every line becomes one JSON object with the MDC as fields — the
+# form a log aggregator can actually query. Boot ships this; no encoder library.
+logging:
+  pattern:
+    # Not env-overridable on purpose: the value contains ':' inside %X{...},
+    # which Spring's placeholder syntax would read as a default separator.
+    correlation: "[%X{requestId:-} %X{userId:-} %X{documentId:-}] "
+  structured:
+    format:
+      console: ${QNOP_LOG_FORMAT:}
+  level:
+    # The application's own packages speak at INFO; everything below is Boot's
+    # default. Raise one package with QNOP_LOG_LEVEL_QNOP=DEBUG when chasing a
+    # specific failure rather than turning up the whole tree.
+    io.qnop: ${QNOP_LOG_LEVEL_QNOP:INFO}
+
 spring:
   lifecycle:
     # Upper bound for the graceful-shutdown drain (issue #495).

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -34,6 +34,22 @@ logging:
     # specific failure rather than turning up the whole tree.
     io.qnop: ${QNOP_LOG_LEVEL_QNOP:INFO}
 
+    # Verbose method tracing of the service layer: entry with the call's ids, exit
+    # with the result's shape and duration (MethodTraceAspect). Its own switch, so
+    # DEBUG here does not also turn the rest of io.qnop to DEBUG — and OFF here
+    # keeps the traffic down when io.qnop is at DEBUG for one specific hunt.
+    # A single class: QNOP_LOG_LEVEL_TRACE stays INFO and set
+    # logging.level.io.qnop.trace.ReviewService=DEBUG instead.
+    io.qnop.trace: ${QNOP_LOG_LEVEL_TRACE:INFO}
+
+    # The layers below the application, each off unless asked for. They are noisy by
+    # design — one request can be dozens of statements — which is why none of them is
+    # tied to the switch above.
+    org.hibernate.SQL: ${QNOP_LOG_SQL:INFO}
+    org.springframework.security: ${QNOP_LOG_LEVEL_SECURITY:INFO}
+    org.springframework.web: ${QNOP_LOG_LEVEL_WEB:INFO}
+    org.springframework.transaction: ${QNOP_LOG_LEVEL_TX:INFO}
+
 spring:
   lifecycle:
     # Upper bound for the graceful-shutdown drain (issue #495).

--- a/qnop-app/src/test/java/io/qnop/architecture/ArchitectureRulesTest.java
+++ b/qnop-app/src/test/java/io/qnop/architecture/ArchitectureRulesTest.java
@@ -64,6 +64,8 @@ class ArchitectureRulesTest {
             .definedBy("io.qnop.web..", "io.qnop.bootstrap..")
             .layer("Security")
             .definedBy("io.qnop.security..")
+            .layer("Observability")
+            .definedBy("io.qnop.observability..")
             // Spi is intentionally consumable by everyone (plugin contract).
             .whereLayer("Web")
             .mayNotBeAccessedByAnyLayer()
@@ -71,6 +73,11 @@ class ArchitectureRulesTest {
             // layers; it never depends back on them (see securityFoundationStaysPure).
             .whereLayer("Security")
             .mayOnlyBeAccessedByLayers("Web", "Service")
+            // The diagnostic context (issue #659) is deliberately reachable from
+            // everywhere that logs — it carries ids into the MDC and depends on
+            // nothing but slf4j.
+            .whereLayer("Observability")
+            .mayOnlyBeAccessedByLayers("Web", "Service", "Repository", "Security")
             .whereLayer("Service")
             .mayOnlyBeAccessedByLayers("Web")
             .whereLayer("Repository")

--- a/qnop-app/src/test/java/io/qnop/architecture/LogPrivacyTest.java
+++ b/qnop-app/src/test/java/io/qnop/architecture/LogPrivacyTest.java
@@ -70,7 +70,17 @@ class LogPrivacyTest {
           "getComment()",
           ".comment()",
           "getExcerpt()",
-          ".excerpt()");
+          ".excerpt()",
+          // Bare identifiers too, for the case an accessor list cannot see: a
+          // local variable already holding the value. Only names with one
+          // possible meaning — `to` is deliberately absent, because a version
+          // diff legitimately logs a `from`/`to` pair of numbers.
+          "email",
+          "emailAddress",
+          "recipientEmail",
+          "displayName",
+          "fileName",
+          "username");
 
   private static final Pattern LOG_CALL =
       Pattern.compile("\\blog\\.(trace|debug|info|warn|error)\\s*\\(");

--- a/qnop-app/src/test/java/io/qnop/architecture/LogPrivacyTest.java
+++ b/qnop-app/src/test/java/io/qnop/architecture/LogPrivacyTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * No personal data in the logs (issue #659, ADR-0054).
+ *
+ * <p>A log file has no access control, no retention policy and no subject-access route. Ids belong
+ * there; the things people typed do not — a review title is regularly somebody's name, and so is an
+ * uploaded file name.
+ *
+ * <p>Deliberately a source scan rather than an ArchUnit rule. ArchUnit sees that a class calls
+ * {@code Document.getTitle()} and that it calls {@code Logger.info()}, never that the first is an
+ * argument to the second; the data flow this is about is invisible in the dependency model. Reading
+ * the text finds exactly the shape that matters, and it stays a lint — a wrong flag is silenced by
+ * not writing the value into the log, which is the point.
+ */
+class LogPrivacyTest {
+
+  /**
+   * Accessors whose value is user-entered.
+   *
+   * <p>Not a guess at what is sensitive: each of these returns something a person typed, which is
+   * why none of them can be assumed harmless. New ones belong here as they appear.
+   */
+  private static final List<String> FORBIDDEN =
+      List.of(
+          "getTitle()",
+          ".title()",
+          "getEmail()",
+          ".email()",
+          "getDisplayName()",
+          ".displayName()",
+          "getUsername()",
+          ".username()",
+          "getFileName()",
+          ".fileName()",
+          "getComment()",
+          ".comment()",
+          "getExcerpt()",
+          ".excerpt()");
+
+  private static final Pattern LOG_CALL =
+      Pattern.compile("\\blog\\.(trace|debug|info|warn|error)\\s*\\(");
+
+  @Test
+  @DisplayName("no log statement passes something a user typed")
+  void logsCarryNoPersonalData() {
+    List<String> offences = new ArrayList<>();
+    for (Path source : mainSources()) {
+      String code = stripComments(read(source));
+      Matcher matcher = LOG_CALL.matcher(code);
+      while (matcher.find()) {
+        String call = argumentsOf(code, matcher.end() - 1);
+        FORBIDDEN.stream()
+            .filter(call::contains)
+            .forEach(
+                forbidden ->
+                    offences.add(
+                        source.getFileName()
+                            + ": log call passes "
+                            + forbidden
+                            + " → "
+                            + oneLine(call)));
+      }
+    }
+
+    assertThat(offences)
+        .withFailMessage(
+            "These log statements would write user-entered text into a log file (issue #659):%n%s%n%n"
+                + "Log the id instead; the value itself belongs in the database or the audit "
+                + "trail, where access is controlled.",
+            String.join(System.lineSeparator(), offences))
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("the scan actually reads the sources it claims to")
+  void theScanSeesTheCode() {
+    // A privacy test that silently scanned nothing would pass forever. This is
+    // the guard on the guard.
+    List<Path> sources = mainSources();
+    assertThat(sources).hasSizeGreaterThan(200);
+    assertThat(sources.stream().map(Path::toString)).anyMatch(path -> path.contains("qnop-core"));
+    assertThat(sources.stream().map(Path::toString)).anyMatch(path -> path.contains("qnop-app"));
+
+    long logging = sources.stream().filter(source -> LOG_CALL.matcher(read(source)).find()).count();
+    assertThat(logging).isGreaterThan(20);
+  }
+
+  /** Every production source file of the two modules that hold logic. */
+  private static List<Path> mainSources() {
+    Path root = repositoryRoot();
+    List<Path> sources = new ArrayList<>();
+    for (String module : List.of("qnop-core", "qnop-app")) {
+      Path main = root.resolve(module).resolve("src/main/java");
+      if (!Files.isDirectory(main)) {
+        continue;
+      }
+      try (Stream<Path> walk = Files.walk(main)) {
+        walk.filter(path -> path.toString().endsWith(".java")).forEach(sources::add);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+    return sources;
+  }
+
+  /** Walks up from the working directory until the settings file names the repository root. */
+  private static Path repositoryRoot() {
+    Path candidate = Path.of("").toAbsolutePath();
+    while (candidate != null && !Files.exists(candidate.resolve("settings.gradle.kts"))) {
+      candidate = candidate.getParent();
+    }
+    if (candidate == null) {
+      throw new IllegalStateException("could not locate the repository root");
+    }
+    return candidate;
+  }
+
+  /**
+   * The text between the call's parentheses.
+   *
+   * <p>Counted rather than matched to a closing bracket, because a log call routinely nests calls
+   * and its arguments span several lines.
+   */
+  private static String argumentsOf(String code, int openParen) {
+    int depth = 0;
+    for (int index = openParen; index < code.length(); index++) {
+      char character = code.charAt(index);
+      if (character == '(') {
+        depth++;
+      } else if (character == ')') {
+        depth--;
+        if (depth == 0) {
+          return code.substring(openParen + 1, index);
+        }
+      }
+    }
+    return code.substring(openParen);
+  }
+
+  /**
+   * Removes comments and string literals.
+   *
+   * <p>Both would otherwise produce false alarms: this very file names the forbidden accessors in
+   * prose, and a message like "could not read the title" contains one as plain text.
+   */
+  private static String stripComments(String code) {
+    StringBuilder out = new StringBuilder(code.length());
+    int index = 0;
+    while (index < code.length()) {
+      char character = code.charAt(index);
+      if (character == '/' && index + 1 < code.length() && code.charAt(index + 1) == '/') {
+        while (index < code.length() && code.charAt(index) != '\n') {
+          index++;
+        }
+      } else if (character == '/' && index + 1 < code.length() && code.charAt(index + 1) == '*') {
+        index += 2;
+        while (index + 1 < code.length()
+            && !(code.charAt(index) == '*' && code.charAt(index + 1) == '/')) {
+          index++;
+        }
+        index += 2;
+      } else if (character == '"') {
+        out.append(' '); // keep the argument shape, drop the content
+        index++;
+        while (index < code.length() && code.charAt(index) != '"') {
+          index += code.charAt(index) == '\\' ? 2 : 1;
+        }
+        index++;
+      } else {
+        out.append(character);
+        index++;
+      }
+    }
+    return out.toString();
+  }
+
+  private static String oneLine(String text) {
+    String collapsed = text.replaceAll("\\s+", " ").trim();
+    return collapsed.length() <= 120 ? collapsed : collapsed.substring(0, 120) + "…";
+  }
+
+  private static String read(Path path) {
+    try {
+      return Files.readString(path);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/observability/LogContextIT.java
+++ b/qnop-app/src/test/java/io/qnop/observability/LogContextIT.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
 
 /**
@@ -44,6 +45,7 @@ import org.springframework.test.web.servlet.MvcResult;
  * prove nothing, so these tests read what was actually written.
  */
 @ExtendWith(OutputCaptureExtension.class)
+@TestPropertySource(properties = "logging.level.io.qnop.web=DEBUG")
 class LogContextIT extends SeededIntegrationTest {
 
   private static final Logger log = LoggerFactory.getLogger(LogContextIT.class);
@@ -114,6 +116,23 @@ class LogContextIT extends SeededIntegrationTest {
     // attribute the next request — a different person — to whoever came before.
     assertThat(MDC.get(LogContext.REQUEST_ID)).isNull();
     assertThat(MDC.get(LogContext.USER_ID)).isNull();
+  }
+
+  @Test
+  @DisplayName("the request line names the route, not the URI the caller typed")
+  void requestLineUsesTheRouteTemplate(CapturedOutput output) throws Exception {
+    UUID unknown = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            get("/api/v1/documents/{id}", unknown)
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isNotFound());
+
+    // The template, because the same shape of route also accepts a slug, and a slug is
+    // a display name. Logging "/api/v1/documents/{documentId}" says as much about where
+    // the request went, and groups every call to that route together.
+    assertThat(output).contains("GET /api/v1/documents/{documentId} -> 404");
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/observability/LogContextIT.java
+++ b/qnop-app/src/test/java/io/qnop/observability/LogContextIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * The diagnostic context, proven against the console rather than the configuration (issue #659).
+ *
+ * <p>The failure mode this exists for is silent: MDC values can be set perfectly and never reach a
+ * log line, because Boot's default pattern prints none of them. Asserting the property is set would
+ * prove nothing, so these tests read what was actually written.
+ */
+@ExtendWith(OutputCaptureExtension.class)
+class LogContextIT extends SeededIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(LogContextIT.class);
+
+  @Test
+  @DisplayName("a request gets an id, returns it, and stamps it on the lines it produces")
+  void requestIdReachesTheOutput(CapturedOutput output) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(get("/api/v1/config").header("Authorization", "Bearer " + token(MEMBER_ID)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String requestId = result.getResponse().getHeader("X-Request-Id");
+    assertThat(requestId).isNotBlank();
+
+    // The header alone would only prove the filter ran. Writing a line while the
+    // context is what the request left behind proves the pattern renders it.
+    MDC.put(LogContext.REQUEST_ID, requestId);
+    MDC.put(LogContext.USER_ID, MEMBER_ID.toString());
+    try {
+      log.info("a line written inside a request context");
+    } finally {
+      MDC.clear();
+    }
+
+    // The composed field, not the two ids somewhere on the page: a loose contains
+    // would pass on a line that merely happens to mention them, which is exactly
+    // the false confidence this test exists to avoid.
+    assertThat(output).contains("[" + requestId + " " + MEMBER_ID + " ]");
+  }
+
+  @Test
+  @DisplayName("an inbound request id is honoured, so a call can be traced across services")
+  void inboundRequestIdIsKept() throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(get("/api/v1/config").header("X-Request-Id", "edge-7f31a2"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    assertThat(result.getResponse().getHeader("X-Request-Id")).isEqualTo("edge-7f31a2");
+  }
+
+  @Test
+  @DisplayName("an inbound id that could forge a log line is replaced, not trusted")
+  void hostileRequestIdIsReplaced() throws Exception {
+    // A newline in an id lets a caller write their own log lines. The value ends
+    // up in a file people read as a record, so it is not taken on trust.
+    MvcResult result =
+        mockMvc
+            .perform(get("/api/v1/config").header("X-Request-Id", "abc\nINFO forged line"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String issued = result.getResponse().getHeader("X-Request-Id");
+    assertThat(issued).isNotNull().doesNotContain("forged").doesNotContain("\n");
+  }
+
+  @Test
+  @DisplayName("the context does not survive the request that set it")
+  void contextIsClearedBetweenRequests() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/config").header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk());
+
+    // Tomcat reuses threads; MockMvc reuses this one. A value left behind would
+    // attribute the next request — a different person — to whoever came before.
+    assertThat(MDC.get(LogContext.REQUEST_ID)).isNull();
+    assertThat(MDC.get(LogContext.USER_ID)).isNull();
+  }
+
+  @Test
+  @DisplayName("a scope restores what it found, so nesting cannot orphan the outer value")
+  void scopesNest() {
+    UUID outer = UUID.randomUUID();
+    UUID inner = UUID.randomUUID();
+
+    try (LogContext.Scope ignored = LogContext.document(outer)) {
+      assertThat(LogContext.get(LogContext.DOCUMENT_ID)).isEqualTo(outer.toString());
+      try (LogContext.Scope nested = LogContext.document(inner)) {
+        assertThat(LogContext.get(LogContext.DOCUMENT_ID)).isEqualTo(inner.toString());
+      }
+      // Restored rather than cleared: clearing would leave the rest of the outer
+      // scope's lines unattributed.
+      assertThat(LogContext.get(LogContext.DOCUMENT_ID)).isEqualTo(outer.toString());
+    }
+    assertThat(LogContext.get(LogContext.DOCUMENT_ID)).isNull();
+  }
+
+  @Test
+  @DisplayName("a null value leaves the key absent rather than printing the word null")
+  void nullValuesAreAbsent() {
+    try (LogContext.Scope ignored = LogContext.scope(LogContext.USER_ID, null)) {
+      assertThat(LogContext.get(LogContext.USER_ID)).isNull();
+    }
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/observability/MethodTraceAspectIT.java
+++ b/qnop-app/src/test/java/io/qnop/observability/MethodTraceAspectIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.qnop.service.PublicProfileService;
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * The verbose DEBUG trace, and the line it must not cross (issue #659, ADR-0054).
+ *
+ * <p>Tracing is only worth having if it can be left switchable in a real deployment, and it can
+ * only be left switchable if raising the level cannot start writing personal data. The subject here
+ * is deliberately {@code getProfileBySlug}: a slug is derived from someone's display name, so an
+ * aspect that printed its arguments would put a person's name in the log the moment DEBUG went on.
+ */
+@ExtendWith(OutputCaptureExtension.class)
+@TestPropertySource(properties = "logging.level.io.qnop.trace=DEBUG")
+class MethodTraceAspectIT extends SeededIntegrationTest {
+
+  /** Distinctive enough that finding it in the output can only mean the aspect wrote it. */
+  private static final String SLUG = "trace-probe-slug-not-a-real-person";
+
+  @Autowired private PublicProfileService profiles;
+
+  @Test
+  @DisplayName("a call is traced by name and shape, never by argument value")
+  void argumentsAreDescribedNotPrinted(CapturedOutput output) {
+    assertThatThrownBy(() -> profiles.getProfileBySlug(SLUG)).isInstanceOf(RuntimeException.class);
+
+    assertThat(output).contains("getProfileBySlug(String(len=" + SLUG.length() + ")");
+    // The whole point. If this ever fails, the aspect is writing what users typed.
+    assertThat(output).doesNotContain(SLUG);
+  }
+
+  @Test
+  @DisplayName("a failure is traced as a shape too, so the frame it left is visible")
+  void failuresAreTraced(CapturedOutput output) {
+    assertThatThrownBy(() -> profiles.getProfileBySlug(SLUG)).isInstanceOf(RuntimeException.class);
+
+    assertThat(output).containsPattern("✗ getProfileBySlug threw \\w+ \\[\\d+ ms]");
+  }
+
+  @Test
+  @DisplayName("an id is printed, and the call is timed on the way out")
+  void idsAreKeptAndCallsAreTimed(CapturedOutput output) {
+    profiles.getProfile(MEMBER_ID);
+
+    // A UUID resolves only for somebody with database access; a name resolves for
+    // anyone holding the file. That difference is the whole rule.
+    assertThat(output).contains("getProfile(" + MEMBER_ID + ")");
+    // The duration is why this is worth switching on for a slow flow rather than a
+    // broken one, and the return is described by type — never by content.
+    assertThat(output).containsPattern("← getProfile = PublicProfileView \\[\\d+ ms]");
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/observability/UnhandledExceptionLoggingIT.java
+++ b/qnop-app/src/test/java/io/qnop/observability/UnhandledExceptionLoggingIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * An unexpected failure must be reconstructible (issue #659).
+ *
+ * <p>This is the case the whole diagnostic context exists for, and it was the one that used to slip
+ * through: with no handler, the exception left the dispatcher, the filter chain unwound, {@link
+ * io.qnop.web.RequestLogContextFilter} cleared the MDC, and only then did the servlet container
+ * write the stack trace — correlated to nothing.
+ */
+@ExtendWith(OutputCaptureExtension.class)
+@Import(UnhandledExceptionLoggingIT.FailingEndpoint.class)
+class UnhandledExceptionLoggingIT extends SeededIntegrationTest {
+
+  /** {@code ApiPathConfig} prefixes every {@code @RestController} with {@code /api/v1}. */
+  private static final String MAPPING = "/test-only/failure";
+
+  private static final String PATH = "/api/v1" + MAPPING;
+
+  @TestConfiguration
+  @RestController
+  static class FailingEndpoint {
+    @GetMapping(MAPPING)
+    String boom() {
+      throw new IllegalStateException("the storage backend is unreachable");
+    }
+  }
+
+  @Test
+  @DisplayName("an unhandled failure is logged with its request id and answered with the envelope")
+  void unhandledFailureIsLoggedAndCorrelated(CapturedOutput output) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(get(PATH).header("Authorization", "Bearer " + token(MEMBER_ID)))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.code").value("INTERNAL_ERROR"))
+            .andReturn();
+
+    String requestId = result.getResponse().getHeader("X-Request-Id");
+    assertThat(requestId).isNotBlank();
+
+    // The two halves that make a report answerable: the failure itself, and the id
+    // the user can quote. Either alone is what this issue set out to fix.
+    assertThat(output)
+        .contains("Unhandled IllegalStateException")
+        .contains("the storage backend is unreachable")
+        .contains(requestId);
+  }
+
+  @Test
+  @DisplayName("the internal message is not handed to the caller")
+  void internalsStayInternal() throws Exception {
+    mockMvc
+        .perform(get(PATH).header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.message").value("The request could not be completed."));
+  }
+
+  @Test
+  @DisplayName("a missing route is still a 404, not swallowed into a 500")
+  void springsOwnExceptionsAreLeftAlone() throws Exception {
+    // The catch-all matches Exception, so the guard against it shadowing Spring's own
+    // status-carrying exceptions is the part worth asserting.
+    mockMvc
+        .perform(get("/api/v1/no-such-route").header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     // Persistence: JPA entities + Spring Data repositories live in this module.
     implementation(libs.spring.boot.starter.data.jpa)
 
+    // Method tracing for the service layer at DEBUG (issue #659, ADR-0054).
+    implementation(libs.aspectjweaver)
+
     // Security & crypto foundation (issue #10, ADR-0022): the framework-light
     // io.qnop.security layer — validated properties, BCrypt, TextEncryptor, HKDF.
     // The servlet filter chain lives in qnop-app; core stays free of

--- a/qnop-core/src/main/java/io/qnop/observability/LogContext.java
+++ b/qnop-core/src/main/java/io/qnop/observability/LogContext.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.observability;
+
+import java.util.UUID;
+import org.slf4j.MDC;
+
+/**
+ * The diagnostic context every log line carries (issue #659, ADR-0054).
+ *
+ * <p>Logs answer "what happened to this user, on this review, in this request". Threading those ids
+ * through every signature would be unbearable, so they live in the MDC and the pattern prints them.
+ *
+ * <p><strong>Only ids.</strong> Never a name, an address, a review title, a file name or annotation
+ * text. A UUID is still personal data, but it is pseudonymous: resolving it takes database access
+ * someone has to be entitled to, and a log file that leaks does not read as a list of people. Free
+ * text cannot offer that, because whatever a user typed is whatever a user typed.
+ *
+ * <p><strong>Always scoped.</strong> Threads are pooled: a value left behind reappears under the
+ * next request, which is a different person. That is not untidiness — it is a false attribution in
+ * exactly the record someone later reads as evidence. Hence {@link #scope}: the value is removed by
+ * closing, and try-with-resources makes forgetting hard rather than merely discouraged.
+ */
+public final class LogContext {
+
+  /** One request, minted at the edge and echoed to the client so a user can quote it. */
+  public static final String REQUEST_ID = "requestId";
+
+  /** The authenticated caller, or absent for anonymous traffic. */
+  public static final String USER_ID = "userId";
+
+  /** The HTTP verb and the path — never the query string, which carries what a user typed. */
+  public static final String METHOD = "method";
+
+  public static final String PATH = "path";
+
+  /** The review being acted on — the thread that ties a request to the jobs it triggered. */
+  public static final String DOCUMENT_ID = "documentId";
+
+  /** The queued job being run, and its type. */
+  public static final String JOB_ID = "jobId";
+
+  public static final String JOB_TYPE = "jobType";
+
+  private LogContext() {}
+
+  /**
+   * Puts a value in the context until the returned scope is closed.
+   *
+   * <p>Restores whatever was there before rather than blindly clearing: nesting happens (a job
+   * handler inside a request in tests, a document scope inside another), and clearing would leave
+   * the outer scope's lines unattributed for the rest of its life.
+   *
+   * <p>A null value is not an error and not a blank entry — the key simply stays absent, so an
+   * anonymous request prints no user rather than the word "null".
+   */
+  public static Scope scope(String key, Object value) {
+    String previous = MDC.get(key);
+    if (value == null) {
+      MDC.remove(key);
+    } else {
+      MDC.put(key, value.toString());
+    }
+    return () -> {
+      if (previous == null) {
+        MDC.remove(key);
+      } else {
+        MDC.put(key, previous);
+      }
+    };
+  }
+
+  /** The review a piece of work concerns, for as long as the scope is open. */
+  public static Scope document(UUID documentId) {
+    return scope(DOCUMENT_ID, documentId);
+  }
+
+  /** What the context currently holds for a key, or null. Mainly for tests. */
+  public static String get(String key) {
+    return MDC.get(key);
+  }
+
+  /**
+   * A context entry that ends when it is closed.
+   *
+   * <p>{@link AutoCloseable} without a checked exception, so it reads as {@code try (var ignored =
+   * LogContext.document(id))} and never forces a catch nobody wants.
+   */
+  @FunctionalInterface
+  public interface Scope extends AutoCloseable {
+    @Override
+    void close();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/observability/MethodTraceAspect.java
+++ b/qnop-core/src/main/java/io/qnop/observability/MethodTraceAspect.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.observability;
+
+import java.lang.reflect.Array;
+import java.time.temporal.Temporal;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Verbose tracing of the service layer, on at DEBUG and silent otherwise (issue #659, ADR-0054).
+ *
+ * <p>One pointcut rather than a log line in every method: hand-written entry and exit lines are
+ * hundreds of edits that drift from the first refactor onwards, and they cost their noise at every
+ * level rather than only where it is wanted.
+ *
+ * <p>Loggers are named {@code io.qnop.trace.<SimpleName>}, so tracing has its own switch — {@code
+ * logging.level.io.qnop.trace=DEBUG} for everything, or one class when a single flow is in question
+ * — without turning the rest of {@code io.qnop} to DEBUG at the same time.
+ *
+ * <p><strong>Arguments are described, not printed.</strong> Ids, numbers, booleans and enums are
+ * safe and are exactly what makes a trace useful. A {@code String} is not: at this layer it is
+ * almost always a review title, an address or a comment, and no whitelist of parameter names
+ * survives a rename. So a string is rendered as its length, and any other object as its type. That
+ * keeps the DEBUG log as free of personal data as the INFO log — a file on disk does not become
+ * less readable because a level was raised to produce it.
+ */
+@Aspect
+@Component
+public class MethodTraceAspect {
+
+  private static final String TRACE_LOGGER_PREFIX = "io.qnop.trace.";
+
+  /** One logger per traced class, resolved once rather than on every call. */
+  private static final Map<Class<?>, Logger> LOGGERS = new ConcurrentHashMap<>();
+
+  /**
+   * Every public method of an {@code @Service} bean.
+   *
+   * <p>The service layer is where the decisions are; repositories are covered better by Hibernate's
+   * own SQL logging, and the web layer by the request line.
+   *
+   * <p>Scoped to the stereotype rather than to the package, and not by preference:
+   * {@code @ConfigurationProperties} records live in {@code io.qnop.service} too, a record is
+   * final, and matching one makes Spring try to CGLIB-subclass it — which fails at startup rather
+   * than degrading quietly. The stereotype names the beans whose behaviour is worth tracing anyway.
+   */
+  @Pointcut(
+      "execution(public * io.qnop.service..*(..))"
+          + " && @within(org.springframework.stereotype.Service)")
+  void serviceMethods() {}
+
+  @Around("serviceMethods()")
+  public Object trace(ProceedingJoinPoint call) throws Throwable {
+    Logger log = loggerFor(call.getTarget().getClass());
+    if (!log.isDebugEnabled()) {
+      // The common case in production: no formatting, no timing, nothing but the
+      // proceed. Guarded rather than trusted to the logger, because building the
+      // argument list is not free.
+      return call.proceed();
+    }
+
+    String method = call.getSignature().getName();
+    log.debug("→ {}({})", method, describeAll(call.getArgs()));
+    long started = System.nanoTime();
+    try {
+      Object result = call.proceed();
+      log.debug("← {} = {} [{} ms]", method, describe(result), millisSince(started));
+      return result;
+    } catch (Throwable failure) {
+      // Only that it came out here, and how far it got. The failure itself is logged
+      // where it is handled; repeating the trace at every frame is how a log becomes
+      // unreadable.
+      log.debug(
+          "✗ {} threw {} [{} ms]",
+          method,
+          failure.getClass().getSimpleName(),
+          millisSince(started));
+      throw failure;
+    }
+  }
+
+  private static Logger loggerFor(Class<?> target) {
+    return LOGGERS.computeIfAbsent(
+        target,
+        type ->
+            LoggerFactory.getLogger(
+                TRACE_LOGGER_PREFIX + type.getSimpleName().replace("$$SpringCGLIB$$0", "")));
+  }
+
+  private static long millisSince(long startedNanos) {
+    return (System.nanoTime() - startedNanos) / 1_000_000;
+  }
+
+  private static String describeAll(Object[] arguments) {
+    StringBuilder rendered = new StringBuilder();
+    for (int index = 0; index < arguments.length; index++) {
+      if (index > 0) {
+        rendered.append(", ");
+      }
+      rendered.append(describe(arguments[index]));
+    }
+    return rendered.toString();
+  }
+
+  /**
+   * What a value may say about itself.
+   *
+   * <p>The list is deliberately short: everything not on it is described by type and size only.
+   * Erring towards "type only" costs a little detail in a debug session; erring the other way puts
+   * whatever a user typed into a file with no access control.
+   */
+  private static String describe(Object value) {
+    return switch (value) {
+      case null -> "null";
+      case UUID id -> id.toString();
+      case Number number -> number.toString();
+      case Boolean flag -> flag.toString();
+      case Enum<?> constant -> constant.name();
+      case Temporal instant -> instant.toString();
+      // Length, never content: at this layer a String is a title, an address or a
+      // comment far more often than it is an identifier.
+      case CharSequence text -> "String(len=" + text.length() + ")";
+      case Optional<?> maybe ->
+          maybe.map(inner -> "Optional[" + describe(inner) + "]").orElse("Optional.empty");
+      case Collection<?> items -> items.getClass().getSimpleName() + "(" + items.size() + ")";
+      case Map<?, ?> entries -> "Map(" + entries.size() + ")";
+      default -> {
+        if (value.getClass().isArray()) {
+          yield value.getClass().getSimpleName() + "(" + Array.getLength(value) + ")";
+        }
+        yield value.getClass().getSimpleName();
+      }
+    };
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/branding/ImageDimensions.java
+++ b/qnop-core/src/main/java/io/qnop/service/branding/ImageDimensions.java
@@ -29,6 +29,8 @@ import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
 /**
@@ -39,6 +41,8 @@ import org.w3c.dom.Element;
  * byte-size cap.
  */
 public record ImageDimensions(int width, int height) {
+
+  private static final Logger log = LoggerFactory.getLogger(ImageDimensions.class);
 
   private static final Pattern VIEW_BOX =
       Pattern.compile("\\s*[-+0-9.eE]+\\s+[-+0-9.eE]+\\s+([-+0-9.eE]+)\\s+([-+0-9.eE]+)\\s*");
@@ -89,6 +93,10 @@ public record ImageDimensions(int width, int height) {
       }
       return Optional.empty();
     } catch (Exception e) {
+      // A catch-all over XML parsing of an uploaded file: "unreadable" is the
+      // right answer to the caller, but silence is the wrong answer to whoever
+      // later asks why a valid-looking logo had no dimensions (issue #659).
+      log.debug("Could not read SVG dimensions from an uploaded asset", e);
       return Optional.empty();
     }
   }

--- a/qnop-core/src/main/java/io/qnop/service/convert/LibreOfficeConverter.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/LibreOfficeConverter.java
@@ -20,9 +20,13 @@
  */
 package io.qnop.service.convert;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +52,12 @@ import org.springframework.stereotype.Component;
 public class LibreOfficeConverter implements OfficeConverter {
 
   private static final Logger log = LoggerFactory.getLogger(LibreOfficeConverter.class);
+
+  /** Enough for a stack of LibreOffice complaints, far short of anything that fills a log file. */
+  private static final int MAX_CAPTURED_OUTPUT = 4_000;
+
+  /** How long to wait for the reader once the process is already gone. */
+  private static final Duration OUTPUT_DRAIN_GRACE = Duration.ofSeconds(2);
 
   private final OfficeConverterProperties properties;
 
@@ -125,7 +135,13 @@ public class LibreOfficeConverter implements OfficeConverter {
       workspace = Files.createTempDirectory("qnop-convert-");
       Path input = workspace.resolve("document." + sourceExtension);
       Files.write(input, source);
+      long started = System.nanoTime();
       run(workspace, input);
+      log.info(
+          "Converted {} bytes of {} to PDF in {} ms",
+          source.length,
+          sourceExtension,
+          (System.nanoTime() - started) / 1_000_000);
 
       Path output = workspace.resolve("document.pdf");
       if (!Files.exists(output)) {
@@ -160,18 +176,29 @@ public class LibreOfficeConverter implements OfficeConverter {
             workspace.toString(),
             input.toString());
 
-    Process process =
-        new ProcessBuilder(command)
-            .redirectErrorStream(true)
-            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-            .start();
+    // Kept rather than discarded (issue #659): a non-zero exit used to leave nothing
+    // but a status number, and what LibreOffice actually complained about is the one
+    // thing a developer needs. The workspace path holds no user-chosen name — the
+    // input is always "document.<ext>" under a generated temp directory — so the
+    // output carries nothing personal.
+    Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    StringBuilder output = new StringBuilder();
+    Thread drain = drainInto(process, output);
     try {
       if (!process.waitFor(properties.timeout().toMillis(), TimeUnit.MILLISECONDS)) {
         process.destroyForcibly();
+        log.warn(
+            "The office converter did not finish within {}; it said: {}",
+            properties.timeout(),
+            saidOrNothing(drain, output));
         throw new OfficeConversionException(
             "the converter did not finish within " + properties.timeout());
       }
       if (process.exitValue() != 0) {
+        log.warn(
+            "The office converter exited with status {}; it said: {}",
+            process.exitValue(),
+            saidOrNothing(drain, output));
         throw new OfficeConversionException(
             "the converter exited with status " + process.exitValue());
       }
@@ -180,6 +207,49 @@ public class LibreOfficeConverter implements OfficeConverter {
       Thread.currentThread().interrupt();
       throw new OfficeConversionException("interrupted while converting a document", e);
     }
+  }
+
+  /**
+   * Reads the process output on its own thread.
+   *
+   * <p>Not optional: with the pipe kept rather than discarded, a converter that writes more than
+   * the OS buffer holds would block forever on a reader that only starts after {@code waitFor}. The
+   * capture is bounded for the same reason the buffer is — a runaway process must not become a
+   * runaway log line.
+   */
+  private static Thread drainInto(Process process, StringBuilder sink) {
+    Thread thread =
+        new Thread(
+            () -> {
+              try (BufferedReader reader =
+                  new BufferedReader(
+                      new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                int character;
+                while ((character = reader.read()) != -1) {
+                  if (sink.length() < MAX_CAPTURED_OUTPUT) {
+                    sink.append((char) character);
+                  }
+                }
+              } catch (IOException e) {
+                // The process is gone or the pipe broke; there is nothing left to read
+                // and nothing a failed drain changes about the conversion's outcome.
+              }
+            },
+            "office-converter-output");
+    thread.setDaemon(true);
+    thread.start();
+    return thread;
+  }
+
+  /** Whatever the converter managed to say, collapsed onto one line. */
+  private static String saidOrNothing(Thread drain, StringBuilder output) {
+    try {
+      drain.join(OUTPUT_DRAIN_GRACE.toMillis());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    String said = output.toString().replaceAll("\\s+", " ").trim();
+    return said.isEmpty() ? "(nothing)" : said;
   }
 
   /** Best-effort cleanup: a leftover temp directory must not fail a conversion that succeeded. */

--- a/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/document/DocumentExtractionJobHandler.java
@@ -22,6 +22,7 @@ package io.qnop.service.document;
 
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
+import io.qnop.observability.LogContext;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobHandler;
 import io.qnop.service.job.JobPayload;
@@ -107,6 +108,16 @@ public class DocumentExtractionJobHandler implements JobHandler {
     if (version.getExtractionStatus() == ExtractionStatus.READY) {
       return; // idempotent: replay after a crash-past-the-work
     }
+
+    // From here on the lines carry the review (issue #659). Without it, extraction is
+    // the one place where a failure a user reports on their review has no way back to
+    // it: the job runs on its own thread, long after the upload's request is gone.
+    try (LogContext.Scope ignored = LogContext.document(version.getDocumentId())) {
+      extract(version, versionId);
+    }
+  }
+
+  private void extract(DocumentVersion version, UUID versionId) {
 
     // What gets extracted is the PDF, whether that is the upload or the conversion of
     // it (issue #343). The renditions service converts at most once per version and

--- a/qnop-core/src/main/java/io/qnop/service/job/JobQueuePoller.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobQueuePoller.java
@@ -20,6 +20,7 @@
  */
 package io.qnop.service.job;
 
+import io.qnop.observability.LogContext;
 import java.util.List;
 import java.util.UUID;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -55,14 +56,26 @@ public class JobQueuePoller {
   @SchedulerLock(name = "jobQueuePoller", lockAtMostFor = "PT2M")
   public void poll() {
     List<UUID> claimed = jobService.claimBatch();
+    if (claimed.isEmpty()) {
+      return; // the common tick: say nothing rather than a line every five seconds
+    }
+    log.debug("Claimed {} job(s) to run", claimed.size());
     for (UUID id : claimed) {
-      try {
-        jobService.runOne(id);
-      } catch (RuntimeException e) {
+      // Async work has no request behind it, so without this the whole extraction
+      // and re-anchoring cascade would log unattributed (issue #659). The scope
+      // closes before the next job, so one job's id can never label another's.
+      try (LogContext.Scope ignored = LogContext.scope(LogContext.JOB_ID, id)) {
         try {
-          jobService.recordFailure(id, e);
-        } catch (RuntimeException recordError) {
-          log.error("Could not record failure for job {}", id, recordError);
+          jobService.runOne(id);
+        } catch (RuntimeException e) {
+          // The queue's own retry/backoff decides what happens next; this is the
+          // line that says a job attempt went wrong at all.
+          log.warn("Job {} failed and will be retried or failed by the queue", id, e);
+          try {
+            jobService.recordFailure(id, e);
+          } catch (RuntimeException recordError) {
+            log.error("Could not record failure for job {}", id, recordError);
+          }
         }
       }
     }

--- a/qnop-core/src/main/java/io/qnop/service/job/JobService.java
+++ b/qnop-core/src/main/java/io/qnop/service/job/JobService.java
@@ -22,6 +22,7 @@ package io.qnop.service.job;
 
 import io.qnop.entity.Job;
 import io.qnop.entity.JobStatus;
+import io.qnop.observability.LogContext;
 import io.qnop.repository.JobRepository;
 import java.time.Duration;
 import java.time.Instant;
@@ -107,9 +108,17 @@ public class JobService {
     if (handler == null) {
       throw new IllegalStateException("No JobHandler registered for type: " + job.getType());
     }
-    handler.handle(job.getPayload());
-    job.markDone();
-    repository.save(job);
+    // The type belongs on every line the handler writes: an id alone says which
+    // job, not what it was trying to do (issue #659).
+    try (LogContext.Scope ignored = LogContext.scope(LogContext.JOB_TYPE, job.getType())) {
+      long startedAt = System.nanoTime();
+      handler.handle(job.getPayload());
+      job.markDone();
+      repository.save(job);
+      // One line per completed job, with the duration: the cheapest way to see a
+      // handler that has quietly become slow.
+      log.info("Job done in {} ms", (System.nanoTime() - startedAt) / 1_000_000);
+    }
   }
 
   /**

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailService.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailService.java
@@ -77,7 +77,10 @@ public class MailService {
       sender.send(message);
       return new SendResult.Sent(to);
     } catch (Exception e) {
-      log.warn("Failed to send mail to {}: {}", to, e.getMessage());
+      // Never the address (issue #659): a failed send would otherwise write a
+      // recipient into a log file on every SMTP hiccup. The request or job in the
+      // diagnostic context is enough to find which send this was.
+      log.warn("Failed to send mail: {}", e.getMessage());
       return new SendResult.Failed(e.getMessage());
     }
   }
@@ -89,7 +92,7 @@ public class MailService {
     try {
       mail = templates.render(key, vars, locale);
     } catch (RuntimeException e) {
-      log.warn("Failed to render template {} for {}: {}", key, to, e.getMessage());
+      log.warn("Failed to render mail template {}: {}", key, e.getMessage());
       return new SendResult.Failed("template render failed: " + e.getMessage());
     }
     return sendMail(to, mail.subject(), mail.bodyPlain(), mail.bodyHtml());

--- a/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReanchorJobHandler.java
@@ -24,6 +24,7 @@ import io.qnop.entity.AnnotationPlacement;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ExtractionStatus;
 import io.qnop.entity.PlacementStatus;
+import io.qnop.observability.LogContext;
 import io.qnop.repository.AnnotationPlacementRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.service.job.JobHandler;
@@ -92,6 +93,15 @@ public class ReanchorJobHandler implements JobHandler {
       return; // idempotent: the document was deleted after enqueue
     }
     DocumentVersion version = found.get();
+    // Ties the re-anchoring lines to the review they concern (issue #659). Scoped
+    // rather than merely set: this runs on a pooled worker, and a value left behind
+    // would attribute the next job to this review.
+    try (LogContext.Scope ignored = LogContext.document(version.getDocumentId())) {
+      reanchor(version, versionId);
+    }
+  }
+
+  private void reanchor(DocumentVersion version, UUID versionId) {
     if (version.getExtractionStatus() != ExtractionStatus.READY
         || version.getRenderedDocument() == null) {
       // Enqueued transactionally with the READY write, so this can only be a broken invariant —
@@ -103,17 +113,32 @@ public class ReanchorJobHandler implements JobHandler {
 
     List<AnnotationPlacement> pending =
         placements.findByDocumentVersionIdAndStatus(versionId, PlacementStatus.PENDING);
+    int moved = 0;
+    int orphaned = 0;
     for (AnnotationPlacement placement : pending) {
       AnchorResolver.Resolution resolution = resolver.resolve(placement.getAnchor(), rendered);
       switch (resolution.outcome()) {
         case PLACED -> placement.markPlaced(resolution.anchorJson());
-        case MOVED -> placement.markMoved(resolution.anchorJson());
-        case ORPHANED -> placement.markOrphaned();
+        case MOVED -> {
+          placement.markMoved(resolution.anchorJson());
+          moved++;
+        }
+        case ORPHANED -> {
+          placement.markOrphaned();
+          orphaned++;
+        }
       }
       placements.save(placement);
     }
     if (!pending.isEmpty()) {
-      log.info("Re-anchored {} placement(s) on version {}.", pending.size(), versionId);
+      // The breakdown, not just the count: "annotations vanished after the new version"
+      // is a support report, and orphaned-versus-moved is the first thing to know.
+      log.info(
+          "Re-anchored {} placement(s) on version {}: {} moved, {} orphaned",
+          pending.size(),
+          versionId,
+          moved,
+          orphaned);
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewDeletionService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewDeletionService.java
@@ -134,12 +134,10 @@ public class ReviewDeletionService {
             events.publishEvent(
                 new ReviewEvent.ReviewDeleted(
                     documentId, actorId, deleted.ownerId(), deleted.title())));
-    log.info(
-        "Review {} ({}) deleted by {}; {} storage object(s) released.",
-        documentId,
-        deleted.title(),
-        actorId,
-        objects);
+    // The title is deliberately absent (issue #659): it is user content and
+    // routinely carries a name. The audit trail keeps it, behind access control;
+    // a log file has neither.
+    log.info("Review deleted by {}; {} storage object(s) released", actorId, objects);
     return new DeletedReview(documentId, deleted.title(), objects);
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -43,6 +43,8 @@ import io.qnop.service.review.ReviewWorkflowMachine.TransitionResult;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,6 +61,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 public class ReviewWorkflowService {
+
+  private static final Logger log = LoggerFactory.getLogger(ReviewWorkflowService.class);
 
   /** Audit event type for a workflow state change; detail carries {@code {"from","to"}}. */
   static final String AUDIT_WORKFLOW_TRANSITION = "workflow.transition";
@@ -372,6 +376,14 @@ public class ReviewWorkflowService {
             : machine.transition(from, target, context);
     switch (result) {
       case TransitionResult.Allowed allowed -> {
+        // The review id rides in the diagnostic context on a request; the sweeps that
+        // transition without one open their own document scope.
+        log.info(
+            "Workflow {} -> {} ({}) by {}",
+            from,
+            allowed.target(),
+            manual ? "requested" : "derived",
+            actorId);
         document.setWorkflowState(allowed.target());
         // Record the terminal instant once, so the auto-archive sweep (issue #576) has a cheap
         // "closed since" predicate. FINALIZED/CANCELLED are terminal, so this fires exactly once.
@@ -379,9 +391,11 @@ public class ReviewWorkflowService {
           document.setClosedAt(Instant.now());
         }
       }
-      case TransitionResult.Denied denied ->
-          throw new WorkflowTransitionException(
-              WorkflowTransitionException.INVALID_TRANSITION, denied.reason());
+      case TransitionResult.Denied denied -> {
+        log.info("Workflow {} -> {} denied: {}", from, target, denied.reason());
+        throw new WorkflowTransitionException(
+            WorkflowTransitionException.INVALID_TRANSITION, denied.reason());
+      }
     }
     auditEvents.save(
         new AuditEvent(

--- a/qnop-core/src/main/java/io/qnop/service/review/export/DocxAnnotationRenderer.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/export/DocxAnnotationRenderer.java
@@ -643,7 +643,13 @@ public class DocxAnnotationRenderer implements AnnotationExportRenderer {
               Units.toEMU(size.width()),
               Units.toEMU(size.height()));
     } catch (Exception e) {
-      log.warn("Could not embed {} in the Word report", resolved.fileName(), e);
+      // The file name is the uploader's, and uploaders name files after people
+      // (issue #659). The type and size say enough to diagnose an embed failure.
+      log.warn(
+          "Could not embed a {} attachment of {} bytes in the Word report",
+          resolved.contentType(),
+          resolved.content().length,
+          e);
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/storage/S3StorageProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/storage/S3StorageProvider.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -46,6 +48,8 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
  * (SaaS) identically — the S3 API is the abstraction, so there is no multi-cloud layer.
  */
 public class S3StorageProvider implements StorageProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(S3StorageProvider.class);
 
   /**
    * The content-addressed key shape this adapter accepts: {@code sha256/<2-hex-shard>/<64-hex>}, as
@@ -67,10 +71,13 @@ public class S3StorageProvider implements StorageProvider {
   @Override
   public void put(String key, InputStream content, long contentLength, String contentType) {
     requireValidKey(key);
+    long started = System.nanoTime();
     try {
       s3.putObject(
           PutObjectRequest.builder().bucket(bucket).key(key).contentType(contentType).build(),
           RequestBody.fromInputStream(content, contentLength));
+      // Keys are content-addressed and pattern-checked (issue #337): a hash, never a name.
+      log.debug("PUT {} ({} bytes, {}) in {} ms", key, contentLength, contentType, millis(started));
     } catch (S3Exception e) {
       throw new StorageException("Failed to store object " + key, e);
     }
@@ -79,13 +86,16 @@ public class S3StorageProvider implements StorageProvider {
   @Override
   public Optional<StorageContent> get(String key) {
     requireValidKey(key);
+    long started = System.nanoTime();
     try {
       ResponseInputStream<GetObjectResponse> stream =
           s3.getObject(GetObjectRequest.builder().bucket(bucket).key(key).build());
       GetObjectResponse response = stream.response();
+      log.debug("GET {} ({} bytes) in {} ms", key, response.contentLength(), millis(started));
       return Optional.of(
           new StorageContent(stream, response.contentLength(), response.contentType()));
     } catch (NoSuchKeyException e) {
+      log.debug("GET {} missed", key);
       return Optional.empty();
     } catch (S3Exception e) {
       throw new StorageException("Failed to read object " + key, e);
@@ -117,6 +127,7 @@ public class S3StorageProvider implements StorageProvider {
     }
     try {
       s3.deleteObject(b -> b.bucket(bucket).key(key));
+      log.debug("DELETE {}", key);
       return true;
     } catch (S3Exception e) {
       throw new StorageException("Failed to delete object " + key, e);
@@ -143,6 +154,10 @@ public class S3StorageProvider implements StorageProvider {
     } catch (S3Exception e) {
       throw new StorageException("Failed to list objects under prefix", e);
     }
+  }
+
+  private static long millis(long startedNanos) {
+    return (System.nanoTime() - startedNanos) / 1_000_000;
   }
 
   /**


### PR DESCRIPTION
Closes #659.

Before this, answering "it failed yesterday afternoon" was impossible: no request id, no user attribution, nothing tying an async job to what caused it. Measured on `main`: 98 log statements across 35 files out of 187 service classes, **no** logging configuration, and **zero** MDC usage. Meanwhile personal data was already in there — `ReviewDeletionService` wrote the review title.

## The diagnostic context

`LogContext` owns the MDC keys and hands out scopes that *restore* rather than clear, so nesting cannot orphan an outer value. Ids are set at the edges rather than threaded through signatures:

- `RequestLogContextFilter` — mints the request id **before** Spring Security, so a rejected login has one too, and echoes it as `X-Request-Id` for a user to quote. Wipes the whole MDC in `finally`; Tomcat pools threads, and a value left behind attributes the next request — a different person — to whoever came before.
- `UserLogContextFilter` — the caller, **after** Security. Two filters because no single filter can be on both sides of authentication.
- `DocumentLogContextInterceptor` — the review, from the parsed URI template, so every `/documents/{documentId}/…` route is covered including the ones added next year. UUIDs only: the same path accepts a slug, and a slug is user-chosen text.
- The job poller and `JobService` scope `jobId`/`jobType`; the extraction and re-anchoring handlers scope the review, so async work ties back to the review a user is reporting about.

Boot's default console pattern prints no MDC, so `logging.pattern.correlation` was the difference between this working and being invisible. `QNOP_LOG_FORMAT=ecs` switches the whole thing to structured JSON without a new dependency.

## Failures are logged where the context still exists

Neither exception handler logged anything, and there was no catch-all. An unhandled failure left the dispatcher, the filter chain unwound and cleared the MDC, and only then did the container write the stack trace — correlated to nothing. `UnhandledExceptionHandler` catches it inside the chain.

Ordered `LOWEST_PRECEDENCE` on purpose: `Exception` matches everything, and at default precedence it would shadow the specific handlers and turn every 403 and 404 into a 500. What Spring and Spring Security own is rethrown.

Also fixed: the office converter discarded its own output, so a failed DOCX conversion reported nothing but an exit status. It is now captured (bounded, drained on its own thread so a chatty converter cannot deadlock on a full pipe).

## Verbose DEBUG

`MethodTraceAspect` traces every public `@Service` method — call, return shape, duration, and the frame an exception left through. One pointcut instead of a log statement in several hundred methods that drifts from the first refactor onwards.

```
DEBUG io.qnop.trace.PublicProfileService : → getProfile(a3f1…)
DEBUG io.qnop.trace.PublicProfileService : ← getProfile = PublicProfileView [4 ms]
```

Switches, each off by default: `QNOP_LOG_LEVEL_TRACE`, `QNOP_LOG_SQL`, `QNOP_LOG_LEVEL_SECURITY`, `QNOP_LOG_LEVEL_WEB` (adds a line per request: method, route, status, duration), `QNOP_LOG_LEVEL_TX`. Trace loggers are named `io.qnop.trace.<Class>`, so a single class can be raised on its own.

## Privacy (GDPR)

A log file has no access control, no retention policy and no subject-access route. Ids yes — a UUID is pseudonymous and resolving it takes database access someone must be entitled to. Names, addresses, titles, annotation text, file names, slugs and client IPs no.

- Fixed leaks: the review title in `ReviewDeletionService`, the file name in `DocxAnnotationRenderer`, and the recipient address in `MailService`.
- **Raising a level must not start writing personal data**, so the aspect describes arguments rather than printing them: ids/numbers/enums/timestamps as themselves, a `String` as its length, anything else as its type. The cost is real (a job name is hidden along with a review title) and accepted, because no shape rule separates `review-purge` from `max-mustermann`.
- The MDC's `path` now holds the matched route template rather than the raw URI, which carried the same slugs the document scope already refused.
- `LogPrivacyTest` scans the sources for log calls reaching user-entered values. Deliberately a source scan, not ArchUnit: ArchUnit sees that a class calls `getTitle()` and that it calls `Logger.info()`, never that the first is an argument to the second.

The guard is a net, not a proof, and this PR contains the evidence: it did **not** catch `MailService` logging its recipient, because the address sat in a local named `to`. Found by reading the code. Unambiguous identifier names are now checked too; `to` stays out, because a version diff legitimately logs a `from`/`to` pair of numbers.

## ADR

`docs/adr/0054-logging-and-diagnostic-context.md` — what is logged, what deliberately is not, level semantics, and the rejected alternatives (JSON everywhere, entry/exit at INFO, hand-written DEBUG lines, printing arguments at DEBUG, an ArchUnit rule, Micrometer tracing — deferred, not rejected).

## Test plan

- [x] `./gradlew build` — green (Spotless, ArchUnit, full suite incl. Testcontainers)
- [x] `LogContextIT` — 7 tests asserting the **rendered console output**, not the configuration: the failure mode here is silent, and asserting "property is set" would prove nothing
- [x] `UnhandledExceptionLoggingIT` — proven by disabling the advice and watching the assertions fail; also asserts a missing route still 404s rather than being swallowed
- [x] `MethodTraceAspectIT` — a `String` argument is never printed; ids are; failures and durations are traced
- [x] `LogPrivacyTest` — verified against a real violation (title reintroduced, test named the file and expression, removed again)
- [ ] Reviewer check: `QNOP_LOG_FORMAT=ecs` against a real deployment target's log pipeline

Two things worth a reviewer's eye. The catch-all handler changes the response shape for previously unhandled exceptions from Boot's default error body to our `ErrorResponse` envelope — deliberate, and the full IT suite passes. And the aspect now proxies 58 service beans; the pointcut is scoped to the `@Service` stereotype rather than the package because `@ConfigurationProperties` records live there too and a record cannot be CGLIB-subclassed, which failed at startup until it was narrowed.

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
