### PR TITLE
fix(ui): cache the timezone offset formatters and steady the picker tests (#716)

### DIFF
--- a/qnop-ui/src/components/TimezonePicker.tsx
+++ b/qnop-ui/src/components/TimezonePicker.tsx
@@ -21,12 +21,43 @@
 
 import { useMemo } from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
-import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
 import { buildTimezoneOptions, type TimezoneOption } from '../utils/timezoneOptions';
 
 const MONO = '"JetBrains Mono", ui-monospace, monospace';
+
+/**
+ * The option row, as two `styled` components rather than `Box`/`Typography`
+ * carrying an `sx` prop (issue #716).
+ *
+ * The engine lists ~418 zones and the listbox is not virtualised, so opening
+ * the picker renders every one of them. An inline `sx` per element meant two
+ * emotion serialisations per row — ~836 per open; `styled` resolves them once
+ * at module load, so a row costs a class name.
+ *
+ * Worth knowing before optimising further: this is a real but *minor* part of
+ * the open cost. Measured in jsdom, opening went ~2.1 s → ~1.8 s, while 418
+ * plain `<li>` render in ~0.1 s — so the remaining ~1.7 s is MUI's per-option
+ * Autocomplete machinery, which only virtualisation or a capped option list
+ * would remove.
+ *
+ * These carry no dynamic values, which is exactly why they can be hoisted; if a
+ * future variant needs one, prefer a prop-driven `styled` over reintroducing
+ * `sx` here.
+ */
+const OptionRow = styled('li')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 16,
+});
+
+const OptionOffset = styled('span')(({ theme }) => ({
+  fontFamily: MONO,
+  fontSize: 12,
+  color: theme.palette.text.secondary,
+  flexShrink: 0,
+}));
 
 interface TimezonePickerProps {
   /** The current IANA zone id. */
@@ -85,20 +116,10 @@ export function TimezonePicker({
       renderOption={(props, option) => {
         const { key, ...rest } = props;
         return (
-          <Box
-            component="li"
-            key={key}
-            {...rest}
-            sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}
-          >
+          <OptionRow key={key} {...rest}>
             <span>{option.label}</span>
-            <Typography
-              component="span"
-              sx={{ fontFamily: MONO, fontSize: 12, color: 'text.secondary', flexShrink: 0 }}
-            >
-              {option.offset}
-            </Typography>
-          </Box>
+            <OptionOffset>{option.offset}</OptionOffset>
+          </OptionRow>
         );
       }}
     />

--- a/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.test.tsx
+++ b/qnop-ui/src/components/admin/settings/ApplicationSettingsForm.test.tsx
@@ -70,13 +70,22 @@ describe('ApplicationSettingsForm — default timezone', () => {
     expect(screen.getByRole('textbox', { name: /application name/i })).toBeInTheDocument();
   });
 
+  // Budget and `delay: null` as in TimezoneSetting.test.tsx: opening the picker
+  // renders ~418 zones, and resolving one by accessible name costs ~1.1 s in
+  // jsdom — a query cost, not a production one (issue #716).
   it('lists known zones with their offsets when opened', async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderWithProviders(<ApplicationSettingsForm />);
 
     await user.click(screen.getByRole('combobox', { name: /default timezone/i }));
-    expect(await screen.findByRole('option', { name: /Asia\/Tokyo/ })).toBeInTheDocument();
-  });
+    const tokyo = await screen.findByRole('option', { name: /Asia\/Tokyo/ });
+
+    // The row carries the zone AND its offset — the two halves the option
+    // renders. Asserted explicitly because #716 rebuilt this markup from
+    // Box/Typography with `sx` into hoisted `styled` elements.
+    expect(tokyo).toHaveTextContent('Asia/Tokyo');
+    expect(tokyo).toHaveTextContent(/GMT[+-]\d/);
+  }, 15_000);
 
   it('renders a governed setting read-only and says who set it', () => {
     renderWithProviders(<ApplicationSettingsForm />);

--- a/qnop-ui/src/components/profile/TimezoneSetting.test.tsx
+++ b/qnop-ui/src/components/profile/TimezoneSetting.test.tsx
@@ -42,8 +42,18 @@ describe('TimezoneSetting', () => {
     expect(screen.getByText(/following the workspace default/i)).toBeInTheDocument();
   });
 
+  // Opening the picker is expensive in jsdom for reasons no user pays for: the
+  // engine lists ~418 zones, and `findByRole('option', { name })` computes an
+  // accessible name for every one of them — measured at ~1.1 s, on top of ~0.5 s
+  // for MUI's own per-option work. Against the 5 s default that left too little
+  // headroom under `vitest run`'s parallel load, and this test failed roughly
+  // one full run in three (issue #716). The generous budget here is for the
+  // query cost, not for slow production code: the offset computation it used to
+  // wait on was ~25× faster after caching the Intl formatters.
   it('saves the picked zone', async () => {
-    const user = userEvent.setup();
+    // `delay: null` drops userEvent's artificial inter-event pauses (~0.35 s
+    // here) without weakening the interaction it simulates.
+    const user = userEvent.setup({ delay: null });
     const onChange = vi.fn();
     renderWithProviders(
       <TimezoneSetting value="UTC" isExplicit={false} saving={false} onChange={onChange} />,
@@ -54,5 +64,5 @@ describe('TimezoneSetting', () => {
     await user.click(option);
 
     expect(onChange).toHaveBeenCalledWith('Asia/Tokyo');
-  });
+  }, 15_000);
 });

--- a/qnop-ui/src/utils/timezoneOptions.test.ts
+++ b/qnop-ui/src/utils/timezoneOptions.test.ts
@@ -56,3 +56,79 @@ describe('zoneOffsetLabel', () => {
     expect(zoneOffsetLabel('Nowhere/Void')).toBe('');
   });
 });
+
+describe('formatter reuse (issue #716)', () => {
+  /**
+   * Counts `Intl.DateTimeFormat` constructions while `run` executes. Construction
+   * — not formatting — is what made the picker expensive: ~49 ms of a ~108 ms
+   * build across the engine's ~418 zones.
+   */
+  function countConstructions(run: () => void): number {
+    const original = Intl.DateTimeFormat;
+    let constructions = 0;
+    const spy = new Proxy(original, {
+      construct(target, args: [string?, Intl.DateTimeFormatOptions?]) {
+        constructions += 1;
+        return new target(...args);
+      },
+      apply(target, _thisArg, args: [string?, Intl.DateTimeFormatOptions?]) {
+        constructions += 1;
+        return target(...args);
+      },
+    });
+    Intl.DateTimeFormat = spy;
+    try {
+      run();
+    } finally {
+      Intl.DateTimeFormat = original;
+    }
+    return constructions;
+  }
+
+  it('constructs no formatter on a rebuild — the cost is paid once per zone', () => {
+    buildTimezoneOptions(); // warm the cache, whatever the engine lists
+
+    const constructions = countConstructions(() => buildTimezoneOptions());
+
+    // The list itself is still rebuilt (so offsets stay live); only the
+    // formatters survive, which is where the time went.
+    expect(constructions).toBe(0);
+  });
+
+  it('reuses one formatter across repeated reads of the same zone', () => {
+    zoneOffsetLabel('Europe/Berlin');
+
+    const constructions = countConstructions(() => {
+      zoneOffsetLabel('Europe/Berlin');
+      zoneOffsetLabel('Europe/Berlin');
+    });
+
+    expect(constructions).toBe(0);
+  });
+
+  it('keeps offsets live across instants — a cached formatter carries no date', () => {
+    // The reason this caches formatters and not the finished list: a formatter
+    // is date-independent, so a zone that shifts with DST still reads correctly
+    // for any instant. New York is GMT-4 in July and GMT-5 in January.
+    const july = new Date('2026-07-01T12:00:00Z');
+    const january = new Date('2026-01-01T12:00:00Z');
+
+    expect(zoneOffsetLabel('America/New_York', july)).toBe('GMT-4');
+    expect(zoneOffsetLabel('America/New_York', january)).toBe('GMT-5');
+    // …and back again, proving the first read did not pin the offset.
+    expect(zoneOffsetLabel('America/New_York', july)).toBe('GMT-4');
+  });
+
+  it('does not cache a zone the engine rejects', () => {
+    expect(zoneOffsetLabel('Nowhere/Void')).toBe('');
+
+    // A rejected zone throws in the constructor, so nothing lands in the cache
+    // and a later call retries rather than serving a poisoned entry — which is
+    // also why junk input cannot grow the map without bound.
+    const constructions = countConstructions(() => {
+      expect(zoneOffsetLabel('Nowhere/Void')).toBe('');
+    });
+
+    expect(constructions).toBe(1);
+  });
+});

--- a/qnop-ui/src/utils/timezoneOptions.ts
+++ b/qnop-ui/src/utils/timezoneOptions.ts
@@ -64,10 +64,35 @@ function supportedZones(): string[] {
   }
 }
 
+/**
+ * Offset formatters, one per zone, reused for the lifetime of the page.
+ *
+ * Constructing an `Intl.DateTimeFormat` is the expensive part of reading an
+ * offset — measured over the ~418 zones the engine lists, construction costs
+ * ~49 ms against ~10 ms for the formatting itself, and a full option list took
+ * ~108 ms to build. A formatter carries no date, so one instance answers for
+ * any instant: caching them cuts a rebuild to ~4 ms without making any offset
+ * stale, which is why this caches the *formatters* and not the finished list
+ * (issue #716).
+ *
+ * A `Map` keyed by zone id is bounded by the engine's own zone list, so it
+ * cannot grow without limit even if a caller passes junk — an unusable zone
+ * throws in the constructor and is never cached.
+ */
+const offsetFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function offsetFormatter(zone: string): Intl.DateTimeFormat {
+  const cached = offsetFormatters.get(zone);
+  if (cached) return cached;
+  const created = new Intl.DateTimeFormat('en-GB', { timeZone: zone, timeZoneName: 'shortOffset' });
+  offsetFormatters.set(zone, created);
+  return created;
+}
+
 /** The current short offset label for a zone (e.g. `GMT+2`), or `''` if the zone is unknown. */
 export function zoneOffsetLabel(zone: string, at: Date = new Date()): string {
   try {
-    const part = new Intl.DateTimeFormat('en-GB', { timeZone: zone, timeZoneName: 'shortOffset' })
+    const part = offsetFormatter(zone)
       .formatToParts(at)
       .find((p) => p.type === 'timeZoneName');
     // Normalise "GMT" (UTC) to a signed form for consistent chips.


### PR DESCRIPTION
Closes #716.

The timezone-picker tests timed out at vitest's 5 s default in roughly one full parallel run in three, while passing in isolation. Profiling the open path found one real production cost — and, dominating it, several the test harness alone pays.

## The production cost, and why the fix differs from the issue

`buildTimezoneOptions` constructed a fresh `Intl.DateTimeFormat` per zone. Constructing, not formatting, is the expensive part:

| over the ~418 zones the engine lists | |
|---|---|
| construction | **49 ms** |
| `formatToParts` on fresh formatters | 10 ms |
| `formatToParts` on reused formatters | **5 ms** |
| a whole `buildTimezoneOptions()` | 108 ms |

Nothing cached it, and `TimezonePicker` rebuilds on every selection — so each zone change blocked the main thread ~108 ms.

The issue proposed caching the finished list. **Caching the formatters is better**, and it is what this does: a rebuild drops to ~4 ms, `buildTimezoneOptions` stays a pure function returning live offsets, and standalone `zoneOffsetLabel` callers (`profile/TimezoneSetting.tsx`) benefit too. Crucially a formatter carries no date, so one instance answers for any instant — **the DST-staleness caveat the issue raised disappears**, along with the TTL and invalidation logic a cached list would have needed.

## Why that alone did not fix the flake

It was never the bulk of the ~2.1 s an open costs in jsdom. Measured breakdown:

| Component | Cost | Who pays |
|---|---|---|
| `findByRole('option', { name })` computing accessible names over 418 options | **~1.1 s** | test harness only |
| MUI's per-option Autocomplete machinery | ~0.5 s | users, partly |
| `userEvent`'s artificial inter-event delay | ~0.35 s | test harness only |
| emotion serialising an inline `sx` per row (~836 per open) | ~0.3 s | users |
| the raw DOM (418 plain `<li>` render in ~0.1 s) | ~0.1 s | users |

The largest single component is a query cost no user ever pays. So, in addition to the formatter cache:

- **The per-option `sx` moves into module-level `styled` components** — real if minor (~2.1 s → ~1.8 s), and ~836 fewer style serialisations per open.
- **The two affected tests get `userEvent.setup({ delay: null })` and a 15 s budget**, with the measurements in a comment. Deliberately per-test — a global `testTimeout` raise would mask unrelated slow tests.

## This contradicts an acceptance criterion I wrote on the issue

The issue says *"raising `testTimeout` should be rejected — it hides a 200 ms-per-interaction cost real users pay."* That was reasoned from a cost model the profiling disproved. The 200 ms users paid is genuinely fixed (25× faster); what is budgeted for is harness overhead. Rather than quietly shipping something the issue does not describe, the full measurements and the reversal are [recorded as a comment on #716](https://github.com/qnophq/qnop/issues/716#issuecomment-5195287997).

## Tests

- **Formatter reuse** asserted by counting `Intl.DateTimeFormat` constructions through a `Proxy` — a rebuild constructs zero, and repeated reads of one zone construct zero.
- **Offsets stay live across instants** — New York reads `GMT-4` in July and `GMT-5` in January, and back again. This is the test that proves the cache cannot pin a stale offset, i.e. that the DST concern really is gone.
- **A rejected zone is not cached** — it throws in the constructor, so nothing lands in the map and a later call retries rather than serving a poisoned entry (also why junk input cannot grow the map without bound).
- **The option row's markup changed**, and nothing covered it: the existing test was called *"lists known zones with their offsets"* but only matched the name. It now asserts both halves the row renders.

`extra` behaviour already had a test ("folds in an extra zone not otherwise listed"), so the regression criterion on the issue was already met — my claim there that it lacked coverage was wrong.

## Verification

- [x] **5 consecutive full runs, no timeout** — 1309/1309 each, on the committed state and again after merging `main`
- [x] `tsc -b --noEmit`, `eslint`, `prettier --check`
- [x] No global `testTimeout` change (`vitest.config.ts` untouched)

## Deliberately not done

Removing the remaining ~0.5 s of MUI per-option work needs either **virtualisation** (`ListboxComponent` plus a windowing library — a new app-wide runtime dependency) or a **capped option list** (`createFilterOptions({ limit })` — zero dependency, but it changes the UX: a capped list until you type, and it would break the "open and find Asia/Tokyo" assertions).

Both are product decisions rather than flake fixes, so neither is smuggled in here. Worth a follow-up if the picker ever feels slow in a real browser — where this cost is far smaller than in jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 5) via Claude Code
