### PR TITLE
fix(deps): pin patched undici and ip-address for the generator's dev chain

### DIFF
--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   brace-expansion@<5.0.8: 5.0.9
   shell-quote@<=1.8.4: 1.10.0
+  ip-address@<10.3.1: 10.3.1
+  undici@<7.29.0: 7.29.0
 
 importers:
 
@@ -1928,8 +1930,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   is-alphabetical@2.0.1:
@@ -3038,8 +3040,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -5276,7 +5278,7 @@ snapshots:
       hasown: 2.0.4
       side-channel: 1.1.1
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -5447,7 +5449,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6449,7 +6451,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.3.1
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -6673,7 +6675,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/qnop-ui/pnpm-workspace.yaml
+++ b/qnop-ui/pnpm-workspace.yaml
@@ -14,6 +14,14 @@ allowBuilds:
 # patches only the 5.0.x line, so the two former per-line pins (1.1.16 and
 # 5.0.7) collapse into a single override onto 5.0.8. That is safe for the CJS
 # consumers in the tree: 5.0.8 still publishes a `require` export condition.
+#
+# undici GHSA (cross-user information disclosure) and ip-address GHSA-mwp4-54f8-5fhr
+# (Address4 reads leading-zero octets as decimal where resolvers read octal, so a
+# check and the resolver disagree) join them (issue #701). Both are reachable only
+# through @openapitools/openapi-generator-cli's proxy chain, which runs when the
+# typed client is regenerated and never ships.
 overrides:
   'brace-expansion@<5.0.8': 5.0.9
   'shell-quote@<=1.8.4': 1.10.0
+  'ip-address@<10.3.1': 10.3.1
+  'undici@<7.29.0': 7.29.0


### PR DESCRIPTION
Closes #701.

`pnpm audit --audit-level high` fails on every branch, `main` included, on two advisories published today. No pull request can go green until this lands, which is why it is on its own rather than folded into whatever PR happened to hit it first (#700).

| package | vulnerable | pinned to | reached via |
|---|---|---|---|
| `undici` | `>=7.0.0 <7.29.0` | `7.29.0` | `@openapitools/openapi-generator-cli` proxy chain |
| `ip-address` | `<=10.3.0` | `10.3.1` | `... > socks-proxy-agent > socks > ip-address` |

Both are transitive **dev** dependencies: the generator runs when the typed client is regenerated and never reaches the bundle. The audit is still right to fail — a broken build is the correct answer to an unpatched high — so this fixes the tree rather than lowering `--audit-level`.

They join the overrides already in `pnpm-workspace.yaml` from #557 and #605. Worth knowing: pnpm 11 no longer reads a `pnpm.overrides` block in `package.json` and only warns about it during install, so overrides put there look applied and are not.

Renovate owns versions here (ADR-0017). These are a stopgap and should be dropped once the generator's own tree carries the patched versions.

## Test plan

- [x] `pnpm audit --audit-level high` → *No known vulnerabilities found*
- [x] `pnpm lint`, `pnpm format:check`, `tsc`, `pnpm test:run` (1301) and `pnpm build` green with the overrides applied

## Also in here

A second, unrelated-looking commit: `docs/branding/.gitignore` now covers pnpm's install artefacts. That directory keeps no lock file — `package-lock.json` has been ignored since it was added — but the pnpm equivalents were not, so `pnpm install` there leaves two untracked files that a `git add -A` elsewhere sweeps into whatever commit is being made. That is precisely what happened while making the first commit here, which is why it belongs in this PR rather than a separate one.

🤖 Co-Author: Claude (Opus 5) via Claude Code

