### PR TITLE
docs: track directory-listing submission windows and submitted state

### DIFF
--- a/docs/marketing/listings/README.md
+++ b/docs/marketing/listings/README.md
@@ -9,9 +9,25 @@ when the positioning changes.
 | Directory | Status | Kit |
 |---|---|---|
 | [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted-data) | ⏳ **Blocked until 2026-11-19** — their rule: *"first released more than 4 months ago"* (qnop v1.0.0: 2026-07-19) | [awesome-selfhosted-qnop.yml](awesome-selfhosted-qnop.yml) |
-| [AlternativeTo](https://alternativeto.net/manage-item/) | Ready — needs an AlternativeTo account | [alternativeto.md](alternativeto.md) |
-| [selfh.st](https://selfh.st/apps/) | Ready — submit via their apps-list GitHub repo or contact form | [selfhst.md](selfhst.md) |
-| [SaaSHub](https://www.saashub.com/submit) | Ready — needs a SaaSHub account | [saashub.md](saashub.md) |
+| [AlternativeTo](https://alternativeto.net/manage-item/) | ⏳ **Blocked until 2026-08-09, 10:32 (Europe/Stockholm)** — new-app submissions require an account age of 7+ days; the account exists, so this is a pure waiting period | [alternativeto.md](alternativeto.md) |
+| [selfh.st](https://selfh.st/apps/) | ✅ **Submitted** via their Project Launch form — awaiting listing | [selfhst.md](selfhst.md) |
+| [SaaSHub](https://www.saashub.com/submit) | ✅ **Submitted**, ownership verified — awaiting listing | [saashub.md](saashub.md) |
+
+Two of the four directories gate submission on elapsed time rather than on
+content, so those kits sit finished until their window opens. Both waiting
+periods carry the exact moment they expire; an earlier attempt only burns a
+moderation slot.
+
+## AlternativeTo — how to submit (on/after 2026-08-09, 10:32 Europe/Stockholm)
+
+1. Sign in with the existing account — the 7-day age requirement is counted
+   from account creation, so the timestamp above is when it becomes eligible,
+   not when the submission is due.
+2. Open <https://alternativeto.net/manage-item/> and paste the fields from
+   [alternativeto.md](alternativeto.md).
+3. Add the alternatives and tags from the kit; they drive most of the
+   discovery traffic on that site.
+4. Upload the screenshots named in the kit and submit for moderation.
 
 ## awesome-selfhosted — how to submit (on/after 2026-11-19)
 

--- a/docs/marketing/listings/alternativeto.md
+++ b/docs/marketing/listings/alternativeto.md
@@ -4,6 +4,10 @@
 
 Submit at <https://alternativeto.net/manage-item/> (account required).
 
+> **Not yet submitted** — new-app submissions need an account age of 7+ days,
+> so the earliest possible attempt is **2026-08-09, 10:32 (Europe/Stockholm)**.
+> See the status table in [README.md](README.md).
+
 **Name:** qnop
 
 **Tagline (short):** Self-hosted document review with line-precise annotations

--- a/docs/marketing/listings/saashub.md
+++ b/docs/marketing/listings/saashub.md
@@ -4,6 +4,10 @@
 
 Submit at <https://www.saashub.com/submit> (account required).
 
+> **Already submitted** and ownership-verified — awaiting listing. Keep this
+> kit as the reference for later edits instead of submitting again. See the
+> status table in [README.md](README.md).
+
 **Name:** qnop
 
 **Tagline:** Self-hosted document review your team actually wants to finish

--- a/docs/marketing/listings/selfhst.md
+++ b/docs/marketing/listings/selfhst.md
@@ -7,6 +7,10 @@ regularly features new apps. Submission: open an issue/PR against their apps
 list repository (linked from <https://selfh.st/apps/>) or use the contact
 form; new-release announcements can also be sent for the weekly roundup.
 
+> **Already submitted** via their Project Launch form — awaiting listing. Keep
+> this kit as the reference for the newsletter pitch and later edits instead of
+> submitting again. See the status table in [README.md](README.md).
+
 **Name:** qnop
 
 **One-liner:** Document review platform — line-precise PDF/Word annotations,


### PR DESCRIPTION
Closes #699.

## Summary

The status table in `docs/marketing/listings/README.md` still described three of the four directories as "Ready". Two of them are done and one is on a clock, so the table no longer matched reality:

| Directory | Before | After |
|---|---|---|
| awesome-selfhosted | ⏳ blocked until 2026-11-19 | unchanged |
| AlternativeTo | Ready — needs an account | ⏳ **blocked until 2026-08-09, 10:32 (Europe/Stockholm)** — new-app submissions require an account age of 7+ days; the account exists, so this is a pure waiting period |
| selfh.st | Ready | ✅ **submitted** via their Project Launch form — awaiting listing |
| SaaSHub | Ready | ✅ **submitted**, ownership verified — awaiting listing |

Also added an "AlternativeTo — how to submit" section mirroring the existing awesome-selfhosted one, so the waiting period ends with instructions rather than a lookup, and a one-line state note at the top of `alternativeto.md`, `selfhst.md` and `saashub.md` so a finished kit is not submitted a second time by accident. Those notes point back at the table, which stays the single source of truth.

## Notes

The issue gives no dates for the two completed submissions, so the table records them as "awaiting listing" without an invented timestamp. Happy to add the real submission dates on top if they're at hand — that would make the table usable as a history, not just as a state.

## Test plan

Docs-only, no code paths touched.

- [x] `docs/` markdown is outside the `qnop-ui` Prettier gate, so no formatter run applies
- [x] SPDX headers unchanged (all four files already carried them)
- [x] Relative links (`README.md` ↔ kits) resolve within the same directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 5) via Claude Code
