### PR TITLE
fix(auth): hide password reset where the deployment does not offer it

### DIFF
--- a/qnop-api/src/main/resources/openapi/openapi.yaml
+++ b/qnop-api/src/main/resources/openapi/openapi.yaml
@@ -4804,9 +4804,18 @@ components:
             Whether the operator has enabled public self-registration (issue #20).
             The backend enforces the gate independently; flipping this client-side
             cannot bypass the controller check.
+        passwordResetEnabled:
+          type: boolean
+          description: |
+            Whether this deployment offers a self-service password reset
+            (`auth.password_reset_enabled`, issue #713). False hides the "Forgot
+            password?" link and the `/forgot-password` screen, and the endpoint
+            refuses — a reset that quietly does nothing is worse than one that is
+            visibly absent, because the sender waits for a mail that never comes.
       required:
         - oidcProviders
         - selfRegistrationEnabled
+        - passwordResetEnabled
     ServerConfigReview:
       type: object
       description: Public review-related configuration.

--- a/qnop-app/src/main/java/io/qnop/web/AuthPasswordResetController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AuthPasswordResetController.java
@@ -35,8 +35,10 @@ import org.springframework.web.server.ResponseStatusException;
  * AuthPasswordResetApi}. Public; the {@code User} entity never reaches this layer — the flow lives
  * in {@link PasswordResetFlowService} (ADR-0004).
  *
- * <p><strong>Anti-enumeration:</strong> {@code forgot-password} always returns {@code 204},
- * disclosing nothing about whether the address is registered.
+ * <p><strong>Anti-enumeration:</strong> where a reset is offered, {@code forgot-password} always
+ * returns {@code 204}, disclosing nothing about whether the address is registered. Where the
+ * deployment offers none it returns {@code 403} instead — which reveals nothing about any person,
+ * only about the instance, and the public config says as much already (issue #713).
  */
 @RestController
 public class AuthPasswordResetController implements AuthPasswordResetApi {
@@ -49,6 +51,12 @@ public class AuthPasswordResetController implements AuthPasswordResetApi {
 
   @Override
   public ResponseEntity<Void> forgotPassword(ForgotPasswordRequest request) {
+    if (!passwordResetFlow.enabled()) {
+      // Refusing beats the silent 204 this used to give: the sender would
+      // otherwise be told a mail was on its way and wait for one that was never
+      // going to be sent.
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "PASSWORD_RESET_DISABLED");
+    }
     passwordResetFlow.requestReset(request.getEmail());
     return ResponseEntity.noContent().build();
   }

--- a/qnop-app/src/main/java/io/qnop/web/ConfigController.java
+++ b/qnop-app/src/main/java/io/qnop/web/ConfigController.java
@@ -122,7 +122,11 @@ public class ConfigController implements ServerConfigApi {
             .auth(
                 new ServerConfigAuth()
                     .oidcProviders(enabledOidcProviders())
-                    .selfRegistrationEnabled(settings.selfRegistrationEnabled()))
+                    .selfRegistrationEnabled(settings.selfRegistrationEnabled())
+                    // So the login page can leave out a link that leads nowhere
+                    // (issue #713).
+                    .passwordResetEnabled(
+                        settings.getBoolean(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED)))
             .review(
                 new ServerConfigReview()
                     .freeReattachEnabled(

--- a/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
+++ b/qnop-app/src/test/java/io/qnop/web/ConfigControllerTest.java
@@ -122,6 +122,9 @@ class ConfigControllerTest {
         .andExpect(jsonPath("$.general.siteName").value("qnop"))
         .andExpect(jsonPath("$.general.defaultTimezone").value("Europe/Berlin"))
         .andExpect(jsonPath("$.auth.selfRegistrationEnabled").value(false))
+        // The login page needs this to decide whether "Forgot password?" leads
+        // anywhere (issue #713).
+        .andExpect(jsonPath("$.auth.passwordResetEnabled").exists())
         .andExpect(jsonPath("$.auth.oidcProviders").isArray())
         .andExpect(jsonPath("$.auth.oidcProviders").isEmpty())
         .andExpect(jsonPath("$.upload.maxDocumentSizeMb").value(50))

--- a/qnop-app/src/test/java/io/qnop/web/SeededPasswordResetIT.java
+++ b/qnop-app/src/test/java/io/qnop/web/SeededPasswordResetIT.java
@@ -20,11 +20,13 @@
  */
 package io.qnop.web;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.qnop.testsupport.SeededIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -39,6 +41,20 @@ import org.springframework.http.MediaType;
 class SeededPasswordResetIT extends SeededIntegrationTest {
 
   private static final String FORGOT = "/api/v1/auth/forgot-password";
+
+  @org.springframework.beans.factory.annotation.Autowired
+  private io.qnop.service.ApplicationSettingsService settings;
+
+  /**
+   * Application settings are shared state that outlives a single test — the service caches them and
+   * the row stays written. A case that switches the reset off therefore has to switch it back, or
+   * every later test in this class runs against a deployment it did not ask for.
+   */
+  @org.junit.jupiter.api.AfterEach
+  void restoreResetSetting() {
+    settings.update(java.util.Map.of("auth.password_reset_enabled", "true"), null);
+  }
+
   private static final String RESET = "/api/v1/auth/reset-password";
 
   @ParameterizedTest
@@ -77,5 +93,46 @@ class SeededPasswordResetIT extends SeededIntegrationTest {
                 .content("{\"token\":\"whatever\",\"newPassword\":\"short\"}"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @DisplayName("a deployment without self-service reset refuses instead of going quiet (#713)")
+  void refusesWhereResetIsDisabled() throws Exception {
+    settings.update(java.util.Map.of("auth.password_reset_enabled", "false"), null);
+
+    // It used to answer 204 and do nothing, so the sender waited for a mail that
+    // was never going to be sent. What is disclosed here is a property of the
+    // instance, which /config publishes anyway — never anything about a person.
+    mockMvc
+        .perform(
+            post(FORGOT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"member@qnop.test\"}"))
+        .andExpect(status().isForbidden());
+
+    mockMvc
+        .perform(get("/api/v1/config"))
+        .andExpect(jsonPath("$.auth.passwordResetEnabled").value(false));
+  }
+
+  @Test
+  @DisplayName("with reset enabled the answer stays uniform, known address or not")
+  void answerStaysUniformWhereResetIsEnabled() throws Exception {
+    settings.update(java.util.Map.of("auth.password_reset_enabled", "true"), null);
+
+    // The anti-enumeration property is the one thing #713 must not have broken:
+    // both of these are 204, and a caller learns nothing from the difference.
+    mockMvc
+        .perform(
+            post(FORGOT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"member@qnop.test\"}"))
+        .andExpect(status().isNoContent());
+    mockMvc
+        .perform(
+            post(FORGOT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"nobody-at-all@qnop.test\"}"))
+        .andExpect(status().isNoContent());
   }
 }

--- a/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
+++ b/qnop-core/src/main/java/io/qnop/service/auth/PasswordResetFlowService.java
@@ -59,12 +59,23 @@ public class PasswordResetFlowService {
     this.settings = settings;
   }
 
+  /** Whether this deployment offers a self-service reset at all (issue #713). */
+  public boolean enabled() {
+    return settings.getBoolean(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED);
+  }
+
   /**
    * Issues a reset token and emails the link, only for an enabled local account. Silent otherwise.
+   *
+   * <p>Silence covers the address, never the feature: a caller learns nothing about whether this
+   * e-mail is registered, but a deployment that offers no reset at all says so (see {@link
+   * #enabled()} and the controller). Those are different secrets — one is about a person, the other
+   * is in the public config already — and conflating them left a sender waiting for a mail that was
+   * never going to arrive.
    */
   @Transactional
   public void requestReset(String email) {
-    if (!settings.getBoolean(ApplicationSettingKey.AUTH_PASSWORD_RESET_ENABLED)) {
+    if (!enabled()) {
       return;
     }
     userService

--- a/qnop-ui/src/pages/auth/ForgotPasswordPage.test.tsx
+++ b/qnop-ui/src/pages/auth/ForgotPasswordPage.test.tsx
@@ -24,16 +24,29 @@ import { fireEvent, screen } from '@testing-library/react';
 import { AxiosError, type AxiosResponse } from 'axios';
 import { axe } from 'vitest-axe';
 import { renderWithProviders } from '../../test/renderWithProviders';
+import { useConfig } from '../../api/hooks/useConfig';
 import { forgotPassword } from '../../api/auth';
 import { ForgotPasswordPage } from './ForgotPasswordPage';
 
 vi.mock('../../api/auth', () => ({ forgotPassword: vi.fn() }));
+vi.mock('../../api/hooks/useConfig', () => ({ useConfig: vi.fn() }));
 const forgotPasswordFn = vi.mocked(forgotPassword);
+
+/** @param passwordResetEnabled undefined leaves the config still loading. */
+function mockConfig(passwordResetEnabled?: boolean) {
+  vi.mocked(useConfig).mockReturnValue({
+    data: passwordResetEnabled === undefined ? undefined : { auth: { passwordResetEnabled } },
+    isLoading: passwordResetEnabled === undefined,
+  } as unknown as ReturnType<typeof useConfig>);
+}
 
 const AXE_OPTIONS = { rules: { region: { enabled: false } } };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The ordinary case: a deployment that offers the reset. Cases about a
+  // deployment without one say so themselves (issue #713).
+  mockConfig(true);
 });
 
 describe('ForgotPasswordPage', () => {
@@ -67,5 +80,23 @@ describe('ForgotPasswordPage', () => {
     const { container } = renderWithProviders(<ForgotPasswordPage />);
 
     expect(await axe(container, AXE_OPTIONS)).toHaveNoViolations();
+  });
+
+  it('sends nobody to the form where the deployment offers no reset (#713)', () => {
+    mockConfig(false);
+    renderWithProviders(<ForgotPasswordPage />);
+
+    // The screen is for a capability this deployment does not have, and the
+    // endpoint refuses anyway — asking for an address first would be theatre.
+    expect(screen.queryByLabelText(/Email/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the form while the config is still loading', () => {
+    // "Not known yet" is not "off": bouncing somebody off a page they are
+    // entitled to would be the worse mistake.
+    mockConfig(undefined);
+    renderWithProviders(<ForgotPasswordPage />);
+
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/pages/auth/ForgotPasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ForgotPasswordPage.tsx
@@ -28,13 +28,15 @@ import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import { Mail } from 'lucide-react';
-import { Link as RouterLink } from 'react-router';
+import { Link as RouterLink, Navigate } from 'react-router';
+import { useConfig } from '../../api/hooks/useConfig';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { forgotPassword } from '../../api/auth';
 import { apiErrorMessage } from '../../utils/apiError';
 
 /** Requests a password-reset email. The response is a uniform acknowledgement. */
 export function ForgotPasswordPage() {
+  const { data: config, isLoading: configLoading } = useConfig();
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -53,6 +55,13 @@ export function ForgotPasswordPage() {
       setSubmitting(false);
     }
   };
+
+  // Same shape as RegisterPage: a screen for a capability the deployment does not
+  // offer is not a screen, and the endpoint refuses anyway (issue #713). Nothing
+  // is decided while the config is still loading — "not known yet" is not "off".
+  if (!configLoading && !config?.auth?.passwordResetEnabled) {
+    return <Navigate to="/login" replace />;
+  }
 
   return (
     <AuthLayout

--- a/qnop-ui/src/pages/auth/LoginPage.test.tsx
+++ b/qnop-ui/src/pages/auth/LoginPage.test.tsx
@@ -34,6 +34,8 @@ vi.mock('../../api/hooks/useConfig', () => ({
 
 interface ConfigShape {
   selfRegistrationEnabled?: boolean;
+  /** Whether the deployment offers a self-service reset (issue #713). */
+  passwordResetEnabled?: boolean;
   oidcProviders?: unknown[];
   /** The operator's sign-in notice (issue #664), when one is configured. */
   banner?: { severity: string; message: string; linkLabel?: string; linkUrl?: string };
@@ -41,11 +43,15 @@ interface ConfigShape {
 
 function mockConfig({
   selfRegistrationEnabled = false,
+  passwordResetEnabled = true,
   oidcProviders = [],
   banner,
 }: ConfigShape = {}) {
   vi.mocked(useConfig).mockReturnValue({
-    data: { auth: { selfRegistrationEnabled, oidcProviders }, banner },
+    data: {
+      auth: { selfRegistrationEnabled, passwordResetEnabled, oidcProviders },
+      banner,
+    },
   } as unknown as ReturnType<typeof useConfig>);
 }
 
@@ -283,5 +289,16 @@ describe('LoginPage', () => {
     renderLogin();
 
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('leaves out the reset link where the deployment offers no reset (#713)', () => {
+    mockConfig({ passwordResetEnabled: false });
+    renderLogin();
+
+    // The link used to lead to a form whose submit was silently swallowed, so the
+    // sender waited for a mail nobody was going to send.
+    expect(screen.queryByRole('link', { name: /Forgot password/ })).not.toBeInTheDocument();
+    // The rest of the form is untouched — this is one capability, not the page.
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/pages/auth/LoginPage.tsx
+++ b/qnop-ui/src/pages/auth/LoginPage.tsx
@@ -65,6 +65,10 @@ export function LoginPage() {
   const [submitting, setSubmitting] = useState(false);
 
   const canRegister = !!config?.auth?.selfRegistrationEnabled;
+  // Issue #713: a deployment may run without self-service reset. The link used to
+  // lead to a form whose submit was silently swallowed, so the sender waited for a
+  // mail nobody was going to send.
+  const canResetPassword = !!config?.auth?.passwordResetEnabled;
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -122,16 +126,18 @@ export function LoginPage() {
               autoComplete="current-password"
               required
             />
-            <Box sx={{ textAlign: 'right', mt: 0.75 }}>
-              <Link
-                component={RouterLink}
-                to="/forgot-password"
-                underline="hover"
-                sx={{ fontSize: 13 }}
-              >
-                Forgot password?
-              </Link>
-            </Box>
+            {canResetPassword && (
+              <Box sx={{ textAlign: 'right', mt: 0.75 }}>
+                <Link
+                  component={RouterLink}
+                  to="/forgot-password"
+                  underline="hover"
+                  sx={{ fontSize: 13 }}
+                >
+                  Forgot password?
+                </Link>
+              </Box>
+            )}
           </Box>
 
           <Button

--- a/qnop-ui/src/pages/auth/ResetPasswordPage.tsx
+++ b/qnop-ui/src/pages/auth/ResetPasswordPage.tsx
@@ -26,6 +26,7 @@ import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import { Link as RouterLink, useSearchParams } from 'react-router';
+import { useConfig } from '../../api/hooks/useConfig';
 import { AuthLayout } from '../../components/auth/AuthLayout';
 import { PasswordField } from '../../components/auth/PasswordField';
 import { PasswordStrengthMeter } from '../../components/auth/PasswordStrengthMeter';
@@ -35,6 +36,9 @@ import { passwordStrength } from '../../utils/passwordStrength';
 
 /** Completes a password reset using the token from the emailed link. */
 export function ResetPasswordPage() {
+  // The reset itself keeps working from a valid link even where the self-service
+  // request is off — an administrator may still hand somebody a link (#713).
+  const canResetPassword = !!useConfig().data?.auth?.passwordResetEnabled;
   const [params] = useSearchParams();
   const token = params.get('token') ?? '';
   const [password, setPassword] = useState('');
@@ -77,10 +81,18 @@ export function ResetPasswordPage() {
       ) : !token ? (
         <>
           <Alert severity="error" sx={{ mb: 2 }}>
-            This link is invalid or incomplete. Please request a new one.
+            {canResetPassword
+              ? 'This link is invalid or incomplete. Please request a new one.'
+              : 'This link is invalid or incomplete, and this deployment does not offer self-service password reset. An administrator can set a new password for you.'}
           </Alert>
-          <Link component={RouterLink} to="/forgot-password" underline="hover">
-            Request a new link
+          {/* Only where there is somewhere to go: pointing at /forgot-password on a
+              deployment without reset would send the reader in a circle (#713). */}
+          <Link
+            component={RouterLink}
+            to={canResetPassword ? '/forgot-password' : '/login'}
+            underline="hover"
+          >
+            {canResetPassword ? 'Request a new link' : 'To sign in'}
           </Link>
         </>
       ) : (


### PR DESCRIPTION
Closes #713.

The sign-in page rendered "Forgot password?" whatever `auth.password_reset_enabled` said. Worse than the issue reports: the flow behind it did not fail. `requestReset` returned early when the setting was off, so the sender got the usual *"if that address exists, a mail is on its way"* and waited for one nobody was going to send. A broken link is visibly broken; this was a confident wrong answer.

## What changed

**`/config`** reports `auth.passwordResetEnabled`, next to `selfRegistrationEnabled` and for the same reason.

**Three places read it** — the link on the sign-in page, the `/forgot-password` screen (redirects to `/login`, the shape `RegisterPage` already uses), and the *"request a new link"* offer on the reset screen, which is exactly what somebody with an expired token is looking at.

**The endpoint refuses with 403** instead of going quiet.

## The bit worth checking

The silent 204 existed to stop account enumeration, so replacing it deserves scrutiny. The two secrets are different:

- *"does this address exist here"* — about a person, still hidden. Where a reset **is** offered, a known and an unknown address both answer 204, and that is now pinned by its own test rather than left as a property nobody asserts.
- *"does this deployment do resets at all"* — about the instance, and `/config` publishes it anyway.

The reset screen still works from a valid link where self-service is off: an administrator may hand somebody one, and only the self-service request goes away.

## Test plan

- [x] `./gradlew build` green; `pnpm lint`, `format:check`, `tsc`, `test:run` (1308) and `build` green
- [x] `SeededPasswordResetIT`: 403 where disabled, and the uniform 204 preserved where enabled
- [x] `LoginPage.test` / `ForgotPasswordPage.test`: link absent, route redirects, and the form still shown while the config is loading — "not known yet" is not "off"
- [ ] Reviewer: on demo.qnop.io (`auth.password_reset_enabled=false`) the link should be gone and `/forgot-password` should land on `/login`

🤖 Co-Author: Claude (Opus 5) via Claude Code