### PR TITLE
feat(tracking): opt-in 'full' for tracking.forward_client_ip

### DIFF
--- a/docs/adr/0056-usage-tracking.md
+++ b/docs/adr/0056-usage-tracking.md
@@ -41,6 +41,22 @@ The server checks again on every forwarded measurement (`TrackedUrlSanitizer`): 
 
 Proxying raises a question direct measurement never asks. Forward nothing and the backend counts a whole company as one visitor; forward the real address and proxying has withheld nothing. So `X-Forwarded-For` carries the address truncated to its /24 (IPv4) or /64 (IPv6) — Matomo's own anonymisation, and the long-standing middle ground of German data-protection practice. `tracking.forward_client_ip=none` remains available, with distorted counts as the stated cost.
 
+### Amendment (2026-08-05, issue #712): a third option, opt-in
+
+Running the public demo produced a need the pair above could not express. The operator wanted to see exact addresses **in their own Umami instance** — to tell a returning evaluator from a bot, and to line abuse up with what the logs already show. Under the original two options the only way there was to stop proxying, which would have given up every other protection at once.
+
+So `tracking.forward_client_ip` takes a third value, `full`. Three things make that defensible rather than a hole in the floor:
+
+- **It is opt-in and never a default.** Existing deployments are untouched, and an unreadable setting value falls to `anonymized` — the fallback direction is deliberate, because a typo must not start forwarding personal data.
+- **It loosens exactly one thing.** Consent and Do-Not-Track keep applying as configured; the path anonymisation, the collect allowlist and the SSRF checks are unaffected. A test pins this rather than leaving it as an intention.
+- **It is not a disclosure to a third party.** The self-hosted case sends the address to the operator's own analytics instance — the same operator whose web server already logged it. What changes is which of their systems sees it, and that is a decision they are entitled to make under their own legal basis.
+
+The wording follows `tracking.consent_required`: the setting says plainly that the legal basis, the consent record and the retention are the operator's to hold, and the admin screen repeats it where the choice is made rather than only in a document nobody has open.
+
+One thing this amendment does **not** provide, and an operator relying on it should know: changing an application setting currently leaves no audit trail, so "when did this deployment start forwarding full addresses, and who decided" is not answerable from qnop today. That gap is tracked in issue #718.
+
+**A note on the mechanism.** `full` parses the address and re-emits it canonically rather than passing the resolved string through. That is not tidiness: behind a trusted proxy, `X-Forwarded-For` carries whatever that proxy passed along, and the truncating path only validated it as a side effect of having to understand it. Forwarding raw would have put unvalidated foreign text into an outgoing header.
+
 ### Four gates, any of which says no
 
 Operator configuration, Do-Not-Track/GPC, the account-level opt-out, and consent. All four must agree before a script tag is even created. The consent answer lives in the browser (the sign-in screen is measured, and nobody has an account yet at that point); the opt-out lives on the account, so it follows a person across devices and outlives a cleared browser store. Administrators and auditors are excluded unless an operator explicitly includes them — a handful of privileged people is barely a statistic and very much personal data.

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
@@ -119,8 +119,10 @@ public enum ApplicationSettingKey {
       "anonymized",
       "What reaches the backend as the visitor's address. 'anonymized' truncates it (IPv4 to /24,"
           + " IPv6 to /64) so visitors stay countable without being identifiable; 'none' sends"
-          + " nothing, and the backend then sees every reviewer as one visitor.",
-      List.of("anonymized", "none")),
+          + " nothing, and the backend then sees every reviewer as one visitor; 'full' sends the"
+          + " exact address. A full address is personal data: the legal basis, the consent and the"
+          + " retention are the operator's call, not this server's (issue #712).",
+      List.of("anonymized", "none", "full")),
   SMTP_ENABLED(
       "smtp.enabled",
       SettingValueType.BOOLEAN,

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingKey.java
@@ -76,7 +76,7 @@ public enum ApplicationSettingKey {
       "false",
       "Whether anonymous usage tracking is enabled. Measurement runs through this server, never"
           + " past it: the browser loads the analytics script from qnop and sends its events to"
-          + " qnop, which forwards them (issue #666)."),
+          + " qnop, which forwards them. Visitors never talk to the analytics backend directly."),
   TRACKING_PROVIDER(
       "tracking.provider",
       SettingValueType.ENUM,
@@ -117,11 +117,10 @@ public enum ApplicationSettingKey {
       "tracking.forward_client_ip",
       SettingValueType.ENUM,
       "anonymized",
-      "What reaches the backend as the visitor's address. 'anonymized' truncates it (IPv4 to /24,"
-          + " IPv6 to /64) so visitors stay countable without being identifiable; 'none' sends"
-          + " nothing, and the backend then sees every reviewer as one visitor; 'full' sends the"
-          + " exact address. A full address is personal data: the legal basis, the consent and the"
-          + " retention are the operator's call, not this server's (issue #712).",
+      "How much of a visitor's IP address is passed on to your analytics backend. Anonymised"
+          + " shortens it, so visitors stay countable without being identifiable. Not forwarded"
+          + " means the backend counts everyone as a single visitor. Full sends the exact address,"
+          + " which is personal data — you need your own legal basis for it.",
       List.of("anonymized", "none", "full")),
   SMTP_ENABLED(
       "smtp.enabled",

--- a/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
@@ -60,8 +60,8 @@ public enum UserSettingKey {
       "email_review_notifications",
       SettingValueType.ENUM,
       "DAILY",
-      "When to email about review activity: IMMEDIATE per event, DAILY as one"
-          + " morning summary, or OFF (issues #316/#680).",
+      "How often to email you about activity in your reviews: as it happens, once a day as a"
+          + " morning digest, or never. Mentions reach you straight away either way.",
       List.of("IMMEDIATE", "DAILY", "OFF")),
   // Separate from the general review-activity toggle: a mention is a direct "you are needed here"
   // signal, so it carries its own opt-out and is not silenced by turning off general thread mail
@@ -70,7 +70,8 @@ public enum UserSettingKey {
       "email_mentions",
       SettingValueType.BOOLEAN,
       "true",
-      "Receive an email when someone @mentions you in a review (issue #462)."),
+      "Receive an email when someone @mentions you in a review. Kept separate from general review"
+          + " activity, so muting the rest does not mute being addressed personally."),
   // Tied to the account rather than the browser (issue #666): somebody who has
   // opted out has opted out on their laptop and their tablet, and a cleared
   // browser store must not quietly re-enrol them.
@@ -78,7 +79,7 @@ public enum UserSettingKey {
       "usage_tracking_opt_out",
       SettingValueType.BOOLEAN,
       "false",
-      "Exclude me from anonymous usage measurement, on every device I sign in from (issue #666).");
+      "Exclude me from anonymous usage measurement, on every device I sign in from.");
 
   private static final Map<String, UserSettingKey> BY_KEY =
       Arrays.stream(values())

--- a/qnop-core/src/main/java/io/qnop/service/tracking/ClientIpFormatter.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/ClientIpFormatter.java
@@ -35,15 +35,53 @@ import java.util.Optional;
  * anonymisation does and what German data-protection authorities have long treated as the workable
  * middle. Visitors stay countable; individuals do not stay identifiable.
  */
-public final class ClientIpAnonymizer {
+public final class ClientIpFormatter {
 
-  private ClientIpAnonymizer() {}
+  private ClientIpFormatter() {}
 
   /**
-   * Returns the truncated form of {@code ip}, or empty when it is missing or unparseable — in which
-   * case nothing is forwarded, because a half-understood address is not worth guessing at.
+   * The exact address, canonicalised — for {@code tracking.forward_client_ip=full} (issue #712).
+   *
+   * <p>It parses just as {@link #anonymize} does, and that is the point rather than tidiness. The
+   * resolved address is only trustworthy as far as the proxy in front of this server is: behind
+   * one, {@code X-Forwarded-For} carries whatever that proxy passed along. Forwarding the raw
+   * string would put unvalidated foreign text into an outgoing header, and until now nothing had to
+   * say so because truncating an address requires understanding it first.
+   */
+  public static Optional<String> normalize(String ip) {
+    return parse(ip).map(InetAddress::getHostAddress);
+  }
+
+  /**
+   * The address truncated to its /24 (IPv4) or /64 (IPv6) — the default, and the recommendation.
    */
   public static Optional<String> anonymize(String ip) {
+    return parse(ip)
+        .flatMap(
+            parsed -> {
+              byte[] address = parsed.getAddress();
+              if (address.length == 4) {
+                address[3] = 0;
+              } else if (address.length == 16) {
+                for (int i = 8; i < 16; i++) {
+                  address[i] = 0;
+                }
+              } else {
+                return Optional.empty();
+              }
+              try {
+                return Optional.of(InetAddress.getByAddress(address).getHostAddress());
+              } catch (UnknownHostException e) {
+                return Optional.empty();
+              }
+            });
+  }
+
+  /**
+   * Parses a literal address, or empty when it is missing or unparseable — in which case nothing is
+   * forwarded in any mode, because a half-understood address is not worth guessing at.
+   */
+  private static Optional<InetAddress> parse(String ip) {
     if (ip == null || ip.isBlank()) {
       return Optional.empty();
     }
@@ -51,27 +89,12 @@ public final class ClientIpAnonymizer {
     if (value.startsWith("[") && value.endsWith("]")) {
       value = value.substring(1, value.length() - 1);
     }
-    byte[] address;
     try {
       // Literal only: this must never trigger a DNS lookup on a request path.
       if (!isIpLiteral(value)) {
         return Optional.empty();
       }
-      address = InetAddress.getByName(value).getAddress();
-    } catch (UnknownHostException e) {
-      return Optional.empty();
-    }
-    if (address.length == 4) {
-      address[3] = 0;
-    } else if (address.length == 16) {
-      for (int i = 8; i < 16; i++) {
-        address[i] = 0;
-      }
-    } else {
-      return Optional.empty();
-    }
-    try {
-      return Optional.of(InetAddress.getByAddress(address).getHostAddress());
+      return Optional.of(InetAddress.getByName(value));
     } catch (UnknownHostException e) {
       return Optional.empty();
     }

--- a/qnop-core/src/main/java/io/qnop/service/tracking/ClientIpForwarding.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/ClientIpForwarding.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * How much of the visitor's address travels to the analytics backend (issues #666/#712).
+ *
+ * <p>Three settings rather than two, because a self-hosted operator turned out to need a case the
+ * pair could not express: seeing exact addresses in their <em>own</em> analytics instance, to tell
+ * a returning evaluator from a bot. That is not a disclosure to a third party — but it is personal
+ * data, so it is opt-in and never the default.
+ */
+public enum ClientIpForwarding {
+  /** Nothing travels; the backend counts every visitor as one. */
+  NONE,
+  /** Truncated to /24 or /64 — countable without being identifiable. The default. */
+  ANONYMIZED,
+  /** The exact address. Personal data, and the operator's legal basis to hold. */
+  FULL;
+
+  /** Reads the stored setting value, defaulting to {@link #ANONYMIZED} for anything unexpected. */
+  public static ClientIpForwarding parse(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return ANONYMIZED;
+    }
+    return switch (raw.trim().toLowerCase(Locale.ROOT)) {
+      case "none" -> NONE;
+      case "full" -> FULL;
+      // Including "anonymized" and anything unrecognised: an unreadable value must
+      // fall to the privacy-preserving option, never to the loosest one.
+      default -> ANONYMIZED;
+    };
+  }
+
+  /**
+   * What to put in {@code X-Forwarded-For}, or empty when nothing should travel.
+   *
+   * <p>Both modes that send anything parse first, so an address this server could not understand is
+   * forwarded in no mode at all.
+   */
+  public Optional<String> format(String clientIp) {
+    return switch (this) {
+      case NONE -> Optional.empty();
+      case ANONYMIZED -> ClientIpFormatter.anonymize(clientIp);
+      case FULL -> ClientIpFormatter.normalize(clientIp);
+    };
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingConfigService.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingConfigService.java
@@ -104,8 +104,8 @@ public class TrackingConfigService {
             settings.getBoolean(ApplicationSettingKey.TRACKING_CONSENT_REQUIRED),
             settings.getBoolean(ApplicationSettingKey.TRACKING_RESPECT_DNT),
             settings.getBoolean(ApplicationSettingKey.TRACKING_PRIVILEGED_ROLES),
-            "anonymized"
-                .equals(settings.getString(ApplicationSettingKey.TRACKING_FORWARD_CLIENT_IP))));
+            ClientIpForwarding.parse(
+                settings.getString(ApplicationSettingKey.TRACKING_FORWARD_CLIENT_IP))));
   }
 
   private static String trimTrailingSlash(String value) {

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProxyService.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingProxyService.java
@@ -187,10 +187,12 @@ public class TrackingProxyService {
     if (userAgent != null && !userAgent.isBlank()) {
       request.header("User-Agent", userAgent);
     }
-    if (active.forwardClientIp()) {
-      ClientIpAnonymizer.anonymize(clientIp)
-          .ifPresent(truncated -> request.header("X-Forwarded-For", truncated));
-    }
+    // Truncated, exact or nothing (issues #666/#712) — and in every case parsed
+    // first, so an address this server could not read travels in no mode at all.
+    active
+        .forwardClientIp()
+        .format(clientIp)
+        .ifPresent(forwarded -> request.header("X-Forwarded-For", forwarded));
 
     try {
       HttpResponse<Void> response =

--- a/qnop-core/src/main/java/io/qnop/service/tracking/TrackingRuntimeConfig.java
+++ b/qnop-core/src/main/java/io/qnop/service/tracking/TrackingRuntimeConfig.java
@@ -34,7 +34,8 @@ package io.qnop.service.tracking;
  * @param consentRequired whether the client must ask before loading anything
  * @param respectDnt whether a Do-Not-Track browser is left alone
  * @param trackPrivilegedRoles whether administrators and auditors are measured too
- * @param forwardClientIp whether a truncated visitor address travels with each measurement
+ * @param forwardClientIp how much of the visitor's address travels with each measurement (issue
+ *     #712): nothing, truncated, or exact
  */
 public record TrackingRuntimeConfig(
     TrackingProvider provider,
@@ -44,4 +45,4 @@ public record TrackingRuntimeConfig(
     boolean consentRequired,
     boolean respectDnt,
     boolean trackPrivilegedRoles,
-    boolean forwardClientIp) {}
+    ClientIpForwarding forwardClientIp) {}

--- a/qnop-core/src/test/java/io/qnop/service/tracking/ClientIpFormatterTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/ClientIpFormatterTest.java
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /** Truncating the visitor address that the proxy forwards (issue #666). */
-class ClientIpAnonymizerTest {
+class ClientIpFormatterTest {
 
   @Test
   @DisplayName("IPv4 keeps its network, loses its host")
   void truncatesIpv4() {
-    assertThat(ClientIpAnonymizer.anonymize("203.0.113.42")).contains("203.0.113.0");
-    assertThat(ClientIpAnonymizer.anonymize("10.1.2.3")).contains("10.1.2.0");
+    assertThat(ClientIpFormatter.anonymize("203.0.113.42")).contains("203.0.113.0");
+    assertThat(ClientIpFormatter.anonymize("10.1.2.3")).contains("10.1.2.0");
   }
 
   @Test
@@ -40,7 +40,7 @@ class ClientIpAnonymizerTest {
   void truncatesIpv6() {
     // A /64 is one subscriber line, not one device — the same trade the IPv4 /24
     // makes, at the size IPv6 hands out.
-    assertThat(ClientIpAnonymizer.anonymize("2001:db8:85a3:1:1a2b:3c4d:5e6f:7a8b"))
+    assertThat(ClientIpFormatter.anonymize("2001:db8:85a3:1:1a2b:3c4d:5e6f:7a8b"))
         .hasValueSatisfying(
             value -> assertThat(value).startsWith("2001:db8:85a3:1:").endsWith("0:0:0:0"));
   }
@@ -48,17 +48,17 @@ class ClientIpAnonymizerTest {
   @Test
   @DisplayName("brackets around an IPv6 literal are tolerated")
   void tolerName() {
-    assertThat(ClientIpAnonymizer.anonymize("[2001:db8::1]")).isPresent();
+    assertThat(ClientIpFormatter.anonymize("[2001:db8::1]")).isPresent();
   }
 
   @Test
   @DisplayName("forwards nothing rather than guessing")
   void failsClosed() {
-    assertThat(ClientIpAnonymizer.anonymize(null)).isEmpty();
-    assertThat(ClientIpAnonymizer.anonymize("")).isEmpty();
-    assertThat(ClientIpAnonymizer.anonymize("not-an-ip")).isEmpty();
+    assertThat(ClientIpFormatter.anonymize(null)).isEmpty();
+    assertThat(ClientIpFormatter.anonymize("")).isEmpty();
+    assertThat(ClientIpFormatter.anonymize("not-an-ip")).isEmpty();
     // A hostname must never be resolved on a request path, so it is simply refused.
-    assertThat(ClientIpAnonymizer.anonymize("analytics.example.com")).isEmpty();
-    assertThat(ClientIpAnonymizer.anonymize("999.1.1.1")).isEmpty();
+    assertThat(ClientIpFormatter.anonymize("analytics.example.com")).isEmpty();
+    assertThat(ClientIpFormatter.anonymize("999.1.1.1")).isEmpty();
   }
 }

--- a/qnop-core/src/test/java/io/qnop/service/tracking/ClientIpForwardingTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/ClientIpForwardingTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.service.tracking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** What each mode puts on the wire (issue #712). */
+class ClientIpForwardingTest {
+
+  @Test
+  @DisplayName("full forwards the exact address, anonymized truncates, none sends nothing")
+  void modesDiffer() {
+    assertThat(ClientIpForwarding.FULL.format("203.0.113.42")).contains("203.0.113.42");
+    assertThat(ClientIpForwarding.ANONYMIZED.format("203.0.113.42")).contains("203.0.113.0");
+    assertThat(ClientIpForwarding.NONE.format("203.0.113.42")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("an address this server cannot read travels in no mode, full included")
+  void unparseableTravelsNowhere() {
+    // The guarantee that made the raw-passthrough shortcut unacceptable: behind a
+    // trusted proxy, X-Forwarded-For carries whatever that proxy passed along, and
+    // it would otherwise reach an outgoing header unread.
+    for (String bad :
+        new String[] {null, "", "   ", "not-an-address", "203.0.113.999", "evil\r\nX-Foo: bar"}) {
+      assertThat(ClientIpForwarding.FULL.format(bad)).as("FULL(%s)", bad).isEmpty();
+      assertThat(ClientIpForwarding.ANONYMIZED.format(bad)).as("ANONYMIZED(%s)", bad).isEmpty();
+    }
+  }
+
+  @Test
+  @DisplayName("an IPv6 address survives full and loses its host half when anonymized")
+  void ipv6() {
+    String address = "2001:db8:85a3:1:1a2b:3c4d:5e6f:7a8b";
+
+    assertThat(ClientIpForwarding.FULL.format(address)).isPresent();
+    assertThat(ClientIpForwarding.ANONYMIZED.format(address))
+        .hasValueSatisfying(value -> assertThat(value).doesNotContain("7a8b"));
+  }
+
+  @Test
+  @DisplayName("an unreadable setting falls to anonymized, never to full")
+  void parseFallsToThePrivacyPreservingOption() {
+    // The direction of the fallback is the point: a typo in a settings row must not
+    // start forwarding personal data.
+    assertThat(ClientIpForwarding.parse("full")).isEqualTo(ClientIpForwarding.FULL);
+    assertThat(ClientIpForwarding.parse("FULL")).isEqualTo(ClientIpForwarding.FULL);
+    assertThat(ClientIpForwarding.parse("none")).isEqualTo(ClientIpForwarding.NONE);
+    assertThat(ClientIpForwarding.parse("anonymized")).isEqualTo(ClientIpForwarding.ANONYMIZED);
+    assertThat(ClientIpForwarding.parse("nonsense")).isEqualTo(ClientIpForwarding.ANONYMIZED);
+    assertThat(ClientIpForwarding.parse(null)).isEqualTo(ClientIpForwarding.ANONYMIZED);
+  }
+}

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackingConfigServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackingConfigServiceTest.java
@@ -67,7 +67,7 @@ class TrackingConfigServiceTest {
               assertThat(config.provider()).isEqualTo(TrackingProvider.PLAUSIBLE);
               assertThat(config.scriptUrl()).isEqualTo("https://plausible.io/js/script.manual.js");
               assertThat(config.collectBaseUrl()).isEqualTo("https://plausible.io");
-              assertThat(config.forwardClientIp()).isTrue();
+              assertThat(config.forwardClientIp()).isEqualTo(ClientIpForwarding.ANONYMIZED);
             });
   }
 
@@ -136,6 +136,24 @@ class TrackingConfigServiceTest {
   void forwardIpIsOptional() {
     when(settings.getString(ApplicationSettingKey.TRACKING_FORWARD_CLIENT_IP)).thenReturn("none");
     assertThat(service(false).current())
-        .hasValueSatisfying(c -> assertThat(c.forwardClientIp()).isFalse());
+        .hasValueSatisfying(
+            c -> assertThat(c.forwardClientIp()).isEqualTo(ClientIpForwarding.NONE));
+  }
+
+  @Test
+  @DisplayName("choosing full addresses loosens nothing else (#712)")
+  void fullAddressesLeaveTheOtherGatesAlone() {
+    when(settings.getString(ApplicationSettingKey.TRACKING_FORWARD_CLIENT_IP)).thenReturn("full");
+
+    // The promise attached to the opt-in: consent and Do-Not-Track keep applying
+    // exactly as configured. They are separate settings, and this pins that they
+    // stay separate rather than being read together by some later convenience.
+    assertThat(service(false).current())
+        .hasValueSatisfying(
+            config -> {
+              assertThat(config.forwardClientIp()).isEqualTo(ClientIpForwarding.FULL);
+              assertThat(config.consentRequired()).isTrue();
+              assertThat(config.respectDnt()).isTrue();
+            });
   }
 }

--- a/qnop-core/src/test/java/io/qnop/service/tracking/TrackingProxyServiceTest.java
+++ b/qnop-core/src/test/java/io/qnop/service/tracking/TrackingProxyServiceTest.java
@@ -88,7 +88,7 @@ class TrackingProxyServiceTest {
                     false,
                     false,
                     false,
-                    true)));
+                    ClientIpForwarding.ANONYMIZED)));
     proxy = new TrackingProxyService(config, defaults());
   }
 
@@ -140,7 +140,7 @@ class TrackingProxyServiceTest {
                     false,
                     false,
                     false,
-                    true)));
+                    ClientIpForwarding.ANONYMIZED)));
 
     proxy.forward(
         "POST",

--- a/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.test.tsx
+++ b/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.test.tsx
@@ -42,6 +42,15 @@ const settings: AdminSetting[] = [
     sensitive: false,
   },
   {
+    // The opt-in that loosens a privacy floor (issue #712).
+    key: 'tracking.forward_client_ip',
+    value: 'full',
+    type: 'ENUM' as AdminSetting['type'],
+    description: 'What reaches the backend as the visitor address.',
+    sensitive: false,
+    allowedValues: ['anonymized', 'none', 'full'],
+  },
+  {
     // Governed by a capability the operator withheld (issue #681): shown,
     // because the ceiling is the answer to "why was my file refused", but not
     // editable here.
@@ -85,5 +94,18 @@ describe('ApplicationSettingsForm — default timezone', () => {
     expect(screen.getByText(/Set by this deployment/)).toBeInTheDocument();
     // Ungoverned settings are untouched — the form is not read-only wholesale.
     expect(screen.getByRole('textbox', { name: /application name/i })).toBeEnabled();
+  });
+
+  it('warns where the operator chose to forward exact addresses (#712)', () => {
+    renderWithProviders(<ApplicationSettingsForm />);
+
+    // Said where the choice is made, not only in a document nobody has open —
+    // and it names the duties rather than second-guessing the decision.
+    const warning = screen.getByText(/Exact addresses are personal data/);
+    expect(warning).toBeInTheDocument();
+    expect(screen.getByText(/legal basis/)).toBeInTheDocument();
+    // The other gates are explicitly said to survive, which is the promise the
+    // opt-in was granted on.
+    expect(screen.getByText(/Do-Not-Track keep applying/)).toBeInTheDocument();
   });
 });

--- a/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
+++ b/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.tsx
@@ -125,6 +125,7 @@ const SELECT_OPTIONS: Record<string, { value: string; label: string }[]> = {
   'tracking.forward_client_ip': [
     { value: 'anonymized', label: 'Anonymised (recommended)' },
     { value: 'none', label: 'Do not forward' },
+    { value: 'full', label: 'Full address (personal data)' },
   ],
   'auth.self_registration_default_role': [
     { value: 'MEMBER', label: 'Member' },
@@ -443,6 +444,11 @@ function SettingField({ setting, value, error, onChange }: SettingFieldProps) {
   // means editable.
   const locked = setting.editable === false;
   const lockNote = 'Set by this deployment.';
+  // Issue #712: an opt-in that loosens a privacy floor should say so where it is
+  // chosen, not only in a document nobody has open. Shown on the current value
+  // rather than as a confirmation dialog — the operator has decided; what they
+  // need is the list of duties that come with the decision.
+  const forwardsFullAddress = setting.key === 'tracking.forward_client_ip' && value === 'full';
 
   if (setting.type === 'BOOLEAN') {
     return (
@@ -488,22 +494,32 @@ function SettingField({ setting, value, error, onChange }: SettingFieldProps) {
   const options = optionsFor(setting);
   if (options) {
     return (
-      <TextField
-        select
-        label={label}
-        value={value}
-        disabled={locked}
-        onChange={(e) => onChange(e.target.value)}
-        error={Boolean(error)}
-        helperText={error ?? (locked ? `${setting.description} ${lockNote}` : setting.description)}
-        sx={{ maxWidth: 480 }}
-      >
-        {options.map((option) => (
-          <MenuItem key={option.value} value={option.value}>
-            {option.label}
-          </MenuItem>
-        ))}
-      </TextField>
+      <Stack spacing={1.5} sx={{ maxWidth: 480 }}>
+        <TextField
+          select
+          label={label}
+          value={value}
+          disabled={locked}
+          onChange={(e) => onChange(e.target.value)}
+          error={Boolean(error)}
+          helperText={
+            error ?? (locked ? `${setting.description} ${lockNote}` : setting.description)
+          }
+        >
+          {options.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </TextField>
+        {forwardsFullAddress && (
+          <Alert severity="warning">
+            Exact addresses are personal data. The legal basis, the consent record and the retention
+            period are yours to hold — this server only forwards what you configure here. Consent
+            and Do-Not-Track keep applying as you set them.
+          </Alert>
+        )}
+      </Stack>
     );
   }
 


### PR DESCRIPTION
Closes #712.

Running the public demo produced a need the existing `anonymized | none` pair could not express: the operator wants to see exact addresses **in their own Umami instance**, to tell a returning evaluator from a bot and to line abuse up with what their logs already show. Under the two options the only route there was to stop proxying, which would have given up every other protection at once.

## Why this is not a hole in the floor

- **Opt-in, never a default** — and an unreadable setting value falls to `anonymized`. The direction of that fallback is deliberate: a typo in a settings row must not start forwarding personal data.
- **It loosens exactly one thing** — consent and Do-Not-Track keep applying as configured, and a test pins that rather than leaving it as an intention. Path anonymisation, the collect allowlist and the SSRF checks are untouched.
- **Not a disclosure to a third party** — the self-hosted case sends the address to the operator's own analytics instance, the same operator whose web server already logged it. What changes is which of their systems sees it, under their own legal basis.

## The part worth reviewing closely

`full` **parses** the address and re-emits it canonically rather than passing the resolved string through. Behind a trusted proxy, `X-Forwarded-For` carries whatever that proxy passed along, and the truncating path only ever validated it as a side effect of having to understand it in order to truncate. A naive `full` would have put unvalidated foreign text into an outgoing header; `ClientIpForwardingTest` feeds it a CRLF injection among other junk and asserts that nothing travels in any mode.

Refactors that come with it, both internal — the published contract never exposed this setting: `ClientIpAnonymizer` → `ClientIpFormatter` (it now also produces the exact address), and `TrackingRuntimeConfig.forwardClientIp` from `boolean` to a three-valued `ClientIpForwarding`.

## What this does not provide

Changing an application setting leaves **no audit trail** today, so "when did this deployment start forwarding full addresses, and who decided" is not answerable from qnop. That is out of scope here and tracked in **#718**; the ADR amendment states it plainly, because an operator documenting a legal basis should not discover it later.

## Test plan

- [x] `./gradlew build` green; `pnpm lint`, `format:check`, `tsc`, `test:run` (1309) and `build` green
- [x] Each mode's wire format, unparseable input in every mode, IPv6, and the fallback direction
- [x] Consent and DNT unchanged when `full` is selected
- [x] The admin screen warns where the choice is made
- [ ] Reviewer: with `full` on the demo, confirm Umami records the exact address and that a DNT browser is still not measured

🤖 Co-Author: Claude (Opus 5) via Claude Code