### PR TITLE
chore: ignore pnpm's install artefacts in the branding tools

### DIFF
--- a/docs/branding/.gitignore
+++ b/docs/branding/.gitignore
@@ -1,4 +1,11 @@
 node_modules/
+# No lock file is kept for these tools: the fonts and the generator are pinned in
+# package.json, and the assets they produce are committed rather than rebuilt on
+# demand. pnpm's own artefacts join package-lock.json here — a plain `pnpm install`
+# in this directory writes both, and pnpm-workspace.yaml lands with a placeholder
+# it asks you to fill in, which is not a file anyone meant to keep.
 package-lock.json
+pnpm-lock.yaml
+pnpm-workspace.yaml
 Manrope\[wght\].ttf
 SpaceGrotesk\[wght\].ttf


### PR DESCRIPTION
Follow-up to #701/#702, which merged before this commit reached the branch.

`docs/branding` keeps no lock file — `package-lock.json` has been ignored there since it was added — but the pnpm equivalents were not. A plain `pnpm install` in that directory therefore leaves two untracked files, and a `git add -A` made anywhere in the repo sweeps them into whatever commit is being written. That is exactly what happened while fixing the audit overrides; it was caught by reading the diff, which is not a control I would rely on twice.

`pnpm-workspace.yaml` is the odder of the two: pnpm writes it containing a literal `set this to true or false` placeholder, so it is plainly not a file anyone meant to keep.

## Test plan

- [x] `git status --porcelain --ignored docs/branding/` lists both files as ignored (`!!`)
- [x] No behaviour change outside version control

🤖 Co-Author: Claude (Opus 5) via Claude Code