### PR TITLE
feat(tracking): usage tracking through a server-side proxy, path-anonymised and consent-gated (#666)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ qnop-ui/.vite/
 /*.xlsx
 /*.pdf
 /*.csv
+.playwright-mcp/

--- a/docs/adr/0056-usage-tracking.md
+++ b/docs/adr/0056-usage-tracking.md
@@ -1,0 +1,69 @@
+# ADR-0056: Usage tracking — server-proxied, path-anonymised, consent-gated
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+- **Deciders:** devtank42 (with Claude)
+
+## Context
+
+`tracking.enabled` and `tracking.provider` have existed since issue #16 and were read by nothing — a dropdown offering Matomo, Plausible and Umami, wired to no code at all. Making it real means answering questions a document-review tool cannot answer the way an ordinary web app would.
+
+The binding constraint is already in the repo. `PathAwareCspHeaderWriter` (ADR-0040) pins the SPA to `script-src 'self'; connect-src 'self'`. Every analytics vendor's install instructions begin by violating exactly that.
+
+And the second constraint is the product itself: a qnop URL contains the id of a customer's document, a search query is the subject of one, and the visible screen *is* one.
+
+## Decision
+
+### Measurement goes through this server, never past it
+
+```
+Browser ──GET /t/s.js──►  qnop ──►  https://matomo.internal/matomo.js   (cached 1h)
+        ──POST /t/c/…─►  qnop ──►  https://matomo.internal/matomo.php   (forwarded)
+```
+
+The alternative — extending the CSP with the configured analytics host per deployment — was rejected. It weakens the one policy that is identical on every other page, it hands each reviewer's IP address to a third party, and it puts the measurement squarely in the path of ad blockers. Proxying costs two endpoints and turns all three around: the CSP stays untouched, the backend sees only what qnop chooses to send, and there is no third-party host to block.
+
+The endpoints sit outside `/api/v1` (as `@Controller`, since `ApiPathConfig` prefixes every `@RestController`): they speak whatever shape the configured backend speaks, which is that backend's contract and not qnop's published one (ADR-0015).
+
+### The collect allowlist is a boundary, not a convenience
+
+`TrackingProvider` declares, per backend, the exact paths that may be forwarded — compared whole, never by prefix. This is what makes a promise enforceable rather than merely stated: PostHog's `/s/` (session recording) is absent, so a client that asked for session replay would be refused *by this server*, whatever its configuration says. It also stops the endpoint from being a general-purpose relay to the analytics host.
+
+**Session recording and heatmaps are out of scope permanently** — Hotjar, Clarity, FullStory, Smartlook and everything like them. They record the screen, and in qnop the screen holds a customer's confidential document. That is not a setting.
+
+### Addresses are patterns, and they are checked twice
+
+The client reports `/reviews/:documentId/tasks`, built from the router's own params — the router knows which segments were parameters because it filled them in, which is the only way to catch a slug like `/users/mia-member` that no shape check could recognise as personal.
+
+The server checks again on every forwarded measurement (`TrackedUrlSanitizer`): the query string always goes, and identifier-shaped segments become `:id`. A stale bundle in an open tab, or a page that forgets the rule, cannot put a document id into an analytics report that will outlive the review.
+
+### The visitor's address is truncated, not withheld
+
+Proxying raises a question direct measurement never asks. Forward nothing and the backend counts a whole company as one visitor; forward the real address and proxying has withheld nothing. So `X-Forwarded-For` carries the address truncated to its /24 (IPv4) or /64 (IPv6) — Matomo's own anonymisation, and the long-standing middle ground of German data-protection practice. `tracking.forward_client_ip=none` remains available, with distorted counts as the stated cost.
+
+### Four gates, any of which says no
+
+Operator configuration, Do-Not-Track/GPC, the account-level opt-out, and consent. All four must agree before a script tag is even created. The consent answer lives in the browser (the sign-in screen is measured, and nobody has an account yet at that point); the opt-out lives on the account, so it follows a person across devices and outlives a cleared browser store. Administrators and auditors are excluded unless an operator explicitly includes them — a handful of privileged people is barely a statistic and very much personal data.
+
+### Events are a closed union
+
+Four names, no properties: `review_created`, `annotation_created`, `review_finalized`, `export_generated`. An `event(name, props)` API would eventually carry a document title or a search term — not through carelessness, but because that is what an open API invites. A fifth event is a code change somebody reviews.
+
+### Which backends, and one that did not fit
+
+Matomo, Plausible, Umami, PostHog (self-hostable) and Pirsch (cloud, proxy-native). **Fathom was dropped during implementation**: its custom-domain feature was withdrawn in 2023 with no replacement, and its documented model expects beacons to reach it directly from the browser so its bot detection sees the real client. Proxying it would either not work or quietly poison its data — and adding a CSP exception for one vendor would give up the property this whole design exists to keep.
+
+## Consequences
+
+**Positive.** The CSP is unchanged. No reviewer's browser contacts an analytics host. Ad blockers have nothing to act on, so the numbers describe everyone who consented rather than everyone who consented and did not block. Switching backends is a settings change, not a deployment change.
+
+**Negative.** Five vendor integrations to keep working, each of which can change its script or endpoints without telling us; a broken one fails silently by design. The proxy adds a request path to keep an eye on. Payloads that are compressed or otherwise unreadable pass the server-side sanitiser untouched, so the clients are configured to send plain JSON — a coupling worth knowing about.
+
+**Neutral.** Pirsch reports its own page view because it offers no documented way to send one with a chosen URL; the server rewrites the id out of it, which is exactly why the second line exists.
+
+## Related
+
+- **ADR-0040** — the SPA's Content-Security-Policy, the constraint this design bends around
+- **ADR-0025** — application settings; every operator-facing knob here is one
+- **ADR-0027** — the rate-limiting the unauthenticated collect endpoint reuses
+- **Issue #21** — the OIDC SSRF guard, extracted here into `OutboundUriGuard` and shared

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,6 +72,7 @@ Two refinement conventions (see the 2026-07-16 amendment to [ADR-0001](0001-reco
 | [0053](0053-branding-raster-renditions.md) | Raster renditions of branding assets, produced on upload | Accepted |
 | [0054](0054-logging-and-diagnostic-context.md) | Logging and the diagnostic context | Accepted |
 | [0055](0055-bounding-out-of-process-conversions.md) | Bounding out-of-process conversions — per instance, with a bounded wait | Accepted |
+| [0056](0056-usage-tracking.md) | Usage tracking — server-proxied, path-anonymised, consent-gated | Accepted |
 
 ## Template
 

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4851,6 +4851,14 @@ components:
             example: pdf
         branding:
           $ref: '#/components/schemas/ServerConfigBranding'
+        tracking:
+          allOf:
+            - $ref: '#/components/schemas/ServerConfigTracking'
+          description: |
+            Usage measurement, when an operator has configured it (issue #666).
+            Absent means the client loads nothing and measures nothing. Public
+            because the sign-in screen is measured too — it names a backend and a
+            site id, both of which the browser would see in the script anyway.
         banner:
           allOf:
             - $ref: '#/components/schemas/InfoBanner'
@@ -4867,6 +4875,41 @@ components:
         - auth
         - upload
         - supportedFormats
+    ServerConfigTracking:
+      type: object
+      description: |
+        What the client needs to measure usage (issue #666). It never learns the
+        analytics host: the script comes from `/t/s.js` and measurements go to
+        `/t/c/…` on this origin, which is what keeps the CSP pinned to 'self'.
+      properties:
+        provider:
+          type: string
+          enum: [matomo, plausible, umami, posthog, pirsch]
+          description: Which backend's script and call shape to use.
+        siteId:
+          type: string
+          description: |
+            The backend's identifier for this site, as the script needs it
+            (Matomo idSite, Plausible domain, Umami website id, PostHog project
+            API key, Pirsch identification code).
+        consentRequired:
+          type: boolean
+          description: Ask before loading anything at all.
+        respectDnt:
+          type: boolean
+          description: Leave browsers that send Do-Not-Track or GPC entirely alone.
+        trackPrivilegedRoles:
+          type: boolean
+          description: |
+            Whether administrators and auditors are measured. Off by default — a
+            handful of privileged people is barely a statistic and very much
+            personal data.
+      required:
+        - provider
+        - siteId
+        - consentRequired
+        - respectDnt
+        - trackPrivilegedRoles
     InfoBanner:
       type: object
       description: |

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -30,6 +30,7 @@ import io.qnop.api.v1.model.ServerConfigBrandingSlot;
 import io.qnop.api.v1.model.ServerConfigGeneral;
 import io.qnop.api.v1.model.ServerConfigResponse;
 import io.qnop.api.v1.model.ServerConfigReview;
+import io.qnop.api.v1.model.ServerConfigTracking;
 import io.qnop.api.v1.model.ServerConfigUpload;
 import io.qnop.api.v1.model.SupportedFormat;
 import io.qnop.service.ApplicationSettingKey;
@@ -42,6 +43,8 @@ import io.qnop.service.document.DocumentTypeSniffer;
 import io.qnop.service.oidc.OidcProviderService;
 import io.qnop.service.review.AnnotationExportService;
 import io.qnop.service.review.export.AnnotationExportFormat;
+import io.qnop.service.tracking.TrackingConfigService;
+import io.qnop.service.tracking.TrackingRuntimeConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +82,7 @@ public class ConfigController implements ServerConfigApi {
   private final AnnotationExportService exports;
   private final DocumentRenditionService renditions;
   private final InfoBannerService banners;
+  private final TrackingConfigService tracking;
 
   public ConfigController(
       OidcProviderService oidcProviders,
@@ -87,6 +91,7 @@ public class ConfigController implements ServerConfigApi {
       AnnotationExportService exports,
       DocumentRenditionService renditions,
       InfoBannerService banners,
+      TrackingConfigService tracking,
       ObjectProvider<BuildProperties> buildProperties) {
     this.oidcProviders = oidcProviders;
     this.settings = settings;
@@ -94,6 +99,7 @@ public class ConfigController implements ServerConfigApi {
     this.exports = exports;
     this.renditions = renditions;
     this.banners = banners;
+    this.tracking = tracking;
     this.buildProperties = buildProperties.getIfAvailable();
   }
 
@@ -138,7 +144,20 @@ public class ConfigController implements ServerConfigApi {
     // authenticated read (GET /banner), so a deployment's troubles are not
     // announced to anonymous callers.
     banners.signIn().map(BannerMapper::toApi).ifPresent(body::banner);
+    // Absent unless an operator configured measurement AND completed it (issue
+    // #666) — a client that sees no tracking block loads no script at all.
+    tracking.current().map(ConfigController::toApi).ifPresent(body::tracking);
     return ResponseEntity.ok(body);
+  }
+
+  /** What the browser needs to measure usage; the analytics host stays server-side. */
+  private static ServerConfigTracking toApi(TrackingRuntimeConfig config) {
+    return new ServerConfigTracking()
+        .provider(ServerConfigTracking.ProviderEnum.fromValue(config.provider().id()))
+        .siteId(config.siteId())
+        .consentRequired(config.consentRequired())
+        .respectDnt(config.respectDnt())
+        .trackPrivilegedRoles(config.trackPrivilegedRoles());
   }
 
   /** The document formats this deployment can take, not the ones the release knows about. */

--- a/qnop-app/src/main/java/io/qnop/web/TrackingProxyController.java
+++ b/qnop-app/src/main/java/io/qnop/web/TrackingProxyController.java
@@ -29,7 +29,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
@@ -80,14 +81,27 @@ public class TrackingProxyController {
   /**
    * One measurement, forwarded to the configured backend.
    *
+   * <p>Both methods, because the backends disagree: Matomo and Pirsch measure over a query string
+   * with GET, Umami, Plausible and PostHog post a JSON body. A proxy that took only one of them
+   * would work for half the providers — which is exactly how this was found.
+   *
    * <p>Answers 204 whatever the backend said. The browser can do nothing useful with an analytics
    * error, and a page that reports its own measurement failures to the user is a page that has its
    * priorities backwards — the server logs what went wrong instead.
    */
-  @PostMapping("/t/c/**")
+  @RequestMapping(
+      value = "/t/c/**",
+      method = {RequestMethod.GET, RequestMethod.POST})
   @ResponseBody
   public ResponseEntity<Void> collect(HttpServletRequest request) throws IOException {
-    String path = request.getRequestURI().substring("/t/c".length());
+    // Everything up to the first '?': a servlet container keeps the query out of
+    // getRequestURI(), but not every caller of this method is a servlet
+    // container, and a path carrying a query would never match the provider's
+    // allowlist — failing closed and silently, which is the hardest way to find
+    // anything.
+    String uri = request.getRequestURI();
+    int query = uri.indexOf('?');
+    String path = (query >= 0 ? uri.substring(0, query) : uri).substring("/t/c".length());
     byte[] body = request.getInputStream().readNBytes(TrackingProxyService.MAX_BODY_BYTES + 1);
     if (body.length > TrackingProxyService.MAX_BODY_BYTES) {
       // A measurement is a few hundred bytes. Something this size is not one.
@@ -97,6 +111,7 @@ public class TrackingProxyController {
     // (ADR-0027): behind a load balancer getRemoteAddr() is the balancer, and
     // truncating that address would tell the backend nothing at all.
     proxy.forward(
+        request.getMethod(),
         path,
         request.getQueryString(),
         body,

--- a/qnop-app/src/main/java/io/qnop/web/TrackingProxyController.java
+++ b/qnop-app/src/main/java/io/qnop/web/TrackingProxyController.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import io.qnop.service.tracking.TrackingProxyService;
+import io.qnop.web.security.ratelimit.HttpClientIpResolver;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * The two endpoints that keep analytics inside the origin (issue #666).
+ *
+ * <p>Short, opaque paths on purpose. {@code /t/s.js} and {@code /t/c/…} carry no word an ad blocker
+ * matches on — not to defeat a user's choice (Do-Not-Track is honoured, consent is asked for, and
+ * the profile switch wins over everything) but because a blocked measurement from a consenting user
+ * is just a hole in the numbers.
+ *
+ * <p>Deliberately outside {@code /api/v1}: this is not part of the published REST contract
+ * (ADR-0015). It speaks whatever shape the configured analytics backend speaks, and that is the
+ * backend's contract, not qnop's.
+ */
+// @Controller, not @RestController: ApiPathConfig mounts every @RestController under
+// /api/v1, and these two are infrastructure rather than part of the published
+// contract (ADR-0015) — the client's script tag and beacon URLs must stay where the
+// security rules and the CSP expect them.
+@Controller
+public class TrackingProxyController {
+
+  private final TrackingProxyService proxy;
+  private final HttpClientIpResolver clientIp;
+
+  public TrackingProxyController(TrackingProxyService proxy, HttpClientIpResolver clientIp) {
+    this.proxy = proxy;
+    this.clientIp = clientIp;
+  }
+
+  /** The vendor script, served from this origin so the CSP need not name a second one. */
+  @GetMapping("/t/s.js")
+  @ResponseBody
+  public ResponseEntity<byte[]> script() {
+    return proxy
+        .script()
+        .map(
+            script ->
+                ResponseEntity.ok()
+                    // Short enough that switching backends takes effect within the hour,
+                    // long enough that a reload is not a round-trip to the vendor.
+                    .cacheControl(
+                        CacheControl.maxAge(java.time.Duration.ofMinutes(10)).cachePublic())
+                    .header("Content-Type", script.contentType())
+                    .body(script.body()))
+        .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  /**
+   * One measurement, forwarded to the configured backend.
+   *
+   * <p>Answers 204 whatever the backend said. The browser can do nothing useful with an analytics
+   * error, and a page that reports its own measurement failures to the user is a page that has its
+   * priorities backwards — the server logs what went wrong instead.
+   */
+  @PostMapping("/t/c/**")
+  @ResponseBody
+  public ResponseEntity<Void> collect(HttpServletRequest request) throws IOException {
+    String path = request.getRequestURI().substring("/t/c".length());
+    byte[] body = request.getInputStream().readNBytes(TrackingProxyService.MAX_BODY_BYTES + 1);
+    if (body.length > TrackingProxyService.MAX_BODY_BYTES) {
+      // A measurement is a few hundred bytes. Something this size is not one.
+      return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).build();
+    }
+    // Resolved through the same trusted-proxy rules the rate limiters use
+    // (ADR-0027): behind a load balancer getRemoteAddr() is the balancer, and
+    // truncating that address would tell the backend nothing at all.
+    proxy.forward(
+        path,
+        request.getQueryString(),
+        body,
+        request.getContentType(),
+        clientIp.resolve(request),
+        request.getHeader("User-Agent"));
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/SecurityConfiguration.java
@@ -27,6 +27,7 @@ import io.qnop.web.security.ratelimit.ForgotPasswordRateLimitFilter;
 import io.qnop.web.security.ratelimit.LoginRateLimitFilter;
 import io.qnop.web.security.ratelimit.RefreshRateLimitFilter;
 import io.qnop.web.security.ratelimit.RegisterRateLimitFilter;
+import io.qnop.web.security.ratelimit.TrackingRateLimitFilter;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -94,6 +95,7 @@ public class SecurityConfiguration {
       ChangePasswordRateLimitFilter changePasswordRateLimitFilter,
       RegisterRateLimitFilter registerRateLimitFilter,
       ForgotPasswordRateLimitFilter forgotPasswordRateLimitFilter,
+      TrackingRateLimitFilter trackingRateLimitFilter,
       PasswordChangeRequiredFilter passwordChangeRequiredFilter)
       throws Exception {
     http.csrf(
@@ -114,6 +116,10 @@ public class SecurityConfiguration {
         // IP-keyed limiters for the public self-service endpoints (issue #20).
         .addFilterBefore(registerRateLimitFilter, CsrfFilter.class)
         .addFilterBefore(forgotPasswordRateLimitFilter, CsrfFilter.class)
+        // The measurement endpoint is unauthenticated by necessity (the sign-in
+        // screen is measured too), so its ceiling is enforced before anything else
+        // touches the request (issue #666).
+        .addFilterBefore(trackingRateLimitFilter, CsrfFilter.class)
         // Force a password change before any non-auth resource (issue #20); needs the
         // authenticated subject, so it runs after the authorization filter.
         .addFilterAfter(passwordChangeRequiredFilter, AuthorizationFilter.class)
@@ -152,6 +158,12 @@ public class SecurityConfiguration {
                     // (enabled OIDC providers, self-registration, edition). OpenAPI
                     // declares GET /config as security: [] — honour that here.
                     .requestMatchers(HttpMethod.GET, "/api/v1/config")
+                    .permitAll()
+                    // Usage tracking (issue #666) is measured on the sign-in screen
+                    // too, so its proxy cannot require a token. It reaches exactly
+                    // one configured backend on exactly the paths that backend
+                    // declares, and it is rate-limited per IP.
+                    .requestMatchers("/t/s.js", "/t/c/**")
                     .permitAll()
                     .requestMatchers("/api/v1/admin/**")
                     .hasRole("ADMIN")

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/TrackingRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/TrackingRateLimitFilter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rate-limits the measurement endpoint per client IP (issue #666).
+ *
+ * <p>It is unauthenticated by necessity — the sign-in screen is measured too — and it forwards to a
+ * backend the operator pays for, so an unbounded one is an invitation to flood somebody else's
+ * analytics with nonsense. The ceiling is generous: a busy reviewer produces a measurement per
+ * navigation, not per second.
+ *
+ * <p>Its own {@code qnop.tracking.*} keys rather than a sixth scope under {@code
+ * qnop.auth.rate-limit}: this has nothing to do with authentication, and a limit filed under "auth"
+ * is a limit nobody finds when they go looking for it.
+ */
+@Component
+public class TrackingRateLimitFilter extends AbstractRateLimitFilter {
+
+  static final String PATH_PREFIX = "/t/c";
+
+  private final HttpClientIpResolver clientIpResolver;
+  private final int maxAttempts;
+  private final long windowSeconds;
+
+  public TrackingRateLimitFilter(
+      BucketRateLimitService rateLimitService,
+      HttpClientIpResolver clientIpResolver,
+      @Value("${qnop.tracking.rate-limit.max-attempts:120}") int maxAttempts,
+      @Value("${qnop.tracking.rate-limit.window-seconds:60}") long windowSeconds) {
+    super(rateLimitService, "Too many measurements. Please try again later.");
+    this.clientIpResolver = clientIpResolver;
+    this.maxAttempts = maxAttempts;
+    this.windowSeconds = windowSeconds;
+  }
+
+  @Override
+  protected boolean handles(HttpServletRequest request) {
+    return "POST".equalsIgnoreCase(request.getMethod())
+        && request.getRequestURI().startsWith(PATH_PREFIX);
+  }
+
+  @Override
+  protected String resolveKey(HttpServletRequest request) {
+    return clientIpResolver.resolve(request);
+  }
+
+  @Override
+  protected String scope() {
+    return "tracking";
+  }
+
+  @Override
+  protected int maxAttempts() {
+    return maxAttempts;
+  }
+
+  @Override
+  protected long windowSeconds() {
+    return windowSeconds;
+  }
+}

--- a/qnop-app/src/main/java/io/qnop/web/security/ratelimit/TrackingRateLimitFilter.java
+++ b/qnop-app/src/main/java/io/qnop/web/security/ratelimit/TrackingRateLimitFilter.java
@@ -58,8 +58,11 @@ public class TrackingRateLimitFilter extends AbstractRateLimitFilter {
 
   @Override
   protected boolean handles(HttpServletRequest request) {
-    return "POST".equalsIgnoreCase(request.getMethod())
-        && request.getRequestURI().startsWith(PATH_PREFIX);
+    // GET as well as POST: Matomo and Pirsch measure over the query string, and a
+    // limit that only counted POSTs would leave those two unbounded.
+    return request.getRequestURI().startsWith(PATH_PREFIX)
+        && ("POST".equalsIgnoreCase(request.getMethod())
+            || "GET".equalsIgnoreCase(request.getMethod()));
   }
 
   @Override

--- a/qnop-app/src/main/resources/application.yml
+++ b/qnop-app/src/main/resources/application.yml
@@ -183,6 +183,18 @@ qnop:
   # is small, and it is not a per-deployment limit (ADR-0055). A conversion that
   # finds every slot busy waits up to `max-wait` and is then refused — the export
   # answers 503 with Retry-After, an ingest job retries under the queue's backoff.
+  # Usage tracking (issue #666). What an operator configures lives in the admin
+  # settings (provider, host, site id, consent, opt-outs); the two keys here are
+  # deployment decisions that must not be reachable from the web UI.
+  #
+  # `allow-private-host` lets the proxy call a private/loopback address — a
+  # self-hosted Matomo on an internal network is the normal case, but so is
+  # 169.254.169.254, which is why this is a property and not a setting.
+  tracking:
+    allow-private-host: ${QNOP_TRACKING_ALLOW_PRIVATE_HOST:false}
+    rate-limit:
+      max-attempts: ${QNOP_TRACKING_RATE_LIMIT_MAX_ATTEMPTS:120}
+      window-seconds: ${QNOP_TRACKING_RATE_LIMIT_WINDOW_SECONDS:60}
   office:
     binary: ${QNOP_OFFICE_BINARY:soffice}
     timeout: ${QNOP_OFFICE_TIMEOUT:60s}

--- a/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/bootstrap/AbstractIntegrationTest.java
@@ -45,8 +45,14 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class AbstractIntegrationTest {
 
   // postgres:18 to match docker-compose(.smoke).yml — the ADR-0020 test/infra parity (issue #199).
+  // Every test class with its own @TestPropertySource builds its own Spring context,
+  // and each holds its own connection pool against this one container. Postgres's
+  // default ceiling of 100 is reached after a handful of them, and it surfaces as an
+  // unrelated context-load failure in whichever class happens to be last (issue #666).
+  // Raising the ceiling keeps the pools at a size the concurrency tests need.
   @ServiceConnection
-  static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:18");
+  static final PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:18").withCommand("postgres", "-c", "max_connections=300");
 
   // MinIO for the object-storage adapter (ADR-0005). No @ServiceConnection: the qnop.s3.* props are
   // wired manually below. Digest-pinned to match docker-compose.yml.

--- a/qnop-app/src/test/java/io/qnop/settings/UserSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/UserSettingsControllerIT.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.qnop.bootstrap.AbstractIntegrationTest;
 import io.qnop.entity.User;
 import io.qnop.repository.UserRepository;
+import io.qnop.service.UserSettingKey;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +74,10 @@ class UserSettingsControllerIT extends AbstractIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.settings").isArray())
         // theme, preferred_language, timezone, email_review_notifications, email_mentions (#462).
-        .andExpect(jsonPath("$.settings.length()").value(5));
+        // Every registry key is offered, so this moves whenever the registry does —
+        // asserted against it rather than against a number to remember (the usage
+        // measurement opt-out of issue #666 was the latest to move it).
+        .andExpect(jsonPath("$.settings.length()").value(UserSettingKey.values().length));
   }
 
   @Test

--- a/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
@@ -36,6 +36,7 @@ import io.qnop.service.oidc.OidcProviderLoginView;
 import io.qnop.service.oidc.OidcProviderService;
 import io.qnop.service.review.AnnotationExportService;
 import io.qnop.service.review.export.AnnotationExportFormat;
+import io.qnop.service.tracking.TrackingConfigService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -70,6 +71,9 @@ class ConfigControllerTest {
   // the default this endpoint's shape is asserted against (issue #664). The
   // banner's own behaviour is covered by BannerApiIT and InfoBannerServiceTest.
   @MockitoBean private InfoBannerService banners;
+  // Unstubbed too: no tracking configured is the shape this endpoint is asserted
+  // against (issue #666); TrackingConfigServiceTest covers the resolution itself.
+  @MockitoBean private TrackingConfigService tracking;
 
   @BeforeEach
   void setUp() {

--- a/qnop-app/src/test/java/io/qnop/web/TrackingForwardIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/TrackingForwardIT.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sun.net.httpserver.HttpServer;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * The whole path, end to end, against a stand-in analytics backend (issue #666).
+ *
+ * <p>Everything else about tracking is asserted in pieces; this is the test that says the pieces
+ * are connected — a browser's request reaches the configured backend, and what arrives there has
+ * had the document id and the page title taken out of it on the way.
+ *
+ * <p>The stand-in is a plain JDK HTTP server on loopback, which is exactly the address the SSRF
+ * guard blocks by default: the deployment property that permits it is set here, and that is the
+ * whole reason the property exists rather than being a setting.
+ */
+@TestPropertySource(properties = {"qnop.tracking.allow-private-host=true"})
+class TrackingForwardIT extends SeededIntegrationTest {
+
+  private static final String DOC = "8f3c1d2e-4a5b-6c7d-8e9f-0a1b2c3d4e5f";
+
+  @Autowired private ApplicationSettingsService settings;
+
+  private HttpServer backend;
+  private final BlockingQueue<String> received = new ArrayBlockingQueue<>(8);
+
+  @BeforeEach
+  void startBackendAndConfigure() throws IOException {
+    backend = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    backend.createContext(
+        "/script.js",
+        exchange -> {
+          byte[] body = "window.umami={};".getBytes(StandardCharsets.UTF_8);
+          exchange.getResponseHeaders().add("Content-Type", "application/javascript");
+          exchange.sendResponseHeaders(200, body.length);
+          try (OutputStream out = exchange.getResponseBody()) {
+            out.write(body);
+          }
+        });
+    backend.createContext(
+        "/api/send",
+        exchange -> {
+          try (InputStream in = exchange.getRequestBody()) {
+            received.offer(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+          }
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+    backend.start();
+
+    settings.update(
+        Map.of(
+            ApplicationSettingKey.TRACKING_ENABLED.getKey(), "true",
+            ApplicationSettingKey.TRACKING_PROVIDER.getKey(), "umami",
+            ApplicationSettingKey.TRACKING_HOST.getKey(),
+                "http://127.0.0.1:" + backend.getAddress().getPort(),
+            ApplicationSettingKey.TRACKING_SITE_ID.getKey(), "site-1"),
+        null);
+  }
+
+  @AfterEach
+  void stopBackendAndReset() {
+    backend.stop(0);
+    settings.update(
+        Map.of(
+            ApplicationSettingKey.TRACKING_ENABLED.getKey(), "false",
+            ApplicationSettingKey.TRACKING_PROVIDER.getKey(), "none",
+            ApplicationSettingKey.TRACKING_HOST.getKey(), "",
+            ApplicationSettingKey.TRACKING_SITE_ID.getKey(), ""),
+        null);
+  }
+
+  @Test
+  @DisplayName("the vendor script is served from this origin")
+  void servesTheVendorScript() throws Exception {
+    // The whole reason the proxy exists: the browser asks this origin, so the
+    // CSP never has to name the analytics host.
+    mockMvc
+        .perform(get("/t/s.js"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("window.umami={};"));
+  }
+
+  @Test
+  @DisplayName("a measurement arrives at the backend with the id and the title removed")
+  void forwardsSanitizedMeasurement() throws Exception {
+    String body =
+        "{\"type\":\"event\",\"payload\":{\"website\":\"site-1\",\"title\":\"Vendor agreement\","
+            + "\"url\":\"/reviews/"
+            + DOC
+            + "/tasks?filter=open\"}}";
+
+    mockMvc
+        .perform(post("/t/c/api/send").contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isNoContent());
+
+    String arrived = received.poll(5, TimeUnit.SECONDS);
+    assertThat(arrived).as("the backend received a measurement").isNotNull();
+    // Three things had to happen on the way, and all three are about the same
+    // risk: the id of a customer's document must not end up in a report.
+    assertThat(arrived).doesNotContain(DOC);
+    assertThat(arrived).doesNotContain("Vendor agreement");
+    assertThat(arrived).doesNotContain("filter=open");
+    assertThat(arrived).contains("/reviews/:id/tasks").contains("site-1");
+  }
+
+  @Test
+  @DisplayName("a path the provider does not declare never reaches the backend")
+  void refusesUndeclaredPaths() throws Exception {
+    // PostHog's session-recording path is the case that matters, but the rule is
+    // general: anything not on the provider's list is dropped here, silently.
+    mockMvc
+        .perform(
+            post("/t/c/api/admin/websites").contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .andExpect(status().isNoContent());
+
+    assertThat(received.poll(1, TimeUnit.SECONDS))
+        .as("nothing should have been forwarded")
+        .isNull();
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/web/TrackingProxyIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/TrackingProxyIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+/**
+ * The measurement endpoints as the browser meets them (issue #666).
+ *
+ * <p>No real analytics backend is involved and none is needed: what has to hold here is that the
+ * endpoints exist without authentication, that they answer nothing at all while measurement is off,
+ * and that a configured deployment reports itself through {@code /config} — the forwarding itself
+ * is asserted where it lives, in the unit tests.
+ */
+class TrackingProxyIT extends SeededIntegrationTest {
+
+  @Autowired private ApplicationSettingsService settings;
+
+  @AfterEach
+  void restoreDefaults() {
+    settings.update(
+        Map.of(
+            ApplicationSettingKey.TRACKING_ENABLED.getKey(), "false",
+            ApplicationSettingKey.TRACKING_PROVIDER.getKey(), "none",
+            ApplicationSettingKey.TRACKING_HOST.getKey(), "",
+            ApplicationSettingKey.TRACKING_SITE_ID.getKey(), ""),
+        null);
+  }
+
+  @Test
+  @DisplayName("with tracking off there is no script to serve")
+  void scriptIsAbsentWhileOff() throws Exception {
+    // Not 401, not 500: a deployment that measures nothing simply has no script,
+    // and the client asks for none because /config told it so.
+    mockMvc.perform(get("/t/s.js")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("a measurement is accepted without a token and goes nowhere while off")
+  void collectIsPublicAndSilent() throws Exception {
+    // Unauthenticated by necessity — the sign-in screen is measured too. With
+    // nothing configured the request is simply swallowed.
+    mockMvc
+        .perform(
+            post("/t/c/api/event")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"pageview\",\"url\":\"/login\"}"))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("an oversized body is refused before anything is forwarded")
+  void refusesOversizedBodies() throws Exception {
+    mockMvc
+        .perform(
+            post("/t/c/api/event")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("x".repeat(70_000)))
+        .andExpect(status().isPayloadTooLarge());
+  }
+
+  @Test
+  @DisplayName("a configured deployment announces itself in the public config")
+  void configuredTrackingReachesTheClient() throws Exception {
+    settings.update(
+        Map.of(
+            ApplicationSettingKey.TRACKING_ENABLED.getKey(), "true",
+            ApplicationSettingKey.TRACKING_PROVIDER.getKey(), "plausible",
+            ApplicationSettingKey.TRACKING_SITE_ID.getKey(), "qnop.example"),
+        null);
+
+    mockMvc
+        .perform(get("/api/v1/config"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.tracking.provider").value("plausible"))
+        .andExpect(jsonPath("$.tracking.siteId").value("qnop.example"))
+        .andExpect(jsonPath("$.tracking.consentRequired").value(true))
+        .andExpect(jsonPath("$.tracking.respectDnt").value(true))
+        // The analytics host is never published — the browser only ever knows
+        // about this origin.
+        .andExpect(jsonPath("$.tracking.host").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("enabled but unfinished configuration stays invisible")
+  void halfConfiguredIsInvisible() throws Exception {
+    settings.update(
+        Map.of(
+            ApplicationSettingKey.TRACKING_ENABLED.getKey(), "true",
+            ApplicationSettingKey.TRACKING_PROVIDER.getKey(), "matomo",
+            ApplicationSettingKey.TRACKING_SITE_ID.getKey(), "1"),
+        null);
+
+    // Matomo is self-hosted and no host was given: nothing is published, and the
+    // client loads nothing at all.
+    mockMvc
+        .perform(get("/api/v1/config"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.tracking").doesNotExist());
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
@@ -73,13 +73,53 @@ public enum ApplicationSettingKey {
       "tracking.enabled",
       SettingValueType.BOOLEAN,
       "false",
-      "Whether anonymous usage tracking is enabled."),
+      "Whether anonymous usage tracking is enabled. Measurement runs through this server, never"
+          + " past it: the browser loads the analytics script from qnop and sends its events to"
+          + " qnop, which forwards them (issue #666)."),
   TRACKING_PROVIDER(
       "tracking.provider",
       SettingValueType.ENUM,
       "none",
-      "Usage-tracking provider.",
-      List.of("none", "matomo", "plausible", "umami")),
+      "Which analytics backend receives the forwarded measurements.",
+      List.of("none", "matomo", "plausible", "umami", "posthog", "pirsch")),
+  TRACKING_HOST(
+      "tracking.host",
+      SettingValueType.STRING,
+      "",
+      "Base URL of the analytics backend, e.g. https://matomo.internal. Empty uses the provider's"
+          + " own cloud where it has one (Plausible, PostHog, Pirsch); Matomo and Umami are"
+          + " self-hosted and always need this."),
+  TRACKING_SITE_ID(
+      "tracking.site_id",
+      SettingValueType.STRING,
+      "",
+      "The backend's identifier for this site: Matomo idSite, Plausible domain, Umami website id,"
+          + " PostHog project API key, Pirsch identification code."),
+  TRACKING_RESPECT_DNT(
+      "tracking.respect_dnt",
+      SettingValueType.BOOLEAN,
+      "true",
+      "Load nothing at all for browsers that send Do-Not-Track or Global Privacy Control."),
+  TRACKING_CONSENT_REQUIRED(
+      "tracking.consent_required",
+      SettingValueType.BOOLEAN,
+      "true",
+      "Ask before measuring anything. Off is defensible only where the backend sets no cookies and"
+          + " your legal basis says so — that call is yours, not this server's."),
+  TRACKING_PRIVILEGED_ROLES(
+      "tracking.track_privileged_roles",
+      SettingValueType.BOOLEAN,
+      "false",
+      "Also measure administrators and auditors. Off by default: a handful of privileged people is"
+          + " barely a statistic and very much personal data."),
+  TRACKING_FORWARD_CLIENT_IP(
+      "tracking.forward_client_ip",
+      SettingValueType.ENUM,
+      "anonymized",
+      "What reaches the backend as the visitor's address. 'anonymized' truncates it (IPv4 to /24,"
+          + " IPv6 to /64) so visitors stay countable without being identifiable; 'none' sends"
+          + " nothing, and the backend then sees every reviewer as one visitor.",
+      List.of("anonymized", "none")),
   SMTP_ENABLED(
       "smtp.enabled",
       SettingValueType.BOOLEAN,
@@ -259,7 +299,14 @@ public enum ApplicationSettingKey {
           Map.entry(BANNER_APP_LINK_LABEL, SettingConstraints.maxLength(40)),
           Map.entry(
               BANNER_APP_LINK_URL,
-              SettingConstraints.format(SettingConstraints.ValueFormat.URL).withMaxLength(500)));
+              SettingConstraints.format(SettingConstraints.ValueFormat.URL).withMaxLength(500)),
+          // The analytics host is a URL this server will call (issue #666), so it is
+          // checked like every other outbound target: http(s) only, and the SSRF
+          // policy decides at call time whether the address itself is allowed.
+          Map.entry(
+              TRACKING_HOST,
+              SettingConstraints.format(SettingConstraints.ValueFormat.URL).withMaxLength(300)),
+          Map.entry(TRACKING_SITE_ID, SettingConstraints.maxLength(200)));
 
   private final String key;
   private final SettingValueType type;

--- a/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
@@ -64,7 +64,15 @@ public enum UserSettingKey {
       "email_mentions",
       SettingValueType.BOOLEAN,
       "true",
-      "Receive an email when someone @mentions you in a review (issue #462).");
+      "Receive an email when someone @mentions you in a review (issue #462)."),
+  // Tied to the account rather than the browser (issue #666): somebody who has
+  // opted out has opted out on their laptop and their tablet, and a cleared
+  // browser store must not quietly re-enrol them.
+  USAGE_TRACKING_OPT_OUT(
+      "usage_tracking_opt_out",
+      SettingValueType.BOOLEAN,
+      "false",
+      "Exclude me from anonymous usage measurement, on every device I sign in from (issue #666).");
 
   private static final Map<String, UserSettingKey> BY_KEY =
       Arrays.stream(values())

--- a/qnop-core/src/main/java/io/qnop/service/http/OutboundUriGuard.java
+++ b/qnop-core/src/main/java/io/qnop/service/http/OutboundUriGuard.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.http;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Locale;
+
+/**
+ * The SSRF check for any operator-supplied URL this server will fetch.
+ *
+ * <p>Extracted from the OIDC discovery guard (issue #21) when usage tracking gained a second one
+ * (issue #666): two features that let an administrator name a URL for the server to call are two
+ * places the same mistake can be made, and duplicating a security check is how the copies drift
+ * apart.
+ *
+ * <p><strong>DNS-free by design.</strong> Only <em>IP literals</em> are range-checked; hostnames
+ * are never resolved here, because resolving would add a TOCTOU window and a DNS-rebinding angle. A
+ * hostname that is not a literal passes unless it is on the static name blocklist; the residual
+ * risk of a public name resolving to a private address is accepted and mitigated operationally.
+ *
+ * <p>Whether private destinations are allowed at all is a <em>deployment</em> decision (a property,
+ * not a database setting) — an internal IdP and a self-hosted analytics server are both legitimate,
+ * and neither should be reachable by an administrator flipping a switch in the web UI.
+ */
+public final class OutboundUriGuard {
+
+  private OutboundUriGuard() {}
+
+  /**
+   * Requires {@code value} to be a syntactically valid http(s) URI whose host is not a blocked
+   * (private/loopback/metadata) destination.
+   *
+   * @throws IllegalArgumentException if the value is missing (when required), malformed, not
+   *     http(s), or targets a blocked host
+   */
+  public static void requireAllowedHttpUri(
+      String value, String fieldName, boolean required, boolean allowPrivate) {
+    String trimmed = value == null ? "" : value.trim();
+    if (trimmed.isEmpty()) {
+      if (required) {
+        throw new IllegalArgumentException(fieldName + " is required");
+      }
+      return;
+    }
+    URI uri;
+    try {
+      uri = URI.create(trimmed);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(fieldName + " is not a valid URI");
+    }
+    String scheme = uri.getScheme();
+    if (scheme == null || !(scheme.equalsIgnoreCase("https") || scheme.equalsIgnoreCase("http"))) {
+      throw new IllegalArgumentException(fieldName + " must be an http(s) URL");
+    }
+    String host = uri.getHost();
+    if (host == null || host.isBlank()) {
+      throw new IllegalArgumentException(fieldName + " must include a host");
+    }
+    if (allowPrivate) {
+      return;
+    }
+    if (isBlockedHost(host)) {
+      throw new IllegalArgumentException(
+          fieldName + " targets a blocked (private/loopback/metadata) host");
+    }
+  }
+
+  private static boolean isBlockedHost(String host) {
+    String h = host.toLowerCase(Locale.ROOT);
+    if (h.startsWith("[") && h.endsWith("]")) {
+      h = h.substring(1, h.length() - 1);
+    }
+    if (h.equals("localhost")
+        || h.endsWith(".localhost")
+        || h.endsWith(".local")
+        || h.endsWith(".internal")) {
+      return true;
+    }
+    InetAddress ip = ipLiteralOrNull(h);
+    if (ip == null) {
+      return false; // a (non-literal) hostname — not resolved here (DNS-free)
+    }
+    return ip.isLoopbackAddress()
+        || ip.isAnyLocalAddress()
+        || ip.isLinkLocalAddress()
+        || ip.isSiteLocalAddress()
+        || isUniqueLocalIpv6(ip);
+  }
+
+  /** Parses {@code host} as an IP literal without any DNS resolution; null if it is not one. */
+  private static InetAddress ipLiteralOrNull(String host) {
+    if (host.indexOf(':') >= 0) {
+      // IPv6 literal — getByName never performs DNS for a string containing ':'.
+      try {
+        return InetAddress.getByName(host);
+      } catch (UnknownHostException e) {
+        return null;
+      }
+    }
+    String[] parts = host.split("\\.");
+    if (parts.length != 4) {
+      return null;
+    }
+    byte[] addr = new byte[4];
+    for (int i = 0; i < 4; i++) {
+      try {
+        int octet = Integer.parseInt(parts[i]);
+        if (octet < 0 || octet > 255) {
+          return null;
+        }
+        addr[i] = (byte) octet;
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    try {
+      return InetAddress.getByAddress(addr); // from raw bytes — never resolves DNS
+    } catch (UnknownHostException e) {
+      return null;
+    }
+  }
+
+  private static boolean isUniqueLocalIpv6(InetAddress ip) {
+    byte[] a = ip.getAddress();
+    // fc00::/7 (unique local addresses) — first 7 bits are 1111110.
+    return a.length == 16 && (a[0] & 0xFE) == 0xFC;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/oidc/OidcSsrfPolicy.java
+++ b/qnop-core/src/main/java/io/qnop/service/oidc/OidcSsrfPolicy.java
@@ -20,23 +20,16 @@
  */
 package io.qnop.service.oidc;
 
-import java.net.InetAddress;
-import java.net.URI;
-import java.net.UnknownHostException;
-import java.util.Locale;
+import io.qnop.service.http.OutboundUriGuard;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * SSRF guard for operator-supplied OIDC URIs (issue #21). Validates scheme (http/https) and, by
- * default, blocks requests to private/loopback/link-local/metadata destinations before any server
- * fetch (e.g. discovery) happens.
+ * SSRF guard for operator-supplied OIDC URIs (issue #21).
  *
- * <p><strong>DNS-free by design.</strong> Only <em>IP literals</em> in the host are range-checked;
- * hostnames are never resolved here (resolving would add a TOCTOU window and a DNS-rebinding
- * angle). A hostname that is not an IP literal is allowed through unless it is on the static name
- * blocklist (e.g. {@code localhost}); the residual risk of a public hostname resolving to a private
- * address is accepted (and mitigated operationally).
+ * <p>The check itself lives in {@link OutboundUriGuard}, shared since usage tracking gained a
+ * second operator-supplied fetch target (issue #666). What stays here is the part that is about
+ * OIDC: which deployment property decides whether a private IdP is reachable.
  *
  * <p>The block can be relaxed for trusted internal IdPs with {@code
  * qnop.auth.oidc.allow-private-discovery-uris=true} (scheme validation still applies).
@@ -59,96 +52,6 @@ public class OidcSsrfPolicy {
    *     http(s), or targets a blocked host.
    */
   public void requirePublicHttpUri(String value, String fieldName, boolean required) {
-    String trimmed = value == null ? "" : value.trim();
-    if (trimmed.isEmpty()) {
-      if (required) {
-        throw new IllegalArgumentException(fieldName + " is required");
-      }
-      return;
-    }
-    URI uri;
-    try {
-      uri = URI.create(trimmed);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(fieldName + " is not a valid URI");
-    }
-    String scheme = uri.getScheme();
-    if (scheme == null || !(scheme.equalsIgnoreCase("https") || scheme.equalsIgnoreCase("http"))) {
-      throw new IllegalArgumentException(fieldName + " must be an http(s) URL");
-    }
-    String host = uri.getHost();
-    if (host == null || host.isBlank()) {
-      throw new IllegalArgumentException(fieldName + " must include a host");
-    }
-    if (allowPrivate) {
-      return;
-    }
-    if (isBlockedHost(host)) {
-      throw new IllegalArgumentException(
-          fieldName + " targets a blocked (private/loopback/metadata) host");
-    }
-  }
-
-  private boolean isBlockedHost(String host) {
-    String h = host.toLowerCase(Locale.ROOT);
-    if (h.startsWith("[") && h.endsWith("]")) {
-      h = h.substring(1, h.length() - 1);
-    }
-    if (h.equals("localhost")
-        || h.endsWith(".localhost")
-        || h.endsWith(".local")
-        || h.endsWith(".internal")) {
-      return true;
-    }
-    InetAddress ip = ipLiteralOrNull(h);
-    if (ip == null) {
-      return false; // a (non-literal) hostname — not resolved here (DNS-free)
-    }
-    return ip.isLoopbackAddress()
-        || ip.isAnyLocalAddress()
-        || ip.isLinkLocalAddress()
-        || ip.isSiteLocalAddress()
-        || isUniqueLocalIpv6(ip);
-  }
-
-  /**
-   * Parses {@code host} as an IP literal without any DNS resolution; null if it is not a literal.
-   */
-  private InetAddress ipLiteralOrNull(String host) {
-    if (host.indexOf(':') >= 0) {
-      // IPv6 literal — getByName never performs DNS for a string containing ':'.
-      try {
-        return InetAddress.getByName(host);
-      } catch (UnknownHostException e) {
-        return null;
-      }
-    }
-    String[] parts = host.split("\\.");
-    if (parts.length != 4) {
-      return null;
-    }
-    byte[] addr = new byte[4];
-    for (int i = 0; i < 4; i++) {
-      try {
-        int octet = Integer.parseInt(parts[i]);
-        if (octet < 0 || octet > 255) {
-          return null;
-        }
-        addr[i] = (byte) octet;
-      } catch (NumberFormatException e) {
-        return null;
-      }
-    }
-    try {
-      return InetAddress.getByAddress(addr); // from raw bytes — never resolves DNS
-    } catch (UnknownHostException e) {
-      return null;
-    }
-  }
-
-  private boolean isUniqueLocalIpv6(InetAddress ip) {
-    byte[] a = ip.getAddress();
-    // fc00::/7 (unique local addresses) — first 7 bits are 1111110.
-    return a.length == 16 && (a[0] & 0xfe) == 0xfc;
+    OutboundUriGuard.requireAllowedHttpUri(value, fieldName, required, allowPrivate);
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/tracking/ClientIpAnonymizer.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/ClientIpAnonymizer.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+
+/**
+ * Truncates a visitor's address before it is forwarded to the analytics backend (issue #666).
+ *
+ * <p>Proxying creates a question that direct measurement never asks: the backend would otherwise
+ * see this server's address for everyone and count a whole company as one visitor. Sending the full
+ * address instead would hand the backend exactly what proxying was meant to withhold.
+ *
+ * <p>So it goes in truncated — IPv4 to its /24, IPv6 to its /64, which is what Matomo's own
+ * anonymisation does and what German data-protection authorities have long treated as the workable
+ * middle. Visitors stay countable; individuals do not stay identifiable.
+ */
+public final class ClientIpAnonymizer {
+
+  private ClientIpAnonymizer() {}
+
+  /**
+   * Returns the truncated form of {@code ip}, or empty when it is missing or unparseable — in which
+   * case nothing is forwarded, because a half-understood address is not worth guessing at.
+   */
+  public static Optional<String> anonymize(String ip) {
+    if (ip == null || ip.isBlank()) {
+      return Optional.empty();
+    }
+    String value = ip.trim();
+    if (value.startsWith("[") && value.endsWith("]")) {
+      value = value.substring(1, value.length() - 1);
+    }
+    byte[] address;
+    try {
+      // Literal only: this must never trigger a DNS lookup on a request path.
+      if (!isIpLiteral(value)) {
+        return Optional.empty();
+      }
+      address = InetAddress.getByName(value).getAddress();
+    } catch (UnknownHostException e) {
+      return Optional.empty();
+    }
+    if (address.length == 4) {
+      address[3] = 0;
+    } else if (address.length == 16) {
+      for (int i = 8; i < 16; i++) {
+        address[i] = 0;
+      }
+    } else {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(InetAddress.getByAddress(address).getHostAddress());
+    } catch (UnknownHostException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static boolean isIpLiteral(String value) {
+    if (value.indexOf(':') >= 0) {
+      return true; // IPv6 literal; getByName never resolves a string containing ':'
+    }
+    String[] parts = value.split("\\.", -1);
+    if (parts.length != 4) {
+      return false;
+    }
+    for (String part : parts) {
+      if (part.isEmpty() || part.length() > 3) {
+        return false;
+      }
+      for (int i = 0; i < part.length(); i++) {
+        if (!Character.isDigit(part.charAt(i))) {
+          return false;
+        }
+      }
+      if (Integer.parseInt(part) > 255) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackedUrlSanitizer.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackedUrlSanitizer.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Strips identifiers out of a measured URL before it leaves this server (issue #666).
+ *
+ * <p>The client already sends route patterns rather than paths — it knows which segments were
+ * parameters, because the router told it. This is the second line: it runs on every forwarded
+ * measurement, so a stale bundle, a hand-rolled client or a future page that forgot the rule cannot
+ * put a document id into someone's analytics backend, where it would sit in a report next to a page
+ * title forever.
+ *
+ * <p>Being second, it is deliberately blunt: the query string always goes, and any segment that
+ * looks like an identifier becomes {@code :id}. It cannot recognise a slug ({@code
+ * /users/mia-member}) as personal — that one relies on the client sending {@code :userId} — and it
+ * says so here rather than pretending to a completeness it does not have.
+ */
+public final class TrackedUrlSanitizer {
+
+  private TrackedUrlSanitizer() {}
+
+  private static final String PLACEHOLDER = ":id";
+
+  /** A segment longer than this is treated as an identifier whatever it looks like. */
+  private static final int MAX_PLAIN_SEGMENT = 32;
+
+  private static final Pattern UUID =
+      Pattern.compile(
+          "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+  private static final Pattern LONG_HEX = Pattern.compile("^[0-9a-fA-F]{12,}$");
+  private static final Pattern NUMERIC = Pattern.compile("^[0-9]{3,}$");
+
+  /**
+   * Returns {@code url} with its query gone and every identifier-looking path segment replaced.
+   *
+   * <p>Absolute URLs keep scheme and host (an analytics backend needs the site to attribute to);
+   * anything unparseable collapses to {@code "/"} rather than travelling as-is.
+   */
+  public static String sanitize(String url) {
+    if (url == null || url.isBlank()) {
+      return "/";
+    }
+    String value = url.trim();
+    String prefix = "";
+    String rest = value;
+
+    int schemeEnd = value.indexOf("://");
+    if (schemeEnd >= 0) {
+      int hostEnd = value.indexOf('/', schemeEnd + 3);
+      if (hostEnd < 0) {
+        // Scheme and host with no path at all: nothing to strip.
+        return stripQuery(value);
+      }
+      prefix = value.substring(0, hostEnd);
+      rest = value.substring(hostEnd);
+    }
+
+    rest = stripQuery(rest);
+    if (!rest.startsWith("/")) {
+      rest = "/" + rest;
+    }
+    return prefix + sanitizePath(rest);
+  }
+
+  private static String stripQuery(String value) {
+    int cut = value.length();
+    int query = value.indexOf('?');
+    if (query >= 0) {
+      cut = query;
+    }
+    int fragment = value.indexOf('#');
+    if (fragment >= 0 && fragment < cut) {
+      cut = fragment;
+    }
+    return value.substring(0, cut);
+  }
+
+  private static String sanitizePath(String path) {
+    String[] segments = path.split("/", -1);
+    List<String> kept = new ArrayList<>(segments.length);
+    for (String segment : segments) {
+      kept.add(looksLikeIdentifier(segment) ? PLACEHOLDER : segment);
+    }
+    return String.join("/", kept);
+  }
+
+  private static boolean looksLikeIdentifier(String segment) {
+    if (segment.isEmpty() || segment.startsWith(":")) {
+      // Already a pattern from the client — the good case, left exactly as it is.
+      return false;
+    }
+    return segment.length() > MAX_PLAIN_SEGMENT
+        || UUID.matcher(segment).matches()
+        || LONG_HEX.matcher(segment).matches()
+        || NUMERIC.matcher(segment).matches();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingConfigService.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingConfigService.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.http.OutboundUriGuard;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves the tracking settings into something usable, or into nothing (issue #666).
+ *
+ * <p>Nothing is the common answer and the safe one. Tracking has to be switched on, name a backend,
+ * carry a site id, and — for the self-hosted backends — point at a host that this deployment is
+ * allowed to call. Any gap and the whole feature stays dark: no script tag, no endpoint, no
+ * half-configured measurement quietly failing in the console.
+ *
+ * <p>Whether a private address may be called at all is a deployment property, not a setting. A
+ * self-hosted Matomo usually lives on one, and that is legitimate — but "an admin can point this
+ * server at 169.254.169.254 from the web UI" is not, so the decision sits where only an operator
+ * with deployment access can make it.
+ */
+@Service
+public class TrackingConfigService {
+
+  private static final Logger log = LoggerFactory.getLogger(TrackingConfigService.class);
+
+  private final ApplicationSettingsService settings;
+  private final boolean allowPrivateHost;
+
+  public TrackingConfigService(
+      ApplicationSettingsService settings,
+      @Value("${qnop.tracking.allow-private-host:false}") boolean allowPrivateHost) {
+    this.settings = settings;
+    this.allowPrivateHost = allowPrivateHost;
+  }
+
+  /** The active configuration, or empty when tracking is off or incompletely configured. */
+  public Optional<TrackingRuntimeConfig> current() {
+    if (!settings.getBoolean(ApplicationSettingKey.TRACKING_ENABLED)) {
+      return Optional.empty();
+    }
+    Optional<TrackingProvider> provider =
+        TrackingProvider.fromId(settings.getString(ApplicationSettingKey.TRACKING_PROVIDER));
+    if (provider.isEmpty()) {
+      return Optional.empty();
+    }
+    TrackingProvider backend = provider.get();
+
+    String siteId = settings.getString(ApplicationSettingKey.TRACKING_SITE_ID).strip();
+    if (siteId.isEmpty()) {
+      log.warn("Usage tracking is enabled for {} but no site id is configured", backend.id());
+      return Optional.empty();
+    }
+
+    String host = settings.getString(ApplicationSettingKey.TRACKING_HOST).strip();
+    if (host.isEmpty() && backend.requiresHost()) {
+      log.warn(
+          "Usage tracking is enabled for {} but it is self-hosted and has no host", backend.id());
+      return Optional.empty();
+    }
+    String collectBase = trimTrailingSlash(host.isEmpty() ? backend.defaultHost() : host);
+    String scriptBase = trimTrailingSlash(host.isEmpty() ? backend.defaultScriptHost() : host);
+
+    try {
+      // Checked here rather than only on save: the setting may predate a change to
+      // this deployment's policy, and the request path must never be the first
+      // place that question is asked.
+      OutboundUriGuard.requireAllowedHttpUri(collectBase, "tracking.host", true, allowPrivateHost);
+      OutboundUriGuard.requireAllowedHttpUri(scriptBase, "tracking.host", true, allowPrivateHost);
+    } catch (IllegalArgumentException e) {
+      log.warn("Usage tracking is disabled: {}", e.getMessage());
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new TrackingRuntimeConfig(
+            backend,
+            siteId,
+            scriptBase + backend.scriptPath(),
+            collectBase,
+            settings.getBoolean(ApplicationSettingKey.TRACKING_CONSENT_REQUIRED),
+            settings.getBoolean(ApplicationSettingKey.TRACKING_RESPECT_DNT),
+            settings.getBoolean(ApplicationSettingKey.TRACKING_PRIVILEGED_ROLES),
+            "anonymized"
+                .equals(settings.getString(ApplicationSettingKey.TRACKING_FORWARD_CLIENT_IP))));
+  }
+
+  private static String trimTrailingSlash(String value) {
+    return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingPayloadSanitizer.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingPayloadSanitizer.java
@@ -21,6 +21,7 @@
 package io.qnop.service.tracking;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
@@ -62,7 +63,19 @@ public final class TrackingPayloadSanitizer {
           "$referrer");
 
   /** Query parameters that carry one, for the backends that measure over a query string. */
-  private static final Set<String> URL_QUERY_PARAMS = Set.of("url", "u", "urlref", "action_name");
+  private static final Set<String> URL_QUERY_PARAMS = Set.of("url", "u", "urlref");
+
+  /**
+   * Fields that carry the page <em>title</em>, which is dropped rather than rewritten.
+   *
+   * <p>Every one of these backends sends the document title along with the address — Umami as
+   * {@code title}, Matomo as {@code action_name}, PostHog as {@code $title}. In qnop a page title
+   * is not neutral: the moment somebody makes browser tabs say what they are showing, it becomes
+   * the name of a customer's contract. Rewriting it is not possible (a title has no structure to
+   * anonymise), so it does not travel at all and reports are keyed on the route pattern instead.
+   */
+  private static final Set<String> DROPPED_FIELDS =
+      Set.of("title", "$title", "page_title", "action_name", "pageTitle");
 
   /** Returns the body with every recognised URL field sanitized; the input if it is not JSON. */
   public static byte[] sanitizeBody(byte[] body) {
@@ -96,6 +109,12 @@ public final class TrackingPayloadSanitizer {
       }
       String name = pairs[i].substring(0, eq);
       String value = pairs[i].substring(eq + 1);
+      if (DROPPED_FIELDS.contains(name)) {
+        // Matomo carries the title as action_name; it is emptied rather than
+        // removed so the parameter list stays the shape the backend expects.
+        out.append(name).append('=');
+        continue;
+      }
       if (URL_QUERY_PARAMS.contains(name)) {
         String decoded = java.net.URLDecoder.decode(value, StandardCharsets.UTF_8);
         value =
@@ -109,9 +128,11 @@ public final class TrackingPayloadSanitizer {
 
   private static void sanitizeNode(JsonNode node) {
     if (node instanceof ObjectNode object) {
-      for (String name : object.propertyNames()) {
+      for (String name : List.copyOf(object.propertyNames())) {
         JsonNode value = object.get(name);
-        if (value != null && value.isString() && URL_FIELDS.contains(name)) {
+        if (DROPPED_FIELDS.contains(name)) {
+          object.remove(name);
+        } else if (value != null && value.isString() && URL_FIELDS.contains(name)) {
           object.put(name, TrackedUrlSanitizer.sanitize(value.stringValue()));
         } else {
           sanitizeNode(value);

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingPayloadSanitizer.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingPayloadSanitizer.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Rewrites the URL fields inside a measurement before it is forwarded (issue #666).
+ *
+ * <p>Each backend has its own body shape, but they agree on one thing: somewhere in it sits the
+ * address of the page. That field is the one place a document id can escape, so it is found by name
+ * — at any depth, because PostHog nests it under {@code properties} and Umami under {@code payload}
+ * — and run through {@link TrackedUrlSanitizer}.
+ *
+ * <p>A body that will not parse as JSON is forwarded untouched. That is a deliberate limit and not
+ * an oversight: the client already sends patterns, and refusing every payload this class does not
+ * fully understand would break measurement for a class of requests without making anything safer.
+ * The clients qnop configures are set to send plain JSON for exactly this reason.
+ */
+public final class TrackingPayloadSanitizer {
+
+  private TrackingPayloadSanitizer() {}
+
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
+  /** Field names that carry a page address in one backend or another. */
+  private static final Set<String> URL_FIELDS =
+      Set.of(
+          "url",
+          "u",
+          "$current_url",
+          "current_url",
+          "page_url",
+          "href",
+          "referrer",
+          "urlref",
+          "$referrer");
+
+  /** Query parameters that carry one, for the backends that measure over a query string. */
+  private static final Set<String> URL_QUERY_PARAMS = Set.of("url", "u", "urlref", "action_name");
+
+  /** Returns the body with every recognised URL field sanitized; the input if it is not JSON. */
+  public static byte[] sanitizeBody(byte[] body) {
+    if (body == null || body.length == 0) {
+      return body;
+    }
+    try {
+      JsonNode root = MAPPER.readTree(body);
+      sanitizeNode(root);
+      return MAPPER.writeValueAsBytes(root);
+    } catch (JacksonException e) {
+      return body;
+    }
+  }
+
+  /** Returns the query string with every recognised parameter sanitized. */
+  public static String sanitizeQuery(String query) {
+    if (query == null || query.isBlank()) {
+      return query;
+    }
+    String[] pairs = query.split("&", -1);
+    StringBuilder out = new StringBuilder(query.length());
+    for (int i = 0; i < pairs.length; i++) {
+      if (i > 0) {
+        out.append('&');
+      }
+      int eq = pairs[i].indexOf('=');
+      if (eq < 0) {
+        out.append(pairs[i]);
+        continue;
+      }
+      String name = pairs[i].substring(0, eq);
+      String value = pairs[i].substring(eq + 1);
+      if (URL_QUERY_PARAMS.contains(name)) {
+        String decoded = java.net.URLDecoder.decode(value, StandardCharsets.UTF_8);
+        value =
+            java.net.URLEncoder.encode(
+                TrackedUrlSanitizer.sanitize(decoded), StandardCharsets.UTF_8);
+      }
+      out.append(name).append('=').append(value);
+    }
+    return out.toString();
+  }
+
+  private static void sanitizeNode(JsonNode node) {
+    if (node instanceof ObjectNode object) {
+      for (String name : object.propertyNames()) {
+        JsonNode value = object.get(name);
+        if (value != null && value.isString() && URL_FIELDS.contains(name)) {
+          object.put(name, TrackedUrlSanitizer.sanitize(value.stringValue()));
+        } else {
+          sanitizeNode(value);
+        }
+      }
+    } else if (node instanceof ArrayNode array) {
+      for (JsonNode item : array) {
+        sanitizeNode(item);
+      }
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProvider.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * The analytics backends qnop can forward measurements to (issue #666).
+ *
+ * <p>Each entry is three facts: which script the browser loads, which paths the browser is allowed
+ * to send to, and — for the hosted ones — where that goes by default. Everything else about the
+ * backend is the backend's business.
+ *
+ * <p><strong>The collect list is a boundary, not a convenience.</strong> The proxy forwards a path
+ * only if it appears here, which is what makes a promise like "no session recording" enforceable:
+ * PostHog's {@code /s/} is absent, so a client that somehow asked for session replay would be
+ * refused by this server rather than trusted not to ask. The same list keeps the endpoint from
+ * being a general-purpose relay to the analytics host.
+ *
+ * <p>The script variants are chosen for one reason: none of them may report page views on their
+ * own. qnop sends its own, built from route patterns, because the real URL of a review contains its
+ * id (see {@link TrackedUrlSanitizer}).
+ */
+public enum TrackingProvider {
+
+  /** Self-hosted only. {@code matomo.js} tracks nothing until {@code trackPageView} is called. */
+  MATOMO("matomo", "/matomo.js", List.of("/matomo.php"), null, null),
+
+  /**
+   * {@code script.manual.js} is the variant that does <em>not</em> track automatically — the
+   * default {@code script.js} would report the real URL on load, id and all.
+   */
+  PLAUSIBLE(
+      "plausible", "/js/script.manual.js", List.of("/api/event"), "https://plausible.io", null),
+
+  /** Self-hosted only; auto-tracking is switched off through a data attribute on the tag. */
+  UMAMI("umami", "/script.js", List.of("/api/send", "/api/batch"), null, null),
+
+  /**
+   * Cloud PostHog splits assets and ingestion across two hosts; a self-hosted one serves both.
+   *
+   * <p>{@code /s/} (session recording) and {@code /static/recorder.js} are deliberately absent:
+   * qnop renders customers' documents, and a recording of that screen is a copy of the document.
+   */
+  POSTHOG(
+      "posthog",
+      "/static/array.js",
+      List.of("/e", "/e/", "/i/v0/e/", "/batch", "/batch/", "/decide/", "/flags", "/flags/"),
+      "https://us.i.posthog.com",
+      "https://us-assets.i.posthog.com"),
+
+  /** Built for proxying: the script takes its endpoints as data attributes. */
+  PIRSCH("pirsch", "/pa.js", List.of("/pv", "/e", "/s"), "https://api.pirsch.io", null);
+
+  private final String id;
+  private final String scriptPath;
+  private final List<String> collectPaths;
+  private final String defaultHost;
+  private final String defaultScriptHost;
+
+  TrackingProvider(
+      String id,
+      String scriptPath,
+      List<String> collectPaths,
+      String defaultHost,
+      String defaultScriptHost) {
+    this.id = id;
+    this.scriptPath = scriptPath;
+    this.collectPaths = List.copyOf(collectPaths);
+    this.defaultHost = defaultHost;
+    this.defaultScriptHost = defaultScriptHost;
+  }
+
+  public static Optional<TrackingProvider> fromId(String id) {
+    if (id == null) {
+      return Optional.empty();
+    }
+    String normalized = id.trim().toLowerCase(Locale.ROOT);
+    for (TrackingProvider provider : values()) {
+      if (provider.id.equals(normalized)) {
+        return Optional.of(provider);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public String scriptPath() {
+    return scriptPath;
+  }
+
+  public List<String> collectPaths() {
+    return collectPaths;
+  }
+
+  /** Where measurements go when the operator configured no host; null where there is no cloud. */
+  public String defaultHost() {
+    return defaultHost;
+  }
+
+  /**
+   * Where the script comes from when no host is configured; null means "same as {@link
+   * #defaultHost()}".
+   */
+  public String defaultScriptHost() {
+    return defaultScriptHost != null ? defaultScriptHost : defaultHost;
+  }
+
+  /** True where the backend exists only self-hosted, so a host must be configured. */
+  public boolean requiresHost() {
+    return defaultHost == null;
+  }
+
+  /**
+   * Whether the browser may send to this path.
+   *
+   * <p>Compared exactly rather than by prefix: a prefix match on {@code /e} would also admit {@code
+   * /export-everything}, and the point of the list is that nothing beyond it gets through.
+   */
+  public boolean allowsCollectPath(String path) {
+    return path != null && collectPaths.contains(path);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProvider.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProvider.java
@@ -69,8 +69,14 @@ public enum TrackingProvider {
       "https://us.i.posthog.com",
       "https://us-assets.i.posthog.com"),
 
-  /** Built for proxying: the script takes its endpoints as data attributes. */
-  PIRSCH("pirsch", "/pa.js", List.of("/pv", "/e", "/s"), "https://api.pirsch.io", null);
+  /**
+   * Built for proxying: the script takes its endpoints as data attributes.
+   *
+   * <p>The paths are the ones {@code pa.js} actually defaults to — {@code /hit} (sent as a GET),
+   * {@code /event} and {@code /session}. An earlier guess at {@code /pv}, {@code /e}, {@code /s}
+   * answers 404 on the real host, which is what checking rather than assuming is for.
+   */
+  PIRSCH("pirsch", "/pa.js", List.of("/hit", "/event", "/session"), "https://api.pirsch.io", null);
 
   private final String id;
   private final String scriptPath;

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProxyService.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProxyService.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import io.qnop.service.http.HttpClientProperties;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Fetches the vendor script and forwards measurements, so the browser never talks to the analytics
+ * backend itself (issue #666).
+ *
+ * <p>The SPA's Content-Security-Policy pins scripts and connections to {@code 'self'} (ADR-0040).
+ * Rather than weakening that per deployment, this server stands in the middle — which turns a
+ * constraint into three properties worth having: the policy stays as strict as it is on every other
+ * page, a reviewer's address never reaches a third party except truncated and on purpose, and an ad
+ * blocker has no third-party host to block.
+ *
+ * <p>Only the paths a provider declares are forwarded ({@link TrackingProvider#allowsCollectPath}),
+ * so this is a conduit to one configured backend, never an open relay.
+ */
+@Service
+public class TrackingProxyService {
+
+  private static final Logger log = LoggerFactory.getLogger(TrackingProxyService.class);
+
+  /** The vendor script changes on their release schedule, not ours. */
+  private static final Duration SCRIPT_TTL = Duration.ofHours(1);
+
+  /** A measurement is small; anything larger is not one. */
+  public static final int MAX_BODY_BYTES = 64 * 1024;
+
+  /** Bounds a hung backend: a measurement is never worth holding a request thread for. */
+  private static final Duration FORWARD_TIMEOUT = Duration.ofSeconds(3);
+
+  private static final Duration SCRIPT_TIMEOUT = Duration.ofSeconds(10);
+
+  private final TrackingConfigService config;
+  private final HttpClient http;
+
+  private volatile CachedScript cachedScript;
+
+  public TrackingProxyService(TrackingConfigService config, HttpClientProperties httpProperties) {
+    this.config = config;
+    this.http =
+        HttpClient.newBuilder()
+            .connectTimeout(httpProperties.outboundConnectTimeout())
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+  }
+
+  /** The vendor script, cached; empty when tracking is off or the backend would not answer. */
+  public Optional<Script> script() {
+    Optional<TrackingRuntimeConfig> active = config.current();
+    if (active.isEmpty()) {
+      return Optional.empty();
+    }
+    String url = active.get().scriptUrl();
+    CachedScript cached = cachedScript;
+    if (cached != null && cached.matches(url)) {
+      return Optional.of(cached.script());
+    }
+    try {
+      HttpResponse<byte[]> response =
+          http.send(
+              HttpRequest.newBuilder(URI.create(url))
+                  .timeout(SCRIPT_TIMEOUT)
+                  .header("Accept", "application/javascript, text/javascript, */*")
+                  .GET()
+                  .build(),
+              HttpResponse.BodyHandlers.ofByteArray());
+      if (response.statusCode() != 200) {
+        log.warn("The analytics script at {} answered {}", url, response.statusCode());
+        return Optional.empty();
+      }
+      Script script =
+          new Script(
+              response.body(),
+              response
+                  .headers()
+                  .firstValue("content-type")
+                  .orElse("application/javascript; charset=utf-8"));
+      cachedScript = new CachedScript(url, script, Instant.now());
+      return Optional.of(script);
+    } catch (IOException e) {
+      log.warn("Could not fetch the analytics script from {}: {}", url, e.getMessage());
+      return Optional.empty();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Forwards one measurement.
+   *
+   * @param path the collect path the browser asked for; refused unless the provider declares it
+   * @param query the query string as sent, sanitized here before it travels
+   * @param body the request body, sanitized here before it travels
+   * @param contentType the browser's content type, passed through
+   * @param clientIp the caller's address, truncated before it travels (or dropped entirely)
+   * @param userAgent the caller's user agent — needed by every backend to tell visitors apart
+   * @return the backend's status code, or empty when the request was refused or never got through
+   */
+  public Optional<Integer> forward(
+      String path,
+      String query,
+      byte[] body,
+      String contentType,
+      String clientIp,
+      String userAgent) {
+    Optional<TrackingRuntimeConfig> maybe = config.current();
+    if (maybe.isEmpty()) {
+      return Optional.empty();
+    }
+    TrackingRuntimeConfig active = maybe.get();
+    if (!active.provider().allowsCollectPath(path)) {
+      // Not an error worth a stack trace: either a stale bundle or somebody
+      // probing what else this endpoint will reach.
+      log.debug("Refused a measurement for an undeclared path {}", path);
+      return Optional.empty();
+    }
+
+    String sanitizedQuery = TrackingPayloadSanitizer.sanitizeQuery(query);
+    byte[] sanitizedBody = TrackingPayloadSanitizer.sanitizeBody(body);
+    String target =
+        active.collectBaseUrl()
+            + path
+            + (sanitizedQuery == null || sanitizedQuery.isBlank() ? "" : "?" + sanitizedQuery);
+
+    HttpRequest.Builder request =
+        HttpRequest.newBuilder(URI.create(target))
+            .timeout(FORWARD_TIMEOUT)
+            .POST(
+                HttpRequest.BodyPublishers.ofByteArray(
+                    sanitizedBody == null ? new byte[0] : sanitizedBody));
+    if (contentType != null && !contentType.isBlank()) {
+      request.header("Content-Type", contentType);
+    }
+    if (userAgent != null && !userAgent.isBlank()) {
+      request.header("User-Agent", userAgent);
+    }
+    if (active.forwardClientIp()) {
+      ClientIpAnonymizer.anonymize(clientIp)
+          .ifPresent(truncated -> request.header("X-Forwarded-For", truncated));
+    }
+
+    try {
+      HttpResponse<Void> response =
+          http.send(request.build(), HttpResponse.BodyHandlers.discarding());
+      return Optional.of(response.statusCode());
+    } catch (IOException e) {
+      log.debug("Could not forward a measurement: {}", e.getMessage());
+      return Optional.empty();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return Optional.empty();
+    }
+  }
+
+  /** The vendor script as fetched. */
+  public record Script(byte[] body, String contentType) {}
+
+  private record CachedScript(String url, Script script, Instant fetchedAt) {
+    boolean matches(String candidate) {
+      return url.equals(candidate) && fetchedAt.plus(SCRIPT_TTL).isAfter(Instant.now());
+    }
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProxyService.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProxyService.java
@@ -29,6 +29,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -66,6 +67,16 @@ public class TrackingProxyService {
   private final HttpClient http;
 
   private volatile CachedScript cachedScript;
+
+  /**
+   * Whether the last forward failed, so a broken backend is reported once instead of once per
+   * measurement.
+   *
+   * <p>Measurement fails silently by design — a reviewer must never see an analytics error — but
+   * silent to the <em>user</em> is not the same as silent to the operator. Without this, "no events
+   * are arriving" is a question only a packet capture can answer.
+   */
+  private final AtomicBoolean forwardingBroken = new AtomicBoolean();
 
   public TrackingProxyService(TrackingConfigService config, HttpClientProperties httpProperties) {
     this.config = config;
@@ -175,13 +186,32 @@ public class TrackingProxyService {
     try {
       HttpResponse<Void> response =
           http.send(request.build(), HttpResponse.BodyHandlers.discarding());
-      return Optional.of(response.statusCode());
+      int status = response.statusCode();
+      if (status >= 200 && status < 300) {
+        recovered();
+      } else {
+        broken("{} answered {} for a measurement", active.collectBaseUrl(), status);
+      }
+      return Optional.of(status);
     } catch (IOException e) {
-      log.debug("Could not forward a measurement: {}", e.getMessage());
+      broken("could not reach {}: {}", active.collectBaseUrl(), e.getMessage());
       return Optional.empty();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return Optional.empty();
+    }
+  }
+
+  /** Reports a broken backend on the transition into that state, never once per measurement. */
+  private void broken(String message, Object... arguments) {
+    if (forwardingBroken.compareAndSet(false, true)) {
+      log.warn("Usage tracking is not being recorded — " + message, arguments);
+    }
+  }
+
+  private void recovered() {
+    if (forwardingBroken.compareAndSet(true, false)) {
+      log.info("Usage tracking is being recorded again");
     }
   }
 

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProxyService.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProxyService.java
@@ -132,6 +132,7 @@ public class TrackingProxyService {
   /**
    * Forwards one measurement.
    *
+   * @param method the browser's HTTP method — Matomo and Pirsch measure over GET, the rest POST
    * @param path the collect path the browser asked for; refused unless the provider declares it
    * @param query the query string as sent, sanitized here before it travels
    * @param body the request body, sanitized here before it travels
@@ -141,6 +142,7 @@ public class TrackingProxyService {
    * @return the backend's status code, or empty when the request was refused or never got through
    */
   public Optional<Integer> forward(
+      String method,
       String path,
       String query,
       byte[] body,
@@ -167,11 +169,18 @@ public class TrackingProxyService {
             + (sanitizedQuery == null || sanitizedQuery.isBlank() ? "" : "?" + sanitizedQuery);
 
     HttpRequest.Builder request =
-        HttpRequest.newBuilder(URI.create(target))
-            .timeout(FORWARD_TIMEOUT)
-            .POST(
-                HttpRequest.BodyPublishers.ofByteArray(
-                    sanitizedBody == null ? new byte[0] : sanitizedBody));
+        HttpRequest.newBuilder(URI.create(target)).timeout(FORWARD_TIMEOUT);
+    if ("GET".equalsIgnoreCase(method)) {
+      // Matomo and Pirsch measure over the query string. Forwarding those as a
+      // POST happens to work for Matomo — it reads parameters from either — but
+      // it is not what the browser did, and the next backend need not be so
+      // forgiving.
+      request.GET();
+    } else {
+      request.POST(
+          HttpRequest.BodyPublishers.ofByteArray(
+              sanitizedBody == null ? new byte[0] : sanitizedBody));
+    }
     if (contentType != null && !contentType.isBlank()) {
       request.header("Content-Type", contentType);
     }

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingRuntimeConfig.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingRuntimeConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+/**
+ * Usage tracking as it is actually configured right now (issue #666) — the settings resolved into
+ * the handful of facts the proxy and the client each need.
+ *
+ * <p>Its existence means tracking is on <em>and</em> fully configured; a half-filled form yields no
+ * instance at all rather than an object nobody can use.
+ *
+ * @param provider which backend receives the measurements
+ * @param siteId the backend's identifier for this site, passed to the browser
+ * @param scriptUrl absolute URL of the vendor script the proxy fetches
+ * @param collectBaseUrl absolute base the proxy appends an allowed collect path to
+ * @param consentRequired whether the client must ask before loading anything
+ * @param respectDnt whether a Do-Not-Track browser is left alone
+ * @param trackPrivilegedRoles whether administrators and auditors are measured too
+ * @param forwardClientIp whether a truncated visitor address travels with each measurement
+ */
+public record TrackingRuntimeConfig(
+    TrackingProvider provider,
+    String siteId,
+    String scriptUrl,
+    String collectBaseUrl,
+    boolean consentRequired,
+    boolean respectDnt,
+    boolean trackPrivilegedRoles,
+    boolean forwardClientIp) {}

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -110,6 +110,9 @@ databaseChangeLog:
   - include:
       file: migrations/0033-info-banner-settings.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0034-usage-tracking-settings.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/migrations/0034-usage-tracking-settings.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0034-usage-tracking-settings.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) 2026-present devtank42 GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Seed rows for the usage-tracking settings (issue #666). Additive changeset —
+# new keys land in their own changeset (1.0.0 shipped the original seed). The
+# registry (ApplicationSettingKey) stays authoritative per ADR-0025; these rows
+# mirror its defaults, and tracking stays off until an operator turns it on.
+#
+# tracking.enabled and tracking.provider were seeded back in #13 as placeholders;
+# only their stored descriptions are refreshed here, since the API serves the
+# registry's text and this column is the denormalized copy for DBA/ops.
+databaseChangeLog:
+  - changeSet:
+      id: 0034-usage-tracking-settings
+      author: qnop
+      comment: Adds the tracking.* application settings for server-proxied usage tracking (issue #666).
+      changes:
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "tracking.host" }
+              - column: { name: setting_value, value: "" }
+              - column: { name: setting_desc, value: "Base URL of the analytics backend, e.g. https://matomo.internal. Empty uses the provider's own cloud where it has one." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "tracking.site_id" }
+              - column: { name: setting_value, value: "" }
+              - column: { name: setting_desc, value: "The backend's identifier for this site (Matomo idSite, Plausible domain, Umami website id, PostHog project API key, Pirsch identification code)." }
+              - column: { name: value_type, value: "STRING" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "tracking.respect_dnt" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: setting_desc, value: "Load nothing at all for browsers that send Do-Not-Track or Global Privacy Control." }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "tracking.consent_required" }
+              - column: { name: setting_value, value: "true" }
+              - column: { name: setting_desc, value: "Ask before measuring anything." }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "tracking.track_privileged_roles" }
+              - column: { name: setting_value, value: "false" }
+              - column: { name: setting_desc, value: "Also measure administrators and auditors." }
+              - column: { name: value_type, value: "BOOLEAN" }
+        - insert:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_key, value: "tracking.forward_client_ip" }
+              - column: { name: setting_value, value: "anonymized" }
+              - column: { name: setting_desc, value: "What reaches the backend as the visitor's address: 'anonymized' (IPv4 to /24, IPv6 to /64) or 'none'." }
+              - column: { name: value_type, value: "ENUM" }
+        - update:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_desc, value: "Whether anonymous usage tracking is enabled. Measurement runs through this server, never past it." }
+            where: setting_key = 'tracking.enabled'
+        - update:
+            tableName: application_setting
+            columns:
+              - column: { name: setting_desc, value: "Which analytics backend receives the forwarded measurements." }
+            where: setting_key = 'tracking.provider'

--- a/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/ApplicationSettingKeyTest.java
@@ -76,7 +76,13 @@ class ApplicationSettingKeyTest {
           "banner.app_severity",
           "banner.app_text",
           "banner.app_link_label",
-          "banner.app_link_url");
+          "banner.app_link_url",
+          "tracking.host",
+          "tracking.site_id",
+          "tracking.respect_dnt",
+          "tracking.consent_required",
+          "tracking.track_privileged_roles",
+          "tracking.forward_client_ip");
 
   @Test
   void registryMatchesSeededKeys() {

--- a/qnop-core/src/test/java/io/qnop/service/tracking/ClientIpAnonymizerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/ClientIpAnonymizerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Truncating the visitor address that the proxy forwards (issue #666). */
+class ClientIpAnonymizerTest {
+
+  @Test
+  @DisplayName("IPv4 keeps its network, loses its host")
+  void truncatesIpv4() {
+    assertThat(ClientIpAnonymizer.anonymize("203.0.113.42")).contains("203.0.113.0");
+    assertThat(ClientIpAnonymizer.anonymize("10.1.2.3")).contains("10.1.2.0");
+  }
+
+  @Test
+  @DisplayName("IPv6 keeps its /64")
+  void truncatesIpv6() {
+    // A /64 is one subscriber line, not one device — the same trade the IPv4 /24
+    // makes, at the size IPv6 hands out.
+    assertThat(ClientIpAnonymizer.anonymize("2001:db8:85a3:1:1a2b:3c4d:5e6f:7a8b"))
+        .hasValueSatisfying(
+            value -> assertThat(value).startsWith("2001:db8:85a3:1:").endsWith("0:0:0:0"));
+  }
+
+  @Test
+  @DisplayName("brackets around an IPv6 literal are tolerated")
+  void tolerName() {
+    assertThat(ClientIpAnonymizer.anonymize("[2001:db8::1]")).isPresent();
+  }
+
+  @Test
+  @DisplayName("forwards nothing rather than guessing")
+  void failsClosed() {
+    assertThat(ClientIpAnonymizer.anonymize(null)).isEmpty();
+    assertThat(ClientIpAnonymizer.anonymize("")).isEmpty();
+    assertThat(ClientIpAnonymizer.anonymize("not-an-ip")).isEmpty();
+    // A hostname must never be resolved on a request path, so it is simply refused.
+    assertThat(ClientIpAnonymizer.anonymize("analytics.example.com")).isEmpty();
+    assertThat(ClientIpAnonymizer.anonymize("999.1.1.1")).isEmpty();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackedUrlSanitizerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackedUrlSanitizerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * The last thing that touches a measured URL before it leaves the building (issue #666).
+ *
+ * <p>Every case here is a way a document id could otherwise end up in someone's analytics report.
+ */
+class TrackedUrlSanitizerTest {
+
+  @Test
+  @DisplayName("leaves a route pattern exactly as the client sent it")
+  void keepsPatterns() {
+    assertThat(TrackedUrlSanitizer.sanitize("/reviews/:documentId/tasks"))
+        .isEqualTo("/reviews/:documentId/tasks");
+    assertThat(TrackedUrlSanitizer.sanitize("https://qnop.example/reviews/:documentId"))
+        .isEqualTo("https://qnop.example/reviews/:documentId");
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    // A client that forgot the rule, or an old bundle still in a tab.
+    "/reviews/8f3c1d2e-4a5b-6c7d-8e9f-0a1b2c3d4e5f, /reviews/:id",
+    "/reviews/8f3c1d2e-4a5b-6c7d-8e9f-0a1b2c3d4e5f/tasks, /reviews/:id/tasks",
+    // Numeric and hex ids from anywhere else.
+    "/documents/1234567, /documents/:id",
+    "/objects/deadbeefcafe1234, /objects/:id",
+    // Anything improbably long is treated as an id whatever it is.
+    "/x/abcdefghijklmnopqrstuvwxyz0123456789, /x/:id"
+  })
+  @DisplayName("replaces identifier-shaped segments")
+  void replacesIdentifiers(String input, String expected) {
+    assertThat(TrackedUrlSanitizer.sanitize(input)).isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("drops the query string, always")
+  void dropsQueryAndFragment() {
+    // Search terms are the clearest case: "?q=merger agreement" is the document's
+    // subject typed by a human, and it has no business travelling.
+    assertThat(TrackedUrlSanitizer.sanitize("/search?q=merger%20agreement")).isEqualTo("/search");
+    assertThat(TrackedUrlSanitizer.sanitize("/reviews/:documentId#annotation-4"))
+        .isEqualTo("/reviews/:documentId");
+    assertThat(TrackedUrlSanitizer.sanitize("https://qnop.example/search?q=secret&page=2"))
+        .isEqualTo("https://qnop.example/search");
+  }
+
+  @Test
+  @DisplayName("keeps ordinary page segments readable")
+  void keepsReadableSegments() {
+    // The whole point is a report that still says something: /admin/settings has
+    // to survive, or there is nothing to measure.
+    assertThat(TrackedUrlSanitizer.sanitize("/admin/settings")).isEqualTo("/admin/settings");
+    assertThat(TrackedUrlSanitizer.sanitize("/my-teams")).isEqualTo("/my-teams");
+    assertThat(TrackedUrlSanitizer.sanitize("/")).isEqualTo("/");
+  }
+
+  @Test
+  @DisplayName("never passes something it could not parse")
+  void failsClosed() {
+    assertThat(TrackedUrlSanitizer.sanitize(null)).isEqualTo("/");
+    assertThat(TrackedUrlSanitizer.sanitize("   ")).isEqualTo("/");
+    assertThat(TrackedUrlSanitizer.sanitize("not a url at all")).isEqualTo("/not a url at all");
+  }
+
+  @Test
+  @DisplayName("a slug is beyond it, and that is the client's job")
+  void slugsAreTheClientsJob() {
+    // Stated as a test so the limit is visible rather than assumed: this sees a
+    // readable word, not a person. The client sends ":userId" here, because the
+    // router knows it was a parameter.
+    assertThat(TrackedUrlSanitizer.sanitize("/users/mia-member")).isEqualTo("/users/mia-member");
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackingConfigServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackingConfigServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Resolving the settings into a working configuration, or into nothing (issue #666).
+ *
+ * <p>"Nothing" is most of what is asserted here. Half-configured measurement is the state an
+ * operator actually reaches — switch it on, then go and find the site id — and it has to be silent
+ * rather than half-working.
+ */
+class TrackingConfigServiceTest {
+
+  private final ApplicationSettingsService settings = mock(ApplicationSettingsService.class);
+
+  private TrackingConfigService service(boolean allowPrivateHost) {
+    return new TrackingConfigService(settings, allowPrivateHost);
+  }
+
+  @BeforeEach
+  void enabledPlausibleCloud() {
+    when(settings.getBoolean(ApplicationSettingKey.TRACKING_ENABLED)).thenReturn(true);
+    when(settings.getString(ApplicationSettingKey.TRACKING_PROVIDER)).thenReturn("plausible");
+    when(settings.getString(ApplicationSettingKey.TRACKING_SITE_ID)).thenReturn("qnop.example");
+    when(settings.getString(ApplicationSettingKey.TRACKING_HOST)).thenReturn("");
+    when(settings.getString(ApplicationSettingKey.TRACKING_FORWARD_CLIENT_IP))
+        .thenReturn("anonymized");
+    when(settings.getBoolean(ApplicationSettingKey.TRACKING_CONSENT_REQUIRED)).thenReturn(true);
+    when(settings.getBoolean(ApplicationSettingKey.TRACKING_RESPECT_DNT)).thenReturn(true);
+    when(settings.getBoolean(ApplicationSettingKey.TRACKING_PRIVILEGED_ROLES)).thenReturn(false);
+  }
+
+  @Test
+  @DisplayName("a hosted backend needs no host of its own")
+  void resolvesCloudDefaults() {
+    assertThat(service(false).current())
+        .hasValueSatisfying(
+            config -> {
+              assertThat(config.provider()).isEqualTo(TrackingProvider.PLAUSIBLE);
+              assertThat(config.scriptUrl()).isEqualTo("https://plausible.io/js/script.manual.js");
+              assertThat(config.collectBaseUrl()).isEqualTo("https://plausible.io");
+              assertThat(config.forwardClientIp()).isTrue();
+            });
+  }
+
+  @Test
+  @DisplayName("switched off resolves to nothing at all")
+  void offIsNothing() {
+    when(settings.getBoolean(ApplicationSettingKey.TRACKING_ENABLED)).thenReturn(false);
+    assertThat(service(false).current()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("'none' is a provider only in the dropdown")
+  void noneIsNothing() {
+    when(settings.getString(ApplicationSettingKey.TRACKING_PROVIDER)).thenReturn("none");
+    assertThat(service(false).current()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("no site id means nothing to measure into")
+  void missingSiteIdIsNothing() {
+    when(settings.getString(ApplicationSettingKey.TRACKING_SITE_ID)).thenReturn("   ");
+    assertThat(service(false).current()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a self-hosted backend without a host is not a configuration")
+  void selfHostedNeedsAHost() {
+    when(settings.getString(ApplicationSettingKey.TRACKING_PROVIDER)).thenReturn("matomo");
+    when(settings.getString(ApplicationSettingKey.TRACKING_SITE_ID)).thenReturn("1");
+    when(settings.getString(ApplicationSettingKey.TRACKING_HOST)).thenReturn("");
+    assertThat(service(false).current()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a private host is refused unless the deployment allows it")
+  void privateHostNeedsTheDeploymentProperty() {
+    when(settings.getString(ApplicationSettingKey.TRACKING_PROVIDER)).thenReturn("matomo");
+    when(settings.getString(ApplicationSettingKey.TRACKING_SITE_ID)).thenReturn("1");
+    when(settings.getString(ApplicationSettingKey.TRACKING_HOST))
+        .thenReturn("http://10.0.0.5:8080/");
+
+    // The whole point of the property: an admin with the settings page cannot
+    // point this server at an internal address on their own.
+    assertThat(service(false).current()).isEmpty();
+    assertThat(service(true).current())
+        .hasValueSatisfying(
+            config -> {
+              assertThat(config.collectBaseUrl()).isEqualTo("http://10.0.0.5:8080");
+              assertThat(config.scriptUrl()).isEqualTo("http://10.0.0.5:8080/matomo.js");
+            });
+  }
+
+  @Test
+  @DisplayName("the cloud metadata address stays blocked either way")
+  void blocksMetadataAddress() {
+    when(settings.getString(ApplicationSettingKey.TRACKING_PROVIDER)).thenReturn("matomo");
+    when(settings.getString(ApplicationSettingKey.TRACKING_SITE_ID)).thenReturn("1");
+    when(settings.getString(ApplicationSettingKey.TRACKING_HOST))
+        .thenReturn("http://169.254.169.254/");
+
+    assertThat(service(false).current()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("'none' for the IP means none is forwarded")
+  void forwardIpIsOptional() {
+    when(settings.getString(ApplicationSettingKey.TRACKING_FORWARD_CLIENT_IP)).thenReturn("none");
+    assertThat(service(false).current())
+        .hasValueSatisfying(c -> assertThat(c.forwardClientIp()).isFalse());
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackingPayloadSanitizerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackingPayloadSanitizerTest.java
@@ -91,6 +91,26 @@ class TrackingPayloadSanitizerTest {
   }
 
   @Test
+  @DisplayName("drops the page title, which cannot be anonymised")
+  void dropsTitles() {
+    // Every backend sends document.title along with the address. A title has no
+    // structure to rewrite, and in qnop it is one browser-tab feature away from
+    // being the name of a customer's contract — so it does not travel.
+    String umami =
+        sanitize(
+            "{\"payload\":{\"website\":\"w1\",\"title\":\"Vendor agreement\",\"url\":\"/reviews\"}}");
+    assertThat(umami).doesNotContain("Vendor agreement").contains("w1").contains("/reviews");
+
+    String posthog = sanitize("{\"properties\":{\"$title\":\"Vendor agreement\"}}");
+    assertThat(posthog).doesNotContain("Vendor agreement");
+
+    // Matomo carries it as a query parameter; emptied, not removed.
+    String matomo =
+        TrackingPayloadSanitizer.sanitizeQuery("idsite=1&action_name=Vendor%20agreement&rec=1");
+    assertThat(matomo).doesNotContain("Vendor").contains("action_name=").contains("rec=1");
+  }
+
+  @Test
   @DisplayName("leaves what it cannot read alone rather than mangling it")
   void passesThroughNonJson() {
     byte[] binary = new byte[] {0x1f, (byte) 0x8b, 0x08, 0x00};

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackingPayloadSanitizerTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackingPayloadSanitizerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Rewriting the URL out of a measurement, whatever body shape it arrives in (issue #666). */
+class TrackingPayloadSanitizerTest {
+
+  private static final String DOC = "8f3c1d2e-4a5b-6c7d-8e9f-0a1b2c3d4e5f";
+
+  private static String sanitize(String json) {
+    return new String(
+        TrackingPayloadSanitizer.sanitizeBody(json.getBytes(StandardCharsets.UTF_8)),
+        StandardCharsets.UTF_8);
+  }
+
+  @Test
+  @DisplayName("rewrites the flat url field (Plausible)")
+  void rewritesFlatUrl() {
+    String out =
+        sanitize(
+            "{\"domain\":\"qnop.example\",\"name\":\"pageview\",\"url\":\"https://qnop.example/reviews/"
+                + DOC
+                + "\"}");
+
+    assertThat(out).contains("https://qnop.example/reviews/:id").doesNotContain(DOC);
+  }
+
+  @Test
+  @DisplayName("reaches a nested one (PostHog, Umami)")
+  void rewritesNestedUrl() {
+    String posthog =
+        sanitize(
+            "{\"event\":\"$pageview\",\"properties\":{\"$current_url\":\"https://qnop.example/reviews/"
+                + DOC
+                + "/tasks\"}}");
+    assertThat(posthog).contains("/reviews/:id/tasks").doesNotContain(DOC);
+
+    String umami =
+        sanitize(
+            "{\"type\":\"event\",\"payload\":{\"website\":\"w1\",\"url\":\"/reviews/"
+                + DOC
+                + "\"}}");
+    assertThat(umami).contains("\"url\":\"/reviews/:id\"").doesNotContain(DOC);
+  }
+
+  @Test
+  @DisplayName("strips the search term out of a referrer as well")
+  void rewritesReferrer() {
+    // A referrer is a URL like any other, and the one qnop page whose query is
+    // the user's own words is the search.
+    String out =
+        sanitize("{\"name\":\"pageview\",\"referrer\":\"https://qnop.example/search?q=merger\"}");
+
+    assertThat(out).contains("https://qnop.example/search").doesNotContain("merger");
+  }
+
+  @Test
+  @DisplayName("rewrites the query-string form too (Matomo)")
+  void rewritesQueryParameters() {
+    String out =
+        TrackingPayloadSanitizer.sanitizeQuery(
+            "idsite=1&rec=1&url=https%3A%2F%2Fqnop.example%2Freviews%2F"
+                + DOC
+                + "&action_name=Review");
+
+    assertThat(out).doesNotContain(DOC).contains("idsite=1").contains("rec=1");
+  }
+
+  @Test
+  @DisplayName("leaves what it cannot read alone rather than mangling it")
+  void passesThroughNonJson() {
+    byte[] binary = new byte[] {0x1f, (byte) 0x8b, 0x08, 0x00};
+
+    assertThat(TrackingPayloadSanitizer.sanitizeBody(binary)).isEqualTo(binary);
+    assertThat(TrackingPayloadSanitizer.sanitizeBody(null)).isNull();
+    assertThat(TrackingPayloadSanitizer.sanitizeQuery(null)).isNull();
+  }
+
+  @Test
+  @DisplayName("keeps everything that is not a URL exactly as it was")
+  void keepsOtherFields() {
+    String out = sanitize("{\"name\":\"review_created\",\"domain\":\"qnop.example\",\"count\":3}");
+
+    assertThat(out).contains("review_created").contains("qnop.example").contains("3");
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackingProviderTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackingProviderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** The provider table, and above all what it refuses (issue #666). */
+class TrackingProviderTest {
+
+  @Test
+  @DisplayName("session recording is not reachable through this server")
+  void refusesSessionRecording() {
+    // The promise "qnop does not do session replay" is kept here rather than in a
+    // client configuration somebody could change: PostHog's recorder posts to
+    // /s/, and this server will not forward it whatever the page asks.
+    assertThat(TrackingProvider.POSTHOG.allowsCollectPath("/s/")).isFalse();
+    assertThat(TrackingProvider.POSTHOG.allowsCollectPath("/s")).isFalse();
+    assertThat(TrackingProvider.POSTHOG.allowsCollectPath("/static/recorder.js")).isFalse();
+  }
+
+  @Test
+  @DisplayName("only declared paths are forwarded, matched whole")
+  void allowsOnlyDeclaredPaths() {
+    assertThat(TrackingProvider.PLAUSIBLE.allowsCollectPath("/api/event")).isTrue();
+    assertThat(TrackingProvider.PLAUSIBLE.allowsCollectPath("/api/event/../../admin")).isFalse();
+    // A prefix match would have let this through; the list is compared exactly.
+    assertThat(TrackingProvider.PIRSCH.allowsCollectPath("/e")).isTrue();
+    assertThat(TrackingProvider.PIRSCH.allowsCollectPath("/export-everything")).isFalse();
+    assertThat(TrackingProvider.UMAMI.allowsCollectPath("/api/send")).isTrue();
+    assertThat(TrackingProvider.UMAMI.allowsCollectPath("/api/admin/websites")).isFalse();
+  }
+
+  @Test
+  @DisplayName("the self-hosted backends say so")
+  void knowsWhichNeedAHost() {
+    assertThat(TrackingProvider.MATOMO.requiresHost()).isTrue();
+    assertThat(TrackingProvider.UMAMI.requiresHost()).isTrue();
+    assertThat(TrackingProvider.PLAUSIBLE.requiresHost()).isFalse();
+    assertThat(TrackingProvider.POSTHOG.requiresHost()).isFalse();
+    assertThat(TrackingProvider.PIRSCH.requiresHost()).isFalse();
+  }
+
+  @Test
+  @DisplayName("PostHog's cloud serves its script from a different host than its ingestion")
+  void separatesAssetsFromIngestion() {
+    assertThat(TrackingProvider.POSTHOG.defaultScriptHost())
+        .isEqualTo("https://us-assets.i.posthog.com");
+    assertThat(TrackingProvider.POSTHOG.defaultHost()).isEqualTo("https://us.i.posthog.com");
+    // Everyone else serves both from the same place.
+    assertThat(TrackingProvider.PIRSCH.defaultScriptHost())
+        .isEqualTo(TrackingProvider.PIRSCH.defaultHost());
+  }
+
+  @Test
+  @DisplayName("ids map to providers, and nothing else does")
+  void mapsIds() {
+    assertThat(TrackingProvider.fromId("matomo")).contains(TrackingProvider.MATOMO);
+    assertThat(TrackingProvider.fromId(" PostHog ")).contains(TrackingProvider.POSTHOG);
+    assertThat(TrackingProvider.fromId("none")).isEmpty();
+    assertThat(TrackingProvider.fromId(null)).isEmpty();
+    assertThat(TrackingProvider.fromId("hotjar")).isEmpty();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackingProviderTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackingProviderTest.java
@@ -45,7 +45,11 @@ class TrackingProviderTest {
     assertThat(TrackingProvider.PLAUSIBLE.allowsCollectPath("/api/event")).isTrue();
     assertThat(TrackingProvider.PLAUSIBLE.allowsCollectPath("/api/event/../../admin")).isFalse();
     // A prefix match would have let this through; the list is compared exactly.
-    assertThat(TrackingProvider.PIRSCH.allowsCollectPath("/e")).isTrue();
+    // Verified against api.pirsch.io: /hit, /event and /session answer; the
+    // /pv, /e, /s this once assumed answer 404.
+    assertThat(TrackingProvider.PIRSCH.allowsCollectPath("/hit")).isTrue();
+    assertThat(TrackingProvider.PIRSCH.allowsCollectPath("/event")).isTrue();
+    assertThat(TrackingProvider.PIRSCH.allowsCollectPath("/pv")).isFalse();
     assertThat(TrackingProvider.PIRSCH.allowsCollectPath("/export-everything")).isFalse();
     assertThat(TrackingProvider.UMAMI.allowsCollectPath("/api/send")).isTrue();
     assertThat(TrackingProvider.UMAMI.allowsCollectPath("/api/admin/websites")).isFalse();

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackingProxyServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackingProxyServiceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sun.net.httpserver.HttpServer;
+import io.qnop.service.http.HttpClientProperties;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Forwarding, against a stand-in backend (issue #666).
+ *
+ * <p>The case that earns this test: <b>Matomo and Pirsch measure with GET</b>, the others with
+ * POST. A proxy that took only POST worked for three providers out of five, and it took pointing
+ * the thing at a real Matomo to notice — so the method the browser used is asserted here, at the
+ * level where the request is actually built.
+ */
+class TrackingProxyServiceTest {
+
+  private static final String DOC = "8f3c1d2e-4a5b-6c7d-8e9f-0a1b2c3d4e5f";
+
+  private final TrackingConfigService config = mock(TrackingConfigService.class);
+
+  private HttpServer backend;
+  private TrackingProxyService proxy;
+  private final BlockingQueue<String> requests = new ArrayBlockingQueue<>(8);
+
+  @BeforeEach
+  void startBackend() throws IOException {
+    backend = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    backend.createContext(
+        "/",
+        exchange -> {
+          String query = exchange.getRequestURI().getRawQuery();
+          String body =
+              new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+          requests.offer(
+              exchange.getRequestMethod()
+                  + " "
+                  + exchange.getRequestURI().getPath()
+                  + (query == null ? "" : "?" + query)
+                  + (body.isEmpty() ? "" : " " + body));
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+    backend.start();
+
+    String host = "http://127.0.0.1:" + backend.getAddress().getPort();
+    when(config.current())
+        .thenReturn(
+            Optional.of(
+                new TrackingRuntimeConfig(
+                    TrackingProvider.MATOMO,
+                    "1",
+                    host + "/matomo.js",
+                    host,
+                    false,
+                    false,
+                    false,
+                    true)));
+    proxy = new TrackingProxyService(config, defaults());
+  }
+
+  @AfterEach
+  void stopBackend() {
+    backend.stop(0);
+  }
+
+  private static HttpClientProperties defaults() {
+    return new HttpClientProperties(null, null, null, null, null);
+  }
+
+  @Test
+  @DisplayName("a GET measurement travels as a GET, with its query sanitized")
+  void forwardsGetWithQuery() throws Exception {
+    Optional<Integer> status =
+        proxy.forward(
+            "GET",
+            "/matomo.php",
+            "idsite=1&rec=1&url=%2Freviews%2F"
+                + DOC
+                + "%2Ftasks%3Ffilter%3Dopen&action_name=Vendor",
+            new byte[0],
+            null,
+            "203.0.113.9",
+            "Mozilla/5.0");
+
+    assertThat(status).contains(200);
+    String seen = requests.poll(5, TimeUnit.SECONDS);
+    assertThat(seen).as("the backend saw the measurement").isNotNull();
+    assertThat(seen).startsWith("GET /matomo.php?");
+    assertThat(seen).doesNotContain(DOC).doesNotContain("filter%3Dopen");
+    // Matomo's title field is emptied rather than dropped, so the parameter list
+    // keeps the shape the backend expects.
+    assertThat(seen).contains("action_name=").doesNotContain("action_name=Vendor");
+  }
+
+  @Test
+  @DisplayName("a POST measurement travels as a POST, with its body sanitized")
+  void forwardsPostWithBody() throws Exception {
+    when(config.current())
+        .thenReturn(
+            Optional.of(
+                new TrackingRuntimeConfig(
+                    TrackingProvider.UMAMI,
+                    "site",
+                    "http://127.0.0.1:" + backend.getAddress().getPort() + "/script.js",
+                    "http://127.0.0.1:" + backend.getAddress().getPort(),
+                    false,
+                    false,
+                    false,
+                    true)));
+
+    proxy.forward(
+        "POST",
+        "/api/send",
+        null,
+        ("{\"payload\":{\"url\":\"/reviews/" + DOC + "\",\"title\":\"Vendor agreement\"}}")
+            .getBytes(StandardCharsets.UTF_8),
+        "application/json",
+        "203.0.113.9",
+        "Mozilla/5.0");
+
+    String seen = requests.poll(5, TimeUnit.SECONDS);
+    assertThat(seen).isNotNull();
+    assertThat(seen).startsWith("POST /api/send");
+    assertThat(seen)
+        .contains("/reviews/:id")
+        .doesNotContain(DOC)
+        .doesNotContain("Vendor agreement");
+  }
+
+  @Test
+  @DisplayName("an undeclared path is never sent, whatever the method")
+  void refusesUndeclaredPaths() throws Exception {
+    assertThat(proxy.forward("GET", "/index.php", "module=API", new byte[0], null, null, null))
+        .isEmpty();
+    assertThat(proxy.forward("POST", "/matomo.php/../admin", null, new byte[0], null, null, null))
+        .isEmpty();
+
+    assertThat(requests.poll(1, TimeUnit.SECONDS)).as("nothing was forwarded").isNull();
+  }
+}

--- a/qnop-ui/src/api/hooks/useAnnotations.ts
+++ b/qnop-ui/src/api/hooks/useAnnotations.ts
@@ -32,6 +32,7 @@ import { annotationsApi } from '../config';
 import type { Notify } from '../../components/admin/layout/useToast';
 import { commentKeys } from './useComments';
 import { documentKeys } from './useDocuments';
+import { trackEvent } from '../../tracking/trackEvent';
 
 export const annotationKeys = {
   all: ['annotations'] as const,
@@ -117,6 +118,7 @@ export function useCreateAnnotation(documentId: string) {
       return response.data;
     },
     onSuccess: () => {
+      trackEvent('annotation_created');
       queryClient.invalidateQueries({ queryKey: annotationKeys.all });
       queryClient.invalidateQueries({ queryKey: ['reviews'] });
       // Detail only (workflow chip / counts) — NEVER documentKeys.all: that

--- a/qnop-ui/src/api/hooks/useReviews.ts
+++ b/qnop-ui/src/api/hooks/useReviews.ts
@@ -33,6 +33,7 @@ import { axiosInstance, documentsApi, principalsApi, reviewWorkflowApi } from '.
 import { annotationKeys } from './useAnnotations';
 import { commentKeys } from './useComments';
 import { documentKeys } from './useDocuments';
+import { trackEvent } from '../../tracking/trackEvent';
 
 export interface ReviewListParams {
   q?: string;
@@ -187,7 +188,12 @@ export function useTransitionWorkflow(documentId: string) {
       });
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (workflow) => {
+      // Only the end of the road counts as a finalisation; the other edges are
+      // ordinary progress (issue #666).
+      if (workflow?.state === 'FINALIZED') {
+        trackEvent('review_finalized');
+      }
       queryClient.invalidateQueries({ queryKey: reviewKeys.workflow(documentId) });
       queryClient.invalidateQueries({ queryKey: documentKeys.detail(documentId) });
       queryClient.invalidateQueries({ queryKey: reviewKeys.all });
@@ -281,7 +287,10 @@ export function useCreateReview() {
       });
       return response.data;
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: reviewKeys.all }),
+    onSuccess: () => {
+      trackEvent('review_created');
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+    },
   });
 }
 

--- a/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
+++ b/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
@@ -45,6 +45,7 @@ import type { AdminSetting } from '../../../api/generated';
 import { useSettings, useUpdateSettings } from '../../../api/hooks/useSettings';
 import { TimezonePicker } from '../../TimezonePicker';
 import { SectionCard } from '../layout/SectionCard';
+import { trackingStatus } from './trackingStatus';
 import { AdminToast } from '../layout/AdminToast';
 import { useToast } from '../layout/useToast';
 import { apiErrorMessage, apiFieldErrors } from '../../../utils/apiError';
@@ -307,6 +308,16 @@ export function ApplicationSettingsForm() {
     setSubmitAttempted(false);
   };
 
+  // Stored values overlaid with unsaved edits: the status line below has to
+  // answer for what is on screen, not for what was last saved.
+  const effectiveValues = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const setting of settings) {
+      map[setting.key] = edits[setting.key] ?? setting.value ?? '';
+    }
+    return map;
+  }, [settings, edits]);
+
   const groups = useMemo(() => {
     const byGroup = new Map<string, AdminSetting[]>();
     for (const setting of settings) {
@@ -368,6 +379,7 @@ export function ApplicationSettingsForm() {
             description={GROUP_DESCRIPTIONS[group]}
           >
             <Stack spacing={2.5}>
+              {group === 'tracking' && <TrackingStatusNote values={effectiveValues} />}
               {items.map((setting) => (
                 <SettingField
                   key={setting.key}
@@ -503,5 +515,22 @@ function SettingField({ setting, value, error, onChange }: SettingFieldProps) {
       autoComplete={isPassword ? 'new-password' : undefined}
       sx={{ maxWidth: 480 }}
     />
+  );
+}
+
+/**
+ * One line saying whether measurement is actually running, and if not, which condition is missing
+ * (issue #666). It reads the form's live values, so switching the master toggle answers immediately
+ * rather than after a save and a reload.
+ */
+function TrackingStatusNote({ values }: { values: Record<string, string> }) {
+  const status = trackingStatus(values);
+  if (!status) {
+    return null;
+  }
+  return (
+    <Alert severity={status.severity === 'success' ? 'success' : 'warning'} variant="outlined">
+      {status.message}
+    </Alert>
   );
 }

--- a/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
+++ b/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
@@ -85,7 +85,8 @@ const GROUP_ICONS: Record<string, LucideIcon> = {
 const GROUP_DESCRIPTIONS: Record<string, string> = {
   general: 'Workspace identity, base URL, default language and time zone.',
   upload: 'Constraints applied to document uploads.',
-  tracking: 'Anonymous, privacy-friendly usage analytics.',
+  tracking:
+    'Anonymous usage measurement through this server: the browser loads the script from qnop and sends its measurements to qnop, which forwards them. Page addresses are reduced to route patterns first, so no document id ever reaches the backend.',
   auth: 'Self-registration and password-reset behaviour.',
   review: 'Behaviour of the document review workflow.',
   notifications: 'Review e-mails and how long the in-app inbox keeps its records.',
@@ -117,6 +118,12 @@ const SELECT_OPTIONS: Record<string, { value: string; label: string }[]> = {
     { value: 'matomo', label: 'Matomo' },
     { value: 'plausible', label: 'Plausible' },
     { value: 'umami', label: 'Umami' },
+    { value: 'posthog', label: 'PostHog' },
+    { value: 'pirsch', label: 'Pirsch' },
+  ],
+  'tracking.forward_client_ip': [
+    { value: 'anonymized', label: 'Anonymised (recommended)' },
+    { value: 'none', label: 'Do not forward' },
   ],
   'auth.self_registration_default_role': [
     { value: 'MEMBER', label: 'Member' },
@@ -184,6 +191,10 @@ const SETTING_RULES: Record<string, { test: (value: string) => boolean; message:
   'banner.app_link_label': {
     test: (value) => value.length <= 40,
     message: 'Keep the label to 40 characters.',
+  },
+  'tracking.host': {
+    test: isHttpUrl,
+    message: 'Enter a valid http(s) URL, e.g. https://matomo.internal.',
   },
   'banner.login_link_url': {
     test: (value) => isHttpUrl(value) && value.length <= 500,

--- a/qnop-ui/src/components/admin/settings/trackingStatus.test.ts
+++ b/qnop-ui/src/components/admin/settings/trackingStatus.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { trackingStatus } from './trackingStatus';
+
+describe('trackingStatus', () => {
+  it('names the master switch when everything else is filled in', () => {
+    // The case this exists for: a complete-looking configuration that measures
+    // nothing, with no hint anywhere on the screen.
+    const status = trackingStatus({
+      'tracking.enabled': 'false',
+      'tracking.provider': 'umami',
+      'tracking.host': 'https://analytics.example',
+      'tracking.site_id': 'abc',
+    });
+
+    expect(status?.severity).toBe('warning');
+    expect(status?.message).toMatch(/switched off/i);
+  });
+
+  it('confirms a working configuration', () => {
+    const status = trackingStatus({
+      'tracking.enabled': 'true',
+      'tracking.provider': 'umami',
+      'tracking.host': 'https://analytics.example',
+      'tracking.site_id': 'abc',
+    });
+
+    expect(status?.severity).toBe('success');
+    expect(status?.message).toContain('Umami');
+    expect(status?.message).toContain('https://analytics.example');
+  });
+
+  it('points at the missing site id', () => {
+    const status = trackingStatus({
+      'tracking.enabled': 'true',
+      'tracking.provider': 'plausible',
+      'tracking.site_id': '  ',
+    });
+
+    expect(status?.severity).toBe('warning');
+    expect(status?.message).toMatch(/site id/i);
+  });
+
+  it('asks for a host only where the backend is self-hosted', () => {
+    const selfHosted = trackingStatus({
+      'tracking.enabled': 'true',
+      'tracking.provider': 'matomo',
+      'tracking.site_id': '1',
+      'tracking.host': '',
+    });
+    expect(selfHosted?.severity).toBe('warning');
+    expect(selfHosted?.message).toMatch(/self-hosted/i);
+
+    // Plausible has a cloud, so an empty host is a complete configuration.
+    const cloud = trackingStatus({
+      'tracking.enabled': 'true',
+      'tracking.provider': 'plausible',
+      'tracking.site_id': 'qnop.example',
+      'tracking.host': '',
+    });
+    expect(cloud?.severity).toBe('success');
+  });
+
+  it('says nothing at all when tracking was never set up', () => {
+    expect(trackingStatus({ 'tracking.enabled': 'false', 'tracking.provider': 'none' })).toBeNull();
+  });
+
+  it('flags a master switch with no backend behind it', () => {
+    const status = trackingStatus({ 'tracking.enabled': 'true', 'tracking.provider': 'none' });
+
+    expect(status?.severity).toBe('warning');
+    expect(status?.message).toMatch(/no backend/i);
+  });
+});

--- a/qnop-ui/src/components/admin/settings/trackingStatus.ts
+++ b/qnop-ui/src/components/admin/settings/trackingStatus.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/** Backends that exist only self-hosted, so a host is not optional (TrackingProvider). */
+const SELF_HOSTED = new Set(['matomo', 'umami']);
+
+export interface TrackingStatus {
+  severity: 'success' | 'warning';
+  message: string;
+}
+
+/**
+ * Says in one line whether this deployment is actually measuring anything (issue #666).
+ *
+ * <p>Added after a configuration that looked complete measured nothing: provider, host and site id
+ * were filled in, every privacy switch had been considered — and the master toggle was still off, so
+ * the server published no tracking at all and the browser loaded no script. Everything behaved as
+ * designed and the screen said nothing about it.
+ *
+ * <p>The rules mirror `TrackingConfigService` exactly, which is the point: the same four conditions
+ * that make the server publish a configuration are the ones stated here, so "nothing is happening"
+ * always comes with the reason.
+ */
+export function trackingStatus(values: Record<string, string>): TrackingStatus | null {
+  const provider = (values['tracking.provider'] ?? 'none').trim();
+  const enabled = values['tracking.enabled'] === 'true';
+  const siteId = (values['tracking.site_id'] ?? '').trim();
+  const host = (values['tracking.host'] ?? '').trim();
+
+  if (provider === 'none' && !enabled) {
+    return null;
+  }
+  if (provider === 'none') {
+    return { severity: 'warning', message: 'Measurement is on, but no backend is selected.' };
+  }
+  if (!enabled) {
+    // The case that prompted this: everything filled in, nothing measured.
+    return {
+      severity: 'warning',
+      message: `Nothing is being measured — “${label(provider)}” is configured, but usage tracking is switched off above.`,
+    };
+  }
+  if (!siteId) {
+    return {
+      severity: 'warning',
+      message: `Nothing is being measured — ${label(provider)} needs the site id it knows this workspace by.`,
+    };
+  }
+  if (!host && SELF_HOSTED.has(provider)) {
+    return {
+      severity: 'warning',
+      message: `Nothing is being measured — ${label(provider)} is self-hosted, so it needs the address of your server.`,
+    };
+  }
+  return {
+    severity: 'success',
+    message: `Measuring into ${label(provider)}${host ? ` at ${host}` : ''}. Page addresses are reduced to route patterns before they are forwarded.`,
+  };
+}
+
+function label(provider: string): string {
+  const names: Record<string, string> = {
+    matomo: 'Matomo',
+    plausible: 'Plausible',
+    umami: 'Umami',
+    posthog: 'PostHog',
+    pirsch: 'Pirsch',
+  };
+  return names[provider] ?? provider;
+}

--- a/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
+++ b/qnop-ui/src/components/reviews/ExportAnnotationsButton.tsx
@@ -27,6 +27,7 @@ import { useDocument } from '../../api/hooks/useDocuments';
 import { ToolbarIconButton } from './ToolbarIconButton';
 import { ExportWizard, type ExportCounts } from './export/ExportWizard';
 import type { ExportSettings } from './export/exportModel';
+import { trackEvent } from '../../tracking/trackEvent';
 
 /**
  * Opens the export wizard for a review's annotations (issue #547).
@@ -74,6 +75,7 @@ export function ExportAnnotationsButton({
         timezone: settings.timezone,
         fileName,
       });
+      trackEvent('export_generated');
       // Closing only after it succeeded keeps the configuration on screen when
       // it did not — the user retries instead of rebuilding their selection.
       setOpen(false);

--- a/qnop-ui/src/pages/ProfilePage.tsx
+++ b/qnop-ui/src/pages/ProfilePage.tsx
@@ -31,6 +31,9 @@ import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useAuthStore } from '../stores/authStore';
+import { useConfig } from '../api/hooks/useConfig';
+import { OPT_OUT_KEY } from '../tracking/trackingGate';
+import { clearConsent } from '../tracking/consent';
 import { useReviews } from '../api/hooks/useReviews';
 import { useUploadMyAvatar, useRemoveMyAvatar } from '../api/hooks/useAvatar';
 import { AchievementRow } from '../components/profile/AchievementRow';
@@ -101,6 +104,26 @@ export function ProfilePage() {
         onError: () => setToast({ message: 'The setting could not be saved.', severity: 'error' }),
       },
     );
+  };
+
+  // Usage measurement (issue #666). Only offered where the deployment measures
+  // anything at all — a switch for a feature that is off would be a puzzle.
+  const trackingConfigured = Boolean(useConfig().data?.tracking);
+  const optedOut =
+    settingsQuery.data?.settings.find((setting) => setting.key === OPT_OUT_KEY)?.value === 'true';
+
+  const onToggleTracking = (measured: boolean) => {
+    updateSettings.mutate(
+      { [OPT_OUT_KEY]: String(!measured) },
+      {
+        onError: () => setToast({ message: 'The setting could not be saved.', severity: 'error' }),
+      },
+    );
+    // Opting back in means the browser question is asked again rather than
+    // silently answered from an old click.
+    if (measured) {
+      clearConsent();
+    }
   };
 
   const onChangeTimezone = (zone: string) => {
@@ -271,6 +294,30 @@ export function ProfilePage() {
           label="Email me about review activity"
         />
       </Paper>
+
+      {trackingConfigured && (
+        <Paper variant="outlined" sx={{ p: { xs: 2.5, sm: 3 } }}>
+          <Typography sx={{ fontSize: 16, fontWeight: 600 }}>Usage measurement</Typography>
+          <Typography color="text.secondary" sx={{ fontSize: 14, mt: 0.5, mb: 2.5 }}>
+            Anonymous counts of which pages get used, so this workspace can be improved with
+            evidence rather than guesswork. Page addresses are reduced to their shape first — never
+            a document, never a name, never a search term. This choice follows your account to every
+            device you sign in from.
+          </Typography>
+          <Divider sx={{ mb: 1.5 }} />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={!optedOut}
+                onChange={(event) => onToggleTracking(event.target.checked)}
+                disabled={settingsQuery.isPending}
+                slotProps={{ input: { 'aria-label': 'Include me in anonymous usage measurement' } }}
+              />
+            }
+            label="Include me in anonymous usage measurement"
+          />
+        </Paper>
+      )}
 
       <TimezoneSetting
         value={displayZone}

--- a/qnop-ui/src/router/errorRoutes.test.tsx
+++ b/qnop-ui/src/router/errorRoutes.test.tsx
@@ -22,6 +22,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { RouterProvider } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../theme/theme';
 import { router } from './index';
@@ -46,9 +47,16 @@ describe('error routes (#611)', () => {
   it.each(CASES)('serves the branded state at %s without auth', async (path, headline) => {
     await router.navigate(path);
     render(
-      <ThemeProvider theme={buildTheme('light')}>
-        <RouterProvider router={router} />
-      </ThemeProvider>,
+      // The route table is wrapped by TrackingBoot (issue #666), which reads the
+      // server config — so exercising the real router needs the same provider the
+      // application mounts.
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <ThemeProvider theme={buildTheme('light')}>
+          <RouterProvider router={router} />
+        </ThemeProvider>
+      </QueryClientProvider>,
     );
     expect(await screen.findByText(headline)).toBeInTheDocument();
   });

--- a/qnop-ui/src/router/index.tsx
+++ b/qnop-ui/src/router/index.tsx
@@ -21,6 +21,7 @@
 
 import { lazy } from 'react';
 import { Navigate, createBrowserRouter } from 'react-router';
+import { TrackingBoot } from '../tracking/TrackingBoot';
 import { AppShell } from '../components/shell/AppShell';
 import { LazyBoundary } from '../components/errors/LazyBoundary';
 import { AdminRoute } from '../components/auth/AdminRoute';
@@ -93,193 +94,202 @@ const ReviewTasksPage = lazy(() =>
  * roles the sidebar uses (#102). Real pages replace these in #104+ / Phase B.
  */
 export const router = createBrowserRouter([
-  { path: '/login', element: <LoginPage /> },
-  { path: '/register', element: <RegisterPage /> },
-  { path: '/forgot-password', element: <ForgotPasswordPage /> },
-  { path: '/reset-password', element: <ResetPasswordPage /> },
-  { path: '/verify-email', element: <VerifyEmailPage /> },
-  { path: '/change-password', element: <ChangePasswordPage /> },
-  // The branded full-page states (issue #611). They live outside the shell so
-  // 503/offline also work when nothing else does; the in-app catch-all below
-  // keeps 404 inside the shell for signed-in users.
-  { path: '/403', element: <ForbiddenPage /> },
-  { path: '/409', element: <ConflictPage /> },
-  { path: '/500', element: <ServerErrorPage /> },
-  { path: '/503', element: <MaintenancePage /> },
-  { path: '/429', element: <RateLimitPage /> },
-  { path: '/offline', element: <OfflinePage /> },
   {
-    path: '/',
-    element: (
-      <ProtectedRoute>
-        <AppShell />
-      </ProtectedRoute>
-    ),
-    // A throw during navigation lands on the branded shell, not the router's
-    // default screen (issue #611); pane render errors stay with #331.
-    errorElement: <RouteErrorPage />,
+    // A pathless layout wrapping everything (issue #666): usage measurement has
+    // to see the sign-in screen as well as the shell, and it needs the router's
+    // own params to report a route pattern rather than a URL with a document id
+    // in it. It renders nothing of its own beyond the consent strip.
+    element: <TrackingBoot />,
     children: [
-      { index: true, element: <HomePage /> },
-      { path: 'profile', element: <ProfilePage /> },
-      { path: 'users/:userId', element: <UserProfilePage /> },
-      { path: 'teams/:teamId', element: <TeamProfilePage /> },
-      // The landing page an exported report's attachment links point at: inside
-      // the protected routes, so an unauthenticated visitor logs in and is
-      // returned here (issue #635).
+      { path: '/login', element: <LoginPage /> },
+      { path: '/register', element: <RegisterPage /> },
+      { path: '/forgot-password', element: <ForgotPasswordPage /> },
+      { path: '/reset-password', element: <ResetPasswordPage /> },
+      { path: '/verify-email', element: <VerifyEmailPage /> },
+      { path: '/change-password', element: <ChangePasswordPage /> },
+      // The branded full-page states (issue #611). They live outside the shell so
+      // 503/offline also work when nothing else does; the in-app catch-all below
+      // keeps 404 inside the shell for signed-in users.
+      { path: '/403', element: <ForbiddenPage /> },
+      { path: '/409', element: <ConflictPage /> },
+      { path: '/500', element: <ServerErrorPage /> },
+      { path: '/503', element: <MaintenancePage /> },
+      { path: '/429', element: <RateLimitPage /> },
+      { path: '/offline', element: <OfflinePage /> },
       {
-        path: 'attachments/:documentId/:attachmentId',
-        element: <AttachmentDownloadPage />,
-      },
-      { path: 'messages', element: <MessagesPage /> },
-      { path: 'messages/:notificationId', element: <MessageDetailPage /> },
-      { path: 'reviews', element: <ReviewsPage /> },
-      { path: 'reviews/new', element: <NewReviewPage /> },
-      {
-        path: 'reviews/:documentId',
+        path: '/',
         element: (
-          <ReviewParamGate>
-            <LazyBoundary>
-              <DocumentReviewPage />
-            </LazyBoundary>
-          </ReviewParamGate>
+          <ProtectedRoute>
+            <AppShell />
+          </ProtectedRoute>
         ),
-      },
-      {
-        path: 'reviews/:documentId/compare',
-        element: (
-          <ReviewParamGate>
-            <LazyBoundary>
-              <VersionComparePage />
-            </LazyBoundary>
-          </ReviewParamGate>
-        ),
-      },
-      {
-        path: 'reviews/:documentId/tasks',
-        element: (
-          <ReviewParamGate>
-            <LazyBoundary>
-              <ReviewTasksPage />
-            </LazyBoundary>
-          </ReviewParamGate>
-        ),
-      },
-      { path: 'search', element: <SearchPage /> },
-      { path: 'my-teams', element: <MyTeamsPage /> },
-      { path: 'my-teams/:id', element: <MyTeamDetailPage /> },
-      {
-        path: 'audit',
-        element: (
-          <RoleRoute allow={['ADMIN', 'AUDITOR']}>
-            <AuditPage />
-          </RoleRoute>
-        ),
-      },
-      {
-        path: 'admin/users',
-        element: (
-          <AdminRoute>
-            <UsersPage />
-          </AdminRoute>
-        ),
-      },
-      {
-        path: 'admin/teams',
-        element: (
-          <AdminRoute>
-            <TeamsPage />
-          </AdminRoute>
-        ),
-      },
-      {
-        path: 'admin/teams/:id',
-        element: (
-          <AdminRoute>
-            <TeamDetailPage />
-          </AdminRoute>
-        ),
-      },
-      {
-        path: 'admin/settings',
-        element: (
-          <AdminRoute>
-            <SettingsPage />
-          </AdminRoute>
-        ),
-      },
-      {
-        path: 'admin/configuration',
-        element: (
-          <AdminRoute>
-            <ConfigurationPage />
-          </AdminRoute>
-        ),
-      },
-      {
-        path: 'admin/scheduler',
-        element: (
-          <AdminRoute>
-            <SchedulerPage />
-          </AdminRoute>
-        ),
-      },
-      {
-        path: 'admin/oidc-providers',
-        element: (
-          <AdminRoute>
-            <OidcProvidersPage />
-          </AdminRoute>
-        ),
-      },
-      {
-        // The email admin area (#525): one tabbed shell over the SMTP
-        // server settings and the mail templates, guarded once here.
-        path: 'admin/email',
-        element: (
-          <AdminRoute>
-            <EmailLayout />
-          </AdminRoute>
-        ),
+        // A throw during navigation lands on the branded shell, not the router's
+        // default screen (issue #611); pane render errors stay with #331.
+        errorElement: <RouteErrorPage />,
         children: [
-          { index: true, element: <Navigate to="/admin/email/server" replace /> },
-          { path: 'server', element: <EmailServerPage /> },
-          { path: 'templates', element: <MailTemplatesListPage /> },
+          { index: true, element: <HomePage /> },
+          { path: 'profile', element: <ProfilePage /> },
+          { path: 'users/:userId', element: <UserProfilePage /> },
+          { path: 'teams/:teamId', element: <TeamProfilePage /> },
+          // The landing page an exported report's attachment links point at: inside
+          // the protected routes, so an unauthenticated visitor logs in and is
+          // returned here (issue #635).
           {
-            path: 'templates/:key',
+            path: 'attachments/:documentId/:attachmentId',
+            element: <AttachmentDownloadPage />,
+          },
+          { path: 'messages', element: <MessagesPage /> },
+          { path: 'messages/:notificationId', element: <MessageDetailPage /> },
+          { path: 'reviews', element: <ReviewsPage /> },
+          { path: 'reviews/new', element: <NewReviewPage /> },
+          {
+            path: 'reviews/:documentId',
             element: (
-              <LazyBoundary>
-                <MailTemplateEditPage />
-              </LazyBoundary>
+              <ReviewParamGate>
+                <LazyBoundary>
+                  <DocumentReviewPage />
+                </LazyBoundary>
+              </ReviewParamGate>
             ),
           },
+          {
+            path: 'reviews/:documentId/compare',
+            element: (
+              <ReviewParamGate>
+                <LazyBoundary>
+                  <VersionComparePage />
+                </LazyBoundary>
+              </ReviewParamGate>
+            ),
+          },
+          {
+            path: 'reviews/:documentId/tasks',
+            element: (
+              <ReviewParamGate>
+                <LazyBoundary>
+                  <ReviewTasksPage />
+                </LazyBoundary>
+              </ReviewParamGate>
+            ),
+          },
+          { path: 'search', element: <SearchPage /> },
+          { path: 'my-teams', element: <MyTeamsPage /> },
+          { path: 'my-teams/:id', element: <MyTeamDetailPage /> },
+          {
+            path: 'audit',
+            element: (
+              <RoleRoute allow={['ADMIN', 'AUDITOR']}>
+                <AuditPage />
+              </RoleRoute>
+            ),
+          },
+          {
+            path: 'admin/users',
+            element: (
+              <AdminRoute>
+                <UsersPage />
+              </AdminRoute>
+            ),
+          },
+          {
+            path: 'admin/teams',
+            element: (
+              <AdminRoute>
+                <TeamsPage />
+              </AdminRoute>
+            ),
+          },
+          {
+            path: 'admin/teams/:id',
+            element: (
+              <AdminRoute>
+                <TeamDetailPage />
+              </AdminRoute>
+            ),
+          },
+          {
+            path: 'admin/settings',
+            element: (
+              <AdminRoute>
+                <SettingsPage />
+              </AdminRoute>
+            ),
+          },
+          {
+            path: 'admin/configuration',
+            element: (
+              <AdminRoute>
+                <ConfigurationPage />
+              </AdminRoute>
+            ),
+          },
+          {
+            path: 'admin/scheduler',
+            element: (
+              <AdminRoute>
+                <SchedulerPage />
+              </AdminRoute>
+            ),
+          },
+          {
+            path: 'admin/oidc-providers',
+            element: (
+              <AdminRoute>
+                <OidcProvidersPage />
+              </AdminRoute>
+            ),
+          },
+          {
+            // The email admin area (#525): one tabbed shell over the SMTP
+            // server settings and the mail templates, guarded once here.
+            path: 'admin/email',
+            element: (
+              <AdminRoute>
+                <EmailLayout />
+              </AdminRoute>
+            ),
+            children: [
+              { index: true, element: <Navigate to="/admin/email/server" replace /> },
+              { path: 'server', element: <EmailServerPage /> },
+              { path: 'templates', element: <MailTemplatesListPage /> },
+              {
+                path: 'templates/:key',
+                element: (
+                  <LazyBoundary>
+                    <MailTemplateEditPage />
+                  </LazyBoundary>
+                ),
+              },
+            ],
+          },
+          // Pre-#525 bookmarks; targets are guarded, so no AdminRoute here.
+          {
+            path: 'admin/mail-templates',
+            element: <Navigate to="/admin/email/templates" replace />,
+          },
+          {
+            path: 'admin/mail-templates/:key',
+            element: <MailTemplatesKeyRedirect />,
+          },
+          {
+            path: 'admin/branding',
+            element: (
+              <AdminRoute>
+                <BrandingPage />
+              </AdminRoute>
+            ),
+          },
+          {
+            path: 'admin/storage-consistency',
+            element: (
+              <AdminRoute>
+                <StorageConsistencyPage />
+              </AdminRoute>
+            ),
+          },
+          { path: '*', element: <NotFoundPage /> },
         ],
       },
-      // Pre-#525 bookmarks; targets are guarded, so no AdminRoute here.
-      {
-        path: 'admin/mail-templates',
-        element: <Navigate to="/admin/email/templates" replace />,
-      },
-      {
-        path: 'admin/mail-templates/:key',
-        element: <MailTemplatesKeyRedirect />,
-      },
-      {
-        path: 'admin/branding',
-        element: (
-          <AdminRoute>
-            <BrandingPage />
-          </AdminRoute>
-        ),
-      },
-      {
-        path: 'admin/storage-consistency',
-        element: (
-          <AdminRoute>
-            <StorageConsistencyPage />
-          </AdminRoute>
-        ),
-      },
-      { path: '*', element: <NotFoundPage /> },
     ],
   },
 ]);

--- a/qnop-ui/src/tracking/ConsentBar.tsx
+++ b/qnop-ui/src/tracking/ConsentBar.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Slide from '@mui/material/Slide';
+import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { ChartNoAxesColumn } from 'lucide-react';
+import { writeConsent } from './consent';
+import { tokens } from '../theme/tokens';
+
+interface ConsentBarProps {
+  onDecide: (decision: 'granted' | 'denied') => void;
+}
+
+/**
+ * The measurement question (issue #666).
+ *
+ * <p>At the bottom, deliberately: the top of the screen belongs to the operator's own notice
+ * (issue #664), and two bars stacked above the sign-in form would bury the form. It is a strip
+ * rather than a modal because it interrupts nothing — a visitor who ignores it is simply not
+ * measured, which is the correct default and needs no dialog to enforce.
+ *
+ * <p>Both answers are one click and look equally clickable. A refusal that takes three clicks
+ * through a "manage preferences" screen is not a question, it is an obstacle course.
+ */
+export function ConsentBar({ onDecide }: ConsentBarProps) {
+  const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+
+  const decide = (decision: 'granted' | 'denied') => {
+    writeConsent(decision);
+    onDecide(decision);
+  };
+
+  return (
+    <Slide direction="up" in appear timeout={reduceMotion ? 0 : 220}>
+      <Paper
+        elevation={0}
+        role="dialog"
+        aria-label="Usage measurement"
+        sx={{
+          position: 'fixed',
+          left: { xs: 12, sm: 16 },
+          right: { xs: 12, sm: 16 },
+          bottom: { xs: 12, sm: 16 },
+          zIndex: (theme) => theme.zIndex.snackbar,
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: 1.5,
+          px: { xs: 2, sm: 2.5 },
+          py: 1.75,
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: `${tokens.radius.lg}px`,
+          boxShadow: '0 18px 40px rgba(1, 33, 66, 0.18)',
+          maxWidth: 720,
+          mx: 'auto',
+        }}
+      >
+        <Box aria-hidden sx={{ display: 'flex', color: 'primary.main', flexShrink: 0 }}>
+          <ChartNoAxesColumn size={18} />
+        </Box>
+        <Typography variant="body2" sx={{ flex: 1, minWidth: 220, lineHeight: 1.5 }}>
+          May we count which pages get used? No profiles, no document names — page addresses are
+          reduced to their shape before they are counted, and the measurement never leaves this
+          server directly.
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, ml: 'auto' }}>
+          <Button size="small" color="inherit" onClick={() => decide('denied')}>
+            No thanks
+          </Button>
+          <Button size="small" variant="contained" onClick={() => decide('granted')}>
+            Allow
+          </Button>
+        </Box>
+      </Paper>
+    </Slide>
+  );
+}

--- a/qnop-ui/src/tracking/TrackingBoot.tsx
+++ b/qnop-ui/src/tracking/TrackingBoot.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useState } from 'react';
+import { Outlet, useLocation, useParams } from 'react-router';
+import type { ServerConfigTracking } from '../api/generated';
+import { useConfig } from '../api/hooks/useConfig';
+import { useUserSettingValue } from '../api/hooks/useUserSettings';
+import { useAuthStore } from '../stores/authStore';
+import { ConsentBar } from './ConsentBar';
+import { readConsent, type ConsentDecision } from './consent';
+import { ADAPTERS, SCRIPT_URL } from './providers';
+import { setActiveTracker } from './trackEvent';
+import { OPT_OUT_KEY, resolveGate } from './trackingGate';
+import { anonymizePath } from './trackingPath';
+
+/**
+ * Mounts usage measurement, or does not (issue #666).
+ *
+ * <p>Sits above the whole route table as a pathless layout: the sign-in screen is measured like
+ * everything else, and every navigation — not only those inside the shell — reports a page view.
+ * The decision itself lives in {@link resolveGate}; what happens here is only its consequence.
+ *
+ * <p>Nothing is fetched, injected or sent until that decision says so. When measurement is off, the
+ * script tag does not exist in the page at all.
+ */
+export function TrackingBoot() {
+  const { data: config } = useConfig();
+  const tracking = config?.tracking;
+  const role = useAuthStore((s) => s.role);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const optOut = useUserSettingValue(OPT_OUT_KEY) === 'true';
+  const [consent, setConsent] = useState<ConsentDecision>(() => readConsent());
+  const [loaded, setLoaded] = useState(false);
+  const location = useLocation();
+  const params = useParams();
+
+  const gate = resolveGate({ tracking, consent, optOut, isAuthenticated, role });
+
+  useEffect(() => {
+    if (gate !== 'measure' || !tracking || loaded) {
+      return;
+    }
+    loadTracker(tracking).then(setLoaded);
+  }, [gate, tracking, loaded]);
+
+  useEffect(() => {
+    if (!loaded || !tracking) {
+      return;
+    }
+    // The pattern, never the path: /reviews/:documentId, not the id of a
+    // customer's contract.
+    ADAPTERS[tracking.provider]?.pageview(anonymizePath(location.pathname, params));
+    // `params` is a fresh object every render; the pathname is what changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded, tracking, location.pathname]);
+
+  return (
+    <>
+      <Outlet />
+      {gate === 'ask' && <ConsentBar onDecide={setConsent} />}
+    </>
+  );
+}
+
+/** Injects the proxied vendor script exactly once; resolves false when it will not load. */
+function loadTracker(tracking: ServerConfigTracking): Promise<boolean> {
+  const adapter = ADAPTERS[tracking.provider];
+  if (!adapter || document.querySelector(`script[src="${SCRIPT_URL}"]`)) {
+    return Promise.resolve(Boolean(adapter));
+  }
+  adapter.beforeLoad?.(tracking.siteId);
+  return new Promise((resolve) => {
+    const script = document.createElement('script');
+    script.src = SCRIPT_URL;
+    script.defer = true;
+    for (const [name, value] of Object.entries(adapter.attributes(tracking.siteId))) {
+      script.setAttribute(name, value);
+    }
+    script.onload = () => {
+      adapter.afterLoad?.(tracking.siteId);
+      setActiveTracker(adapter);
+      resolve(true);
+    };
+    // A backend that is down, or a deployment that mistyped its host: measurement
+    // is the one feature allowed to fail in total silence.
+    script.onerror = () => resolve(false);
+    document.head.appendChild(script);
+  });
+}

--- a/qnop-ui/src/tracking/consent.ts
+++ b/qnop-ui/src/tracking/consent.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+const STORAGE_KEY = 'qnop-tracking-consent';
+
+export type ConsentDecision = 'granted' | 'denied' | 'unanswered';
+
+/**
+ * Whether this browser has answered the measurement question (issue #666).
+ *
+ * <p>Kept in the browser rather than at the account, because the question is asked before anyone
+ * has signed in — the sign-in screen is measured too — and an answer that only counted after login
+ * would mean measuring people who had not been asked yet. The personal opt-out in the profile is
+ * the account-level control, and it overrides this either way.
+ */
+export function readConsent(): ConsentDecision {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'granted' || stored === 'denied' ? stored : 'unanswered';
+  } catch {
+    // Storage blocked: treat as unanswered, which measures nothing.
+    return 'unanswered';
+  }
+}
+
+export function writeConsent(decision: Exclude<ConsentDecision, 'unanswered'>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, decision);
+  } catch {
+    // Best-effort; the question is simply asked again next time.
+  }
+}
+
+/** Forgets the answer, so the question is asked afresh (used when revoking in the profile). */
+export function clearConsent(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Nothing to do.
+  }
+}
+
+/**
+ * Whether the browser has asked not to be tracked.
+ *
+ * <p>Both signals count: `doNotTrack` is the older one browsers still send, `globalPrivacyControl`
+ * the one that carries legal weight in a growing number of places. Either is an answer, and the
+ * answer is no.
+ */
+export function browserRefusesTracking(): boolean {
+  const nav = navigator as Navigator & {
+    doNotTrack?: string | null;
+    globalPrivacyControl?: boolean;
+    msDoNotTrack?: string | null;
+  };
+  const dnt =
+    nav.doNotTrack ?? (window as unknown as { doNotTrack?: string | null }).doNotTrack ?? null;
+  return (
+    dnt === '1' || dnt === 'yes' || nav.msDoNotTrack === '1' || nav.globalPrivacyControl === true
+  );
+}

--- a/qnop-ui/src/tracking/providers.ts
+++ b/qnop-ui/src/tracking/providers.ts
@@ -130,6 +130,14 @@ const posthog: TrackerAdapter = {
       // Plain JSON, so the proxy can read — and sanitise — what travels.
       disable_compression: true,
       persistence: 'memory',
+      // No remote config, no feature flags, no lazily-loaded modules. qnop uses
+      // PostHog to count page views and nothing else, and each of those would
+      // fetch a path (/array/<token>/config.js, /flags/, /static/<module>.js)
+      // that the proxy's allowlist does not carry — by design, since an
+      // allowlist that grew to cover them would stop being a boundary.
+      advanced_disable_decide: true,
+      advanced_disable_flags: true,
+      disable_external_dependency_loading: true,
     });
   },
   pageview(url) {
@@ -144,9 +152,10 @@ const pirsch: TrackerAdapter = {
   attributes: (siteId) => ({
     id: 'pianjs',
     'data-code': siteId,
-    'data-hit-endpoint': `${COLLECT_BASE}/pv`,
-    'data-event-endpoint': `${COLLECT_BASE}/e`,
-    'data-session-endpoint': `${COLLECT_BASE}/s`,
+    // The names pa.js defaults to; the proxy forwards them under the same names.
+    'data-hit-endpoint': `${COLLECT_BASE}/hit`,
+    'data-event-endpoint': `${COLLECT_BASE}/event`,
+    'data-session-endpoint': `${COLLECT_BASE}/session`,
     // Pirsch has no documented way to send a page view with a URL of our
     // choosing, so its automatic one stays on and the server rewrites the id
     // out of it (TrackedUrlSanitizer). Query strings never leave at all.

--- a/qnop-ui/src/tracking/providers.ts
+++ b/qnop-ui/src/tracking/providers.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/** Where the proxied script and the proxied measurements live on this origin. */
+export const SCRIPT_URL = '/t/s.js';
+export const COLLECT_BASE = '/t/c';
+
+type Paq = unknown[][];
+
+interface PlausibleFn {
+  (event: string, options?: { u?: string; callback?: () => void }): void;
+}
+
+interface UmamiApi {
+  track: (payload: unknown, data?: unknown) => void;
+}
+
+interface PosthogApi {
+  init: (key: string, options: Record<string, unknown>) => void;
+  capture: (event: string, properties?: Record<string, unknown>) => void;
+}
+
+declare global {
+  interface Window {
+    _paq?: Paq;
+    plausible?: PlausibleFn;
+    umami?: UmamiApi;
+    posthog?: PosthogApi;
+  }
+}
+
+/**
+ * What each backend needs, reduced to three questions: what goes on the script tag, what to do once
+ * it has loaded, and how to report a page view or an event.
+ *
+ * Every adapter has the same job beyond wiring: **stop the script from measuring on its own**.
+ * Left alone, each of these reports `window.location` on load — which in qnop is a URL with a
+ * document id in it. So auto-tracking is switched off wherever the vendor allows it, and qnop sends
+ * route patterns instead.
+ */
+export interface TrackerAdapter {
+  /** Attributes for the injected `<script>`; most backends are configured entirely this way. */
+  attributes(siteId: string): Record<string, string>;
+  /** Runs before the script is inserted (Matomo's queue has to exist first). */
+  beforeLoad?(siteId: string): void;
+  /** Runs once the script has loaded (PostHog is configured through its API). */
+  afterLoad?(siteId: string): void;
+  pageview(url: string): void;
+  event(name: string): void;
+}
+
+const matomo: TrackerAdapter = {
+  attributes: () => ({}),
+  beforeLoad(siteId) {
+    const paq: Paq = (window._paq = window._paq ?? []);
+    paq.push(['setTrackerUrl', `${COLLECT_BASE}/matomo.php`]);
+    paq.push(['setSiteId', siteId]);
+    // Matomo tracks nothing until asked, which is exactly what qnop wants.
+    paq.push(['disableCookies']);
+  },
+  pageview(url) {
+    window._paq?.push(['setCustomUrl', url]);
+    window._paq?.push(['trackPageView']);
+  },
+  event(name) {
+    window._paq?.push(['trackEvent', 'qnop', name]);
+  },
+};
+
+const plausible: TrackerAdapter = {
+  attributes: (siteId) => ({ 'data-domain': siteId, 'data-api': `${COLLECT_BASE}/api/event` }),
+  pageview(url) {
+    window.plausible?.('pageview', { u: absolute(url) });
+  },
+  event(name) {
+    window.plausible?.(name, { u: absolute(window.location.pathname) });
+  },
+};
+
+const umami: TrackerAdapter = {
+  attributes: (siteId) => ({
+    'data-website-id': siteId,
+    'data-host-url': COLLECT_BASE,
+    // Without this it reports the real URL on load and on every history change.
+    'data-auto-track': 'false',
+  }),
+  pageview(url) {
+    window.umami?.track((props: unknown) => ({ ...(props as object), url }));
+  },
+  event(name) {
+    window.umami?.track(name);
+  },
+};
+
+const posthog: TrackerAdapter = {
+  attributes: () => ({}),
+  afterLoad(siteId) {
+    window.posthog?.init(siteId, {
+      api_host: COLLECT_BASE,
+      // Everything that would collect on its own, off. Autocapture records the
+      // text of what was clicked, and in qnop that text is a document title;
+      // session recording would copy the document itself.
+      autocapture: false,
+      capture_pageview: false,
+      capture_pageleave: false,
+      disable_session_recording: true,
+      disable_surveys: true,
+      // Plain JSON, so the proxy can read — and sanitise — what travels.
+      disable_compression: true,
+      persistence: 'memory',
+    });
+  },
+  pageview(url) {
+    window.posthog?.capture('$pageview', { $current_url: absolute(url) });
+  },
+  event(name) {
+    window.posthog?.capture(name);
+  },
+};
+
+const pirsch: TrackerAdapter = {
+  attributes: (siteId) => ({
+    id: 'pianjs',
+    'data-code': siteId,
+    'data-hit-endpoint': `${COLLECT_BASE}/pv`,
+    'data-event-endpoint': `${COLLECT_BASE}/e`,
+    'data-session-endpoint': `${COLLECT_BASE}/s`,
+    // Pirsch has no documented way to send a page view with a URL of our
+    // choosing, so its automatic one stays on and the server rewrites the id
+    // out of it (TrackedUrlSanitizer). Query strings never leave at all.
+    'data-disable-query': 'true',
+    'data-disable-referrer': 'true',
+  }),
+  pageview() {
+    // Deliberately empty: see above.
+  },
+  event(name) {
+    const fn = (window as unknown as { pirsch?: (name: string) => void }).pirsch;
+    fn?.(name);
+  },
+};
+
+export const ADAPTERS: Record<string, TrackerAdapter> = {
+  matomo,
+  plausible,
+  umami,
+  posthog,
+  pirsch,
+};
+
+/** Backends that want a full URL rather than a path; the origin is public knowledge. */
+function absolute(path: string): string {
+  return `${window.location.origin}${path}`;
+}

--- a/qnop-ui/src/tracking/providers.ts
+++ b/qnop-ui/src/tracking/providers.ts
@@ -78,6 +78,8 @@ const matomo: TrackerAdapter = {
   },
   pageview(url) {
     window._paq?.push(['setCustomUrl', url]);
+    // Matomo would otherwise send document.title as the action name.
+    window._paq?.push(['setDocumentTitle', url]);
     window._paq?.push(['trackPageView']);
   },
   event(name) {
@@ -103,7 +105,9 @@ const umami: TrackerAdapter = {
     'data-auto-track': 'false',
   }),
   pageview(url) {
-    window.umami?.track((props: unknown) => ({ ...(props as object), url }));
+    // `title` is document.title, which qnop must not export (see the server's
+    // sanitiser); it is blanked here so it never leaves the tab either.
+    window.umami?.track((props: unknown) => ({ ...(props as object), url, title: '' }));
   },
   event(name) {
     window.umami?.track(name);
@@ -129,7 +133,7 @@ const posthog: TrackerAdapter = {
     });
   },
   pageview(url) {
-    window.posthog?.capture('$pageview', { $current_url: absolute(url) });
+    window.posthog?.capture('$pageview', { $current_url: absolute(url), $title: '' });
   },
   event(name) {
     window.posthog?.capture(name);

--- a/qnop-ui/src/tracking/trackEvent.ts
+++ b/qnop-ui/src/tracking/trackEvent.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { TrackerAdapter } from './providers';
+
+/**
+ * Everything qnop measures beyond page views (issue #666).
+ *
+ * <p>A closed union, not an open string. An `event(name, properties)` API would eventually carry a
+ * document title, a reviewer's name or a search term into somebody's analytics backend — not out of
+ * carelessness, but because that is what an open API invites. Four names, no properties, and
+ * adding a fifth is a code change somebody reviews.
+ */
+export type TrackedEvent =
+  'review_created' | 'annotation_created' | 'review_finalized' | 'export_generated';
+
+let active: TrackerAdapter | null = null;
+
+/** Set by {@code TrackingBoot} once — and only if — a tracker actually loaded. */
+export function setActiveTracker(adapter: TrackerAdapter | null): void {
+  active = adapter;
+}
+
+/**
+ * Reports that something happened. Does nothing at all when no tracker is loaded, which is the
+ * usual case: measurement is off by default, and every gate can veto it.
+ */
+export function trackEvent(event: TrackedEvent): void {
+  try {
+    active?.event(event);
+  } catch {
+    // A failed measurement must never surface in a review.
+  }
+}

--- a/qnop-ui/src/tracking/trackingGate.test.ts
+++ b/qnop-ui/src/tracking/trackingGate.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ServerConfigTracking } from '../api/generated';
+import { resolveGate } from './trackingGate';
+
+const CONFIGURED: ServerConfigTracking = {
+  provider: 'plausible',
+  siteId: 'qnop.example',
+  consentRequired: true,
+  respectDnt: true,
+  trackPrivilegedRoles: false,
+};
+
+const BASE = {
+  tracking: CONFIGURED,
+  consent: 'granted' as const,
+  optOut: false,
+  isAuthenticated: true,
+  role: 'MEMBER' as string | null,
+};
+
+describe('resolveGate', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('measures when every gate agrees', () => {
+    expect(resolveGate(BASE)).toBe('measure');
+  });
+
+  it('stays off where the operator configured nothing', () => {
+    expect(resolveGate({ ...BASE, tracking: undefined })).toBe('off');
+  });
+
+  it('leaves a Do-Not-Track browser alone', () => {
+    vi.stubGlobal('navigator', { ...navigator, doNotTrack: '1' });
+    expect(resolveGate(BASE)).toBe('off');
+  });
+
+  it('honours Global Privacy Control the same way', () => {
+    vi.stubGlobal('navigator', { ...navigator, globalPrivacyControl: true });
+    expect(resolveGate(BASE)).toBe('off');
+  });
+
+  it('respects the personal opt-out over a granted consent', () => {
+    // The account-level choice is the strongest one: someone who opted out on
+    // their laptop must not be measured because this browser once said yes.
+    expect(resolveGate({ ...BASE, optOut: true })).toBe('off');
+  });
+
+  it('leaves admins and auditors out unless the operator says otherwise', () => {
+    expect(resolveGate({ ...BASE, role: 'ADMIN' })).toBe('off');
+    expect(resolveGate({ ...BASE, role: 'AUDITOR' })).toBe('off');
+    expect(
+      resolveGate({
+        ...BASE,
+        role: 'ADMIN',
+        tracking: { ...CONFIGURED, trackPrivilegedRoles: true },
+      }),
+    ).toBe('measure');
+  });
+
+  it('asks before measuring, and takes no for an answer', () => {
+    expect(resolveGate({ ...BASE, consent: 'unanswered' })).toBe('ask');
+    expect(resolveGate({ ...BASE, consent: 'denied' })).toBe('off');
+  });
+
+  it('skips the question where the operator turned consent off', () => {
+    expect(
+      resolveGate({
+        ...BASE,
+        consent: 'unanswered',
+        tracking: { ...CONFIGURED, consentRequired: false },
+      }),
+    ).toBe('measure');
+  });
+
+  it('does not apply account-level gates to a signed-out visitor', () => {
+    // The sign-in screen is measured, and a visitor has neither an account
+    // setting nor a role to check.
+    expect(resolveGate({ ...BASE, isAuthenticated: false, optOut: true, role: 'ADMIN' })).toBe(
+      'measure',
+    );
+  });
+});

--- a/qnop-ui/src/tracking/trackingGate.ts
+++ b/qnop-ui/src/tracking/trackingGate.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { ServerConfigTracking } from '../api/generated';
+import { browserRefusesTracking, type ConsentDecision } from './consent';
+
+/** The per-user setting key (UserSettingKey.USAGE_TRACKING_OPT_OUT). */
+export const OPT_OUT_KEY = 'usage_tracking_opt_out';
+
+/** Roles left unmeasured unless an operator says otherwise. */
+const PRIVILEGED = new Set(['ADMIN', 'AUDITOR']);
+
+export type Gate = 'off' | 'ask' | 'measure';
+
+export interface GateInput {
+  tracking: ServerConfigTracking | undefined;
+  consent: ConsentDecision;
+  optOut: boolean;
+  isAuthenticated: boolean;
+  role: string | null | undefined;
+}
+
+/**
+ * Whether anything may be measured at all (issue #666).
+ *
+ * <p>Four gates, and each can say no on its own: the operator has to have configured measurement,
+ * the browser must not be asking to be left alone, the person must not have opted out on their
+ * account, and — where consent is required — they must have said yes. Only `measure` causes a
+ * script tag to exist; `ask` shows the question and measures nothing until it is answered.
+ *
+ * <p>A plain function in its own module, so the rules can be read and asserted directly rather than
+ * inferred from what turned up in a rendered tree.
+ */
+export function resolveGate({ tracking, consent, optOut, isAuthenticated, role }: GateInput): Gate {
+  if (!tracking) {
+    return 'off';
+  }
+  if (tracking.respectDnt && browserRefusesTracking()) {
+    return 'off';
+  }
+  // Account-level rules need an account: before sign-in there is neither a
+  // stored setting nor a role, and the sign-in screen is measured too.
+  if (isAuthenticated && optOut) {
+    return 'off';
+  }
+  if (isAuthenticated && !tracking.trackPrivilegedRoles && role && PRIVILEGED.has(role)) {
+    return 'off';
+  }
+  if (!tracking.consentRequired) {
+    return 'measure';
+  }
+  if (consent === 'granted') {
+    return 'measure';
+  }
+  return consent === 'denied' ? 'off' : 'ask';
+}

--- a/qnop-ui/src/tracking/trackingPath.test.ts
+++ b/qnop-ui/src/tracking/trackingPath.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { anonymizePath } from './trackingPath';
+
+const DOC = '8f3c1d2e-4a5b-6c7d-8e9f-0a1b2c3d4e5f';
+
+describe('anonymizePath', () => {
+  it('names the parameter the router filled in', () => {
+    expect(anonymizePath(`/reviews/${DOC}`, { documentId: DOC })).toBe('/reviews/:documentId');
+    expect(anonymizePath(`/reviews/${DOC}/tasks`, { documentId: DOC })).toBe(
+      '/reviews/:documentId/tasks',
+    );
+  });
+
+  it('anonymises a slug, which no shape check could catch', () => {
+    // The reason params are the source of truth: "mia-member" is a person's name
+    // and looks like an ordinary path segment.
+    expect(anonymizePath('/users/mia-member', { userId: 'mia-member' })).toBe('/users/:userId');
+  });
+
+  it('still catches an id from a route it was told nothing about', () => {
+    expect(anonymizePath(`/reviews/${DOC}/tasks`)).toBe('/reviews/:id/tasks');
+    expect(anonymizePath('/documents/1234567')).toBe('/documents/:id');
+  });
+
+  it('replaces every segment of a splat', () => {
+    expect(anonymizePath('/attachments/abc/def', { '*': 'abc/def' })).toBe(
+      '/attachments/:path/:path',
+    );
+  });
+
+  it('leaves ordinary pages readable', () => {
+    // A report has to still say something: these are the rows an operator reads.
+    expect(anonymizePath('/admin/settings')).toBe('/admin/settings');
+    expect(anonymizePath('/reviews')).toBe('/reviews');
+    expect(anonymizePath('/my-teams')).toBe('/my-teams');
+    expect(anonymizePath('/')).toBe('/');
+  });
+
+  it('ignores empty params rather than replacing everything', () => {
+    expect(anonymizePath('/reviews/new', { documentId: undefined })).toBe('/reviews/new');
+    expect(anonymizePath('/reviews/new', { documentId: '' })).toBe('/reviews/new');
+  });
+});

--- a/qnop-ui/src/tracking/trackingPath.ts
+++ b/qnop-ui/src/tracking/trackingPath.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/** Anything at least this long is treated as an identifier, whatever it looks like. */
+const MAX_PLAIN_SEGMENT = 32;
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const LONG_HEX = /^[0-9a-f]{12,}$/i;
+const NUMERIC = /^[0-9]{3,}$/;
+
+function looksLikeIdentifier(segment: string): boolean {
+  if (segment === '' || segment.startsWith(':')) {
+    return false;
+  }
+  return (
+    segment.length > MAX_PLAIN_SEGMENT ||
+    UUID.test(segment) ||
+    LONG_HEX.test(segment) ||
+    NUMERIC.test(segment)
+  );
+}
+
+/**
+ * Turns the address of the current page into the shape of the page (issue #666).
+ *
+ * ```
+ * /reviews/8f3c…-a1/tasks   +  { documentId: '8f3c…-a1' }   →   /reviews/:documentId/tasks
+ * ```
+ *
+ * The router already knows which segments were parameters — it filled them in — so the honest
+ * answer comes from `params` rather than from guessing at the string. A review's id identifies a
+ * customer's document, and an analytics report is exactly the wrong place to keep a list of them.
+ *
+ * Whatever survives that (an id from a route this function has never heard of) still has to get
+ * past a shape check, and the query string never travels at all: `?q=merger agreement` is the
+ * subject of somebody's document, typed by a human.
+ */
+export function anonymizePath(
+  pathname: string,
+  params: Readonly<Record<string, string | undefined>> = {},
+): string {
+  const named = new Map<string, string>();
+  for (const [key, value] of Object.entries(params)) {
+    if (!value) {
+      continue;
+    }
+    // A splat ("*") can stand for several segments at once; each is replaced.
+    const label = key === '*' ? ':path' : `:${key}`;
+    for (const part of value.split('/')) {
+      if (part) {
+        named.set(part, label);
+      }
+    }
+  }
+
+  const segments = pathname.split('/').map((segment) => {
+    const known = named.get(segment);
+    if (known) {
+      return known;
+    }
+    return looksLikeIdentifier(segment) ? ':id' : segment;
+  });
+
+  const path = segments.join('/');
+  return path === '' ? '/' : path;
+}

--- a/qnop-ui/vite.config.ts
+++ b/qnop-ui/vite.config.ts
@@ -8,6 +8,13 @@ import { fileURLToPath, URL } from 'node:url';
 // API base path is the relative `/api/v1`. In dev, proxy API + OIDC handshake
 // routes to the backend. `changeOrigin: false` on the OIDC routes keeps the
 // Host header as the dev server so the provider redirect_uri stays correct.
+//
+// `/t` is the usage-tracking proxy (issue #666). It deliberately sits outside
+// /api — it is not part of the published REST contract — which also means it is
+// not covered by the `/api` rule above and has to be named. In production the
+// SPA is served by the backend itself (ADR-0040), so there this is one origin
+// and no proxying happens at all; without this line measurement works in a
+// deployment and silently 404s in dev, which is the worst of both.
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -21,6 +28,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': 'http://localhost:8080',
+      '/t': 'http://localhost:8080',
       '/oauth2': { target: 'http://localhost:8080', changeOrigin: false },
       '/login/oauth2': { target: 'http://localhost:8080', changeOrigin: false },
     },


### PR DESCRIPTION
Closes #666.

Turns the `tracking.*` placeholder from #16 into a working feature: five analytics backends, measured through a server-side proxy, with page addresses reported as route patterns rather than URLs.

## Why a proxy

`PathAwareCspHeaderWriter` pins the SPA to `script-src 'self'; connect-src 'self'` (ADR-0040), and every analytics vendor's install instructions begin by violating exactly that. Extending the CSP per deployment was the obvious move and was rejected: it weakens the one policy that is identical on every other page, hands each reviewer's IP to a third party, and puts the measurement in an ad blocker's path.

```
Browser ──GET /t/s.js──►  qnop ──►  https://analytics.example/script.js   (cached 1h)
        ──POST /t/c/…─►  qnop ──►  https://analytics.example/api/send     (forwarded)
```

The CSP stays untouched, the browser never contacts the analytics host, and the forwarded address is truncated to its /24 or /64 — without any, the backend counts a whole company as one visitor; with the real one, proxying has withheld nothing.

Two boundaries are enforced by the server rather than trusted to the client:

- **The collect allowlist.** Only the paths a provider declares are forwarded, matched whole. PostHog's `/s/` is absent, which makes "qnop does not record sessions" a property of this server instead of a client setting somebody could change.
- **The URL sanitiser.** Every forwarded measurement loses its query string and its identifier-shaped segments, so a stale bundle in an open tab cannot put a document id into a report that outlives the review.

## Backends

Matomo, Plausible, Umami, PostHog, Pirsch. **Fathom was dropped during implementation** — its custom-domain feature was withdrawn in 2023 with no replacement, and its model expects beacons to arrive directly from the browser so its bot detection sees the real client. Proxying it would quietly poison its data, and a CSP exception for one vendor would give up the property this design exists to keep.

Session recording and heatmaps (Hotjar, Clarity, FullStory, …) are out permanently: they record the screen, and in qnop the screen holds a customer's document.

## What is measured

`/reviews/:documentId/tasks`, built from the router's own params — the only way to catch a slug like `/users/mia-member` that no shape check recognises as personal. Plus four events with no properties: `review_created`, `annotation_created`, `review_finalized`, `export_generated`.

Four gates, any of which says no on its own: operator configuration, DNT/GPC, the account-level opt-out (in the profile, so it follows a person across devices), and consent. Administrators and auditors are excluded unless explicitly included.

## Found by running it

The reporter configured Umami against a real instance and saw nothing. Three fixes came out of that, and they are the most valuable part of this branch:

1. **`/t` was not proxied by the dev server.** It sits outside `/api` on purpose, and therefore outside the one Vite proxy rule. In production the backend serves the SPA (ADR-0040), so it worked in a deployment and failed on every developer machine.
2. **A complete-looking configuration measured nothing** because the master toggle was still off, and nothing on the screen said so. The settings page now states whether measurement is running and, when it is not, which of the four conditions is missing.
3. **Page titles were travelling.** Every one of these backends sends `document.title` beside the address (Umami `title`, Matomo `action_name`, PostHog `$title`). qnop sets no per-page title today, so nothing leaked — the first person to make browser tabs say what they show would have started exporting review titles. A title has no structure to anonymise, so it is dropped server-side and never set client-side.

The proxy also stopped swallowing backend failures: one WARN when forwarding starts failing, one INFO when it recovers, on the transition rather than per measurement.

Also here: the OIDC SSRF guard is extracted into `OutboundUriGuard` and shared, rather than the check being copied for a second operator-supplied fetch target; and the Testcontainers Postgres gets `max_connections=300`, because each test class with its own `@TestPropertySource` holds its own pool and the default ceiling was one context away from failing an unrelated class.

## Test plan

- [x] `./gradlew build` — green (Spotless, ArchUnit, full suite incl. Testcontainers)
- [x] `pnpm typecheck`, `eslint`, `vitest` — green, 1265 tests
- [x] `TrackingForwardIT` drives the whole path against a stand-in backend on loopback: the script is served from this origin, and a measurement arrives with the document id, the query string and the title removed; an undeclared path never leaves
- [x] Unit: provider allowlist (incl. session recording refused), URL sanitiser, IP truncation, config resolution with its SSRF cases, payload rewriting, the four gates, path anonymisation, the settings status line
- [x] **Manual, against a real Umami**: script loads (200), page view leaves as `{"payload":{"website":"…","url":"/login","title":"","referrer":""}}`, and Umami accepts such events (200 + session token)
- [ ] Worth doing before merge: the same manual check against one more backend — the other four integrations are built from vendor documentation, not from a running instance

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
