### PR TITLE
fix(deps): clear twelve dependency advisories, dropping Netty rather than bumping it (#668)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,15 @@ springBoot = "4.1.0"
 # (com.fasterxml.jackson) — the generated models only carry annotations.
 openapiGenerator = "7.24.0"
 jacksonAnnotations = "2.22"
+# Two pins ahead of the Spring Boot 4.1.0 BOM, both for published advisories
+# (issue #668). Remove them when a Boot release carries these versions or newer;
+# Renovate will offer the bump and the constraint below keeps it honest.
+# - pgjdbc 42.7.12 fixes CVE-2026-54291: with channelBinding=require, a
+#   connection could be silently downgraded to SCRAM without channel binding.
+# - Jackson 3.1.5 fixes CVE-2026-59889: @JsonView was not applied to
+#   @JsonUnwrapped properties on deserialisation.
+postgresql = "42.7.13"
+jackson3 = "3.1.5"
 swaggerAnnotations = "2.2.52"
 jakartaValidation = "3.1.1"
 jakartaAnnotation = "3.0.0"
@@ -96,7 +105,7 @@ liquibase-core = { module = "org.liquibase:liquibase-core" }
 # into this dedicated module; without it on the classpath Liquibase never runs.
 # Pulls liquibase-core transitively. Version via the Spring Boot BOM.
 spring-boot-liquibase = { module = "org.springframework.boot:spring-boot-liquibase" }
-postgresql = { module = "org.postgresql:postgresql" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 
 # OpenAPI contract (ADR-0021). qnop-api-model needs only the annotation libraries
 # the generated POJOs reference (Jackson 2.x annotations + Jakarta Bean
@@ -106,7 +115,7 @@ jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations
 # Jackson 3 (tools.jackson) — the JSON stack Spring Boot 4 uses at runtime; version
 # from the Boot BOM. The annotations above deliberately stay on the shared
 # com.fasterxml 2.x line, which Jackson 3 reads unchanged.
-jackson3-databind = { module = "tools.jackson.core:jackson-databind" }
+jackson3-databind = { module = "tools.jackson.core:jackson-databind", version.ref = "jackson3" }
 # PDF text extraction with glyph positions (ADR-0032, issue #245).
 pdfbox = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfbox" }
 poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }

--- a/qnop-core/build.gradle.kts
+++ b/qnop-core/build.gradle.kts
@@ -71,7 +71,19 @@ dependencies {
     // Object storage (issue #243, ADR-0005): the AWS SDK v2 S3 client backs the
     // StorageProvider default (io.qnop.service.storage) via endpointOverride +
     // path-style, so MinIO / S3 / GCS is a deploy-time config switch.
-    implementation(libs.aws.sdk.s3)
+    implementation(libs.aws.sdk.s3) {
+        // The Netty-based async transport goes with it (issue #668). qnop builds
+        // the *synchronous* S3Client (S3Configuration), which runs on
+        // apache-client — netty-nio-client is never instantiated, yet it drags a
+        // full HTTP/2 and SPDY codec stack onto the classpath and with it ten
+        // advisories qnop cannot execute. An unused protocol parser is attack
+        // surface that earns nothing.
+        //
+        // Consequence to know about: S3AsyncClient will not start without a
+        // transport. Anything that needs it should add one deliberately rather
+        // than inherit one nobody chose.
+        exclude(group = "software.amazon.awssdk", module = "netty-nio-client")
+    }
 
     // PDF extraction (issue #245, ADR-0032): PDFBox turns uploads into RenderedDocuments;
     // Jackson 3 (tools.jackson, BOM-managed — the same stack Boot 4's MVC uses) serializes


### PR DESCRIPTION
Closes #668.

Twelve open code-scanning alerts, all from the SBOM scan (no CodeQL findings). **None is exploitable in qnop as it stands** — which decided *how* to fix them rather than whether to.

## Assessment

| Package | Alerts | Reachable in qnop? |
|---|---|---|
| `netty-codec-http` / `-http2` / `-compression` 4.2.15 | 10 (4 high) | **No.** Arrives only via the AWS SDK's async transport; `S3Configuration` builds the *synchronous* client on `apache-client`. Nothing here parses HTTP with Netty — Tomcat serves, the JDK client and Apache call out. |
| `postgresql` 42.7.11 (CVE-2026-54291, high) | 1 | **Not today.** A `channelBinding=require` connection can be silently downgraded to SCRAM without channel binding; qnop's JDBC URL requests no channel binding. It matters for an operator who does — they would be trusting a guarantee the driver quietly breaks. |
| `jackson-databind` 3.1.4 (CVE-2026-59889, medium) | 1 | **No.** `@JsonView` skipped for `@JsonUnwrapped` on deserialisation; neither annotation appears in this codebase. |

## Fix

**Netty is dropped, not bumped.** `netty-nio-client` is excluded from the S3 dependency: it is never instantiated, it brings a full HTTP/2 and SPDY codec stack, and bumping it would only park the next advisory in this list for code that cannot run. `./gradlew :qnop-app:dependencies` now reports **zero** `io.netty` entries.

Trade-off, stated so it does not surprise anyone later: `S3AsyncClient` will not start without a transport. Whatever needs it should add one deliberately rather than inherit one nobody chose.

**pgjdbc → 42.7.13, Jackson 3 → 3.1.5**, both pinned ahead of the Spring Boot 4.1.0 BOM (there is no newer Boot release carrying them) and commented as temporary. The Jackson pin moves the whole line — the BOM comes along transitively, so core and databind stay in step at 3.1.5.

## Test plan

- [x] `./gradlew build` — green (Spotless, ArchUnit, full suite incl. Testcontainers), so the driver and mapper bumps are exercised against a real Postgres and the JSON round-trips in the extraction pipeline
- [x] `io.netty` gone from the runtime classpath; `apache-client` still present, which is what the synchronous S3 client needs
- [x] `postgresql:42.7.13` and `jackson-{core,databind}:3.1.5` resolved
- [ ] The SBOM scan on this PR should close all twelve alerts

🤖 Co-Author: Claude (Opus 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
