### PR TITLE
feat(notifications): a daily digest, the missing middle between every event and nothing

### DIFF
--- a/qnop-app/src/test/java/io/qnop/notification/NotificationDigestIT.java
+++ b/qnop-app/src/test/java/io/qnop/notification/NotificationDigestIT.java
@@ -56,6 +56,7 @@ class NotificationDigestIT extends SeededIntegrationTest {
   @Autowired private NotificationRepository notifications;
   @Autowired private NotificationDigestRepository watermarks;
   @Autowired private io.qnop.repository.DocumentRepository documents;
+  @Autowired private io.qnop.service.ApplicationSettingsService settings;
 
   private UUID documentId;
 
@@ -65,6 +66,9 @@ class NotificationDigestIT extends SeededIntegrationTest {
     storeUserSetting(MEMBER_ID, "timezone", "UTC");
     // A real review, because notification.document_id is a foreign key — and a
     // digest grouped by document is only meaningful against one.
+    // Without a base URL the renderer deliberately writes no links at all, so a
+    // test about links has to configure one.
+    settings.update(java.util.Map.of("general.base_url", "https://qnop.example"), null);
     io.qnop.entity.Document document = new io.qnop.entity.Document(MEMBER_ID, "Digest subject");
     document.setWorkflowState(io.qnop.entity.WorkflowState.IN_REVIEW);
     documentId = documents.save(document).getId();
@@ -128,6 +132,33 @@ class NotificationDigestIT extends SeededIntegrationTest {
     String summary = digest.digestOnce(false);
 
     assertThat(summary).doesNotStartWith("Sent");
+  }
+
+  @Test
+  @DisplayName("the mail carries counts and a link per document")
+  void mailContentIsASummaryWithWayBack() {
+    unread(MEMBER_ID, NotificationType.COMMENT_ADDED);
+    unread(MEMBER_ID, NotificationType.COMMENT_ADDED);
+    unread(MEMBER_ID, NotificationType.ANNOTATION_CREATED);
+
+    String summary = digest.digestOnce(false);
+    org.junit.jupiter.api.Assumptions.assumeTrue(
+        summary.startsWith("Sent"), "not yet the recipient's send hour on this run");
+
+    org.mockito.ArgumentCaptor<java.util.Map<String, Object>> vars =
+        org.mockito.ArgumentCaptor.forClass(java.util.Map.class);
+    verify(mail)
+        .sendMailFromTemplate(
+            eq(MailTemplateKey.REVIEW_DAILY_DIGEST), eq("member@qnop.test"), vars.capture(), any());
+
+    // Counts, not one line per event — the whole point of the feature.
+    assertThat(vars.getValue().get("digestBody").toString())
+        .contains("Digest subject")
+        .contains("1 new annotation")
+        .contains("2 comments");
+    // And the way back into that specific review, not just the list.
+    assertThat(vars.getValue().get("digestBodyHtml").toString()).contains("/reviews/" + documentId);
+    assertThat(vars.getValue().get("totalPhrase")).isEqualTo("3 updates");
   }
 
   private void unread(UUID recipientId, NotificationType type) {

--- a/qnop-app/src/test/java/io/qnop/notification/NotificationDigestIT.java
+++ b/qnop-app/src/test/java/io/qnop/notification/NotificationDigestIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.qnop.entity.Notification;
+import io.qnop.entity.NotificationType;
+import io.qnop.repository.NotificationDigestRepository;
+import io.qnop.repository.NotificationRepository;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import io.qnop.service.notification.NotificationDigestService;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * The digest end to end (issue #680): who gets one, what it covers, and what a second run does.
+ *
+ * <p>The timezone is pinned to UTC for the recipient so "due" is decided by the wall clock the test
+ * runs on — the hour arithmetic itself is {@link io.qnop.service.notification.DigestScheduleTest}'s
+ * business, and repeating it here would only make this test fail at 07:00.
+ */
+class NotificationDigestIT extends SeededIntegrationTest {
+
+  @MockitoBean private MailService mail;
+
+  @Autowired private NotificationDigestService digest;
+  @Autowired private NotificationRepository notifications;
+  @Autowired private NotificationDigestRepository watermarks;
+  @Autowired private io.qnop.repository.DocumentRepository documents;
+
+  private UUID documentId;
+
+  @BeforeEach
+  void dailyRecipientInUtc() {
+    storeReviewMailCadence(MEMBER_ID, "DAILY");
+    storeUserSetting(MEMBER_ID, "timezone", "UTC");
+    // A real review, because notification.document_id is a foreign key — and a
+    // digest grouped by document is only meaningful against one.
+    io.qnop.entity.Document document = new io.qnop.entity.Document(MEMBER_ID, "Digest subject");
+    document.setWorkflowState(io.qnop.entity.WorkflowState.IN_REVIEW);
+    documentId = documents.save(document).getId();
+  }
+
+  @Test
+  @DisplayName("a second run sends nothing — the watermark holds")
+  void idempotentAcrossRuns() {
+    unread(MEMBER_ID, NotificationType.COMMENT_ADDED);
+    unread(MEMBER_ID, NotificationType.ANNOTATION_CREATED);
+
+    String first = digest.digestOnce(false);
+    String second = digest.digestOnce(false);
+
+    // Whether the first run sent depends on the hour it runs at; what must hold
+    // either way is that the second one adds nothing.
+    if (first.startsWith("Sent")) {
+      verify(mail)
+          .sendMailFromTemplate(eq(MailTemplateKey.REVIEW_DAILY_DIGEST), any(), any(), any());
+      assertThat(second).doesNotStartWith("Sent");
+      assertThat(watermarks.findById(MEMBER_ID)).isPresent();
+    } else {
+      verify(mail, never())
+          .sendMailFromTemplate(eq(MailTemplateKey.REVIEW_DAILY_DIGEST), any(), any(), any());
+    }
+  }
+
+  @Test
+  @DisplayName("a dry run reports without sending or consuming the watermark")
+  void dryRunChangesNothing() {
+    unread(MEMBER_ID, NotificationType.COMMENT_ADDED);
+
+    String summary = digest.digestOnce(true);
+
+    assertThat(summary).contains("nothing changed");
+    verify(mail, never())
+        .sendMailFromTemplate(eq(MailTemplateKey.REVIEW_DAILY_DIGEST), any(), any(), any());
+    // The watermark is untouched, so the real run still has something to send.
+    assertThat(watermarks.findById(MEMBER_ID)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a recipient on immediate mail is not digested")
+  void immediateRecipientsAreSkipped() {
+    storeReviewMailCadence(MEMBER_ID, "IMMEDIATE");
+    unread(MEMBER_ID, NotificationType.COMMENT_ADDED);
+
+    digest.digestOnce(false);
+
+    verify(mail, never())
+        .sendMailFromTemplate(eq(MailTemplateKey.REVIEW_DAILY_DIGEST), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("what was already read in the app does not come back in the mail")
+  void readInAppStaysRead() {
+    Notification read = notifications.save(notification(MEMBER_ID, NotificationType.COMMENT_ADDED));
+    read.markRead(java.time.Instant.now());
+    notifications.save(read);
+
+    String summary = digest.digestOnce(false);
+
+    assertThat(summary).doesNotStartWith("Sent");
+  }
+
+  private void unread(UUID recipientId, NotificationType type) {
+    notifications.save(notification(recipientId, type));
+  }
+
+  private Notification notification(UUID recipientId, NotificationType type) {
+    return Notification.of(recipientId, type).withDocument(documentId);
+  }
+}

--- a/qnop-app/src/test/java/io/qnop/notification/NotificationDigestIT.java
+++ b/qnop-app/src/test/java/io/qnop/notification/NotificationDigestIT.java
@@ -161,6 +161,29 @@ class NotificationDigestIT extends SeededIntegrationTest {
     assertThat(vars.getValue().get("totalPhrase")).isEqualTo("3 updates");
   }
 
+  @Test
+  @DisplayName("each recipient's watermark is committed with their own mail, not at the end")
+  void watermarkCommitsPerRecipient() {
+    // The job is catalogued self-transactional for this reason (issue #680): mail
+    // cannot be rolled back, so a watermark deferred to the end of the run would
+    // be undone by a crash whose mails had already gone out — and the next run
+    // would send them a second time.
+    assertThat(
+            io.qnop.service.scheduler.SchedulerJobCatalog.find(
+                    io.qnop.service.scheduler.SchedulerJobCatalog.NOTIFICATION_DIGEST)
+                .orElseThrow()
+                .selfTransactional())
+        .isTrue();
+
+    unread(MEMBER_ID, NotificationType.COMMENT_ADDED);
+    String summary = digest.digestOnce(false);
+    org.junit.jupiter.api.Assumptions.assumeTrue(
+        summary.startsWith("Sent"), "not yet the recipient's send hour on this run");
+
+    // Visible from outside any transaction this test holds, i.e. actually committed.
+    assertThat(watermarks.findById(MEMBER_ID)).isPresent();
+  }
+
   private void unread(UUID recipientId, NotificationType type) {
     notifications.save(notification(recipientId, type));
   }

--- a/qnop-app/src/test/java/io/qnop/notification/NotificationDigestIT.java
+++ b/qnop-app/src/test/java/io/qnop/notification/NotificationDigestIT.java
@@ -151,11 +151,13 @@ class NotificationDigestIT extends SeededIntegrationTest {
         .sendMailFromTemplate(
             eq(MailTemplateKey.REVIEW_DAILY_DIGEST), eq("member@qnop.test"), vars.capture(), any());
 
-    // Counts, not one line per event — the whole point of the feature.
+    // Headline counts first, then the events themselves in order.
     assertThat(vars.getValue().get("digestBody").toString())
         .contains("Digest subject")
         .contains("1 new annotation")
-        .contains("2 comments");
+        .contains("2 comments")
+        .contains("raised an annotation")
+        .contains("replied in a thread");
     // And the way back into that specific review, not just the list.
     assertThat(vars.getValue().get("digestBodyHtml").toString()).contains("/reviews/" + documentId);
     assertThat(vars.getValue().get("totalPhrase")).isEqualTo("3 updates");

--- a/qnop-app/src/test/java/io/qnop/review/MentionNotificationIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/MentionNotificationIT.java
@@ -65,6 +65,15 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
  */
 class MentionNotificationIT extends SeededIntegrationTest {
 
+  /**
+   * This suite is about the immediate channel, which is now a choice rather than the default (issue
+   * #680) — so the participants say so before anything is asserted.
+   */
+  @org.junit.jupiter.api.BeforeEach
+  void mailPerEvent() {
+    preferImmediateReviewMail(ADMIN_ID, MEMBER_ID, MEMBER2_ID);
+  }
+
   private static final String ANCHOR =
       "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.1}},"
           + "\"textQuote\":{\"quote\":\"the clause\"}}";

--- a/qnop-app/src/test/java/io/qnop/review/ReviewNotificationIT.java
+++ b/qnop-app/src/test/java/io/qnop/review/ReviewNotificationIT.java
@@ -37,14 +37,12 @@ import io.qnop.entity.Document;
 import io.qnop.entity.DocumentVersion;
 import io.qnop.entity.ReviewParticipant;
 import io.qnop.entity.User;
-import io.qnop.entity.UserSetting;
 import io.qnop.entity.WorkflowState;
 import io.qnop.repository.DocumentRepository;
 import io.qnop.repository.DocumentVersionRepository;
 import io.qnop.repository.ReviewParticipantRepository;
 import io.qnop.repository.UserRepository;
 import io.qnop.repository.UserSettingRepository;
-import io.qnop.service.UserSettingKey;
 import io.qnop.service.mail.MailService;
 import io.qnop.service.mail.MailTemplateKey;
 import io.qnop.testsupport.SeededIntegrationTest;
@@ -73,6 +71,15 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * SMTP is involved and the assertions read the exact template key, recipient and variables.
  */
 class ReviewNotificationIT extends SeededIntegrationTest {
+
+  /**
+   * This suite is about the immediate channel, which is now a choice rather than the default (issue
+   * #680) — so the participants say so before anything is asserted.
+   */
+  @org.junit.jupiter.api.BeforeEach
+  void mailPerEvent() {
+    preferImmediateReviewMail(ADMIN_ID, ADMIN2_ID, MEMBER_ID, MEMBER2_ID, AUDITOR_ID);
+  }
 
   private static final String ANCHOR =
       "{\"region\":{\"surfaceIndex\":0,\"box\":{\"x\":0.1,\"y\":0.2,\"width\":0.3,\"height\":0.1}},"
@@ -247,8 +254,9 @@ class ReviewNotificationIT extends SeededIntegrationTest {
   void manualTransitionMailsParticipantsRespectingOptOut() throws Exception {
     seedDocument(false);
     participants.save(ReviewParticipant.forUser(documentId, MEMBER2_ID));
-    userSettings.save(
-        new UserSetting(MEMBER2_ID, UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getKey(), "false"));
+    // OFF rather than "false" now that the setting is three-valued (#680); the
+    // helper replaces the IMMEDIATE row this suite writes for everybody.
+    storeReviewMailCadence(MEMBER2_ID, "OFF");
 
     mockMvc
         .perform(

--- a/qnop-app/src/test/java/io/qnop/scheduler/SchedulerApiIT.java
+++ b/qnop-app/src/test/java/io/qnop/scheduler/SchedulerApiIT.java
@@ -68,7 +68,11 @@ class SchedulerApiIT extends SeededIntegrationTest {
     mockMvc
         .perform(as(get(SCHEDULER), ADMIN_ID))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.items", hasSize(8)))
+        // Counted from the catalogue rather than hard-coded, so adding a job is
+        // a one-line change there instead of a puzzle here.
+        .andExpect(
+            jsonPath(
+                "$.items", hasSize(io.qnop.service.scheduler.SchedulerJobCatalog.jobIds().size())))
         .andExpect(jsonPath("$.items[*].jobId", hasItem(STORAGE_ORPHAN_REAPER)))
         .andExpect(jsonPath("$.items[*].jobId", hasItem(REFRESH_TOKEN_SWEEP)));
   }

--- a/qnop-app/src/test/java/io/qnop/testsupport/SeededIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/testsupport/SeededIntegrationTest.java
@@ -73,6 +73,40 @@ import org.springframework.test.web.servlet.MvcResult;
     })
 public abstract class SeededIntegrationTest extends AbstractIntegrationTest {
 
+  @org.springframework.beans.factory.annotation.Autowired
+  private io.qnop.repository.UserSettingRepository userSettingsForCadence;
+
+  /**
+   * Puts recipients on per-event review mail, for suites that assert immediate delivery.
+   *
+   * <p>Needed since issue #680 made the cadence three-valued with {@code DAILY} as the default: a
+   * seeded account no longer gets a mail per event, which is the point of that change. Suites about
+   * the immediate channel therefore say so out loud rather than relying on a default that now means
+   * the opposite.
+   */
+  protected void preferImmediateReviewMail(UUID... userIds) {
+    for (UUID userId : userIds) {
+      storeReviewMailCadence(userId, "IMMEDIATE");
+    }
+  }
+
+  /**
+   * Writes the cadence for one recipient, replacing whatever was there.
+   *
+   * <p>Update-or-insert rather than a bare insert, because the suites that set a cadence run after
+   * {@link #preferImmediateReviewMail} has already written one — a second insert would hit the
+   * unique key on {@code (user_id, setting_key)}.
+   */
+  protected void storeReviewMailCadence(UUID userId, String cadence) {
+    String key = io.qnop.service.UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getKey();
+    io.qnop.entity.UserSetting setting =
+        userSettingsForCadence
+            .findByUserIdAndSettingKey(userId, key)
+            .orElseGet(() -> new io.qnop.entity.UserSetting(userId, key, cadence));
+    setting.setSettingValue(cadence);
+    userSettingsForCadence.saveAndFlush(setting);
+  }
+
   /** The plaintext behind every seeded user's bcrypt hash (for the real-login flows). */
   public static final String SEED_PASSWORD = "Test-Pass-1234!";
 

--- a/qnop-app/src/test/java/io/qnop/testsupport/SeededIntegrationTest.java
+++ b/qnop-app/src/test/java/io/qnop/testsupport/SeededIntegrationTest.java
@@ -98,12 +98,17 @@ public abstract class SeededIntegrationTest extends AbstractIntegrationTest {
    * unique key on {@code (user_id, setting_key)}.
    */
   protected void storeReviewMailCadence(UUID userId, String cadence) {
-    String key = io.qnop.service.UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getKey();
+    storeUserSetting(
+        userId, io.qnop.service.UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getKey(), cadence);
+  }
+
+  /** Writes any per-user setting, replacing whatever was there. */
+  protected void storeUserSetting(UUID userId, String key, String value) {
     io.qnop.entity.UserSetting setting =
         userSettingsForCadence
             .findByUserIdAndSettingKey(userId, key)
-            .orElseGet(() -> new io.qnop.entity.UserSetting(userId, key, cadence));
-    setting.setSettingValue(cadence);
+            .orElseGet(() -> new io.qnop.entity.UserSetting(userId, key, value));
+    setting.setSettingValue(value);
     userSettingsForCadence.saveAndFlush(setting);
   }
 

--- a/qnop-core/src/main/java/io/qnop/entity/NotificationDigest.java
+++ b/qnop-core/src/main/java/io/qnop/entity/NotificationDigest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * How far the daily digest has got for one recipient (issue #680).
+ *
+ * <p>Two fields because they answer different questions. {@code lastSentAt} is when the last digest
+ * went out; {@code coveredThrough} is the newest {@code createdAt} it actually included.
+ *
+ * <p>Both are instants, never a local date, per ADR-0041 — and that is not only the house rule: a
+ * stored local date would be read against whatever timezone the recipient has <em>now</em>, so
+ * somebody who travels would get two digests in a day or none. The instant plus their current zone
+ * always answers "have they had today's yet" consistently.
+ *
+ * <p>{@code coveredThrough} is deliberately not the run's timestamp: a notification written while
+ * the digest was being assembled would then fall between the query and the update, and would never
+ * be sent by any run.
+ */
+@Entity
+@Table(name = "notification_digest")
+public class NotificationDigest {
+
+  @Id
+  @Column(name = "recipient_id", nullable = false, updatable = false)
+  private UUID recipientId;
+
+  @Column(name = "last_sent_at", nullable = false)
+  private Instant lastSentAt;
+
+  @Column(name = "covered_through", nullable = false)
+  private Instant coveredThrough;
+
+  @Version
+  @Column(name = "version", nullable = false)
+  private long version;
+
+  protected NotificationDigest() {
+    // JPA
+  }
+
+  public NotificationDigest(UUID recipientId, Instant lastSentAt, Instant coveredThrough) {
+    this.recipientId = recipientId;
+    this.lastSentAt = lastSentAt;
+    this.coveredThrough = coveredThrough;
+  }
+
+  public UUID getRecipientId() {
+    return recipientId;
+  }
+
+  public Instant getLastSentAt() {
+    return lastSentAt;
+  }
+
+  public Instant getCoveredThrough() {
+    return coveredThrough;
+  }
+
+  /** Advances the watermark after a digest went out. */
+  public void advance(Instant sentAt, Instant coveredThrough) {
+    this.lastSentAt = sentAt;
+    this.coveredThrough = coveredThrough;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/repository/NotificationDigestRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/NotificationDigestRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.repository;
+
+import io.qnop.entity.NotificationDigest;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** The per-recipient digest watermark (issue #680). */
+public interface NotificationDigestRepository extends JpaRepository<NotificationDigest, UUID> {}

--- a/qnop-core/src/main/java/io/qnop/repository/NotificationRepository.java
+++ b/qnop-core/src/main/java/io/qnop/repository/NotificationRepository.java
@@ -22,6 +22,7 @@ package io.qnop.repository;
 
 import io.qnop.entity.Notification;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -53,6 +54,28 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
   /** The badge's number. */
   long countByRecipientIdAndReadAtIsNull(UUID recipientId);
+
+  /**
+   * Recipients with anything a digest could carry (issue #680).
+   *
+   * <p>Candidates, not the final set: cadence, timezone and whether today's digest already went out
+   * are decided per recipient afterwards. Driving the run from this rather than from the user table
+   * means an instance with ten thousand quiet accounts does no work for them.
+   */
+  @Query("SELECT DISTINCT n.recipientId FROM Notification n WHERE n.readAt IS NULL")
+  List<UUID> findRecipientsWithUnread();
+
+  /**
+   * One recipient's unread notifications newer than their watermark, oldest first (issue #680).
+   *
+   * <p>Unread is the interaction with in-app: anything already read in the app is left out, which
+   * is what makes the evening mail feel considerate rather than redundant.
+   */
+  @Query(
+      "SELECT n FROM Notification n WHERE n.recipientId = :recipientId AND n.readAt IS NULL"
+          + " AND n.createdAt > :after ORDER BY n.createdAt ASC")
+  List<Notification> findUnreadForDigest(
+      @Param("recipientId") UUID recipientId, @Param("after") Instant after);
 
   /** Scoped lookup — an id belonging to somebody else is simply absent (404, never 403). */
   Optional<Notification> findByIdAndRecipientId(UUID id, UUID recipientId);

--- a/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
@@ -52,11 +52,17 @@ public enum UserSettingKey {
       SettingValueType.STRING,
       "",
       "Preferred display timezone (IANA id); empty follows the application default."),
+  // Three-valued rather than a second checkbox (issue #680): with only on/off the
+  // honest choice for a busy review was "off", and a notification system people
+  // mute has failed however correct each mail was. DAILY is the default, so an
+  // account that never touched this gets one summary instead of a mail per event.
   EMAIL_REVIEW_NOTIFICATIONS(
       "email_review_notifications",
-      SettingValueType.BOOLEAN,
-      "true",
-      "Receive email notifications for review activity (issue #316)."),
+      SettingValueType.ENUM,
+      "DAILY",
+      "When to email about review activity: IMMEDIATE per event, DAILY as one"
+          + " morning summary, or OFF (issues #316/#680).",
+      List.of("IMMEDIATE", "DAILY", "OFF")),
   // Separate from the general review-activity toggle: a mention is a direct "you are needed here"
   // signal, so it carries its own opt-out and is not silenced by turning off general thread mail
   // (issue #462).

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -144,6 +144,43 @@ public enum MailTemplateKey {
       "actorName",
       "documentTitle",
       "actionUrl"),
+  // The digest (issue #680). Counts rather than a line per event: "3 new
+  // annotations, 7 comments" is a sentence somebody can act on, where fifty
+  // individual lines are the thing the digest exists to replace. Mustache has no
+  // loops-with-logic worth relying on here, so the service renders the per-document
+  // lines and passes them in as one block.
+  REVIEW_DAILY_DIGEST(
+      "review.daily_digest",
+      "Daily review summary",
+      "Your {{siteName}} review summary",
+      """
+      Hi {{recipientName}},
+
+      Since your last summary, {{totalCount}} thing(s) happened in your reviews:
+
+      {{digestBody}}
+
+      Open your reviews:
+
+      {{actionUrl}}
+
+      You are getting one summary a day because that is your notification setting; you can switch to per-event mail or turn it off in your profile.
+      """,
+      """
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Your review summary</h1>
+      <p style="margin:0 0 14px;color:#3d3f47;font-size:15px;line-height:1.6;">Hi {{recipientName}}, since your last summary {{totalCount}} thing(s) happened in your reviews.</p>
+      {{{digestBodyHtml}}}
+      <p style="margin:22px 0 0;"><a href="{{actionUrl}}" style="display:inline-block;padding:11px 18px;border-radius:8px;background:#18191f;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;">Open your reviews</a></p>
+      <p style="margin:22px 0 0;color:#6b6d76;font-size:13px;line-height:1.6;">You are getting one summary a day because that is your notification setting; you can switch to per-event mail or turn it off in your profile.</p>
+      """,
+      "Open your reviews",
+      "{{totalCount}} thing(s) happened in your reviews since your last summary.",
+      "siteName",
+      "recipientName",
+      "totalCount",
+      "digestBody",
+      "digestBodyHtml",
+      "actionUrl"),
   REVIEW_ANNOTATION_CREATED(
       "review.annotation_created",
       "New annotation",

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -151,12 +151,12 @@ public enum MailTemplateKey {
   // lines and passes them in as one block.
   REVIEW_DAILY_DIGEST(
       "review.daily_digest",
-      "Daily review summary",
-      "{{totalPhrase}} in your reviews",
+      "Daily review digest",
+      "Review digest: {{totalPhrase}} in your reviews",
       """
       Hi {{recipientName}},
 
-      {{totalPhrase}} in your reviews since your last summary:
+      Here is what happened in your reviews since your last digest — {{totalPhrase}} in all:
 
       {{digestBody}}
 
@@ -164,17 +164,17 @@ public enum MailTemplateKey {
 
       {{actionUrl}}
 
-      You are getting one summary a day because that is your notification setting; you can switch to per-event mail or turn it off in your profile.
+      You are getting one digest a day because that is your notification setting; you can switch to per-event mail or turn it off in your profile.
       """,
       """
-      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Your review summary</h1>
-      <p style="margin:0 0 14px;color:#3d3f47;font-size:15px;line-height:1.6;">Hi {{recipientName}}, {{totalPhrase}} in your reviews since your last summary.</p>
+      <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Your review digest</h1>
+      <p style="margin:0 0 14px;color:#3d3f47;font-size:15px;line-height:1.6;">Hi {{recipientName}}, here is what happened in your reviews since your last digest — {{totalPhrase}} in all.</p>
       {{{digestBodyHtml}}}
       <p style="margin:22px 0 0;"><a href="{{actionUrl}}" style="display:inline-block;padding:11px 18px;border-radius:8px;background:#18191f;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;">Open your reviews</a></p>
-      <p style="margin:22px 0 0;color:#6b6d76;font-size:13px;line-height:1.6;">You are getting one summary a day because that is your notification setting; you can switch to per-event mail or turn it off in your profile.</p>
+      <p style="margin:22px 0 0;color:#6b6d76;font-size:13px;line-height:1.6;">You are getting one digest a day because that is your notification setting; you can switch to per-event mail or turn it off in your profile.</p>
       """,
       "Open your reviews",
-      "{{totalPhrase}} since your last summary.",
+      "{{totalPhrase}} in your reviews since your last digest.",
       "siteName",
       "recipientName",
       "totalCount",

--- a/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/mail/MailTemplateKey.java
@@ -152,11 +152,11 @@ public enum MailTemplateKey {
   REVIEW_DAILY_DIGEST(
       "review.daily_digest",
       "Daily review summary",
-      "Your {{siteName}} review summary",
+      "{{totalPhrase}} in your reviews",
       """
       Hi {{recipientName}},
 
-      Since your last summary, {{totalCount}} thing(s) happened in your reviews:
+      {{totalPhrase}} in your reviews since your last summary:
 
       {{digestBody}}
 
@@ -168,16 +168,17 @@ public enum MailTemplateKey {
       """,
       """
       <h1 style="margin:0 0 14px;color:#18191f;font-size:22px;font-weight:700;letter-spacing:-0.01em;line-height:1.3;">Your review summary</h1>
-      <p style="margin:0 0 14px;color:#3d3f47;font-size:15px;line-height:1.6;">Hi {{recipientName}}, since your last summary {{totalCount}} thing(s) happened in your reviews.</p>
+      <p style="margin:0 0 14px;color:#3d3f47;font-size:15px;line-height:1.6;">Hi {{recipientName}}, {{totalPhrase}} in your reviews since your last summary.</p>
       {{{digestBodyHtml}}}
       <p style="margin:22px 0 0;"><a href="{{actionUrl}}" style="display:inline-block;padding:11px 18px;border-radius:8px;background:#18191f;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;">Open your reviews</a></p>
       <p style="margin:22px 0 0;color:#6b6d76;font-size:13px;line-height:1.6;">You are getting one summary a day because that is your notification setting; you can switch to per-event mail or turn it off in your profile.</p>
       """,
       "Open your reviews",
-      "{{totalCount}} thing(s) happened in your reviews since your last summary.",
+      "{{totalPhrase}} since your last summary.",
       "siteName",
       "recipientName",
       "totalCount",
+      "totalPhrase",
       "digestBody",
       "digestBodyHtml",
       "actionUrl"),

--- a/qnop-core/src/main/java/io/qnop/service/notification/DigestContent.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/DigestContent.java
@@ -36,15 +36,25 @@ import java.util.UUID;
  * <p>Deliberately free of database and mail: given a list of notifications it decides what the mail
  * will claim, which is the part worth testing exhaustively. Nothing here queries or sends.
  *
- * <p>Grouped per document, with counts rather than a line per event, because "3 new annotations, 7
- * comments" is the sentence somebody can act on; fifty individual lines are the very thing the
- * digest exists to replace.
+ * <p>Grouped per document: a counted headline first, because "3 new annotations, 7 comments" is the
+ * sentence somebody can act on, then the events themselves in the order they happened, so the
+ * reader can see what actually went on without opening the review.
  */
 public record DigestContent(List<DocumentSummary> documents, int total, Instant coveredThrough) {
 
-  /** One document's share of the digest. */
+  /** One document's share of the digest: the headline counts, then what happened, oldest first. */
   public record DocumentSummary(
-      UUID documentId, Map<NotificationType, Integer> counts, int total) {}
+      UUID documentId, Map<NotificationType, Integer> counts, int total, List<Event> events) {}
+
+  /**
+   * One thing that happened.
+   *
+   * <p>The actor travels as an id, never a name: under per-review anonymity (ADR-0038) a name
+   * belongs to a (review, viewer) pair, so resolving it is the caller's job and must not be guessed
+   * here.
+   */
+  public record Event(
+      Instant at, NotificationType type, UUID actorId, String excerpt, Integer versionNumber) {}
 
   /**
    * Builds the summary. Documents keep the order of their first unread notification, so the digest
@@ -53,16 +63,26 @@ public record DigestContent(List<DocumentSummary> documents, int total, Instant 
    * @param notifications one recipient's unread notifications, oldest first
    */
   public static DigestContent of(List<Notification> notifications) {
-    Map<UUID, Map<NotificationType, Integer>> byDocument = new LinkedHashMap<>();
+    Map<UUID, Map<NotificationType, Integer>> counts = new LinkedHashMap<>();
+    Map<UUID, List<Event>> events = new LinkedHashMap<>();
     Instant newest = null;
     for (Notification notification : notifications) {
       // Notifications without a document (none today, but the type allows it) are
       // counted under a null key rather than dropped: a digest that silently omits
       // something is worse than one with an odd heading.
-      byDocument
-          .computeIfAbsent(
-              notification.getDocumentId(), id -> new EnumMap<>(NotificationType.class))
+      UUID documentId = notification.getDocumentId();
+      counts
+          .computeIfAbsent(documentId, id -> new EnumMap<>(NotificationType.class))
           .merge(notification.getType(), 1, Integer::sum);
+      events
+          .computeIfAbsent(documentId, id -> new ArrayList<>())
+          .add(
+              new Event(
+                  notification.getCreatedAt(),
+                  notification.getType(),
+                  notification.getActorId(),
+                  notification.getExcerpt(),
+                  notification.getVersionNumber()));
       Instant createdAt = notification.getCreatedAt();
       if (createdAt != null && (newest == null || createdAt.isAfter(newest))) {
         newest = createdAt;
@@ -71,10 +91,14 @@ public record DigestContent(List<DocumentSummary> documents, int total, Instant 
 
     List<DocumentSummary> documents = new ArrayList<>();
     int total = 0;
-    for (Map.Entry<UUID, Map<NotificationType, Integer>> entry : byDocument.entrySet()) {
+    for (Map.Entry<UUID, Map<NotificationType, Integer>> entry : counts.entrySet()) {
       int documentTotal = entry.getValue().values().stream().mapToInt(Integer::intValue).sum();
       documents.add(
-          new DocumentSummary(entry.getKey(), Map.copyOf(entry.getValue()), documentTotal));
+          new DocumentSummary(
+              entry.getKey(),
+              Map.copyOf(entry.getValue()),
+              documentTotal,
+              List.copyOf(events.getOrDefault(entry.getKey(), List.of()))));
       total += documentTotal;
     }
     return new DigestContent(List.copyOf(documents), total, newest);

--- a/qnop-core/src/main/java/io/qnop/service/notification/DigestContent.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/DigestContent.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import io.qnop.entity.Notification;
+import io.qnop.entity.NotificationType;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * What one recipient's digest says (issue #680) — a summary, not a concatenated log.
+ *
+ * <p>Deliberately free of database and mail: given a list of notifications it decides what the mail
+ * will claim, which is the part worth testing exhaustively. Nothing here queries or sends.
+ *
+ * <p>Grouped per document, with counts rather than a line per event, because "3 new annotations, 7
+ * comments" is the sentence somebody can act on; fifty individual lines are the very thing the
+ * digest exists to replace.
+ */
+public record DigestContent(List<DocumentSummary> documents, int total, Instant coveredThrough) {
+
+  /** One document's share of the digest. */
+  public record DocumentSummary(
+      UUID documentId, Map<NotificationType, Integer> counts, int total) {}
+
+  /**
+   * Builds the summary. Documents keep the order of their first unread notification, so the digest
+   * reads oldest-first like the inbox it summarises.
+   *
+   * @param notifications one recipient's unread notifications, oldest first
+   */
+  public static DigestContent of(List<Notification> notifications) {
+    Map<UUID, Map<NotificationType, Integer>> byDocument = new LinkedHashMap<>();
+    Instant newest = null;
+    for (Notification notification : notifications) {
+      // Notifications without a document (none today, but the type allows it) are
+      // counted under a null key rather than dropped: a digest that silently omits
+      // something is worse than one with an odd heading.
+      byDocument
+          .computeIfAbsent(
+              notification.getDocumentId(), id -> new EnumMap<>(NotificationType.class))
+          .merge(notification.getType(), 1, Integer::sum);
+      Instant createdAt = notification.getCreatedAt();
+      if (createdAt != null && (newest == null || createdAt.isAfter(newest))) {
+        newest = createdAt;
+      }
+    }
+
+    List<DocumentSummary> documents = new ArrayList<>();
+    int total = 0;
+    for (Map.Entry<UUID, Map<NotificationType, Integer>> entry : byDocument.entrySet()) {
+      int documentTotal = entry.getValue().values().stream().mapToInt(Integer::intValue).sum();
+      documents.add(
+          new DocumentSummary(entry.getKey(), Map.copyOf(entry.getValue()), documentTotal));
+      total += documentTotal;
+    }
+    return new DigestContent(List.copyOf(documents), total, newest);
+  }
+
+  /** Nothing to say — and an empty digest is worse than silence, so no mail goes out. */
+  public boolean isEmpty() {
+    return total == 0;
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/notification/DigestRenderer.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/DigestRenderer.java
@@ -35,6 +35,10 @@ import java.util.UUID;
  *
  * <p>Counts, never one line per event — "3 new annotations, 7 comments" is what somebody can act
  * on, and fifty individual lines are precisely what the digest exists to replace.
+ *
+ * <p>Each document carries its own link, because the digest's job is not to inform but to get
+ * somebody back to the right review. One link to the list would make the reader search for what
+ * they just read about.
  */
 public final class DigestRenderer {
 
@@ -52,31 +56,55 @@ public final class DigestRenderer {
 
   private DigestRenderer() {}
 
-  /** The plain-text block: one line per document, its counts behind an em dash. */
-  public static String plain(DigestContent content, Map<UUID, String> titles) {
+  /**
+   * One document as the digest refers to it: what it is called and where it lives.
+   *
+   * <p>The URL comes from the caller rather than being assembled here, so the review path stays in
+   * one place and this class stays about wording.
+   */
+  public record Target(String title, String url) {}
+
+  /** The plain-text block: one line per document, its counts, then the link on its own line. */
+  public static String plain(DigestContent content, Map<UUID, Target> targets) {
     StringBuilder out = new StringBuilder();
     for (DigestContent.DocumentSummary document : content.documents()) {
+      Target target = targetOf(document, targets);
       out.append("* ")
-          .append(titleOf(document, titles))
+          .append(target.title())
           .append(" — ")
           .append(String.join(", ", phrases(document)))
           .append('\n');
+      if (target.url() != null && !target.url().isBlank()) {
+        out.append("  ").append(target.url()).append('\n');
+      }
     }
     return out.toString().stripTrailing();
   }
 
-  /** The same, as list items for the HTML body. */
-  public static String html(DigestContent content, Map<UUID, String> titles) {
+  /** The same, as list items whose titles are the links. */
+  public static String html(DigestContent content, Map<UUID, Target> targets) {
     StringBuilder out = new StringBuilder("<ul style=\"margin:0 0 4px;padding-left:18px;\">");
     for (DigestContent.DocumentSummary document : content.documents()) {
-      out.append("<li style=\"margin:0 0 8px;color:#3d3f47;font-size:15px;line-height:1.6;\">")
-          .append("<strong>")
-          .append(escape(titleOf(document, titles)))
-          .append("</strong> — ")
-          .append(escape(String.join(", ", phrases(document))))
-          .append("</li>");
+      Target target = targetOf(document, targets);
+      String label = escape(target.title());
+      out.append("<li style=\"margin:0 0 8px;color:#3d3f47;font-size:15px;line-height:1.6;\">");
+      if (target.url() == null || target.url().isBlank()) {
+        out.append("<strong>").append(label).append("</strong>");
+      } else {
+        out.append("<a href=\"")
+            .append(escape(target.url()))
+            .append("\" style=\"color:#18191f;font-weight:600;\">")
+            .append(label)
+            .append("</a>");
+      }
+      out.append(" — ").append(escape(String.join(", ", phrases(document)))).append("</li>");
     }
     return out.append("</ul>").toString();
+  }
+
+  /** A phrase for the total, pluralised — Mustache cannot, and the subject line needs one. */
+  public static String totalPhrase(int total) {
+    return total + (total == 1 ? " update" : " updates");
   }
 
   /** e.g. ["3 new annotations", "7 comments"] — singular where it is one. */
@@ -116,13 +144,16 @@ public final class DigestRenderer {
     };
   }
 
-  private static String titleOf(DigestContent.DocumentSummary document, Map<UUID, String> titles) {
+  private static Target targetOf(
+      DigestContent.DocumentSummary document, Map<UUID, Target> targets) {
     if (document.documentId() == null) {
-      return "Your workspace";
+      return new Target("Your workspace", null);
     }
     // A document deleted between the notification and the digest still gets a
-    // line: the count is true, and pretending it did not happen is worse.
-    return titles.getOrDefault(document.documentId(), "A review you take part in");
+    // line, without a link: the count is true, and pretending it did not happen
+    // is worse than a line that goes nowhere.
+    return targets.getOrDefault(
+        document.documentId(), new Target("A review you take part in", null));
   }
 
   private static String escape(String raw) {

--- a/qnop-core/src/main/java/io/qnop/service/notification/DigestRenderer.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/DigestRenderer.java
@@ -21,10 +21,15 @@
 package io.qnop.service.notification;
 
 import io.qnop.entity.NotificationType;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * Turns a {@link DigestContent} into the two blocks the mail template drops in (issue #680).
@@ -33,8 +38,11 @@ import java.util.UUID;
  * the alternative is a template full of pre-computed booleans, which is harder to read than the
  * sentence it produces.
  *
- * <p>Counts, never one line per event — "3 new annotations, 7 comments" is what somebody can act
- * on, and fifty individual lines are precisely what the digest exists to replace.
+ * <p>Two levels on purpose. The counted headline — "3 new annotations, 7 comments" — is what
+ * somebody can act on at a glance; underneath it the events are listed in the order they happened,
+ * so the reader can follow what went on without opening the review. The headline alone was too
+ * little to decide whether to open anything; a bare list of fifty lines is what the digest exists
+ * to replace.
  *
  * <p>Each document carries its own link, because the digest's job is not to inform but to get
  * somebody back to the right review. One link to the list would make the reader search for what
@@ -54,6 +62,12 @@ public final class DigestRenderer {
           NotificationType.REVIEW_DELETED,
           NotificationType.MENTION);
 
+  /** Long enough to recognise the thread, short enough not to reproduce it. */
+  private static final int EXCERPT_LIMIT = 140;
+
+  private static final DateTimeFormatter TIME =
+      DateTimeFormatter.ofPattern("MMM d, HH:mm", Locale.ENGLISH);
+
   private DigestRenderer() {}
 
   /**
@@ -64,42 +78,128 @@ public final class DigestRenderer {
    */
   public record Target(String title, String url) {}
 
-  /** The plain-text block: one line per document, its counts, then the link on its own line. */
-  public static String plain(DigestContent content, Map<UUID, Target> targets) {
+  /**
+   * The plain-text block.
+   *
+   * @param actorNames resolves an actor id to the name <em>this recipient</em> may see; under
+   *     per-review anonymity that is a pseudonym, so the caller owns this and the renderer never
+   *     looks a name up itself
+   * @param zone the recipient's timezone, so the times read as their own clock
+   */
+  public static String plain(
+      DigestContent content,
+      Map<UUID, Target> targets,
+      Function<UUID, String> actorNames,
+      ZoneId zone) {
     StringBuilder out = new StringBuilder();
     for (DigestContent.DocumentSummary document : content.documents()) {
       Target target = targetOf(document, targets);
-      out.append("* ")
-          .append(target.title())
+      out.append(target.title())
           .append(" — ")
           .append(String.join(", ", phrases(document)))
           .append('\n');
-      if (target.url() != null && !target.url().isBlank()) {
-        out.append("  ").append(target.url()).append('\n');
+      for (DigestContent.Event event : document.events()) {
+        out.append("    ")
+            .append(time(event.at(), zone))
+            .append("  ")
+            .append(sentence(event, actorNames))
+            .append('\n');
+        String excerpt = excerptOf(event);
+        if (excerpt != null) {
+          out.append("            \"").append(excerpt).append("\"\n");
+        }
       }
+      if (target.url() != null && !target.url().isBlank()) {
+        out.append("    ").append(target.url()).append('\n');
+      }
+      out.append('\n');
     }
     return out.toString().stripTrailing();
   }
 
-  /** The same, as list items whose titles are the links. */
-  public static String html(DigestContent content, Map<UUID, Target> targets) {
-    StringBuilder out = new StringBuilder("<ul style=\"margin:0 0 4px;padding-left:18px;\">");
+  /** The same as a block per document: a linked heading, its counts, then the timeline. */
+  public static String html(
+      DigestContent content,
+      Map<UUID, Target> targets,
+      Function<UUID, String> actorNames,
+      ZoneId zone) {
+    StringBuilder out = new StringBuilder();
     for (DigestContent.DocumentSummary document : content.documents()) {
       Target target = targetOf(document, targets);
       String label = escape(target.title());
-      out.append("<li style=\"margin:0 0 8px;color:#3d3f47;font-size:15px;line-height:1.6;\">");
+      out.append(
+          "<div style=\"margin:0 0 18px;padding:0 0 2px;border-left:3px solid #e4e7ec;"
+              + "padding-left:14px;\">");
+      out.append("<p style=\"margin:0 0 2px;font-size:15px;line-height:1.5;\">");
       if (target.url() == null || target.url().isBlank()) {
-        out.append("<strong>").append(label).append("</strong>");
+        out.append("<strong style=\"color:#18191f;\">").append(label).append("</strong>");
       } else {
         out.append("<a href=\"")
             .append(escape(target.url()))
-            .append("\" style=\"color:#18191f;font-weight:600;\">")
+            .append("\" style=\"color:#18191f;font-weight:600;text-decoration:none;\">")
             .append(label)
             .append("</a>");
       }
-      out.append(" — ").append(escape(String.join(", ", phrases(document)))).append("</li>");
+      out.append("</p>");
+      out.append("<p style=\"margin:0 0 8px;color:#6b6d76;font-size:13px;\">")
+          .append(escape(String.join(", ", phrases(document))))
+          .append("</p>");
+      out.append("<table role=\"presentation\" style=\"border-collapse:collapse;width:100%;\">");
+      for (DigestContent.Event event : document.events()) {
+        out.append("<tr>")
+            .append(
+                "<td style=\"padding:2px 10px 2px 0;color:#9a9ea8;font-size:13px;"
+                    + "white-space:nowrap;vertical-align:top;\">")
+            .append(escape(time(event.at(), zone)))
+            .append("</td>")
+            .append("<td style=\"padding:2px 0;color:#3d3f47;font-size:14px;line-height:1.5;\">")
+            .append(escape(sentence(event, actorNames)));
+        String excerpt = excerptOf(event);
+        if (excerpt != null) {
+          out.append("<br><span style=\"color:#6b6d76;font-style:italic;\">")
+              .append(escape("\u201c" + excerpt + "\u201d"))
+              .append("</span>");
+        }
+        out.append("</td></tr>");
+      }
+      out.append("</table></div>");
     }
-    return out.append("</ul>").toString();
+    return out.toString();
+  }
+
+  /** e.g. "Aug 3, 09:12" — dated, because a digest may cover more than one day. */
+  private static String time(Instant at, ZoneId zone) {
+    return at == null ? "" : TIME.format(at.atZone(zone));
+  }
+
+  /** What happened, as a sentence: who did what. */
+  private static String sentence(DigestContent.Event event, Function<UUID, String> actorNames) {
+    String actor = actorNames.apply(event.actorId());
+    return switch (event.type()) {
+      case ANNOTATION_CREATED -> actor + " raised an annotation";
+      case COMMENT_ADDED -> actor + " replied in a thread";
+      case ANNOTATION_DECIDED -> actor + " decided an annotation";
+      case VERSION_UPLOADED ->
+          actor
+              + " uploaded a new version"
+              + (event.versionNumber() == null ? "" : " (v" + event.versionNumber() + ")");
+      case WORKFLOW_CHANGED -> actor + " changed the review status";
+      case PARTICIPANT_ADDED -> actor + " added you to the review";
+      case REVIEW_DELETED -> actor + " deleted the review";
+      case MENTION -> actor + " mentioned you";
+    };
+  }
+
+  /** The quoted line under an event, shortened — a digest is not the place to re-read a thread. */
+  private static String excerptOf(DigestContent.Event event) {
+    String excerpt = event.excerpt();
+    if (excerpt == null || excerpt.isBlank()) {
+      return null;
+    }
+    String collapsed = excerpt.strip().replaceAll("\\s+", " ");
+    return collapsed.length() <= EXCERPT_LIMIT
+        ? collapsed
+        : collapsed.substring(0, EXCERPT_LIMIT - 1).stripTrailing() + "\u2026";
   }
 
   /** A phrase for the total, pluralised — Mustache cannot, and the subject line needs one. */

--- a/qnop-core/src/main/java/io/qnop/service/notification/DigestRenderer.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/DigestRenderer.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import io.qnop.entity.NotificationType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Turns a {@link DigestContent} into the two blocks the mail template drops in (issue #680).
+ *
+ * <p>Rendered here rather than in the template because Mustache has no counting or pluralisation:
+ * the alternative is a template full of pre-computed booleans, which is harder to read than the
+ * sentence it produces.
+ *
+ * <p>Counts, never one line per event — "3 new annotations, 7 comments" is what somebody can act
+ * on, and fifty individual lines are precisely what the digest exists to replace.
+ */
+public final class DigestRenderer {
+
+  /** The order these read best in a summary, most substantive first. */
+  private static final List<NotificationType> ORDER =
+      List.of(
+          NotificationType.ANNOTATION_CREATED,
+          NotificationType.COMMENT_ADDED,
+          NotificationType.ANNOTATION_DECIDED,
+          NotificationType.VERSION_UPLOADED,
+          NotificationType.WORKFLOW_CHANGED,
+          NotificationType.PARTICIPANT_ADDED,
+          NotificationType.REVIEW_DELETED,
+          NotificationType.MENTION);
+
+  private DigestRenderer() {}
+
+  /** The plain-text block: one line per document, its counts behind an em dash. */
+  public static String plain(DigestContent content, Map<UUID, String> titles) {
+    StringBuilder out = new StringBuilder();
+    for (DigestContent.DocumentSummary document : content.documents()) {
+      out.append("* ")
+          .append(titleOf(document, titles))
+          .append(" — ")
+          .append(String.join(", ", phrases(document)))
+          .append('\n');
+    }
+    return out.toString().stripTrailing();
+  }
+
+  /** The same, as list items for the HTML body. */
+  public static String html(DigestContent content, Map<UUID, String> titles) {
+    StringBuilder out = new StringBuilder("<ul style=\"margin:0 0 4px;padding-left:18px;\">");
+    for (DigestContent.DocumentSummary document : content.documents()) {
+      out.append("<li style=\"margin:0 0 8px;color:#3d3f47;font-size:15px;line-height:1.6;\">")
+          .append("<strong>")
+          .append(escape(titleOf(document, titles)))
+          .append("</strong> — ")
+          .append(escape(String.join(", ", phrases(document))))
+          .append("</li>");
+    }
+    return out.append("</ul>").toString();
+  }
+
+  /** e.g. ["3 new annotations", "7 comments"] — singular where it is one. */
+  private static List<String> phrases(DigestContent.DocumentSummary document) {
+    List<String> phrases = new ArrayList<>();
+    for (NotificationType type : ORDER) {
+      int count = document.counts().getOrDefault(type, 0);
+      if (count > 0) {
+        phrases.add(count + " " + noun(type, count));
+      }
+    }
+    // A type nobody thought to name still gets counted rather than vanishing.
+    document
+        .counts()
+        .forEach(
+            (type, count) -> {
+              if (!ORDER.contains(type) && count > 0) {
+                phrases.add(count + " " + (count == 1 ? "update" : "updates"));
+              }
+            });
+    return phrases;
+  }
+
+  private static String noun(NotificationType type, int count) {
+    boolean one = count == 1;
+    return switch (type) {
+      case ANNOTATION_CREATED -> one ? "new annotation" : "new annotations";
+      case COMMENT_ADDED -> one ? "comment" : "comments";
+      case ANNOTATION_DECIDED -> one ? "decision" : "decisions";
+      case VERSION_UPLOADED -> one ? "new version" : "new versions";
+      case WORKFLOW_CHANGED -> one ? "status change" : "status changes";
+      case PARTICIPANT_ADDED -> one ? "new participant" : "new participants";
+      case REVIEW_DELETED -> one ? "deleted review" : "deleted reviews";
+      // Mentions are mailed immediately and so are usually already read by now —
+      // but an unread one still belongs in the summary rather than nowhere.
+      case MENTION -> one ? "mention" : "mentions";
+    };
+  }
+
+  private static String titleOf(DigestContent.DocumentSummary document, Map<UUID, String> titles) {
+    if (document.documentId() == null) {
+      return "Your workspace";
+    }
+    // A document deleted between the notification and the digest still gets a
+    // line: the count is true, and pretending it did not happen is worse.
+    return titles.getOrDefault(document.documentId(), "A review you take part in");
+  }
+
+  private static String escape(String raw) {
+    return raw.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/notification/DigestSchedule.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/DigestSchedule.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+/**
+ * Whether a recipient's digest is due right now (issue #680).
+ *
+ * <p>The rule is "the first run at or after {@value #SEND_HOUR}:00 local time, at most once per
+ * local day" rather than "the run at 08:00". That distinction is what makes the schedule's
+ * frequency an implementation detail instead of the semantics: an hourly cron would miss the
+ * half-hour offsets — 08:00 in Kolkata is 02:30 UTC — while "at or after" simply delivers at 08:30
+ * there. Running more often only makes it more punctual, never wrong.
+ *
+ * <p>Pure and clock-injected, because every interesting case here is a date and a timezone.
+ */
+public final class DigestSchedule {
+
+  /** Local hour from which a digest may go out. Morning, not midnight: it is meant to be read. */
+  public static final int SEND_HOUR = 8;
+
+  /**
+   * How far back a first-ever digest reaches.
+   *
+   * <p>Somebody who switches to DAILY may have weeks of unread notifications; mailing all of them
+   * as a "daily" summary would be a worse first impression than the per-event mail they left.
+   */
+  public static final java.time.Duration FIRST_RUN_LOOKBACK = java.time.Duration.ofHours(24);
+
+  private DigestSchedule() {}
+
+  /**
+   * @param zone the recipient's timezone
+   * @param lastSentAt when their last digest went out, or empty if they never had one
+   */
+  public static boolean isDue(Instant now, ZoneId zone, Optional<Instant> lastSentAt) {
+    ZonedDateTime local = now.atZone(zone);
+    if (local.getHour() < SEND_HOUR) {
+      return false;
+    }
+    LocalDate today = local.toLocalDate();
+    // Both sides converted with the same zone, so the comparison is "was the last
+    // one on an earlier day for this recipient" rather than a server-date guess.
+    return lastSentAt.map(sent -> sent.atZone(zone).toLocalDate().isBefore(today)).orElse(true);
+  }
+
+  /** The instant a digest should collect from: the watermark, or a bounded first-run window. */
+  public static Instant collectFrom(Instant now, Optional<Instant> coveredThrough) {
+    return coveredThrough.orElseGet(() -> now.minus(FIRST_RUN_LOOKBACK));
+  }
+
+  /** The recipient's local date, for logs and tests that reason in calendar days. */
+  public static LocalDate localDate(Instant now, ZoneId zone) {
+    return now.atZone(zone).toLocalDate();
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/notification/NotificationDigestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/NotificationDigestService.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import io.qnop.entity.NotificationDigest;
+import io.qnop.entity.User;
+import io.qnop.repository.DocumentRepository;
+import io.qnop.repository.NotificationDigestRepository;
+import io.qnop.repository.NotificationRepository;
+import io.qnop.repository.UserRepository;
+import io.qnop.repository.UserSettingRepository;
+import io.qnop.service.ApplicationSettingKey;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.service.UserSettingKey;
+import io.qnop.service.mail.MailService;
+import io.qnop.service.mail.MailTemplateKey;
+import io.qnop.service.scheduler.SchedulerJobCatalog;
+import io.qnop.service.scheduler.SchedulerService;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * The daily review digest (issue #680): one summary per recipient per morning, instead of a mail
+ * per event.
+ *
+ * <p>A scheduled reader rather than a third {@link io.qnop.service.review.ReviewNotificationSink},
+ * which was the open question in the issue. A sink is per-event and a digest is per-window, so as a
+ * sink it would only ever queue — and the queue already exists: the in-app sink writes a row for
+ * every event regardless of mail preferences, which is exactly the digest's input. The side effect
+ * of that choice is that a digest can later carry notifications that never came from a review sink
+ * at all.
+ *
+ * <p>Runs hourly and sends to whoever is due, rather than running once at 08:00 — see {@link
+ * DigestSchedule} for why that distinction matters for half-hour timezones.
+ *
+ * <p>Per recipient, each in its own transaction: a run interrupted halfway keeps the digests it has
+ * already sent and the rest follow on the next hour's run, rather than the whole batch rolling back
+ * and re-sending.
+ */
+@Service
+public class NotificationDigestService {
+
+  private static final Logger log = LoggerFactory.getLogger(NotificationDigestService.class);
+
+  /**
+   * Recipients handled per run. A backlog larger than this finishes on the following runs, which
+   * for an hourly job means minutes later.
+   */
+  private static final int MAX_RECIPIENTS_PER_RUN = 500;
+
+  private final NotificationRepository notifications;
+  private final NotificationDigestRepository watermarks;
+  private final UserRepository users;
+  private final UserSettingRepository userSettings;
+  private final DocumentRepository documents;
+  private final ApplicationSettingsService settings;
+  private final MailService mail;
+  private final SchedulerService scheduler;
+  private final TransactionTemplate tx;
+
+  public NotificationDigestService(
+      NotificationRepository notifications,
+      NotificationDigestRepository watermarks,
+      UserRepository users,
+      UserSettingRepository userSettings,
+      DocumentRepository documents,
+      ApplicationSettingsService settings,
+      MailService mail,
+      SchedulerService scheduler,
+      PlatformTransactionManager transactionManager) {
+    this.notifications = notifications;
+    this.watermarks = watermarks;
+    this.users = users;
+    this.userSettings = userSettings;
+    this.documents = documents;
+    this.settings = settings;
+    this.mail = mail;
+    this.scheduler = scheduler;
+    this.tx = new TransactionTemplate(transactionManager);
+  }
+
+  /** Hourly gate; the scheduler decides whether the job is enabled and in dry-run. */
+  @Scheduled(cron = "${qnop.notifications.digest-cron:0 5 * * * *}")
+  @SchedulerLock(name = SchedulerJobCatalog.NOTIFICATION_DIGEST, lockAtMostFor = "PT30M")
+  public void digest() {
+    scheduler.runScheduled(SchedulerJobCatalog.NOTIFICATION_DIGEST);
+  }
+
+  /**
+   * One pass. Self-transactional: each recipient commits on their own, so an interrupted run keeps
+   * what it sent. In {@code dryRun} it reports who would receive one and writes nothing — which
+   * also means a dry run does not consume the watermark.
+   */
+  public String digestOnce(boolean dryRun) {
+    Instant now = Instant.now();
+    List<UUID> candidates = tx.execute(status -> notifications.findRecipientsWithUnread());
+    if (candidates == null || candidates.isEmpty()) {
+      return "Nothing unread anywhere";
+    }
+
+    int sent = 0;
+    int considered = 0;
+    for (UUID recipientId : candidates) {
+      if (considered >= MAX_RECIPIENTS_PER_RUN) {
+        log.info(
+            "Digest run hit its per-run cap of {} recipient(s); the rest follow next hour.",
+            MAX_RECIPIENTS_PER_RUN);
+        break;
+      }
+      considered++;
+      Boolean delivered = tx.execute(status -> digestFor(recipientId, now, dryRun));
+      if (Boolean.TRUE.equals(delivered)) {
+        sent++;
+      }
+    }
+
+    if (dryRun) {
+      return "Would send "
+          + sent
+          + " digest(s) to "
+          + considered
+          + " candidate(s); nothing changed";
+    }
+    return sent == 0
+        ? "No digests were due out of " + considered + " candidate(s)"
+        : "Sent " + sent + " digest(s)";
+  }
+
+  /**
+   * @return whether a digest was (or would have been) sent to this recipient
+   */
+  private boolean digestFor(UUID recipientId, Instant now, boolean dryRun) {
+    Optional<User> maybeUser = users.findById(recipientId);
+    if (maybeUser.isEmpty() || !maybeUser.get().isEnabled()) {
+      return false;
+    }
+    User recipient = maybeUser.get();
+    if (recipient.getEmail() == null || recipient.getEmail().isBlank()) {
+      return false;
+    }
+    if (cadenceFor(recipientId) != ReviewMailCadence.DAILY) {
+      return false;
+    }
+
+    ZoneId zone = zoneFor(recipientId);
+    Optional<NotificationDigest> watermark = watermarks.findById(recipientId);
+    if (!DigestSchedule.isDue(now, zone, watermark.map(NotificationDigest::getLastSentAt))) {
+      return false;
+    }
+
+    Instant from =
+        DigestSchedule.collectFrom(now, watermark.map(NotificationDigest::getCoveredThrough));
+    DigestContent content = DigestContent.of(notifications.findUnreadForDigest(recipientId, from));
+    if (content.isEmpty()) {
+      // No mail, and no watermark either: an empty digest is worse than silence,
+      // and moving the watermark would silently drop whatever arrives next.
+      return false;
+    }
+
+    if (dryRun) {
+      return true;
+    }
+
+    mail.sendMailFromTemplate(
+        MailTemplateKey.REVIEW_DAILY_DIGEST,
+        recipient.getEmail(),
+        varsFor(recipient, content),
+        localeFor(recipientId));
+    // The newest createdAt actually included — never now(), or a notification
+    // written while this was being assembled would fall in the gap.
+    Instant coveredThrough = content.coveredThrough() == null ? from : content.coveredThrough();
+    watermarks.save(
+        watermark
+            .map(
+                existing -> {
+                  existing.advance(now, coveredThrough);
+                  return existing;
+                })
+            .orElseGet(() -> new NotificationDigest(recipientId, now, coveredThrough)));
+    return true;
+  }
+
+  private ReviewMailCadence cadenceFor(UUID userId) {
+    return userSettings
+        .findByUserIdAndSettingKey(userId, UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getKey())
+        .flatMap(setting -> ReviewMailCadence.parse(setting.getSettingValue()))
+        .orElseGet(ReviewMailCadence::registryDefault);
+  }
+
+  /**
+   * The recipient's timezone, falling back to the instance default and then UTC.
+   *
+   * <p>The preference is empty by default (ADR-0041), so without the fallbacks a large share of
+   * recipients would never be due at their own 08:00 — or worse, never at all.
+   */
+  private ZoneId zoneFor(UUID userId) {
+    Optional<String> preferred =
+        userSettings
+            .findByUserIdAndSettingKey(userId, UserSettingKey.TIMEZONE.getKey())
+            .map(setting -> setting.getSettingValue());
+    return parseZone(preferred.orElse(null))
+        .or(() -> parseZone(settings.getString(ApplicationSettingKey.GENERAL_DEFAULT_TIMEZONE)))
+        .orElse(ZoneOffset.UTC);
+  }
+
+  private Optional<ZoneId> parseZone(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(ZoneId.of(raw.trim()));
+    } catch (DateTimeException e) {
+      log.debug("Ignoring unusable timezone '{}' for a digest recipient", raw);
+      return Optional.empty();
+    }
+  }
+
+  private String localeFor(UUID userId) {
+    return userSettings
+        .findByUserIdAndSettingKey(userId, UserSettingKey.PREFERRED_LANGUAGE.getKey())
+        .map(setting -> setting.getSettingValue())
+        .filter(value -> !value.isBlank())
+        .orElse(null);
+  }
+
+  private Map<String, Object> varsFor(User recipient, DigestContent content) {
+    Map<String, Object> vars = new HashMap<>();
+    vars.put("siteName", settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME));
+    vars.put("recipientName", recipient.getDisplayName());
+    vars.put("totalCount", content.total());
+    vars.put("digestBody", DigestRenderer.plain(content, titlesFor(content)));
+    vars.put("digestBodyHtml", DigestRenderer.html(content, titlesFor(content)));
+    vars.put("actionUrl", reviewsUrl());
+    return vars;
+  }
+
+  /** Document titles for the summary, in one query rather than one per group. */
+  private Map<UUID, String> titlesFor(DigestContent content) {
+    List<UUID> ids =
+        content.documents().stream()
+            .map(DigestContent.DocumentSummary::documentId)
+            .filter(java.util.Objects::nonNull)
+            .toList();
+    Map<UUID, String> titles = new LinkedHashMap<>();
+    if (ids.isEmpty()) {
+      return titles;
+    }
+    documents
+        .findAllById(ids)
+        .forEach(document -> titles.put(document.getId(), document.getTitle()));
+    return titles;
+  }
+
+  private String reviewsUrl() {
+    String base = settings.getString(ApplicationSettingKey.GENERAL_BASE_URL);
+    if (base == null || base.isBlank()) {
+      log.warn("general.base_url is not configured — digest links will be relative/broken");
+      base = "";
+    }
+    return base.replaceAll("/+$", "") + "/reviews";
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/notification/NotificationDigestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/NotificationDigestService.java
@@ -261,35 +261,56 @@ public class NotificationDigestService {
     vars.put("siteName", settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME));
     vars.put("recipientName", recipient.getDisplayName());
     vars.put("totalCount", content.total());
-    vars.put("digestBody", DigestRenderer.plain(content, titlesFor(content)));
-    vars.put("digestBodyHtml", DigestRenderer.html(content, titlesFor(content)));
+    Map<UUID, DigestRenderer.Target> targets = targetsFor(content);
+    vars.put("totalPhrase", DigestRenderer.totalPhrase(content.total()));
+    vars.put("digestBody", DigestRenderer.plain(content, targets));
+    vars.put("digestBodyHtml", DigestRenderer.html(content, targets));
     vars.put("actionUrl", reviewsUrl());
     return vars;
   }
 
-  /** Document titles for the summary, in one query rather than one per group. */
-  private Map<UUID, String> titlesFor(DigestContent content) {
+  /**
+   * Title and link per document, in one query rather than one per group.
+   *
+   * <p>A document that has since been deleted simply does not appear here, and the renderer then
+   * writes its line without a link — the count stays true either way.
+   */
+  private Map<UUID, DigestRenderer.Target> targetsFor(DigestContent content) {
     List<UUID> ids =
         content.documents().stream()
             .map(DigestContent.DocumentSummary::documentId)
             .filter(java.util.Objects::nonNull)
             .toList();
-    Map<UUID, String> titles = new LinkedHashMap<>();
+    Map<UUID, DigestRenderer.Target> targets = new LinkedHashMap<>();
     if (ids.isEmpty()) {
-      return titles;
+      return targets;
     }
+    String base = baseUrl();
     documents
         .findAllById(ids)
-        .forEach(document -> titles.put(document.getId(), document.getTitle()));
-    return titles;
+        .forEach(
+            document ->
+                targets.put(
+                    document.getId(),
+                    new DigestRenderer.Target(
+                        document.getTitle(),
+                        base.isEmpty() ? null : base + "/reviews/" + document.getId())));
+    return targets;
+  }
+
+  private String baseUrl() {
+    String base = settings.getString(ApplicationSettingKey.GENERAL_BASE_URL);
+    if (base == null || base.isBlank()) {
+      // Rather than emit relative links that are dead in a mail client, the
+      // renderer leaves them out entirely — configure Settings → General → Base URL.
+      log.warn("general.base_url is not configured — the digest will have no links");
+      return "";
+    }
+    return base.replaceAll("/+$", "");
   }
 
   private String reviewsUrl() {
-    String base = settings.getString(ApplicationSettingKey.GENERAL_BASE_URL);
-    if (base == null || base.isBlank()) {
-      log.warn("general.base_url is not configured — digest links will be relative/broken");
-      base = "";
-    }
-    return base.replaceAll("/+$", "") + "/reviews";
+    String base = baseUrl();
+    return base.isEmpty() ? "" : base + "/reviews";
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/notification/NotificationDigestService.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/NotificationDigestService.java
@@ -87,6 +87,7 @@ public class NotificationDigestService {
   private final UserSettingRepository userSettings;
   private final DocumentRepository documents;
   private final ApplicationSettingsService settings;
+  private final io.qnop.service.review.ReviewIdentityResolver identity;
   private final MailService mail;
   private final SchedulerService scheduler;
   private final TransactionTemplate tx;
@@ -98,6 +99,7 @@ public class NotificationDigestService {
       UserSettingRepository userSettings,
       DocumentRepository documents,
       ApplicationSettingsService settings,
+      io.qnop.service.review.ReviewIdentityResolver identity,
       MailService mail,
       SchedulerService scheduler,
       PlatformTransactionManager transactionManager) {
@@ -107,6 +109,7 @@ public class NotificationDigestService {
     this.userSettings = userSettings;
     this.documents = documents;
     this.settings = settings;
+    this.identity = identity;
     this.mail = mail;
     this.scheduler = scheduler;
     this.tx = new TransactionTemplate(transactionManager);
@@ -197,7 +200,7 @@ public class NotificationDigestService {
     mail.sendMailFromTemplate(
         MailTemplateKey.REVIEW_DAILY_DIGEST,
         recipient.getEmail(),
-        varsFor(recipient, content),
+        varsFor(recipient, content, zone),
         localeFor(recipientId));
     // The newest createdAt actually included — never now(), or a notification
     // written while this was being assembled would fall in the gap.
@@ -256,17 +259,57 @@ public class NotificationDigestService {
         .orElse(null);
   }
 
-  private Map<String, Object> varsFor(User recipient, DigestContent content) {
+  private Map<String, Object> varsFor(User recipient, DigestContent content, ZoneId zone) {
     Map<String, Object> vars = new HashMap<>();
     vars.put("siteName", settings.getString(ApplicationSettingKey.GENERAL_APPLICATION_NAME));
     vars.put("recipientName", recipient.getDisplayName());
     vars.put("totalCount", content.total());
     Map<UUID, DigestRenderer.Target> targets = targetsFor(content);
+    java.util.function.Function<UUID, String> actorNames =
+        actorNamesFor(recipient.getId(), content);
     vars.put("totalPhrase", DigestRenderer.totalPhrase(content.total()));
-    vars.put("digestBody", DigestRenderer.plain(content, targets));
-    vars.put("digestBodyHtml", DigestRenderer.html(content, targets));
+    vars.put("digestBody", DigestRenderer.plain(content, targets, actorNames, zone));
+    vars.put("digestBodyHtml", DigestRenderer.html(content, targets, actorNames, zone));
     vars.put("actionUrl", reviewsUrl());
     return vars;
+  }
+
+  /**
+   * Resolves actor ids to the names <em>this</em> recipient may see.
+   *
+   * <p>Through the same resolver the in-app list uses (ADR-0038), because under per-review
+   * anonymity a name belongs to a (review, viewer) pair — reading it off the user row would leak
+   * the very identity the review was set up to withhold. Resolved once per document and cached for
+   * the mail, since a digest names the same handful of people repeatedly.
+   */
+  private java.util.function.Function<UUID, String> actorNamesFor(
+      UUID recipientId, DigestContent content) {
+    Map<UUID, io.qnop.service.review.ReviewIdentityResolver.ReviewIdentities> perDocument =
+        new LinkedHashMap<>();
+    Map<UUID, String> resolved = new LinkedHashMap<>();
+    for (DigestContent.DocumentSummary document : content.documents()) {
+      if (document.documentId() == null) {
+        continue;
+      }
+      io.qnop.service.review.ReviewIdentityResolver.ReviewIdentities identities;
+      try {
+        identities =
+            perDocument.computeIfAbsent(
+                document.documentId(), id -> identity.forDocument(id, recipientId));
+      } catch (RuntimeException e) {
+        // A review deleted between the notification and the digest: its lines stay,
+        // with a neutral actor rather than no digest at all.
+        continue;
+      }
+      for (DigestContent.Event event : document.events()) {
+        if (event.actorId() != null) {
+          String name = identities.displayName(event.actorId());
+          resolved.putIfAbsent(
+              event.actorId(), name == null || name.isBlank() ? "A participant" : name);
+        }
+      }
+    }
+    return actorId -> actorId == null ? "System" : resolved.getOrDefault(actorId, "A participant");
   }
 
   /**

--- a/qnop-core/src/main/java/io/qnop/service/notification/ReviewMailCadence.java
+++ b/qnop-core/src/main/java/io/qnop/service/notification/ReviewMailCadence.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import io.qnop.service.UserSettingKey;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * When a recipient wants review mail (issue #680).
+ *
+ * <p>Replaces a boolean that offered only "every event" or "nothing". Given that choice on a busy
+ * review, the honest answer was nothing — and a notification nobody receives has failed however
+ * correct it was.
+ *
+ * <p>Shared between the mail sink, which sends only for {@link #IMMEDIATE}, and the digest job,
+ * which collects for {@link #DAILY}. Both read the same setting, so a recipient cannot end up
+ * getting both or neither.
+ */
+public enum ReviewMailCadence {
+  /** One mail per event, as it was before this existed. */
+  IMMEDIATE,
+  /** One summary per morning, in the recipient's own timezone. */
+  DAILY,
+  /** No review mail. In-app notifications are unaffected — they are not this setting's business. */
+  OFF;
+
+  /**
+   * Reads a stored value, tolerating the booleans this setting held before.
+   *
+   * <p>The legacy mapping matches migration 0035 exactly: {@code false} was an explicit opt-out and
+   * stays {@link #OFF}, while {@code true} becomes {@link #DAILY}. Being tolerant here means a
+   * deployment whose migration has not run yet still behaves as intended rather than mailing
+   * somebody who had said no.
+   */
+  public static Optional<ReviewMailCadence> parse(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return Optional.empty();
+    }
+    String value = raw.trim().toUpperCase(Locale.ROOT);
+    return switch (value) {
+      case "TRUE" -> Optional.of(DAILY);
+      case "FALSE" -> Optional.of(OFF);
+      case "IMMEDIATE" -> Optional.of(IMMEDIATE);
+      case "DAILY" -> Optional.of(DAILY);
+      case "OFF" -> Optional.of(OFF);
+      default -> Optional.empty();
+    };
+  }
+
+  /**
+   * What an account that never chose gets — read from the registry rather than repeated here, so
+   * the default has exactly one home (ADR-0025).
+   */
+  public static ReviewMailCadence registryDefault() {
+    return parse(UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getDefaultValue()).orElse(DAILY);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/review/MailNotificationSink.java
+++ b/qnop-core/src/main/java/io/qnop/service/review/MailNotificationSink.java
@@ -27,6 +27,7 @@ import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import io.qnop.service.UserSettingKey;
 import io.qnop.service.mail.MailService;
+import io.qnop.service.notification.ReviewMailCadence;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 
@@ -75,13 +76,25 @@ public class MailNotificationSink implements ReviewNotificationSink {
    * "someone named you"; everything else follows the general review-mail opt-out.
    */
   private boolean optedOut(UUID userId, NotificationType type) {
-    UserSettingKey key =
-        type == NotificationType.MENTION
-            ? UserSettingKey.EMAIL_MENTIONS
-            : UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS;
+    if (type == NotificationType.MENTION) {
+      // Still a plain opt-out: being named personally is the case where latency
+      // actually costs something, so a mention is never held for a digest.
+      return userSettings
+          .findByUserIdAndSettingKey(userId, UserSettingKey.EMAIL_MENTIONS.getKey())
+          .map(setting -> "false".equalsIgnoreCase(setting.getSettingValue()))
+          .orElse(false);
+    }
+    // Everything else follows the cadence (issue #680). This sink is the
+    // immediate channel, so it stays silent for DAILY — the digest job picks
+    // those up from the notification rows the in-app sink writes regardless.
+    return cadenceFor(userId) != ReviewMailCadence.IMMEDIATE;
+  }
+
+  /** The recipient's chosen cadence, or the registry default where they never chose. */
+  private ReviewMailCadence cadenceFor(UUID userId) {
     return userSettings
-        .findByUserIdAndSettingKey(userId, key.getKey())
-        .map(setting -> "false".equalsIgnoreCase(setting.getSettingValue()))
-        .orElse(false);
+        .findByUserIdAndSettingKey(userId, UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getKey())
+        .flatMap(setting -> ReviewMailCadence.parse(setting.getSettingValue()))
+        .orElseGet(ReviewMailCadence::registryDefault);
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBinding.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobBinding.java
@@ -24,6 +24,7 @@ import io.qnop.service.RefreshTokenService;
 import io.qnop.service.TokenRevocationService;
 import io.qnop.service.auth.EmailVerificationTokenService;
 import io.qnop.service.auth.PasswordResetTokenService;
+import io.qnop.service.notification.NotificationDigestService;
 import io.qnop.service.notification.NotificationSweepService;
 import io.qnop.service.review.ReviewArchiveService;
 import io.qnop.service.review.ReviewPurgeService;
@@ -53,7 +54,8 @@ public class SchedulerJobBinding {
       StorageService storage,
       ReviewArchiveService reviewArchive,
       ReviewPurgeService reviewPurge,
-      NotificationSweepService notificationSweep) {
+      NotificationSweepService notificationSweep,
+      NotificationDigestService notificationDigest) {
     scheduler.register(
         SchedulerJobCatalog.EMAIL_VERIFICATION_TOKEN_SWEEP,
         dryRun -> {
@@ -82,5 +84,6 @@ public class SchedulerJobBinding {
     scheduler.register(SchedulerJobCatalog.REVIEW_ARCHIVE, reviewArchive::archiveOnce);
     scheduler.register(SchedulerJobCatalog.REVIEW_PURGE, reviewPurge::purgeOnce);
     scheduler.register(SchedulerJobCatalog.NOTIFICATION_SWEEP, notificationSweep::sweepOnce);
+    scheduler.register(SchedulerJobCatalog.NOTIFICATION_DIGEST, notificationDigest::digestOnce);
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
@@ -43,6 +43,7 @@ public final class SchedulerJobCatalog {
   public static final String REVIEW_ARCHIVE = "reviewArchive";
   public static final String REVIEW_PURGE = "reviewPurge";
   public static final String NOTIFICATION_SWEEP = "notificationSweep";
+  public static final String NOTIFICATION_DIGEST = "notificationDigest";
 
   private static final List<SchedulerJobDefinition> DEFINITIONS =
       List.of(
@@ -119,7 +120,21 @@ public final class SchedulerJobCatalog {
               "0 15 4 * * *",
               true,
               true,
-              true));
+              true),
+          // Hourly, and that is the point rather than an accident (issue #680):
+          // it sends to whoever has reached 08:00 in their own timezone since the
+          // last run, which a single daily run cannot do for more than one zone —
+          // and an hourly grid alone would miss the half-hour offsets.
+          new SchedulerJobDefinition(
+              NOTIFICATION_DIGEST,
+              "Review digest",
+              "Sends each recipient one summary of their unread review notifications, in their own"
+                  + " morning. Recipients on immediate or no mail are skipped, and a quiet day"
+                  + " sends nothing.",
+              "0 5 * * * *",
+              true,
+              true,
+              false));
 
   private static final List<String> IDS =
       DEFINITIONS.stream().map(SchedulerJobDefinition::jobId).toList();

--- a/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
+++ b/qnop-core/src/main/java/io/qnop/service/scheduler/SchedulerJobCatalog.java
@@ -134,7 +134,13 @@ public final class SchedulerJobCatalog {
               "0 5 * * * *",
               true,
               true,
-              false));
+              // Self-transactional (issue #680): a digest is sent per recipient and
+              // its watermark committed with it. Inside the gate's transaction the
+              // watermarks would all commit at the end, so a crash after fifty
+              // recipients would roll back fifty watermarks whose mails are already
+              // delivered — and the next run would send them again. Mail cannot be
+              // rolled back, so the commit must not be deferred past it.
+              true));
 
   private static final List<String> IDS =
       DEFINITIONS.stream().map(SchedulerJobDefinition::jobId).toList();

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -113,6 +113,9 @@ databaseChangeLog:
   - include:
       file: migrations/0034-usage-tracking-settings.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0035-review-notification-cadence.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qnop-core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -116,6 +116,9 @@ databaseChangeLog:
   - include:
       file: migrations/0035-review-notification-cadence.yaml
       relativeToChangelogFile: true
+  - include:
+      file: migrations/0036-notification-digest.yaml
+      relativeToChangelogFile: true
   # Enterprise schema seam (issue #254, ADR-0039): a separately-licensed module
   # (ADR-0002) contributes its changelogs under db/changelog/enterprise/ on its
   # OWN classpath entry; without enterprise JARs this is a no-op. Enterprise

--- a/qnop-core/src/main/resources/db/changelog/migrations/0035-review-notification-cadence.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0035-review-notification-cadence.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2026-present devtank42 GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# email_review_notifications becomes three-valued: IMMEDIATE | DAILY | OFF
+# (issue #680). Additive changeset; the registry (UserSettingKey) stays
+# authoritative per ADR-0025 and this only rewrites the stored rows so none of
+# them holds a value the registry would now reject.
+#
+# The mapping is not symmetrical, on purpose:
+#
+#   "false" -> OFF        An explicit opt-out stays an opt-out. Turning it into
+#                         DAILY would start mailing somebody who had said no,
+#                         which is the one outcome this change must not have.
+#   "true"  -> DAILY      The chosen default (see below). Somebody who ticked
+#                         the box asked for review mail, not specifically for a
+#                         mail per event — that distinction did not exist yet.
+#
+# Rows are only rewritten where they still hold the old boolean text, so re-runs
+# and hand-edited values are left alone.
+#
+# Accounts with no row at all inherit the registry default, which is now DAILY.
+# That is a deliberate, visible change for existing users and belongs in the
+# release notes: mail volume drops from one per event to one per morning.
+databaseChangeLog:
+  - changeSet:
+      id: 0035-review-notification-cadence
+      author: qnop
+      comment: Migrates email_review_notifications from boolean to IMMEDIATE/DAILY/OFF (issue #680).
+      changes:
+        - update:
+            tableName: user_setting
+            columns:
+              - column: { name: setting_value, value: "OFF" }
+            where: setting_key = 'email_review_notifications' AND lower(setting_value) = 'false'
+        - update:
+            tableName: user_setting
+            columns:
+              - column: { name: setting_value, value: "DAILY" }
+            where: setting_key = 'email_review_notifications' AND lower(setting_value) = 'true'
+      rollback:
+        - update:
+            tableName: user_setting
+            columns:
+              - column: { name: setting_value, value: "false" }
+            where: setting_key = 'email_review_notifications' AND setting_value = 'OFF'
+        - update:
+            tableName: user_setting
+            columns:
+              - column: { name: setting_value, value: "true" }
+            where: setting_key = 'email_review_notifications' AND setting_value IN ('DAILY', 'IMMEDIATE')

--- a/qnop-core/src/main/resources/db/changelog/migrations/0036-notification-digest.yaml
+++ b/qnop-core/src/main/resources/db/changelog/migrations/0036-notification-digest.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2026-present devtank42 GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Per-recipient watermark for the daily digest (issue #680). One row per
+# recipient, written after a digest goes out.
+#
+# Two columns rather than one, because they answer different questions:
+#
+#   last_sent_at     when the last digest went out. An instant, never a local
+#                    date (ADR-0041): a stored date would be read against
+#                    whatever timezone the recipient has now, so somebody who
+#                    travels would get two in a day or none. The instant plus
+#                    their current zone answers "have they had today's yet".
+#   covered_through  the newest createdAt actually included. Not now(): rows
+#                    written while the digest was being built would fall in the
+#                    gap between the query and the update and never be sent.
+databaseChangeLog:
+  - changeSet:
+      id: 0036-notification-digest
+      author: qnop
+      comment: Adds the per-recipient digest watermark (issue #680).
+      changes:
+        - createTable:
+            tableName: notification_digest
+            columns:
+              - column:
+                  name: recipient_id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_notification_digest
+                    nullable: false
+              - column:
+                  name: last_sent_at
+                  type: timestamptz
+                  constraints:
+                    nullable: false
+              - column:
+                  name: covered_through
+                  type: timestamptz
+                  constraints:
+                    nullable: false
+              - column:
+                  name: version
+                  type: bigint
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            constraintName: fk_notification_digest_recipient
+            baseTableName: notification_digest
+            baseColumnNames: recipient_id
+            referencedTableName: qnop_user
+            referencedColumnNames: id
+            onDelete: CASCADE

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
@@ -71,6 +71,7 @@ class MailTemplateServiceTest {
           // The digest renders its per-document lines in the service and passes
           // them in as one block (issue #680) — Mustache cannot count.
           Map.entry("totalCount", 11),
+          Map.entry("totalPhrase", "11 updates"),
           Map.entry("digestBody", "* Q3 contract draft — 3 new annotations, 7 comments"),
           Map.entry(
               "digestBodyHtml",

--- a/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/mail/MailTemplateServiceTest.java
@@ -67,7 +67,14 @@ class MailTemplateServiceTest {
           Map.entry("decision", "resolved"),
           Map.entry("versionNumber", "3"),
           Map.entry("oldState", "In review"),
-          Map.entry("newState", "Changes requested"));
+          Map.entry("newState", "Changes requested"),
+          // The digest renders its per-document lines in the service and passes
+          // them in as one block (issue #680) — Mustache cannot count.
+          Map.entry("totalCount", 11),
+          Map.entry("digestBody", "* Q3 contract draft — 3 new annotations, 7 comments"),
+          Map.entry(
+              "digestBodyHtml",
+              "<ul><li><strong>Q3 contract draft</strong> — 3 new annotations, 7 comments</li></ul>"));
 
   private MailTemplateService service;
 

--- a/qnop-core/src/test/java/io/qnop/service/notification/DigestContentTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/notification/DigestContentTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qnop.entity.Notification;
+import io.qnop.entity.NotificationType;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** What the digest claims, given a list of notifications (issue #680). */
+class DigestContentTest {
+
+  private static final UUID DOC_A = UUID.randomUUID();
+  private static final UUID DOC_B = UUID.randomUUID();
+
+  @Test
+  @DisplayName("counts per document rather than a line per event")
+  void countsPerDocument() {
+    DigestContent content =
+        DigestContent.of(
+            List.of(
+                notification(DOC_A, NotificationType.ANNOTATION_CREATED, "2026-08-03T06:00:00Z"),
+                notification(DOC_A, NotificationType.ANNOTATION_CREATED, "2026-08-03T06:05:00Z"),
+                notification(DOC_A, NotificationType.COMMENT_ADDED, "2026-08-03T06:10:00Z"),
+                notification(DOC_B, NotificationType.VERSION_UPLOADED, "2026-08-03T06:20:00Z")));
+
+    assertThat(content.total()).isEqualTo(4);
+    assertThat(content.documents()).hasSize(2);
+    assertThat(content.documents().get(0).counts())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                NotificationType.ANNOTATION_CREATED, 2,
+                NotificationType.COMMENT_ADDED, 1));
+    assertThat(content.documents().get(0).total()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("documents keep the order of their first unread notification")
+  void oldestFirst() {
+    DigestContent content =
+        DigestContent.of(
+            List.of(
+                notification(DOC_B, NotificationType.COMMENT_ADDED, "2026-08-03T05:00:00Z"),
+                notification(DOC_A, NotificationType.COMMENT_ADDED, "2026-08-03T06:00:00Z"),
+                notification(DOC_B, NotificationType.COMMENT_ADDED, "2026-08-03T07:00:00Z")));
+
+    assertThat(content.documents().get(0).documentId()).isEqualTo(DOC_B);
+    assertThat(content.documents().get(1).documentId()).isEqualTo(DOC_A);
+  }
+
+  @Test
+  @DisplayName("the watermark is the newest notification included, never the run's clock")
+  void watermarkIsTheNewestIncluded() {
+    // The distinction that keeps a notification written mid-run from falling into
+    // the gap between the query and the update.
+    DigestContent content =
+        DigestContent.of(
+            List.of(
+                notification(DOC_A, NotificationType.COMMENT_ADDED, "2026-08-03T06:00:00Z"),
+                notification(DOC_A, NotificationType.COMMENT_ADDED, "2026-08-03T06:42:17Z")));
+
+    assertThat(content.coveredThrough()).isEqualTo(Instant.parse("2026-08-03T06:42:17Z"));
+  }
+
+  @Test
+  @DisplayName("nothing unread means nothing to send")
+  void emptyStaysEmpty() {
+    DigestContent content = DigestContent.of(List.of());
+
+    assertThat(content.isEmpty()).isTrue();
+    assertThat(content.total()).isZero();
+    assertThat(content.coveredThrough()).isNull();
+  }
+
+  @Test
+  @DisplayName("a notification without a document is counted, not dropped")
+  void documentlessIsStillCounted() {
+    DigestContent content =
+        DigestContent.of(
+            List.of(notification(null, NotificationType.MENTION, "2026-08-03T06:00:00Z")));
+
+    assertThat(content.total()).isEqualTo(1);
+    assertThat(content.documents()).hasSize(1);
+    assertThat(content.documents().get(0).documentId()).isNull();
+  }
+
+  private static Notification notification(UUID documentId, NotificationType type, String at) {
+    Notification notification = mock(Notification.class);
+    when(notification.getDocumentId()).thenReturn(documentId);
+    when(notification.getType()).thenReturn(type);
+    when(notification.getCreatedAt()).thenReturn(Instant.parse(at));
+    return notification;
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/notification/DigestRendererTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/notification/DigestRendererTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.entity.NotificationType;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** The sentence the digest actually says (issue #680). */
+class DigestRendererTest {
+
+  private static final UUID DOC = UUID.randomUUID();
+
+  @Test
+  @DisplayName("counts read as a summary, in a fixed order, with singulars where it is one")
+  void readsAsASummary() {
+    String plain =
+        DigestRenderer.plain(
+            content(
+                Map.of(
+                    NotificationType.COMMENT_ADDED, 7,
+                    NotificationType.ANNOTATION_CREATED, 3,
+                    NotificationType.VERSION_UPLOADED, 1)),
+            Map.of(DOC, "Vendor Agreement"));
+
+    // Annotations before comments before versions, whatever order they arrived in.
+    assertThat(plain)
+        .isEqualTo("* Vendor Agreement — 3 new annotations, 7 comments, 1 new version");
+  }
+
+  @Test
+  @DisplayName("a title that is gone still gets its line")
+  void deletedDocumentStillCounts() {
+    // The count is true even where the document is not resolvable any more, and
+    // dropping it would understate what happened.
+    String plain =
+        DigestRenderer.plain(content(Map.of(NotificationType.COMMENT_ADDED, 1)), Map.of());
+
+    assertThat(plain).isEqualTo("* A review you take part in — 1 comment");
+  }
+
+  @Test
+  @DisplayName("titles are escaped in the HTML body")
+  void escapesTitles() {
+    String html =
+        DigestRenderer.html(
+            content(Map.of(NotificationType.COMMENT_ADDED, 1)),
+            Map.of(DOC, "Terms & <Conditions>"));
+
+    assertThat(html).contains("Terms &amp; &lt;Conditions&gt;").doesNotContain("<Conditions>");
+  }
+
+  private static DigestContent content(Map<NotificationType, Integer> counts) {
+    int total = counts.values().stream().mapToInt(Integer::intValue).sum();
+    return new DigestContent(
+        List.of(new DigestContent.DocumentSummary(DOC, counts, total)), total, Instant.now());
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/notification/DigestRendererTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/notification/DigestRendererTest.java
@@ -24,9 +24,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.qnop.entity.NotificationType;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -45,15 +47,15 @@ class DigestRendererTest {
                     NotificationType.COMMENT_ADDED, 7,
                     NotificationType.ANNOTATION_CREATED, 3,
                     NotificationType.VERSION_UPLOADED, 1)),
-            Map.of(DOC, target("Vendor Agreement")));
+            Map.of(DOC, target("Vendor Agreement")),
+            NAMES,
+            ZONE);
 
     // Annotations before comments before versions, whatever order they arrived in,
     // and the way back on its own line.
     assertThat(plain)
-        .isEqualTo(
-            "* Vendor Agreement — 3 new annotations, 7 comments, 1 new version\n"
-                + "  https://qnop.example/reviews/"
-                + DOC);
+        .startsWith("Vendor Agreement — 3 new annotations, 7 comments, 1 new version")
+        .endsWith("https://qnop.example/reviews/" + DOC);
   }
 
   @Test
@@ -62,10 +64,11 @@ class DigestRendererTest {
     // The count is true even where the document is not resolvable any more, and
     // dropping it would understate what happened.
     String plain =
-        DigestRenderer.plain(content(Map.of(NotificationType.COMMENT_ADDED, 1)), Map.of());
+        DigestRenderer.plain(
+            content(Map.of(NotificationType.COMMENT_ADDED, 1)), Map.of(), NAMES, ZONE);
 
     // No link either: a line that goes nowhere beats a link that 404s.
-    assertThat(plain).isEqualTo("* A review you take part in — 1 comment");
+    assertThat(plain).isEqualTo("A review you take part in — 1 comment");
   }
 
   @Test
@@ -74,7 +77,9 @@ class DigestRendererTest {
     String html =
         DigestRenderer.html(
             content(Map.of(NotificationType.COMMENT_ADDED, 1)),
-            Map.of(DOC, target("Terms & <Conditions>")));
+            Map.of(DOC, target("Terms & <Conditions>")),
+            NAMES,
+            ZONE);
 
     assertThat(html).contains("Terms &amp; &lt;Conditions&gt;").doesNotContain("<Conditions>");
   }
@@ -86,7 +91,10 @@ class DigestRendererTest {
     // review; one link to the list would make them search for what they just read.
     String html =
         DigestRenderer.html(
-            content(Map.of(NotificationType.COMMENT_ADDED, 2)), Map.of(DOC, target("Contract")));
+            content(Map.of(NotificationType.COMMENT_ADDED, 2)),
+            Map.of(DOC, target("Contract")),
+            NAMES,
+            ZONE);
 
     assertThat(html).contains("href=\"https://qnop.example/reviews/" + DOC + "\"");
     assertThat(html).contains(">Contract</a>");
@@ -98,9 +106,11 @@ class DigestRendererTest {
     String html =
         DigestRenderer.html(
             content(Map.of(NotificationType.COMMENT_ADDED, 1)),
-            Map.of(DOC, new DigestRenderer.Target("Contract", null)));
+            Map.of(DOC, new DigestRenderer.Target("Contract", null)),
+            NAMES,
+            ZONE);
 
-    assertThat(html).contains("<strong>Contract</strong>").doesNotContain("<a href");
+    assertThat(html).contains(">Contract</strong>").doesNotContain("<a href");
   }
 
   @Test
@@ -114,9 +124,67 @@ class DigestRendererTest {
     return new DigestRenderer.Target(title, "https://qnop.example/reviews/" + DOC);
   }
 
+  @Test
+  @DisplayName("events are listed in order, with the time, who and what")
+  void listsEventsChronologically() {
+    String plain =
+        DigestRenderer.plain(
+            content(
+                Map.of(NotificationType.ANNOTATION_CREATED, 1, NotificationType.COMMENT_ADDED, 1),
+                List.of(
+                    event("2026-08-03T07:12:00Z", NotificationType.ANNOTATION_CREATED, "The cap"),
+                    event("2026-08-03T09:40:00Z", NotificationType.COMMENT_ADDED, null))),
+            Map.of(DOC, target("Contract")),
+            NAMES,
+            ZONE);
+
+    // Headline first, then the timeline — the counts say whether to read on, the
+    // lines say what to expect. Times are the recipient's own clock: 07:12Z is
+    // 09:12 in Berlin.
+    assertThat(plain)
+        .containsSubsequence(
+            "Contract — 1 new annotation, 1 comment",
+            "Aug 3, 09:12  Alex Reviewer raised an annotation",
+            "\u201cThe cap\u201d".replace("\u201c", "\"").replace("\u201d", "\""),
+            "Aug 3, 11:40  Alex Reviewer replied in a thread");
+  }
+
+  @Test
+  @DisplayName("a long excerpt is shortened rather than reproduced")
+  void excerptIsShortened() {
+    String plain =
+        DigestRenderer.plain(
+            content(
+                Map.of(NotificationType.COMMENT_ADDED, 1),
+                List.of(
+                    event(
+                        "2026-08-03T09:00:00Z", NotificationType.COMMENT_ADDED, "x".repeat(400)))),
+            Map.of(DOC, target("Contract")),
+            NAMES,
+            ZONE);
+
+    // A digest is not the place to re-read a thread.
+    assertThat(plain).contains("…").doesNotContain("x".repeat(200));
+  }
+
+  private static final ZoneId ZONE = ZoneId.of("Europe/Berlin");
+  private static final Function<UUID, String> NAMES =
+      actorId -> actorId == null ? "System" : "Alex Reviewer";
+
   private static DigestContent content(Map<NotificationType, Integer> counts) {
+    return content(counts, List.of());
+  }
+
+  private static DigestContent content(
+      Map<NotificationType, Integer> counts, List<DigestContent.Event> events) {
     int total = counts.values().stream().mapToInt(Integer::intValue).sum();
     return new DigestContent(
-        List.of(new DigestContent.DocumentSummary(DOC, counts, total)), total, Instant.now());
+        List.of(new DigestContent.DocumentSummary(DOC, counts, total, events)),
+        total,
+        Instant.now());
+  }
+
+  private static DigestContent.Event event(String at, NotificationType type, String excerpt) {
+    return new DigestContent.Event(Instant.parse(at), type, UUID.randomUUID(), excerpt, null);
   }
 }

--- a/qnop-core/src/test/java/io/qnop/service/notification/DigestRendererTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/notification/DigestRendererTest.java
@@ -45,11 +45,15 @@ class DigestRendererTest {
                     NotificationType.COMMENT_ADDED, 7,
                     NotificationType.ANNOTATION_CREATED, 3,
                     NotificationType.VERSION_UPLOADED, 1)),
-            Map.of(DOC, "Vendor Agreement"));
+            Map.of(DOC, target("Vendor Agreement")));
 
-    // Annotations before comments before versions, whatever order they arrived in.
+    // Annotations before comments before versions, whatever order they arrived in,
+    // and the way back on its own line.
     assertThat(plain)
-        .isEqualTo("* Vendor Agreement — 3 new annotations, 7 comments, 1 new version");
+        .isEqualTo(
+            "* Vendor Agreement — 3 new annotations, 7 comments, 1 new version\n"
+                + "  https://qnop.example/reviews/"
+                + DOC);
   }
 
   @Test
@@ -60,6 +64,7 @@ class DigestRendererTest {
     String plain =
         DigestRenderer.plain(content(Map.of(NotificationType.COMMENT_ADDED, 1)), Map.of());
 
+    // No link either: a line that goes nowhere beats a link that 404s.
     assertThat(plain).isEqualTo("* A review you take part in — 1 comment");
   }
 
@@ -69,9 +74,44 @@ class DigestRendererTest {
     String html =
         DigestRenderer.html(
             content(Map.of(NotificationType.COMMENT_ADDED, 1)),
-            Map.of(DOC, "Terms & <Conditions>"));
+            Map.of(DOC, target("Terms & <Conditions>")));
 
     assertThat(html).contains("Terms &amp; &lt;Conditions&gt;").doesNotContain("<Conditions>");
+  }
+
+  @Test
+  @DisplayName("each document links to its own review, not to the list")
+  void everyDocumentLinksToItself() {
+    // The digest's job is not to inform but to get somebody back to the right
+    // review; one link to the list would make them search for what they just read.
+    String html =
+        DigestRenderer.html(
+            content(Map.of(NotificationType.COMMENT_ADDED, 2)), Map.of(DOC, target("Contract")));
+
+    assertThat(html).contains("href=\"https://qnop.example/reviews/" + DOC + "\"");
+    assertThat(html).contains(">Contract</a>");
+  }
+
+  @Test
+  @DisplayName("a document with no link is still named, just not linked")
+  void unlinkedDocument() {
+    String html =
+        DigestRenderer.html(
+            content(Map.of(NotificationType.COMMENT_ADDED, 1)),
+            Map.of(DOC, new DigestRenderer.Target("Contract", null)));
+
+    assertThat(html).contains("<strong>Contract</strong>").doesNotContain("<a href");
+  }
+
+  @Test
+  @DisplayName("the total is pluralised, since the subject line uses it")
+  void totalPhrasePluralises() {
+    assertThat(DigestRenderer.totalPhrase(1)).isEqualTo("1 update");
+    assertThat(DigestRenderer.totalPhrase(11)).isEqualTo("11 updates");
+  }
+
+  private static DigestRenderer.Target target(String title) {
+    return new DigestRenderer.Target(title, "https://qnop.example/reviews/" + DOC);
   }
 
   private static DigestContent content(Map<NotificationType, Integer> counts) {

--- a/qnop-core/src/test/java/io/qnop/service/notification/DigestScheduleTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/notification/DigestScheduleTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * When a digest is due (issue #680) — all of it timezone arithmetic, so all of it worth pinning.
+ */
+class DigestScheduleTest {
+
+  private static final ZoneId BERLIN = ZoneId.of("Europe/Berlin");
+  private static final ZoneId KOLKATA = ZoneId.of("Asia/Kolkata");
+
+  @Test
+  @DisplayName("nothing goes out before the local send hour")
+  void tooEarly() {
+    // 06:00 in Berlin: the run happens, this recipient does not.
+    Instant sixAmBerlin = Instant.parse("2026-08-03T04:00:00Z");
+
+    assertThat(DigestSchedule.isDue(sixAmBerlin, BERLIN, Optional.empty())).isFalse();
+  }
+
+  @Test
+  @DisplayName("a recipient who never had one gets the first run after their 08:00")
+  void firstEver() {
+    Instant nineAmBerlin = Instant.parse("2026-08-03T07:00:00Z");
+
+    assertThat(DigestSchedule.isDue(nineAmBerlin, BERLIN, Optional.empty())).isTrue();
+  }
+
+  @Test
+  @DisplayName("half-hour timezones are served, which an hourly grid alone would miss")
+  void halfHourOffset() {
+    // 08:00 in Kolkata is 02:30 UTC — no hourly run lands on it. The rule is "at
+    // or after", so the 03:00 UTC run (08:30 local) delivers.
+    Instant runBefore = Instant.parse("2026-08-03T02:00:00Z"); // 07:30 local
+    Instant runAfter = Instant.parse("2026-08-03T03:00:00Z"); // 08:30 local
+
+    assertThat(DigestSchedule.isDue(runBefore, KOLKATA, Optional.empty())).isFalse();
+    assertThat(DigestSchedule.isDue(runAfter, KOLKATA, Optional.empty())).isTrue();
+  }
+
+  @Test
+  @DisplayName("at most one per local day, however often the job runs")
+  void onePerDay() {
+    Instant nineAm = Instant.parse("2026-08-03T07:00:00Z");
+    Instant sixPm = Instant.parse("2026-08-03T16:00:00Z");
+    Instant sentThisMorning = Instant.parse("2026-08-03T06:05:00Z");
+
+    // Sent this morning: every later run today declines…
+    assertThat(DigestSchedule.isDue(nineAm, BERLIN, Optional.of(sentThisMorning))).isFalse();
+    assertThat(DigestSchedule.isDue(sixPm, BERLIN, Optional.of(sentThisMorning))).isFalse();
+    // …and tomorrow morning it is due again.
+    assertThat(
+            DigestSchedule.isDue(
+                Instant.parse("2026-08-04T07:00:00Z"), BERLIN, Optional.of(sentThisMorning)))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("the local date decides, not the server's")
+  void localDateNotServerDate() {
+    // 23:30 UTC on the 3rd is already 05:00 on the 4th in Kolkata — before the
+    // send hour there, so it is not due even though the server's date rolled.
+    Instant lateUtc = Instant.parse("2026-08-03T23:30:00Z");
+
+    assertThat(
+            DigestSchedule.isDue(
+                lateUtc, KOLKATA, Optional.of(Instant.parse("2026-08-03T03:00:00Z"))))
+        .isFalse();
+    assertThat(DigestSchedule.localDate(lateUtc, KOLKATA)).isEqualTo(LocalDate.of(2026, 8, 4));
+  }
+
+  @Test
+  @DisplayName("a first digest reaches back a bounded window, not forever")
+  void firstRunIsBounded() {
+    Instant now = Instant.parse("2026-08-03T07:00:00Z");
+
+    // Somebody switching to DAILY may have weeks unread; mailing all of it as a
+    // "daily" summary would be a worse first impression than what they left.
+    assertThat(DigestSchedule.collectFrom(now, Optional.empty()))
+        .isEqualTo(now.minus(DigestSchedule.FIRST_RUN_LOOKBACK));
+    // With a watermark it is exactly that, so nothing is covered twice or skipped.
+    Instant watermark = Instant.parse("2026-08-02T07:03:11Z");
+    assertThat(DigestSchedule.collectFrom(now, Optional.of(watermark))).isEqualTo(watermark);
+  }
+
+  @Test
+  @DisplayName("a recipient who changed timezone is judged by the zone they have now")
+  void travellerIsJudgedByTheirCurrentZone() {
+    // Storing a local date would have frozen the old zone's calendar: this
+    // digest went out at 09:00 Berlin, which is already the 4th in Kolkata, so
+    // somebody who moved there is due again on their 4th and not before.
+    Instant sentBerlinMorning = Instant.parse("2026-08-03T07:00:00Z");
+
+    assertThat(
+            DigestSchedule.isDue(
+                Instant.parse("2026-08-03T20:00:00Z"), KOLKATA, Optional.of(sentBerlinMorning)))
+        .as("still the same local day in Kolkata (01:30 on the 4th is before 08:00)")
+        .isFalse();
+    assertThat(
+            DigestSchedule.isDue(
+                Instant.parse("2026-08-04T03:00:00Z"), KOLKATA, Optional.of(sentBerlinMorning)))
+        .as("08:30 on the 4th in Kolkata — a new local day, so due")
+        .isTrue();
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/notification/ReviewMailCadenceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/notification/ReviewMailCadenceTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.service.UserSettingKey;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** The stored-value mapping, which migration 0035 has to agree with exactly (issue #680). */
+class ReviewMailCadenceTest {
+
+  @Test
+  @DisplayName("an explicit opt-out survives the move away from booleans")
+  void legacyFalseStaysOff() {
+    // The one outcome this change must not have is mailing somebody who had said
+    // no, so "false" maps to OFF and never to the new default.
+    assertThat(ReviewMailCadence.parse("false")).contains(ReviewMailCadence.OFF);
+    assertThat(ReviewMailCadence.parse("FALSE")).contains(ReviewMailCadence.OFF);
+  }
+
+  @Test
+  @DisplayName("the legacy opt-in becomes DAILY, as the migration writes it")
+  void legacyTrueBecomesDaily() {
+    assertThat(ReviewMailCadence.parse("true")).contains(ReviewMailCadence.DAILY);
+  }
+
+  @Test
+  @DisplayName("the three current values read back, whitespace and case aside")
+  void currentValues() {
+    assertThat(ReviewMailCadence.parse("IMMEDIATE")).contains(ReviewMailCadence.IMMEDIATE);
+    assertThat(ReviewMailCadence.parse(" daily ")).contains(ReviewMailCadence.DAILY);
+    assertThat(ReviewMailCadence.parse("off")).contains(ReviewMailCadence.OFF);
+  }
+
+  @Test
+  @DisplayName("anything else is absent, so the caller falls back deliberately")
+  void unknownIsEmpty() {
+    assertThat(ReviewMailCadence.parse(null)).isEmpty();
+    assertThat(ReviewMailCadence.parse("")).isEmpty();
+    assertThat(ReviewMailCadence.parse("weekly")).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  @DisplayName("the default comes from the registry, not from a second copy of it")
+  void defaultFollowsTheRegistry() {
+    assertThat(ReviewMailCadence.registryDefault())
+        .isEqualTo(
+            ReviewMailCadence.parse(UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS.getDefaultValue())
+                .orElseThrow());
+    assertThat(ReviewMailCadence.registryDefault()).isEqualTo(ReviewMailCadence.DAILY);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/review/MailNotificationSinkTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/review/MailNotificationSinkTest.java
@@ -78,8 +78,13 @@ class MailNotificationSinkTest {
   }
 
   private void optOut(UserSettingKey key) {
+    stored(key, "false");
+  }
+
+  /** Stores a raw setting value for the recipient, as the registry would hold it. */
+  private void stored(UserSettingKey key, String value) {
     UserSetting setting = mock(UserSetting.class);
-    when(setting.getSettingValue()).thenReturn("false");
+    when(setting.getSettingValue()).thenReturn(value);
     when(userSettings.findByUserIdAndSettingKey(RECIPIENT_ID, key.getKey()))
         .thenReturn(Optional.of(setting));
   }
@@ -122,16 +127,56 @@ class MailNotificationSinkTest {
 
     assertThat(sink().accepts(intent(NotificationType.MENTION, "a@qnop.test"))).isFalse();
     // …and the dispatcher then offers the reply candidate instead, which is the
-    // fall-through ReviewNotificationServiceTest pins down.
+    // fall-through ReviewNotificationServiceTest pins down. It needs IMMEDIATE
+    // now, since the cadence default no longer mails per event (#680).
+    stored(UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS, "IMMEDIATE");
     assertThat(sink().accepts(intent(NotificationType.COMMENT_ADDED, "a@qnop.test"))).isTrue();
   }
 
   @Test
-  @DisplayName("an ordinary recipient is mailed")
-  void ordinaryRecipient() {
+  @DisplayName("a recipient who chose IMMEDIATE is mailed per event")
+  void immediateRecipient() {
+    emailsEnabled(true);
+    when(userSettings.findByUserIdAndSettingKey(any(), any())).thenReturn(Optional.empty());
+    stored(UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS, "IMMEDIATE");
+
+    assertThat(sink().accepts(intent(NotificationType.COMMENT_ADDED, "a@qnop.test"))).isTrue();
+  }
+
+  @Test
+  @DisplayName("DAILY leaves this sink silent — the digest carries it instead (#680)")
+  void dailyIsNotThisSinksBusiness() {
+    emailsEnabled(true);
+    when(userSettings.findByUserIdAndSettingKey(any(), any())).thenReturn(Optional.empty());
+    stored(UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS, "DAILY");
+
+    assertThat(sink().accepts(intent(NotificationType.COMMENT_ADDED, "a@qnop.test"))).isFalse();
+    // The in-app sink still writes the row, which is what the digest reads, and a
+    // mention still goes out at once — it is not part of the cadence.
+    assertThat(sink().accepts(intent(NotificationType.MENTION, "a@qnop.test"))).isTrue();
+  }
+
+  @Test
+  @DisplayName("a recipient who never chose gets the registry default, which is DAILY")
+  void defaultIsDaily() {
     emailsEnabled(true);
     when(userSettings.findByUserIdAndSettingKey(any(), any())).thenReturn(Optional.empty());
 
-    assertThat(sink().accepts(intent(NotificationType.COMMENT_ADDED, "a@qnop.test"))).isTrue();
+    // The visible half of issue #680: an account that never touched this setting
+    // stops getting a mail per event.
+    assertThat(sink().accepts(intent(NotificationType.COMMENT_ADDED, "a@qnop.test"))).isFalse();
+  }
+
+  @Test
+  @DisplayName("the legacy booleans still read correctly before the migration runs")
+  void legacyValues() {
+    emailsEnabled(true);
+    when(userSettings.findByUserIdAndSettingKey(any(), any())).thenReturn(Optional.empty());
+
+    stored(UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS, "true");
+    assertThat(sink().accepts(intent(NotificationType.COMMENT_ADDED, "a@qnop.test"))).isFalse();
+
+    stored(UserSettingKey.EMAIL_REVIEW_NOTIFICATIONS, "false");
+    assertThat(sink().accepts(intent(NotificationType.COMMENT_ADDED, "a@qnop.test"))).isFalse();
   }
 }

--- a/qnop-ui/src/pages/ProfilePage.tsx
+++ b/qnop-ui/src/pages/ProfilePage.tsx
@@ -27,7 +27,9 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
 import Snackbar from '@mui/material/Snackbar';
 import Stack from '@mui/material/Stack';
+import MenuItem from '@mui/material/MenuItem';
 import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useAuthStore } from '../stores/authStore';
@@ -49,6 +51,7 @@ import {
 } from '../api/hooks/useUserSettings';
 import { useDisplayTimezone } from '../api/hooks/useDisplayTimezone';
 import { TIMEZONE_SETTING_KEY } from '../utils/timezone';
+import { CADENCE_HELP, CADENCE_OPTIONS, normalizeCadence } from '../utils/reviewMailCadence';
 
 type Toast = { message: string; severity: 'success' | 'error' } | null;
 
@@ -77,8 +80,9 @@ export function ProfilePage() {
   const reviewMailsSetting = settingsQuery.data?.settings.find(
     (setting) => setting.key === EMAIL_REVIEW_NOTIFICATIONS_KEY,
   );
-  // Absent value = registry default (true) — the toggle reflects what the server does.
-  const reviewMailsOn = reviewMailsSetting ? reviewMailsSetting.value !== 'false' : true;
+  // Absent value = registry default, which the server reports in the same list —
+  // so the control shows what will actually happen rather than a guess (#680).
+  const reviewMailsCadence = normalizeCadence(reviewMailsSetting?.value);
 
   // The zone actually applied (own preference → workspace default → UTC); an empty stored
   // value means the user has made no explicit choice yet (issue #465).
@@ -93,13 +97,14 @@ export function ProfilePage() {
     reviews,
     userId,
     hasAvatar: Boolean(avatarUrl),
-    notificationsOn: reviewMailsOn,
+    // Any cadence but OFF counts as being reachable (#680).
+    notificationsOn: reviewMailsCadence !== 'OFF',
   });
   const earnedCount = achievements.filter((a) => a.earned).length;
 
-  const onToggleReviewMails = (checked: boolean) => {
+  const onChangeReviewMails = (cadence: string) => {
     updateSettings.mutate(
-      { [EMAIL_REVIEW_NOTIFICATIONS_KEY]: String(checked) },
+      { [EMAIL_REVIEW_NOTIFICATIONS_KEY]: cadence },
       {
         onError: () => setToast({ message: 'The setting could not be saved.', severity: 'error' }),
       },
@@ -282,17 +287,28 @@ export function ProfilePage() {
           in your discussions, decisions, and status changes.
         </Typography>
         <Divider sx={{ mb: 1.5 }} />
-        <FormControlLabel
-          control={
-            <Switch
-              checked={reviewMailsOn}
-              onChange={(event) => onToggleReviewMails(event.target.checked)}
-              disabled={settingsQuery.isPending}
-              slotProps={{ input: { 'aria-label': 'Email me about review activity' } }}
-            />
-          }
+        {/* Three choices rather than a switch (issue #680): with on/off, the only
+            honest answer on a busy review was off, and then the one mail that
+            mattered was missed along with the ninety that did not. */}
+        <TextField
+          select
           label="Email me about review activity"
-        />
+          value={reviewMailsCadence}
+          onChange={(event) => onChangeReviewMails(event.target.value)}
+          disabled={settingsQuery.isPending}
+          helperText={CADENCE_HELP[reviewMailsCadence]}
+          sx={{ maxWidth: 420 }}
+        >
+          {CADENCE_OPTIONS.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Typography color="text.secondary" sx={{ fontSize: 13, mt: 1.5 }}>
+          Mentions reach you straight away either way — being named personally is the one case where
+          waiting costs something.
+        </Typography>
       </Paper>
 
       {trackingConfigured && (

--- a/qnop-ui/src/utils/reviewMailCadence.test.ts
+++ b/qnop-ui/src/utils/reviewMailCadence.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { normalizeCadence } from './reviewMailCadence';
+
+describe('normalizeCadence (#680)', () => {
+  it('keeps an explicit opt-out an opt-out', () => {
+    // The one outcome the change must not have: somebody who had said no
+    // quietly moving to a daily mail.
+    expect(normalizeCadence('false')).toBe('OFF');
+    expect(normalizeCadence('FALSE')).toBe('OFF');
+  });
+
+  it('maps the legacy opt-in the way migration 0035 does', () => {
+    expect(normalizeCadence('true')).toBe('DAILY');
+  });
+
+  it('reads the current values back', () => {
+    expect(normalizeCadence('IMMEDIATE')).toBe('IMMEDIATE');
+    expect(normalizeCadence(' daily ')).toBe('DAILY');
+    expect(normalizeCadence('OFF')).toBe('OFF');
+  });
+
+  it('falls back to the registry default when nothing is stored', () => {
+    expect(normalizeCadence(undefined)).toBe('DAILY');
+    expect(normalizeCadence('weekly')).toBe('DAILY');
+  });
+});

--- a/qnop-ui/src/utils/reviewMailCadence.ts
+++ b/qnop-ui/src/utils/reviewMailCadence.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * The three cadences for review mail (issue #680), and how to read a stored value.
+ *
+ * <p>Its own module rather than living beside the profile screen: a file that exports both
+ * components and plain functions breaks fast refresh, and this is needed by a test as well.
+ */
+export const CADENCE_OPTIONS = [
+  { value: 'IMMEDIATE', label: 'As it happens' },
+  { value: 'DAILY', label: 'Once a day' },
+  { value: 'OFF', label: 'Never' },
+] as const;
+
+export const CADENCE_HELP: Record<string, string> = {
+  IMMEDIATE: 'One email per event.',
+  DAILY: 'One summary each morning, in your timezone. Nothing is sent on a quiet day.',
+  OFF: 'No review emails. In-app notifications are unaffected.',
+};
+
+/**
+ * Reads a stored value, tolerating the booleans this setting held before it became three-valued.
+ *
+ * <p>The mapping matches migration 0035 exactly — `false` was an explicit opt-out and stays `OFF`,
+ * `true` becomes `DAILY` — so a browser holding a response from before the migration still shows
+ * what the server will actually do.
+ */
+export function normalizeCadence(stored: string | undefined): string {
+  const value = (stored ?? '').trim().toUpperCase();
+  if (value === 'TRUE') return 'DAILY';
+  if (value === 'FALSE') return 'OFF';
+  return CADENCE_OPTIONS.some((option) => option.value === value) ? value : 'DAILY';
+}


### PR DESCRIPTION
Closes #680.

Review mail was per-event, so an active review with four participants produced mail by the hundred and the only control was a boolean. Given that choice on a busy review the honest answer was "off" — and then the one mail that mattered was lost along with the ninety that did not. `EMAIL_REVIEW_NOTIFICATIONS` is now `IMMEDIATE | DAILY | OFF`, and a scheduled job sends one summary per recipient per morning.

## ⚠️ Behaviour change for existing users — for the release notes

The registry default is now `DAILY`. **Accounts that never touched this setting stop getting a mail per event** and get one summary each morning instead. That was a deliberate choice (it is also the largest single lever on outgoing mail volume), but it is visible and should be announced.

The two migrations must ship together: **0035** rewrites the stored values, **0036** adds the watermark table the job needs.

Migration 0035's mapping is deliberately asymmetrical:

| stored | becomes | why |
|---|---|---|
| `false` | `OFF` | An explicit opt-out stays an opt-out. Mailing somebody who had said no is the one outcome this change must not have. |
| `true` | `DAILY` | Ticking a box asked for review mail, not specifically for one per event — that distinction did not exist yet. |

## Decisions worth a reviewer's attention

**A scheduled reader, not a third `ReviewNotificationSink`** — the open question in the issue. A sink is per-event and a digest is per-window, so as a sink it would only ever queue; and the queue already exists, since the in-app sink writes a row for every event regardless of mail preference. The consequence, accepted: a digest can later carry notifications no review sink produced.

**"At or after 08:00 local, at most once per local day", not "the 08:00 run."** The job runs hourly. A single daily run serves one timezone, and an hourly grid alone never lands on 08:00 in Kolkata (02:30 UTC) — "at or after" simply delivers there at 08:30.

**The watermark stores instants, never a local date.** ArchUnit's rule (ADR-0041) forced this and was right for a reason the plan had missed: a stored local date is read against whatever timezone the recipient has *now*, so somebody who travels would get two digests in a day or none. `covered_through` is the newest `createdAt` actually included, never `now()`, or a notification written mid-run would fall into the gap between the query and the update.

**Actor names come from `ReviewIdentityResolver`**, the path the in-app list uses — not from the user row. Under per-review anonymity (ADR-0038) a name belongs to a (review, viewer) pair, and reading it off the account would have leaked the identity the review exists to withhold.

**The job is catalogued `selfTransactional`.** Found while writing the manual test instructions, not by a test: inside the scheduler gate's transaction every watermark would commit at the end of the run, so a crash after fifty recipients rolls back fifty watermarks whose mails are already delivered — and the next run sends them again. Mail cannot be rolled back, so the commit must not be deferred past it.

## Test plan

- [x] `./gradlew build` green; `pnpm lint`, `pnpm format:check`, `tsc`, `pnpm test:run` (1305) and `pnpm build` green
- [x] Timezone cases covered exhaustively as plain unit tests — half-hour offsets, local day rollover, a recipient who changed zone
- [x] Idempotency, dry-run, read-in-app, immediate-recipient and mail content covered by `NotificationDigestIT`
- [ ] Reviewer: send one by hand — Mailpit (`docker compose up -d mailpit`), set the test user's timezone to somewhere it is already past 08:00, then Administration → Scheduler → *Review digest* → Run now. Repeating needs `DELETE FROM notification_digest WHERE recipient_id = …`

🤖 Co-Author: Claude (Opus 5) via Claude Code