### PR TITLE
docs: link the live demo from README and listing kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![Latest release](https://img.shields.io/github/v/release/qnophq/qnop)](https://github.com/qnophq/qnop/releases)
 [![Docker pulls](https://img.shields.io/docker/pulls/qnophq/qnop-ce)](https://hub.docker.com/r/qnophq/qnop-ce)
 [![License: AGPL-3.0](https://img.shields.io/github/license/qnophq/qnop)](LICENSE)
+[![Live demo](https://img.shields.io/badge/live_demo-demo.qnop.io-1292EE)](https://demo.qnop.io)
+
+> **[Try the live demo →](https://demo.qnop.io)** Sign in as `member`, `nora` or `paul` (password `Test-Pass-1234!`) or take the read-only auditor view with `auditor` — 14 staged reviews with real annotated discussions await. All data resets every 12 hours.
 
 qnop is a self-hosted, enterprise-grade **document review system**. Upload a document, invite reviewers — individual users or whole teams — and run a coordinated review: passages are marked up right in the browser, discussed in threads, accepted or rejected; changes produce new document versions, and the review is finalized once no open annotation remains. The goal: replace the e-mail-attachment-and-comment-spreadsheet workflow with one place where reviews are precise, accountable — and genuinely satisfying to complete.
 

--- a/docs/marketing/listings/README.md
+++ b/docs/marketing/listings/README.md
@@ -25,5 +25,5 @@ when the positioning changes.
 Their guidelines to respect (they ban LLM-spam and sloppy submissions):
 no words like *free/open-source/self-hosted* in the description, sentence
 case, < 250 chars, `(alternative to …)` suffix is the sanctioned way to
-name competitors. A demo instance URL noticeably helps acceptance —
-if `demo.qnop.io` exists by then, add `demo_url`.
+name competitors. The kit already carries `demo_url` — the live demo at
+https://demo.qnop.io noticeably helps acceptance.

--- a/docs/marketing/listings/alternativeto.md
+++ b/docs/marketing/listings/alternativeto.md
@@ -28,6 +28,7 @@ Submit at <https://alternativeto.net/manage-item/> (account required).
 
 **Links:**
 - Website: https://qnop.io
+- Live demo: https://demo.qnop.io (sign in as `member` / `Test-Pass-1234!`; resets every 12 h)
 - Source: https://github.com/qnophq/qnop
 - Docker: https://hub.docker.com/r/qnophq/qnop-ce
 

--- a/docs/marketing/listings/awesome-selfhosted-qnop.yml
+++ b/docs/marketing/listings/awesome-selfhosted-qnop.yml
@@ -1,9 +1,9 @@
 # Ready-to-submit entry for awesome-selfhosted-data (as software/qnop.yml).
 # Submit ON OR AFTER 2026-11-19 (4 months after the first release, their rule).
-# Add demo_url if a public demo instance exists by then.
 name: qnop
 website_url: https://qnop.io/
 source_code_url: https://github.com/qnophq/qnop
+demo_url: https://demo.qnop.io/
 description: Document review platform with line-precise PDF/Word annotations, threaded discussions, version-aware re-anchoring, audit trail and review gamification (alternative to Filestage, PandaDoc).
 licenses:
   - AGPL-3.0

--- a/docs/marketing/listings/saashub.md
+++ b/docs/marketing/listings/saashub.md
@@ -26,5 +26,6 @@ GoVisually, PageProof
 
 **Links:**
 - Website: https://qnop.io
+- Live demo: https://demo.qnop.io (sign in as `member` / `Test-Pass-1234!`; resets every 12 h)
 - Pricing: https://qnop.io/pricing
 - Source: https://github.com/qnophq/qnop


### PR DESCRIPTION
## Summary

demo.qnop.io is live (#710) — surface it where evaluators look first:

- **README**: live-demo badge + a prominent try-it line with the published demo accounts and the 12-hour-reset note
- **awesome-selfhosted kit**: `demo_url` added (their guidelines say a demo noticeably helps acceptance)
- **AlternativeTo / SaaSHub kits**: demo link added to the Links sections

Closes #714

## Test plan

- [x] README renders correctly (badge + quote block)
- [x] Demo credentials in the README match the sign-in banner on demo.qnop.io

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)