### PR TITLE
fix(review): mutating document endpoints leak review existence via 403-vs-404 (#661)

### DIFF
--- a/qnop-app/src/test/java/io/qnop/review/DocumentMutationAntiEnumerationIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/DocumentMutationAntiEnumerationIT.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.AbstractMockHttpServletRequestBuilder;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * Anti-enumeration across every mutating single-document endpoint (issue #661).
+ *
+ * <p>The read paths answer a non-participant 404 so a review id cannot be probed for existence —
+ * "non-participants must not learn that the document exists" ({@code DocumentAccessService}). The
+ * fix for #661 aligned archive/unarchive with that; this pins the whole family so a future endpoint
+ * cannot quietly reintroduce the leak.
+ *
+ * <p>Two halves, and both matter:
+ *
+ * <ul>
+ *   <li><b>The guard</b> fires each endpoint as a non-participant against a real foreign review and
+ *       against an unknown id, and asserts the two are indistinguishable — the same 404. A 403 (or
+ *       a success) on the foreign one but a 404 on the unknown one is exactly the leak.
+ *   <li><b>The completeness check</b> discovers the mutating {@code
+ *       /documents/&#123;documentId&#125;} endpoints from the live handler mapping and asserts the
+ *       guard covers every one. A new endpoint that is not listed fails the build rather than
+ *       slipping through unguarded.
+ * </ul>
+ *
+ * <p>Each request is crafted only well enough to pass argument resolution and reach the service's
+ * authorization — no business-valid body is needed. That is self-checking: a body too thin to reach
+ * authorization would 400 rather than 404, and the guard would fail loudly, not pass silently.
+ */
+class DocumentMutationAntiEnumerationIT extends SeededIntegrationTest {
+
+  /** A real, enabled user who is not the owner and not a participant of the review under test. */
+  private static final UUID NON_PARTICIPANT = MEMBER2_ID;
+
+  private static final String DOCUMENTS = "/api/v1/documents/";
+
+  @Autowired
+  @Qualifier("requestMappingHandlerMapping")
+  private RequestMappingHandlerMapping handlerMapping;
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+
+  private record Endpoint(
+      String method,
+      String template,
+      Function<UUID, AbstractMockHttpServletRequestBuilder<?>> request) {
+    String signature() {
+      return method + " " + template;
+    }
+  }
+
+  private static MockMultipartFile filePart() {
+    return new MockMultipartFile(
+        "file", "probe.pdf", "application/pdf", "%PDF-1.4\n%%EOF\n".getBytes());
+  }
+
+  /**
+   * One entry per mutating single-document endpoint. Kept in lockstep with the live mapping by
+   * {@link #everyMutatingDocumentEndpointIsCovered()} — add the endpoint here when that fails.
+   */
+  private List<Endpoint> guardedEndpoints() {
+    return List.of(
+        new Endpoint("DELETE", "/api/v1/documents/{documentId}", id -> delete(DOCUMENTS + id)),
+        new Endpoint(
+            "DELETE",
+            "/api/v1/documents/{documentId}/participants/{participantId}",
+            id -> delete(DOCUMENTS + id + "/participants/" + UUID.randomUUID())),
+        new Endpoint(
+            "PATCH",
+            "/api/v1/documents/{documentId}",
+            id -> patch(DOCUMENTS + id).contentType(MediaType.APPLICATION_JSON).content("{}")),
+        new Endpoint(
+            "POST",
+            "/api/v1/documents/{documentId}/annotations",
+            id ->
+                post(DOCUMENTS + id + "/annotations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"versionNumber\":1,\"comment\":\"probe\"}")),
+        new Endpoint(
+            "POST",
+            "/api/v1/documents/{documentId}/archive",
+            id -> post(DOCUMENTS + id + "/archive")),
+        new Endpoint(
+            "POST",
+            "/api/v1/documents/{documentId}/attachments",
+            id -> multipart(DOCUMENTS + id + "/attachments").file(filePart())),
+        new Endpoint(
+            "POST",
+            "/api/v1/documents/{documentId}/participants",
+            id ->
+                post(DOCUMENTS + id + "/participants")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"userId\":\"" + UUID.randomUUID() + "\"}")),
+        new Endpoint(
+            "POST",
+            "/api/v1/documents/{documentId}/unarchive",
+            id -> post(DOCUMENTS + id + "/unarchive")),
+        new Endpoint(
+            "POST",
+            "/api/v1/documents/{documentId}/versions",
+            id -> multipart(DOCUMENTS + id + "/versions").file(filePart())),
+        new Endpoint(
+            "POST", "/api/v1/documents/{documentId}/visit", id -> post(DOCUMENTS + id + "/visit")),
+        new Endpoint(
+            "POST",
+            "/api/v1/documents/{documentId}/workflow",
+            id ->
+                post(DOCUMENTS + id + "/workflow")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"targetState\":\"FINALIZED\"}")));
+  }
+
+  @Test
+  @DisplayName("every mutating document endpoint answers a non-participant 404, unknown or not")
+  void everyMutatingDocumentEndpointHidesExistenceFromNonParticipants() throws Exception {
+    UUID foreign = foreignReview();
+    UUID unknown = UUID.randomUUID();
+
+    for (Endpoint endpoint : guardedEndpoints()) {
+      int onForeign = statusAsNonParticipant(endpoint.request().apply(foreign));
+      int onUnknown = statusAsNonParticipant(endpoint.request().apply(unknown));
+
+      assertThat(onForeign)
+          .as(
+              "%s must answer a non-participant the same for a real-but-invisible review as for an"
+                  + " unknown id — a differing status leaks that the review exists",
+              endpoint.signature())
+          .isEqualTo(404)
+          .isEqualTo(onUnknown);
+    }
+  }
+
+  @Test
+  @DisplayName("the guard covers every mutating /documents/{documentId} endpoint that exists")
+  void everyMutatingDocumentEndpointIsCovered() {
+    Set<String> live = discoverMutatingDocumentEndpoints();
+    Set<String> guarded =
+        guardedEndpoints().stream()
+            .map(Endpoint::signature)
+            .collect(Collectors.toCollection(TreeSet::new));
+
+    assertThat(live)
+        .as(
+            "a mutating /documents/{documentId} endpoint exists that the anti-enumeration guard does"
+                + " not cover (issue #661). Add it to guardedEndpoints() with a request that reaches"
+                + " the service, so it cannot leak a review's existence unnoticed.")
+        .isEqualTo(guarded);
+  }
+
+  private int statusAsNonParticipant(AbstractMockHttpServletRequestBuilder<?> request)
+      throws Exception {
+    return mockMvc
+        .perform(request.header("Authorization", "Bearer " + token(NON_PARTICIPANT)))
+        .andReturn()
+        .getResponse()
+        .getStatus();
+  }
+
+  /** A MEMBER-owned review with one version and no participants — invisible to NON_PARTICIPANT. */
+  private UUID foreignReview() {
+    Document document = new Document(MEMBER_ID, "Anti-enumeration foreign review");
+    document.setWorkflowState(WorkflowState.IN_REVIEW);
+    UUID documentId = documents.save(document).getId();
+    versions.save(
+        new DocumentVersion(
+            documentId, 1, "anti-enum-key", "hash", "application/pdf", 8L, MEMBER_ID));
+    return documentId;
+  }
+
+  /** Mutating verbs on a path keyed directly on {@code {documentId}}, from the live mapping. */
+  private Set<String> discoverMutatingDocumentEndpoints() {
+    Set<String> found = new TreeSet<>();
+    for (RequestMappingInfo info : handlerMapping.getHandlerMethods().keySet()) {
+      var patterns = info.getPathPatternsCondition();
+      if (patterns == null) {
+        continue;
+      }
+      for (var pattern : patterns.getPatterns()) {
+        String path = pattern.getPatternString();
+        if (!path.contains("/documents/{documentId}")) {
+          continue;
+        }
+        for (var method : info.getMethodsCondition().getMethods()) {
+          if (!method.name().equals("GET")) {
+            found.add(method.name() + " " + path);
+          }
+        }
+      }
+    }
+    return found;
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/ReviewArchiveApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewArchiveApiIT.java
@@ -30,9 +30,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.qnop.entity.AuditEvent;
 import io.qnop.entity.Document;
+import io.qnop.entity.ReviewParticipant;
 import io.qnop.entity.WorkflowState;
 import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.review.ReviewArchiveService;
@@ -71,6 +73,7 @@ class ReviewArchiveApiIT extends SeededIntegrationTest {
   @Autowired private DocumentRepository documents;
   @Autowired private AuditEventRepository auditEvents;
   @Autowired private ApplicationSettingsService settings;
+  @Autowired private ReviewParticipantRepository participants;
 
   /**
    * {@code application_setting} deliberately survives {@code clean.sql} (it is migration-seeded),
@@ -340,19 +343,44 @@ class ReviewArchiveApiIT extends SeededIntegrationTest {
   }
 
   @Test
-  @DisplayName("archiving is owner-or-admin only, and an unknown review is a 404")
-  void archivingIsOwnerOrAdminOnly() throws Exception {
-    Document document = closedReview("Archive authz refusal", WorkflowState.FINALIZED, 1);
+  @DisplayName("a non-participant gets 404, not 403 — archive must not leak that the review exists")
+  void archivingHidesExistenceFromNonParticipants() throws Exception {
+    Document document = closedReview("Archive anti-enumeration", WorkflowState.FINALIZED, 1);
 
+    // The read and delete paths answer a non-participant 404 so an id is not
+    // enumerable (issue #661); archive and unarchive must answer the same, not a
+    // 403 that confirms the id resolves to a real review. MEMBER2 is not a
+    // participant of this review, so it is indistinguishable from an unknown id.
     mockMvc
         .perform(as(post("/api/v1/documents/" + document.getId() + "/archive"), MEMBER2_ID))
-        .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$.code").value("NOT_DOCUMENT_OWNER"));
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOCUMENT_NOT_FOUND"));
+    mockMvc
+        .perform(as(post("/api/v1/documents/" + document.getId() + "/unarchive"), MEMBER2_ID))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOCUMENT_NOT_FOUND"));
 
+    // The same 404 an unknown id gives — the two are meant to be indistinguishable.
     mockMvc
         .perform(as(post("/api/v1/documents/" + UUID.randomUUID() + "/archive"), MEMBER_ID))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("DOCUMENT_NOT_FOUND"));
+
+    assertThat(reload(document.getId()).getArchivedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("a participant who is not the owner gets the honest 403 — they already see it")
+  void archivingIsOwnerOnlyForParticipants() throws Exception {
+    Document document = closedReview("Archive participant refusal", WorkflowState.FINALIZED, 1);
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
+
+    // A reviewer can already see the review, so hiding it would be pointless; 403
+    // tells them plainly that archiving is the owner's call.
+    mockMvc
+        .perform(as(post("/api/v1/documents/" + document.getId() + "/archive"), MEMBER2_ID))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("NOT_DOCUMENT_OWNER"));
 
     assertThat(reload(document.getId()).getArchivedAt()).isNull();
   }

--- a/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewWorkflowControllerIT.java
@@ -329,8 +329,26 @@ class ReviewWorkflowControllerIT extends SeededIntegrationTest {
   }
 
   @Test
-  void nonOwnerIsRejectedWith403() throws Exception {
+  void nonParticipantIsRejectedWith404() throws Exception {
+    // A non-participant must not learn the review exists (issue #661): the same 404
+    // the read path gives, not a 403 that confirms the id resolves to a real review.
     Document document = draftOwnedByMember();
+
+    mockMvc
+        .perform(
+            post(workflowPath(document.getId()))
+                .header("Authorization", "Bearer " + token(MEMBER2_ID))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"targetState\":\"IN_REVIEW\"}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOCUMENT_NOT_FOUND"));
+  }
+
+  @Test
+  void participantNonOwnerIsRejectedWith403() throws Exception {
+    // A reviewer can already see the review, so the honest 403 leaks nothing.
+    Document document = draftOwnedByMember();
+    participants.save(ReviewParticipant.forUser(document.getId(), MEMBER2_ID));
 
     mockMvc
         .perform(

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewArchiveService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewArchiveService.java
@@ -27,6 +27,7 @@ import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.scheduler.SchedulerJobCatalog;
 import io.qnop.service.scheduler.SchedulerService;
 import java.time.Duration;
@@ -78,16 +79,19 @@ public class ReviewArchiveService {
   private final DocumentRepository documents;
   private final AuditEventRepository auditEvents;
   private final ApplicationSettingsService settings;
+  private final DocumentAccessService access;
 
   public ReviewArchiveService(
       SchedulerService scheduler,
       DocumentRepository documents,
       AuditEventRepository auditEvents,
-      ApplicationSettingsService settings) {
+      ApplicationSettingsService settings,
+      DocumentAccessService access) {
     this.scheduler = scheduler;
     this.documents = documents;
     this.auditEvents = auditEvents;
     this.settings = settings;
+    this.access = access;
   }
 
   /** Off-peak cron entry point; the gate runs the registered {@link #archiveOnce} work. */
@@ -141,7 +145,7 @@ public class ReviewArchiveService {
   @Transactional
   public Document archive(UUID documentId, UUID actorId, boolean admin) {
     Document document = load(documentId);
-    requireOwnerOrAdmin(document, actorId, admin);
+    requireOwnerOrAdmin(documentId, document, actorId, admin);
     if (!WorkflowState.isClosed(document.getWorkflowState())) {
       throw new WorkflowTransitionException(
           WorkflowTransitionException.REVIEW_NOT_CLOSED,
@@ -160,7 +164,7 @@ public class ReviewArchiveService {
   @Transactional
   public Document unarchive(UUID documentId, UUID actorId, boolean admin) {
     Document document = load(documentId);
-    requireOwnerOrAdmin(document, actorId, admin);
+    requireOwnerOrAdmin(documentId, document, actorId, admin);
     if (document.getArchivedAt() == null) {
       throw new WorkflowTransitionException(
           WorkflowTransitionException.REVIEW_NOT_ARCHIVED, "the review is not archived");
@@ -184,9 +188,24 @@ public class ReviewArchiveService {
         .orElseThrow(() -> new DocumentNotFoundException(documentId));
   }
 
-  private static void requireOwnerOrAdmin(Document document, UUID actorId, boolean admin) {
-    if (!admin && !document.getOwnerId().equals(actorId)) {
-      throw new NotDocumentOwnerException();
+  /**
+   * Owner or admin may archive; everyone else is refused — but the refusal must not leak the
+   * review's existence (issue #661). A caller who cannot even see the review gets the same 404 the
+   * read and delete paths give ({@link DocumentAccessService#isVisible} upholds "non-participants
+   * must not learn that the document exists"); a participant who is simply not the owner already
+   * knows it exists, so they get the honest 403. Mirrors {@code ReviewDeletionService.delete}.
+   *
+   * <p>Keyed on the request's {@code documentId} rather than the loaded entity's id — the two are
+   * equal, and the id the caller asked about is the one the anti-enumeration answer is about.
+   */
+  private void requireOwnerOrAdmin(
+      UUID documentId, Document document, UUID actorId, boolean admin) {
+    if (admin || document.getOwnerId().equals(actorId)) {
+      return;
     }
+    if (!access.isVisible(documentId, actorId, false)) {
+      throw new DocumentNotFoundException(documentId);
+    }
+    throw new NotDocumentOwnerException();
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/ReviewWorkflowService.java
@@ -156,7 +156,7 @@ public class ReviewWorkflowService {
   @Transactional
   public WorkflowStatus transition(UUID documentId, String targetRaw, UUID actorId, boolean admin) {
     Document document = loadForUpdate(documentId);
-    requireOwnerOrAdmin(document, actorId, admin);
+    requireOwnerOrAdmin(documentId, document, actorId, admin);
     WorkflowState target =
         WorkflowState.fromString(targetRaw)
             .orElseThrow(
@@ -262,7 +262,7 @@ public class ReviewWorkflowService {
             .findById(annotationId)
             .orElseThrow(() -> new AnnotationNotFoundException(annotationId));
     Document document = loadForUpdate(annotation.getDocumentId());
-    requireOwnerOrAdmin(document, actorId, admin);
+    requireOwnerOrAdmin(annotation.getDocumentId(), document, actorId, admin);
     // Belt-and-suspenders: a closed review cannot hold OPEN annotations (terminal transitions
     // auto-close them, issue #568), but the guard keeps dismiss symmetric with resolve/reopen.
     requireReviewOpen(document);
@@ -462,9 +462,21 @@ public class ReviewWorkflowService {
         .orElseThrow(() -> new DocumentNotFoundException(documentId));
   }
 
-  private static void requireOwnerOrAdmin(Document document, UUID actorId, boolean admin) {
-    if (!admin && !document.getOwnerId().equals(actorId)) {
-      throw new NotDocumentOwnerException();
+  /**
+   * Owner or admin may transition or dismiss; everyone else is refused without leaking the review's
+   * existence (issue #661). A caller who cannot see the review gets the same 404 the read paths
+   * give ({@link #status} already does this); a participant who is not the owner keeps the honest
+   * 403, since they already know it exists. Mirrors {@code ReviewArchiveService} and {@code
+   * ReviewDeletionService} — the read path here was correct while the write paths were not.
+   */
+  private void requireOwnerOrAdmin(
+      UUID documentId, Document document, UUID actorId, boolean admin) {
+    if (admin || document.getOwnerId().equals(actorId)) {
+      return;
     }
+    if (!documentAccess.isVisible(documentId, actorId, false)) {
+      throw new DocumentNotFoundException(documentId);
+    }
+    throw new NotDocumentOwnerException();
   }
 }

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewArchiveServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewArchiveServiceTest.java
@@ -37,6 +37,7 @@ import io.qnop.repository.AuditEventRepository;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.document.DocumentAccessService;
 import io.qnop.service.scheduler.SchedulerService;
 import java.time.Instant;
 import java.util.List;
@@ -58,9 +59,10 @@ class ReviewArchiveServiceTest {
   @Mock private DocumentRepository documents;
   @Mock private AuditEventRepository auditEvents;
   @Mock private ApplicationSettingsService settings;
+  @Mock private DocumentAccessService access;
 
   private ReviewArchiveService service() {
-    return new ReviewArchiveService(scheduler, documents, auditEvents, settings);
+    return new ReviewArchiveService(scheduler, documents, auditEvents, settings, access);
   }
 
   private static Document closed(WorkflowState state) {
@@ -170,11 +172,29 @@ class ReviewArchiveServiceTest {
   }
 
   @Test
-  void manualArchiveRejectsAStranger() {
+  void manualArchiveHidesAReviewFromNonParticipants() {
+    // A caller who cannot see the review must not be told it exists (issue #661):
+    // the same 404 the read and delete paths give, not a 403 that confirms the id.
     Document doc = closed(WorkflowState.FINALIZED);
+    UUID stranger = UUID.randomUUID();
     when(documents.findById(DOC)).thenReturn(Optional.of(doc));
+    // access.isVisible defaults to false — the stranger is not a participant.
 
-    assertThatThrownBy(() -> service().archive(DOC, UUID.randomUUID(), false))
+    assertThatThrownBy(() -> service().archive(DOC, stranger, false))
+        .isInstanceOf(DocumentNotFoundException.class);
+    verifyNoInteractions(auditEvents);
+  }
+
+  @Test
+  void manualArchiveRejectsAParticipantWhoIsNotTheOwner() {
+    // A reviewer can already see the review, so the honest 403 (owner's call) leaks
+    // nothing — the branch that must stay a 403 rather than collapse to 404.
+    Document doc = closed(WorkflowState.FINALIZED);
+    UUID reviewer = UUID.randomUUID();
+    when(documents.findById(DOC)).thenReturn(Optional.of(doc));
+    when(access.isVisible(DOC, reviewer, false)).thenReturn(true);
+
+    assertThatThrownBy(() -> service().archive(DOC, reviewer, false))
         .isInstanceOf(NotDocumentOwnerException.class);
     verifyNoInteractions(auditEvents);
   }

--- a/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/ReviewWorkflowServiceTest.java
@@ -125,10 +125,26 @@ class ReviewWorkflowServiceTest {
   // --- transition authorization ---------------------------------------------
 
   @Test
-  @DisplayName("a non-owner cannot transition the workflow")
-  void transitionIsOwnerOnly() {
+  @DisplayName("a non-participant cannot tell the review exists — transition answers 404 (#661)")
+  void transitionHidesReviewFromNonParticipants() {
     Document draft = document(WorkflowState.DRAFT);
     when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(draft));
+    // isVisible defaults to false — the stranger is not a participant, so this must be
+    // the same 404 an unknown id gives, not a 403 that confirms the review is real.
+
+    assertThatThrownBy(
+            () -> service.transition(documentId, WorkflowState.IN_REVIEW.name(), stranger, false))
+        .isInstanceOf(DocumentNotFoundException.class);
+    assertThat(draft.getWorkflowState()).isEqualTo(WorkflowState.DRAFT.name());
+    verify(auditEvents, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("a participant who is not the owner cannot transition — 403, not 404")
+  void transitionRejectsAParticipantWhoIsNotTheOwner() {
+    Document draft = document(WorkflowState.DRAFT);
+    when(documents.findByIdForUpdate(documentId)).thenReturn(Optional.of(draft));
+    when(documentAccess.isVisible(documentId, stranger, false)).thenReturn(true);
 
     assertThatThrownBy(
             () -> service.transition(documentId, WorkflowState.IN_REVIEW.name(), stranger, false))
@@ -486,6 +502,9 @@ class ReviewWorkflowServiceTest {
     when(annotations.findById(any())).thenReturn(Optional.of(open));
     when(documents.findByIdForUpdate(documentId))
         .thenReturn(Optional.of(document(WorkflowState.IN_REVIEW)));
+    // The author is a participant, so they can see the review — the refusal is the
+    // honest 403, not the anti-enumeration 404 (#661).
+    when(documentAccess.isVisible(documentId, stranger, false)).thenReturn(true);
 
     assertThatThrownBy(
             () -> service.dismissAnnotation(UUID.randomUUID(), "justified", stranger, false))


### PR DESCRIPTION
Closes #661.

## The bug

Mutating single-document endpoints answered an authenticated **non-participant with 403**, while the read paths answer **404** — letting any signed-in user probe whether an arbitrary document id resolves to a real review, contradicting the invariant the reads uphold:

> 404, not 403: non-participants must not learn that the document exists.
> — `DocumentAccessService.requireVisible`

Two services had the gap: their write paths threw `NotDocumentOwnerException` (403) for any non-owner *without a visibility check*, while their own read paths already 404'd correctly.

- `ReviewArchiveService.archive` / `unarchive`
- `ReviewWorkflowService.transition` / `dismissAnnotation` — **found by the new guard test**, not by hand

`ReviewDeletionService.delete` already did it right (404 for non-visible, 403 for visible-but-unauthorized), and that is the shape both now follow.

## The fix

`requireOwnerOrAdmin` in both services now mirrors the deletion path:

- **non-participant** → 404 (`DOCUMENT_NOT_FOUND`), indistinguishable from an unknown id
- **participant who is not the owner** → 403 (`NOT_DOCUMENT_OWNER`) — they already know it exists
- **owner / admin** → unchanged

Keyed on the request's `documentId` rather than the loaded entity's id (they are equal; the id the caller asked about is the one the anti-enumeration answer is about).

## The guard (why a second bug surfaced)

`DocumentMutationAntiEnumerationIT` has two halves:

1. **Guard** — for each mutating `/documents/{documentId}` endpoint, fire as a non-participant against a real foreign review and against an unknown id; assert the two are the same 404. A 403 (or success) on the real one but 404 on the unknown one *is* the leak.
2. **Completeness** — discover those endpoints from the live `RequestMappingHandlerMapping` and assert every one is covered. A new mutating document endpoint fails the build unless it is added, so the invariant cannot silently regress.

Each request is crafted only well enough to pass argument resolution and reach the service's authorization. That is self-checking: a body too thin to reach authorization 400s rather than 404s, and the guard fails loudly rather than passing silently.

On first run the guard flagged `POST /documents/{documentId}/workflow` (403), which is how the `ReviewWorkflowService` instance was found and fixed in this PR.

## How it was found originally

A live black-box test with two independent MEMBER accounts, `member2` not a participant of `member`'s review:

```
GET    /documents/{id}                     as member2 -> 404   (correct)
DELETE /documents/{id}                     as member2 -> 404   (correct)
POST   /documents/{id}/archive             as member2 -> 403   (leaked existence)  ← fixed to 404
POST   /documents/{id}/workflow            as member2 -> 403   (leaked existence)  ← found by guard, fixed
```

## Severity

**LOW.** Leaks only an existence boolean (never content), requires authentication, and document ids are UUIDv7 (not practically enumerable). It is a real inconsistency with a stated security invariant, now fixed across the family and pinned so it cannot come back.

## Tests

- `DocumentMutationAntiEnumerationIT` — 11 mutating document endpoints, guard + completeness.
- `ReviewArchiveServiceTest`, `ReviewWorkflowServiceTest` (DB-free) — split the old single "non-owner → 403" case into both branches: non-visible → `DocumentNotFoundException`, visible-non-owner → `NotDocumentOwnerException`.
- `ReviewArchiveApiIT`, `ReviewWorkflowControllerIT` — non-participant gets 404; participant-not-owner gets 403. The pre-fix assertions that encoded the leak are corrected.

## Test plan

- [x] `./gradlew build` — green (Spotless, ArchUnit, full suite incl. Testcontainers)
- [x] Guard + completeness cover every mutating `/documents/{documentId}` endpoint

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
