### PR TITLE
docs: Markdown ingest is Enterprise scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **qnop** — "Qualified Notes on Papers": an enterprise **document review** system. Reviewers (individual users or teams) mark up lines/regions of documents, comment, and run a coordinated review workflow (comments accepted/rejected → new document versions → finalized when no open annotations remain). Open-core: an AGPL Community edition plus commercial add-ons (e.g. AI features) and a possible SaaS.
 
-**Scope of supported formats.** The focus is on reviewing **textual documents first — PDF, DOCX, and Markdown (`.md`)**. Other formats (e.g. images, and later possibly more) may follow once the text workflow is solid; such additional formats are a likely **Enterprise** feature rather than Community scope. Design the ingest/anchoring/rendering seams so a new format is an added implementation, not a core rewrite.
+**Scope of supported formats.** Community reviews **PDF and DOCX**. Everything else — Markdown (`qnop-ee#20`), images, and whatever follows — is **Enterprise** scope and lives in the private `qnop-enterprise` repository. Markdown was Community scope until 2026-08-05; see the amendment in ADR-0010 for what changed and why the seams did not. Design the ingest/anchoring/rendering seams so a new format is an added implementation, not a core rewrite.
 
 Read `docs/ARCHITECTURE.md` and `docs/adr/` first — they hold the binding decisions and rationale.
 
@@ -35,7 +35,7 @@ The Spring Boot server **boots and runs** (PostgreSQL + Liquibase + JPA, ADR-002
 
 The REST contract is OpenAPI-first (ADR-0021); the `qnop-ui` SPA consumes the generated client; `GET /api/v1/config` exposes the running edition.
 
-**Genuinely still pending (do not assume they exist):** Markdown ingest (ADR-0010), enterprise runtime extensions and their packaging (ADR-0039), Redis/search (ADR-0013). `docker-compose.yml` provides local Postgres (+ MinIO) for `bootRun`; the test suite spins up its own Postgres **and MinIO** via **Testcontainers** (Docker required).
+**Genuinely still pending (do not assume they exist):** enterprise runtime extensions and their packaging (ADR-0039), Redis/search (ADR-0013). Markdown ingest is no longer Community work — it moved to the enterprise repository (ADR-0010 amendment). `docker-compose.yml` provides local Postgres (+ MinIO) for `bootRun`; the test suite spins up its own Postgres **and MinIO** via **Testcontainers** (Docker required).
 
 ## Stack
 

--- a/docs/adr/0010-docx-representation-strategy.md
+++ b/docs/adr/0010-docx-representation-strategy.md
@@ -19,6 +19,14 @@ Documents arrive as PDF, DOCX, or Markdown. The browser must render them faithfu
 
 Concretely: the `DocumentExtractor` SPI has a DOCX implementation = "convert to PDF out-of-process, then delegate to the PDF extractor". Markdown takes an HTML path; PDF and images are native.
 
+### Amendment (2026-08-05, qnop-ee#20): Markdown is Enterprise scope
+
+The decision above lists Markdown among the formats Community ingests ("Markdown takes an HTML path"), and issue #344 tracked building that extractor. Both are now wrong about *where*: Markdown moved to the private enterprise repository, so Community reviews PDF and DOCX and nothing else.
+
+What does **not** change is the reasoning. Markdown was always going to be the format that proved the seam, because it is the one that cannot funnel through a PDF conversion the way DOCX does — it has no layout to preserve, so it takes the HTML path this ADR named. That the seam has to carry a format the canonical pipeline does not natively fit is exactly why `DocumentExtractor` is a published SPI (ADR-0003/0046) rather than an internal interface. An enterprise module implementing it is the case this architecture was drawn for, not a departure from it.
+
+The practical consequence for this repository: `GET /api/v1/config` keeps reporting `supportedFormats` from the extractors actually registered, so a deployment with the enterprise module simply advertises one more. Nothing here needs a flag, a branch, or a stub.
+
 ### Amendment (2026-07-30, issue #343): the conversion sits one step before the SPI
 
 Implementing this showed the last sentence to be wrong about *where* the seam goes, and right about everything else.

--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4703,13 +4703,19 @@ components:
         - `DOCX` → `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
         - `MD`   → `text/markdown`
 
-        `PDF`, `DOCX` and `MD` are the Community-scope document formats; further
-        formats are an Enterprise feature. A deployment reports what it can
-        actually ingest in `ServerConfig.supportedFormats`, which is a property of
-        the server rather than of the release: `PDF` always, `DOCX` only where an
-        out-of-process office converter is installed, since that is what turns a
-        Word file into something the viewer can render (ADR-0010). Markdown joins
-        once its extractor ships.
+        `PDF` and `DOCX` are the Community-scope document formats; `MD` and
+        anything further are an Enterprise feature (qnop-ee#20, ADR-0010
+        amendment). `MD` stays in this enum deliberately: the value is the
+        vocabulary a client must understand, not a promise that any given server
+        accepts it.
+
+        What a deployment can actually ingest is reported in
+        `ServerConfig.supportedFormats`, which is a property of the server rather
+        than of the release: `PDF` always; `DOCX` only where an out-of-process
+        office converter is installed, since that is what turns a Word file into
+        something the viewer can render (ADR-0010); `MD` only where an enterprise
+        module has registered an extractor for it. A client that reads that list
+        rather than this enum needs no changes when a deployment gains a format.
       enum:
         - PDF
         - DOCX


### PR DESCRIPTION
Follows the transfer of #344 to the private enterprise repository (`qnop-ee#20`). The documentation called Markdown Community scope, so it had to follow — `CLAUDE.md` is what a contributor reads first, and it was about to tell them to build something that is no longer here.

## What changed

**`CLAUDE.md`** — Community reviews PDF and DOCX; Markdown, images and anything further are Enterprise. Markdown also comes off the "genuinely still pending" list, since it is no longer pending *here*.

**`ADR-0010`** — an amendment, not an edit. The original decision records what was decided in July and stays readable as such. The amendment says what changed and, more usefully, what did not: Markdown was always going to be the format that proved the seam, because it is the one that cannot funnel through a PDF conversion the way DOCX does — no layout to preserve, so it takes the HTML path the ADR named. A published `DocumentExtractor` SPI carrying a format the canonical pipeline does not natively fit is the case that architecture was drawn for, not a departure from it.

**`openapi.yaml`** — prose only. The `MD` enum value **stays**: it is the vocabulary a client must understand, not a promise that a given server accepts it. Removing it would be a breaking change to a published contract and would make the enterprise case unrepresentable. What a deployment actually ingests is `ServerConfig.supportedFormats`, and a client reading that list needs no change when a deployment gains a format — the text now says so, and says where `MD` comes from.

## Test plan

- [x] `./gradlew build` green (the API module regenerates from the changed spec)
- [x] `pnpm test:run` green (1305) — the generated client is unchanged, since the enum is unchanged
- [x] No behaviour change: prose and one ADR amendment

🤖 Co-Author: Claude (Opus 5) via Claude Code