### PR TITLE
feat(convert): bound how many LibreOffice conversions may run at once (#651)

### DIFF
--- a/docs/adr/0055-bounding-out-of-process-conversions.md
+++ b/docs/adr/0055-bounding-out-of-process-conversions.md
@@ -1,0 +1,76 @@
+# ADR-0055: Bounding out-of-process conversions — per instance, with a bounded wait
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+Two features convert documents through a LibreOffice subprocess (ADR-0007/0010): the DOCX ingest (#343) renders an upload into the PDF a review is read on, and the annotation export (#639, ADR-0052) renders its Word report to PDF. Nothing capped how many of those subprocesses ran at once.
+
+The two call sites carry very different risk:
+
+- **Export** runs **synchronously in the request thread**. N concurrent export requests start N LibreOffice processes, bounded only by the servlet thread pool. It is authenticated and not free to trigger, but a handful of reviewers exporting a large review at the same moment is an ordinary Monday, not an attack.
+- **Ingest** runs on the durable job queue (ADR-0033). `JobQueuePoller.poll()` claims a batch and executes it in a sequential loop under `@Scheduled(fixedDelay)`, so that path is already effectively one conversion at a time per instance.
+
+Each run is deliberately expensive: a fresh `-env:UserInstallation` profile because LibreOffice refuses to start against a profile another instance holds — a cold start every time, not a warm pool — a temp directory written and deleted, and an office suite's worth of resident memory. The existing 60s timeout bounds *one* conversion; it says nothing about how many start.
+
+The failure this invites is not a clean error. It is a container meeting its memory limit, or conversions slowing each other past the deadline so that requests fail which would have succeeded had they simply queued.
+
+## Decision
+
+**A semaphore in front of the converter, sized by `qnop.office.max-concurrent` (default 2), with a bounded wait (`qnop.office.max-wait`, default 30s) after which the conversion is refused.**
+
+### A decorator, not a semaphore inside the converter
+
+`ThrottledOfficeConverter` implements `OfficeConverter` and wraps the real one; `OfficeConverterConfiguration` makes it `@Primary`, so both call sites get the limit by asking for the interface they already asked for. It is unit-testable without an office suite installed — the thing being tested is the gate, not LibreOffice — and the limit holds for any converter this ever runs.
+
+Only conversions queue. `isAvailable()` passes straight through: config, the export-format list and every upload check ask it on ordinary requests that convert nothing, and queueing those behind a conversion would spread one slow export across pages that have nothing to do with it.
+
+The semaphore is **fair**, so a steady stream of exports cannot starve whoever has waited longest.
+
+### Waiting is bounded, and a refusal is transient
+
+Queueing is kinder than failing — right up to the point where a request thread is held so long that the caller has given up. Past `max-wait`, `OfficeConverterBusyException` says so.
+
+It is deliberately **not permanent** (`OfficeConversionException.isPermanent()` stays false), and that single bit is what makes one exception serve both call sites:
+
+- the **export** answers `503 EXPORT_BUSY` with `Retry-After` — nothing is broken, and a 500 would read like a defect;
+- an **ingest job** propagates it and comes back under the queue's own backoff, rather than failing a version over one busy minute.
+
+Its own exception type, not a message on the general conversion failure, because the web layer has to tell "too many at once" apart from "the converter failed" and matching on text is not a contract.
+
+### The limit is per instance
+
+A semaphore bounds this JVM. Two instances behind a load balancer may each run their maximum, so a deployment's true ceiling is `max-concurrent × instances` — which is the number an operator must size memory against.
+
+Bounding a *deployment* was considered and rejected as out of scope. It needs shared state; ShedLock (ADR-0029) is a mutual-exclusion lock for scheduled jobs, not a counting semaphore, and would fit badly. Redis is deferred (ADR-0013). Per-instance is the honest limit qnop can enforce today, and it is written down here rather than left implied.
+
+### Zero is not a way to switch it off
+
+`max-concurrent` below 1 reads as "unconfigured" and yields the default. There is no unbounded setting, because unbounded is the failure this exists to prevent. `max-wait: 0s` *is* honoured — an operator may legitimately prefer a fast refusal to a held thread.
+
+### Pressure is visible before it becomes refusals
+
+`qnop.office.conversions{state="active"|"waiting"}` and `qnop.office.conversion.limit` are published as gauges (ADR-0037). Without them, an instance running permanently at its limit is invisible until it starts refusing exports: the queue does its job silently right up to the moment it cannot.
+
+## Consequences
+
+**Positive.** A burst of exports queues instead of starting an unbounded number of office processes, which is the difference between slow and out-of-memory. The expensive path stays bounded without any call site knowing. One transient exception yields the right behaviour in both places: 503 for a human waiting on a download, a retry for a job that has time.
+
+**Negative.** An export can now be refused where it previously would have been served (slowly) — the trade the bounded wait makes deliberately. A conversion may wait up to `max-wait` while holding a request thread. The default of 2 is a starting point, not a measurement.
+
+**Neutral.** The ingest path barely changes, since the poller already serialized it; the limit is insurance for the day that loop becomes concurrent.
+
+## Not decided here
+
+**Making the export asynchronous** — a job plus a download-when-ready flow. It may well be the better answer eventually, and it is a different discussion from bounding the process count.
+
+## Related
+
+- **ADR-0007** — copyleft tools out-of-process only; why this is a subprocess at all
+- **ADR-0010** — DOCX representation via conversion, the other call site
+- **ADR-0052** — the annotation export, whose PDF format is the exposed path
+- **ADR-0033** — the durable job queue whose backoff absorbs a transient refusal
+- **ADR-0029** — ShedLock, and why it does not extend this limit across instances
+- **ADR-0037** — the metrics surface the gauges join

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,6 +67,11 @@ Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-reco
 | [0048](0048-cross-namespace-slug-uniqueness.md) | Cross-namespace slug uniqueness (users and teams) | Accepted |
 | [0049](0049-extension-plugin-packaging-model.md) | Extension packaging model — boot-time SPI plugins, not a runtime plugin framework | Proposed |
 | [0050](0050-purging-archived-reviews.md) | Purging archived reviews: irreversible deletion with a shared-object guard | Accepted |
+| [0051](0051-in-app-notifications.md) | In-app notifications — fan-out on write, identity resolved on read | Accepted |
+| [0052](0052-annotation-export.md) | Exporting annotations — server-side, in reading order, one model per format | Accepted |
+| [0053](0053-branding-raster-renditions.md) | Raster renditions of branding assets, produced on upload | Accepted |
+| [0054](0054-logging-and-diagnostic-context.md) | Logging and the diagnostic context | Accepted |
+| [0055](0055-bounding-out-of-process-conversions.md) | Bounding out-of-process conversions — per instance, with a bounded wait | Accepted |
 
 ## Template
 

--- a/qnop-app/src/main/java/io/qnop/bootstrap/OfficeConversionMetrics.java
+++ b/qnop-app/src/main/java/io/qnop/bootstrap/OfficeConversionMetrics.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.qnop.service.convert.ThrottledOfficeConverter;
+import java.util.function.ToDoubleFunction;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes how busy the office converter is (issue #651): {@code
+ * qnop.office.conversions{state="active"}} against {@code state="waiting"}, plus the ceiling as
+ * {@code qnop.office.conversion.limit}.
+ *
+ * <p>Without these, an instance running permanently at its limit is invisible until it starts
+ * refusing exports — the queue does its job silently right up to the moment it cannot. Waiting
+ * above zero for any length of time is the signal that the limit wants raising (or the instance
+ * more memory); active pinned at the limit says the same thing louder.
+ */
+@Component
+class OfficeConversionMetrics implements MeterBinder {
+
+  private final ThrottledOfficeConverter converter;
+
+  OfficeConversionMetrics(ThrottledOfficeConverter converter) {
+    this.converter = converter;
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    gauge(registry, "active", ThrottledOfficeConverter::active);
+    gauge(registry, "waiting", ThrottledOfficeConverter::waiting);
+    Gauge.builder("qnop.office.conversion.limit", converter, c -> c.limit())
+        .description("How many conversions this instance allows at once")
+        .register(registry);
+  }
+
+  private void gauge(
+      MeterRegistry registry, String state, ToDoubleFunction<ThrottledOfficeConverter> value) {
+    Gauge.builder("qnop.office.conversions", converter, value)
+        .tag("state", state)
+        .description("Out-of-process document conversions, running and queued")
+        .register(registry);
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
+++ b/qnop-app/src/main/java/io/qnop/web/DocumentExceptionHandler.java
@@ -22,6 +22,7 @@ package io.qnop.web;
 
 import io.qnop.api.v1.model.ErrorResponse;
 import io.qnop.api.v1.model.FieldError;
+import io.qnop.service.convert.OfficeConverterBusyException;
 import io.qnop.service.document.DocumentValidationException;
 import io.qnop.service.review.AnnotationActionForbiddenException;
 import io.qnop.service.review.AnnotationNotFoundException;
@@ -33,6 +34,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -70,6 +72,21 @@ public class DocumentExceptionHandler {
     // this deployment lacks the converter the format needs (issue #639).
     return error(
         HttpStatus.SERVICE_UNAVAILABLE.value(), "EXPORT_FORMAT_UNAVAILABLE", ex.getMessage());
+  }
+
+  @ExceptionHandler(OfficeConverterBusyException.class)
+  ResponseEntity<ErrorResponse> converterBusy(OfficeConverterBusyException ex) {
+    // 503 and not 500: the server works, it is simply already running as many
+    // conversions as it allows itself (issue #651). Retry-After says so in the one
+    // way a client can act on without reading the message.
+    log.warn("Refused an export: every conversion slot is busy");
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .header(HttpHeaders.RETRY_AFTER, Long.toString(ex.retryAfterSeconds()))
+        .body(
+            new ErrorResponse()
+                .code("EXPORT_BUSY")
+                .message(ex.getMessage())
+                .timestamp(OffsetDateTime.now()));
   }
 
   @ExceptionHandler(DocumentNotFoundException.class)

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -172,3 +172,19 @@ qnop:
     auto-create-bucket: ${QNOP_S3_AUTO_CREATE_BUCKET:false}
     reaper-grace-period: ${QNOP_S3_REAPER_GRACE_PERIOD:PT1H}
     reaper-cron: ${QNOP_S3_REAPER_CRON:0 30 3 * * *}
+  # The out-of-process office converter (issues #639/#343, ADR-0007/0010/0055) — it
+  # turns DOCX uploads into the PDF a review is read on, and renders the annotation
+  # export to PDF. `binary` is resolved on PATH; leave it unless the suite lives
+  # somewhere unusual. A deployment without it simply offers neither, which
+  # `GET /api/v1/config` reports.
+  #
+  # `max-concurrent` bounds how many conversions run at once *on this instance*:
+  # each is a cold-started office suite with that much memory, so the useful number
+  # is small, and it is not a per-deployment limit (ADR-0055). A conversion that
+  # finds every slot busy waits up to `max-wait` and is then refused — the export
+  # answers 503 with Retry-After, an ingest job retries under the queue's backoff.
+  office:
+    binary: ${QNOP_OFFICE_BINARY:soffice}
+    timeout: ${QNOP_OFFICE_TIMEOUT:60s}
+    max-concurrent: ${QNOP_OFFICE_MAX_CONCURRENT:2}
+    max-wait: ${QNOP_OFFICE_MAX_WAIT:30s}

--- a/qnop-app/src/test/java/io/qnop/bootstrap/OfficeConversionMetricsTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/OfficeConversionMetricsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.qnop.service.convert.OfficeConverter;
+import io.qnop.service.convert.OfficeConverterProperties;
+import io.qnop.service.convert.ThrottledOfficeConverter;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The conversion-pressure gauges (issue #651).
+ *
+ * <p>Asserted against a converter that is actually held busy rather than a mock, because the number
+ * that matters — how many are running — is a property of the semaphore, and a mocked answer would
+ * only prove the test's own arithmetic.
+ */
+class OfficeConversionMetricsTest {
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final ExecutorService threads = Executors.newCachedThreadPool();
+
+  @AfterEach
+  void tearDown() {
+    threads.shutdownNow();
+  }
+
+  @Test
+  @Timeout(30)
+  @DisplayName("reports the running conversion, the queued one and the ceiling")
+  void reportsPressure() throws Exception {
+    CountDownLatch running = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    OfficeConverter delegate =
+        new OfficeConverter() {
+          @Override
+          public boolean isAvailable() {
+            return true;
+          }
+
+          @Override
+          public byte[] toPdf(byte[] source, String sourceExtension) {
+            running.countDown();
+            try {
+              release.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+            return "%PDF".getBytes(StandardCharsets.UTF_8);
+          }
+        };
+    ThrottledOfficeConverter converter =
+        new ThrottledOfficeConverter(
+            delegate, new OfficeConverterProperties(null, null, 1, Duration.ofSeconds(5)));
+    new OfficeConversionMetrics(converter).bindTo(registry);
+
+    assertThat(gauge("active")).isZero();
+
+    byte[] source = "a document".getBytes(StandardCharsets.UTF_8);
+    threads.submit(() -> converter.toPdf(source, "docx"));
+    assertThat(running.await(5, TimeUnit.SECONDS)).isTrue();
+    threads.submit(() -> converter.toPdf(source, "docx"));
+    // The second caller has to reach the semaphore before it counts as waiting;
+    // that is a thread start away, not a conversion away.
+    Thread.sleep(250);
+
+    assertThat(gauge("active")).isEqualTo(1.0);
+    assertThat(gauge("waiting")).isEqualTo(1.0);
+    assertThat(registry.find("qnop.office.conversion.limit").gauge().value()).isEqualTo(1.0);
+
+    release.countDown();
+  }
+
+  private double gauge(String state) {
+    Gauge gauge = registry.find("qnop.office.conversions").tag("state", state).gauge();
+    assertThat(gauge).as("gauge qnop.office.conversions{state=%s}", state).isNotNull();
+    return gauge.value();
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/review/AnnotationExportBusyIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/AnnotationExportBusyIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.entity.Document;
+import io.qnop.entity.DocumentVersion;
+import io.qnop.entity.ReviewParticipant;
+import io.qnop.entity.WorkflowState;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.DocumentVersionRepository;
+import io.qnop.repository.ReviewParticipantRepository;
+import io.qnop.service.convert.LibreOfficeConverter;
+import io.qnop.service.convert.ThrottledOfficeConverter;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * What a PDF export does when every conversion slot is already taken (issue #651).
+ *
+ * <p>The slot is held by calling the converter directly rather than by firing a second export: what
+ * is under test is the answer the busy one gets, and a real parallel download would add threading
+ * to the test without adding anything to the assertion.
+ *
+ * <p>The office binary is mocked, because CI and developer machines disagree about whether one
+ * exists — and the limit has to hold either way.
+ */
+@TestPropertySource(properties = {"qnop.office.max-concurrent=1", "qnop.office.max-wait=0s"})
+class AnnotationExportBusyIT extends SeededIntegrationTest {
+
+  @Autowired private DocumentRepository documents;
+  @Autowired private DocumentVersionRepository versions;
+  @Autowired private ReviewParticipantRepository participants;
+  @Autowired private ThrottledOfficeConverter converter;
+
+  @MockitoBean private LibreOfficeConverter office;
+
+  private final ExecutorService threads = Executors.newSingleThreadExecutor();
+  private final CountDownLatch converting = new CountDownLatch(1);
+  private final CountDownLatch release = new CountDownLatch(1);
+
+  private UUID documentId;
+
+  @BeforeEach
+  void seedAndOccupyTheConverter() throws Exception {
+    Document document = new Document(MEMBER_ID, "Vendor agreement");
+    document.setWorkflowState(WorkflowState.IN_REVIEW);
+    documentId = documents.save(document).getId();
+    versions.save(
+        new DocumentVersion(
+            documentId, 1, "sha256/aa/deadbeef", "deadbeef", "application/pdf", 1234L, MEMBER_ID));
+    participants.save(ReviewParticipant.forUser(documentId, MEMBER2_ID));
+
+    when(office.isAvailable()).thenReturn(true);
+    when(office.toPdf(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              converting.countDown();
+              release.await(30, TimeUnit.SECONDS);
+              return "%PDF-1.7".getBytes(StandardCharsets.UTF_8);
+            });
+
+    threads.submit(() -> converter.toPdf(new byte[] {1, 2, 3}, "docx"));
+    assertThat(converting.await(10, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @AfterEach
+  void freeTheConverter() {
+    release.countDown();
+    threads.shutdownNow();
+  }
+
+  @Test
+  @Timeout(60)
+  @DisplayName("a PDF export with no free slot is refused as busy, not as broken")
+  void refusesWhenEverySlotIsTaken() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/documents/" + documentId + "/annotations/export")
+                .param("format", "pdf")
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        // 503, because nothing is wrong: the instance is already converting as much
+        // as it allows itself, and the answer must not read like a defect.
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.code").value("EXPORT_BUSY"))
+        // The one part a client can act on without parsing prose.
+        .andExpect(header().string("Retry-After", "1"));
+  }
+
+  @Test
+  @Timeout(60)
+  @DisplayName("a format that needs no converter is unaffected by a busy one")
+  void otherFormatsStillWork() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/documents/" + documentId + "/annotations/export")
+                .param("format", "xlsx")
+                .header("Authorization", "Bearer " + token(MEMBER_ID)))
+        .andExpect(status().isOk());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverterBusyException.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverterBusyException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.convert;
+
+import java.time.Duration;
+
+/**
+ * Every conversion slot was taken and none freed up in time (issue #651).
+ *
+ * <p>Deliberately <em>not</em> permanent. Nothing is wrong with the document and nothing is wrong
+ * with the server — it was busy for a moment. An ingest job therefore comes back under the queue's
+ * backoff, and an export answers 503 with a {@code Retry-After} rather than a 500 that reads like a
+ * defect.
+ *
+ * <p>Its own type rather than a message on {@link OfficeConversionException}, because the web layer
+ * has to tell "too many at once, try again" apart from "the converter failed", and matching on text
+ * is not a contract.
+ */
+public class OfficeConverterBusyException extends OfficeConversionException {
+
+  /** Never zero: a {@code Retry-After: 0} invites the client straight back into the queue. */
+  private static final long MINIMUM_RETRY_AFTER_SECONDS = 1;
+
+  private final long retryAfterSeconds;
+
+  public OfficeConverterBusyException(int limit, Duration waited) {
+    super(
+        "all "
+            + limit
+            + " conversion slots are in use and none freed up within "
+            + waited.toMillis()
+            + " ms");
+    this.retryAfterSeconds = Math.max(MINIMUM_RETRY_AFTER_SECONDS, waited.toSeconds());
+  }
+
+  /** How long a caller is asked to hold off — the wait it just spent, as a rough guide. */
+  public long retryAfterSeconds() {
+    return retryAfterSeconds;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverterConfiguration.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverterConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.convert;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Puts the concurrency limit (issue #651) in front of the converter, for everyone.
+ *
+ * <p>Wired here rather than annotated onto {@link ThrottledOfficeConverter} so the decorator stays
+ * a plain class a unit test can build around a fake, and so the delegate it wraps is named
+ * explicitly instead of resolved out of a bean type it also implements.
+ *
+ * <p>{@link Primary} because every caller injects the {@link OfficeConverter} interface and none of
+ * them should have to know a limit exists: the export path (issue #639) and the DOCX ingest (issue
+ * #343) both get it by asking for what they already asked for.
+ */
+@Configuration
+public class OfficeConverterConfiguration {
+
+  /**
+   * Declared as the concrete type on purpose: callers get it as an {@link OfficeConverter}, and the
+   * gauges (ADR-0037) can still ask it how full it is without a cast.
+   */
+  @Bean
+  @Primary
+  ThrottledOfficeConverter throttledOfficeConverter(
+      LibreOfficeConverter delegate, OfficeConverterProperties properties) {
+    return new ThrottledOfficeConverter(delegate, properties);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverterProperties.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/OfficeConverterProperties.java
@@ -31,17 +31,32 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @param timeout how long one conversion may take before the process is killed (60s). A cold
  *     LibreOffice needs a second or two; a minute means it has hung, and an export must not hold a
  *     request thread indefinitely because of it.
+ * @param maxConcurrent how many conversions may run at once on this instance (2, issue #651). Each
+ *     run is an office suite's worth of memory and a cold start, so the useful number is small.
+ *     Zero or negative is not a way to switch the limit off — it reads as "unconfigured" and gives
+ *     the default, because an unbounded setting is the failure this exists to prevent.
+ * @param maxWait how long a conversion may wait for a free slot before it is refused (30s). Waiting
+ *     is kinder than failing right up to the point where a request thread is held so long that the
+ *     caller has given up; past that a refusal it can retry is the better answer.
  */
 @ConfigurationProperties(prefix = "qnop.office")
-public record OfficeConverterProperties(String binary, Duration timeout) {
+public record OfficeConverterProperties(
+    String binary, Duration timeout, int maxConcurrent, Duration maxWait) {
+
+  private static final int DEFAULT_MAX_CONCURRENT = 2;
+  private static final Duration DEFAULT_MAX_WAIT = Duration.ofSeconds(30);
 
   public OfficeConverterProperties {
     binary = binary == null || binary.isBlank() ? "soffice" : binary.strip();
     timeout = timeout == null ? Duration.ofSeconds(60) : timeout;
+    maxConcurrent = maxConcurrent < 1 ? DEFAULT_MAX_CONCURRENT : maxConcurrent;
+    // Zero is left as configured: "do not wait at all" is a legitimate choice for an
+    // operator who would rather have a fast refusal than a held thread.
+    maxWait = maxWait == null || maxWait.isNegative() ? DEFAULT_MAX_WAIT : maxWait;
   }
 
   /** The documented defaults — for direct construction in tests and non-Spring callers. */
   public static OfficeConverterProperties defaults() {
-    return new OfficeConverterProperties(null, null);
+    return new OfficeConverterProperties(null, null, 0, null);
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/convert/ThrottledOfficeConverter.java
+++ b/qnop-core/src/main/java/io/qnop/service/convert/ThrottledOfficeConverter.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.convert;
+
+import java.time.Duration;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bounds how many conversions run at once (issue #651).
+ *
+ * <p>A conversion is an office suite: a cold start against a fresh profile, a temp directory, and
+ * that process's whole resident set. One is expensive and known to be; N at once is a container
+ * meeting its memory limit, or conversions slowing each other past the 60s deadline so that
+ * requests fail which would have succeeded had they simply queued. Nothing bounded N — the export
+ * path runs <em>synchronously in the request thread</em>, so the real limit was the servlet thread
+ * pool, and a handful of reviewers exporting a large review at the same moment is an ordinary
+ * Monday.
+ *
+ * <p>A decorator rather than a semaphore inside {@link LibreOfficeConverter}: it is testable
+ * without an office suite installed, and the limit then holds for any converter this ever runs, not
+ * just this one.
+ *
+ * <p>Two choices worth stating, both deliberate (ADR-0055):
+ *
+ * <ul>
+ *   <li><b>Waiting is bounded.</b> Queueing is kinder than failing right up to the point where a
+ *       request thread is held so long the caller has given up. Past {@code qnop.office.max-wait} a
+ *       refusal it can retry is the better answer — and because it is transient, an ingest job just
+ *       comes back later while an export answers 503.
+ *   <li><b>The limit is per instance.</b> A semaphore bounds this JVM. Two instances behind a load
+ *       balancer may each run their maximum; bounding a deployment needs coordination that ShedLock
+ *       (ADR-0029) is not built for, and it is out of scope here.
+ * </ul>
+ *
+ * <p>Only conversions queue. {@link #isAvailable()} is asked by config, the format list and every
+ * upload check, on requests that convert nothing.
+ */
+public class ThrottledOfficeConverter implements OfficeConverter {
+
+  private static final Logger log = LoggerFactory.getLogger(ThrottledOfficeConverter.class);
+
+  /** A wait worth mentioning; below it the queue did its job and nobody needs a line about it. */
+  private static final Duration NOTEWORTHY_WAIT = Duration.ofSeconds(1);
+
+  private final OfficeConverter delegate;
+  private final int limit;
+  private final Duration maxWait;
+
+  /** Fair, so a steady stream of exports cannot starve the one that has waited longest. */
+  private final Semaphore slots;
+
+  private final AtomicInteger waiting = new AtomicInteger();
+
+  public ThrottledOfficeConverter(OfficeConverter delegate, OfficeConverterProperties properties) {
+    this.delegate = delegate;
+    this.limit = properties.maxConcurrent();
+    this.maxWait = properties.maxWait();
+    this.slots = new Semaphore(limit, true);
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return delegate.isAvailable();
+  }
+
+  @Override
+  public byte[] toPdf(byte[] source, String sourceExtension) {
+    long startedWaiting = System.nanoTime();
+    if (!acquire()) {
+      log.warn(
+          "Refused a conversion: all {} slots busy for {} (waiting: {})",
+          limit,
+          maxWait,
+          waiting.get());
+      throw new OfficeConverterBusyException(limit, maxWait);
+    }
+    try {
+      long waited = (System.nanoTime() - startedWaiting) / 1_000_000;
+      if (waited >= NOTEWORTHY_WAIT.toMillis()) {
+        // Not a failure, but the shape of one to come: if this appears often, the
+        // instance is running at its conversion limit and wants a bigger one.
+        log.info("Waited {} ms for one of {} conversion slots", waited, limit);
+      }
+      return delegate.toPdf(source, sourceExtension);
+    } finally {
+      // In a finally and not after the call: a permit lost to a failed conversion
+      // would shrink the limit silently and only surface hours later, as exports
+      // that queue for no visible reason.
+      slots.release();
+    }
+  }
+
+  private boolean acquire() {
+    waiting.incrementAndGet();
+    try {
+      return slots.tryAcquire(maxWait.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new OfficeConversionException("interrupted while waiting for a conversion slot", e);
+    } finally {
+      waiting.decrementAndGet();
+    }
+  }
+
+  /** How many conversions are running right now — for the gauges (ADR-0037). */
+  public int active() {
+    return limit - slots.availablePermits();
+  }
+
+  /** How many callers are queued for a slot right now. */
+  public int waiting() {
+    return waiting.get();
+  }
+
+  /** The configured ceiling, so a dashboard can show how close to it the instance runs. */
+  public int limit() {
+    return limit;
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/convert/ThrottledOfficeConverterTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/convert/ThrottledOfficeConverterTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.convert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The limit on how many conversions run at once (issue #651).
+ *
+ * <p>The delegate is faked rather than real, for the reason the seam exists at all: an office suite
+ * is not something a test may assume. What is asserted is the gate itself — that a third caller
+ * waits while two run, that it proceeds the moment a slot frees, that a caller which waited too
+ * long is refused in a way the job queue will retry, and that no path leaks a permit.
+ */
+class ThrottledOfficeConverterTest {
+
+  private static final byte[] SOURCE = "a document".getBytes(StandardCharsets.UTF_8);
+
+  /** How long a test may wait for something that should happen almost immediately. */
+  private static final Duration SOON = Duration.ofSeconds(5);
+
+  /** How long a test waits to convince itself something does <em>not</em> happen. */
+  private static final Duration BRIEFLY = Duration.ofMillis(250);
+
+  private final ExecutorService threads = Executors.newCachedThreadPool();
+
+  @AfterEach
+  void tearDown() {
+    threads.shutdownNow();
+  }
+
+  /** Blocks inside {@code toPdf} until released, counting how many are inside at once. */
+  private static final class BlockingConverter implements OfficeConverter {
+    private final CountDownLatch entered;
+    private final CountDownLatch release = new CountDownLatch(1);
+    private final AtomicInteger inside = new AtomicInteger();
+    private final AtomicInteger highWaterMark = new AtomicInteger();
+    private volatile RuntimeException failure;
+
+    /**
+     * @param expectedCallers how many must be inside before {@link #entered} opens
+     */
+    BlockingConverter(int expectedCallers) {
+      this.entered = new CountDownLatch(expectedCallers);
+    }
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+    @Override
+    public byte[] toPdf(byte[] source, String sourceExtension) {
+      highWaterMark.accumulateAndGet(inside.incrementAndGet(), Math::max);
+      entered.countDown();
+      try {
+        if (failure != null) {
+          throw failure;
+        }
+        release.await(SOON.toSeconds(), TimeUnit.SECONDS);
+        return ("converted:" + sourceExtension).getBytes(StandardCharsets.UTF_8);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new OfficeConversionException("interrupted", e);
+      } finally {
+        inside.decrementAndGet();
+      }
+    }
+  }
+
+  private static ThrottledOfficeConverter throttled(
+      OfficeConverter delegate, int maxConcurrent, Duration maxWait) {
+    return new ThrottledOfficeConverter(
+        delegate, new OfficeConverterProperties(null, null, maxConcurrent, maxWait));
+  }
+
+  @Test
+  @Timeout(30)
+  @DisplayName("holds callers past the limit outside, then lets one in per freed slot")
+  void boundsHowManyRunAtOnce() throws Exception {
+    BlockingConverter delegate = new BlockingConverter(2);
+    ThrottledOfficeConverter converter = throttled(delegate, 2, SOON);
+
+    List<Future<byte[]>> conversions = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      conversions.add(threads.submit(() -> converter.toPdf(SOURCE, "docx")));
+    }
+
+    assertThat(delegate.entered.await(SOON.toSeconds(), TimeUnit.SECONDS)).isTrue();
+    // The third must still be outside. That is the whole point: a free request thread
+    // is not a reason to start a third office process.
+    Thread.sleep(BRIEFLY.toMillis());
+    assertThat(delegate.inside.get()).isEqualTo(2);
+
+    delegate.release.countDown();
+
+    for (Future<byte[]> conversion : conversions) {
+      assertThat(
+              new String(
+                  conversion.get(SOON.toSeconds(), TimeUnit.SECONDS), StandardCharsets.UTF_8))
+          .isEqualTo("converted:docx");
+    }
+    assertThat(delegate.highWaterMark.get()).isLessThanOrEqualTo(2);
+  }
+
+  @Test
+  @Timeout(30)
+  @DisplayName("refuses a caller that waited too long, transiently so the queue retries it")
+  void refusesAfterTheWait() throws Exception {
+    BlockingConverter delegate = new BlockingConverter(1);
+    ThrottledOfficeConverter converter = throttled(delegate, 1, Duration.ZERO);
+
+    threads.submit(() -> converter.toPdf(SOURCE, "docx"));
+    assertThat(delegate.entered.await(SOON.toSeconds(), TimeUnit.SECONDS)).isTrue();
+
+    // Not permanent: the export answers 503 and an ingest job comes back under the
+    // queue's backoff. Permanent would fail a version over one busy minute.
+    assertThatThrownBy(() -> converter.toPdf(SOURCE, "docx"))
+        .isInstanceOf(OfficeConverterBusyException.class)
+        .satisfies(
+            thrown -> assertThat(((OfficeConversionException) thrown).isPermanent()).isFalse());
+  }
+
+  @Test
+  @Timeout(30)
+  @DisplayName("returns the slot when the conversion fails")
+  void releasesTheSlotOnFailure() {
+    BlockingConverter delegate = new BlockingConverter(1);
+    delegate.failure = new OfficeConversionException("the converter exited with status 1");
+    ThrottledOfficeConverter converter = throttled(delegate, 1, Duration.ZERO);
+
+    assertThatThrownBy(() -> converter.toPdf(SOURCE, "docx"))
+        .isInstanceOf(OfficeConversionException.class);
+
+    // A leaked permit would surface only once the limit is exhausted — hours later
+    // and nowhere near the failure that caused it.
+    assertThatThrownBy(() -> converter.toPdf(SOURCE, "docx"))
+        .isInstanceOf(OfficeConversionException.class)
+        .isNotInstanceOf(OfficeConverterBusyException.class);
+  }
+
+  @Test
+  @Timeout(30)
+  @DisplayName("asking whether a converter exists never queues behind a conversion")
+  void availabilityIsNotThrottled() throws Exception {
+    BlockingConverter delegate = new BlockingConverter(1);
+    ThrottledOfficeConverter converter = throttled(delegate, 1, SOON);
+
+    threads.submit(() -> converter.toPdf(SOURCE, "docx"));
+    assertThat(delegate.entered.await(SOON.toSeconds(), TimeUnit.SECONDS)).isTrue();
+
+    // Config, the upload check and the format list all ask this on ordinary requests
+    // that convert nothing; queueing them behind a conversion would spread one slow
+    // export across pages that have nothing to do with it.
+    assertThat(converter.isAvailable()).isTrue();
+  }
+
+  @Test
+  @Timeout(30)
+  @DisplayName("passes the document through untouched when a slot is free")
+  void delegatesWhenNotContended() {
+    OfficeConverter delegate =
+        new OfficeConverter() {
+          @Override
+          public boolean isAvailable() {
+            return true;
+          }
+
+          @Override
+          public byte[] toPdf(byte[] source, String sourceExtension) {
+            return (new String(source, StandardCharsets.UTF_8) + " as " + sourceExtension)
+                .getBytes(StandardCharsets.UTF_8);
+          }
+        };
+
+    byte[] result = throttled(delegate, 2, SOON).toPdf(SOURCE, "docx");
+
+    assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("a document as docx");
+  }
+
+  @Test
+  @Timeout(30)
+  @DisplayName("a waiter that is interrupted gives up and stays interrupted")
+  void interruptedWaiterGivesUp() throws Exception {
+    BlockingConverter delegate = new BlockingConverter(1);
+    ThrottledOfficeConverter converter = throttled(delegate, 1, Duration.ofMinutes(5));
+
+    threads.submit(() -> converter.toPdf(SOURCE, "docx"));
+    assertThat(delegate.entered.await(SOON.toSeconds(), TimeUnit.SECONDS)).isTrue();
+
+    CountDownLatch done = new CountDownLatch(1);
+    AtomicInteger outcome = new AtomicInteger();
+    Thread waiter =
+        new Thread(
+            () -> {
+              try {
+                converter.toPdf(SOURCE, "docx");
+              } catch (OfficeConversionException e) {
+                // 1 = refused and the flag survived, which is what a shutdown needs:
+                // an interrupt that is swallowed leaves the thread looking healthy.
+                outcome.set(Thread.currentThread().isInterrupted() ? 1 : 2);
+              } finally {
+                done.countDown();
+              }
+            });
+    waiter.start();
+    // Long enough that the waiter is parked on the semaphore rather than still on its
+    // way there; interrupting too early would test nothing.
+    Thread.sleep(BRIEFLY.toMillis());
+    waiter.interrupt();
+
+    assertThat(done.await(SOON.toSeconds(), TimeUnit.SECONDS)).isTrue();
+    assertThat(outcome.get()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
Closes #651.

## What

Nothing capped how many LibreOffice subprocesses ran at once. The **export** path (#639) converts *synchronously in the request thread*, so N concurrent export requests started N office processes, bounded only by the servlet thread pool — a handful of reviewers exporting a large review at the same moment is an ordinary Monday, not an attack. The **ingest** path (#343) was already effectively serialized by the job poller's sequential loop, which is why the exposure sits on the export side.

Each run is deliberately expensive: a cold start against a fresh `-env:UserInstallation` profile, a temp directory, and an office suite's worth of RSS. The existing 60s timeout bounds *one* conversion and says nothing about how many start. The failure that invites is not a clean error — it is a container meeting its memory limit, or conversions slowing each other past the deadline so requests fail that would have succeeded had they queued.

## How

`ThrottledOfficeConverter` wraps the converter behind a **fair** semaphore sized by `qnop.office.max-concurrent` (default 2) and is wired `@Primary`, so both call sites get the limit by injecting the interface they already injected. A decorator rather than a semaphore inside `LibreOfficeConverter`: it is testable with no office suite installed, and the limit holds for any converter this ever runs. `isAvailable()` passes straight through — config, the export-format list and every upload check ask it on requests that convert nothing.

A caller that finds no free slot waits up to `qnop.office.max-wait` (default 30s) and is then refused with `OfficeConverterBusyException`. It is deliberately **not permanent**, and that one bit serves both callers:

- the export answers `503 EXPORT_BUSY` with `Retry-After`,
- an ingest job propagates and comes back under the queue's backoff, instead of failing a version over one busy minute.

Pressure is visible before it becomes refusals: `qnop.office.conversions{state="active"|"waiting"}` and `qnop.office.conversion.limit` as gauges (ADR-0037).

## The two decisions the issue asked to be made deliberately

Both are recorded in **ADR-0055**:

1. **A waiter is bounded, not blocked indefinitely.** Queueing is kinder than failing right up to the point where a request thread is held so long the caller has given up.
2. **The limit is per instance.** A deployment's true ceiling is `max-concurrent × instances`, which is the number an operator sizes memory against. Bounding a *deployment* needs shared state — ShedLock (ADR-0029) is a mutual-exclusion lock, not a counting semaphore, and Redis is deferred (ADR-0013). Out of scope, and written down rather than left implied.

Also out of scope, per the issue: making the export asynchronous.

## Notes

- `max-concurrent` below 1 reads as "unconfigured" and yields the default — there is no unbounded setting, because unbounded is the failure this prevents. `max-wait: 0s` *is* honoured.
- The SPA is unchanged: its export error path already says "The export could not be generated. Please try again.", which is exactly right for a 503-busy.
- The ADR index in `docs/adr/README.md` had stopped at 0050 while 0051–0054 were merged; all four are listed again alongside 0055.
- `@SchedulerLock(lockAtMostFor = PT2M)` on the poller was reviewed and left alone: `claimBatch()` flips jobs to `RUNNING` atomically and `runOne` re-checks, so an expired lock cannot double-run a job. A batch could already exceed 2 minutes before this change; the wait adds at most 30s per DOCX job.

## Test plan

- [x] `./gradlew build` — green (Spotless, ArchUnit, full suite incl. Testcontainers), 1492 tests
- [x] `ThrottledOfficeConverterTest` (DB-free): the limit holds, a waiter proceeds on a freed slot, an over-long wait is refused transiently, no permit leaks on failure, `isAvailable()` is not throttled, an interrupted waiter stays interrupted
- [x] `AnnotationExportBusyIT`: with the only slot held, a PDF export answers 503 / `EXPORT_BUSY` / `Retry-After: 1`, while XLSX is unaffected
- [x] `OfficeConversionMetricsTest`: gauges asserted against a converter actually held busy, not a mock

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
