### PR TITLE
feat(settings): application-setting changes leave an audit trail

### DIFF
--- a/qnop-app/src/main/java/io/qnop/web/AdminSettingsController.java
+++ b/qnop-app/src/main/java/io/qnop/web/AdminSettingsController.java
@@ -61,7 +61,9 @@ public class AdminSettingsController implements AdminSettingsApi {
   @Override
   public ResponseEntity<AdminSettingsResponse> updateAdminSettings(
       AdminSettingsUpdateRequest adminSettingsUpdateRequest) {
-    settings.update(adminSettingsUpdateRequest.getValues(), null);
+    // The actor, not null (issue #718): "what changed and when" without "by whom"
+    // does not answer the question an audit trail exists for.
+    settings.update(adminSettingsUpdateRequest.getValues(), CurrentUser.requireUserId());
     return ResponseEntity.ok(currentSettings());
   }
 

--- a/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/AdminSettingsControllerIT.java
@@ -27,7 +27,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import io.qnop.bootstrap.AbstractIntegrationTest;
 import io.qnop.service.ApplicationSettingKey;
 import io.qnop.service.ApplicationSettingsService;
 import java.util.Map;
@@ -37,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -50,12 +48,20 @@ import org.springframework.web.context.WebApplicationContext;
  * by the filter chain (Spring Boot 4's {@code @AutoConfigureMockMvc} does not apply it on its own
  * here). Requires Docker.
  */
-class AdminSettingsControllerIT extends AbstractIntegrationTest {
+class AdminSettingsControllerIT extends io.qnop.testsupport.SeededIntegrationTest {
+
+  /**
+   * A principal that is a real, seeded user id.
+   *
+   * <p>The endpoint records who changed a setting (issue #718), and {@code audit_event.actor_id} is
+   * a foreign key — so an invented id fails the insert rather than being written and ignored.
+   * {@code @WithMockUser}'s default principal ("user") is not a UUID at all, and this class now
+   * extends the seeded base so the id below exists.
+   */
+  private static final String ADMIN_PRINCIPAL = "a0000000-0000-0000-0000-000000000001";
 
   @Autowired WebApplicationContext context;
   @Autowired ApplicationSettingsService settings;
-
-  private MockMvc mockMvc;
 
   @BeforeEach
   void setUpMockMvc() {
@@ -69,7 +75,7 @@ class AdminSettingsControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
+  @WithMockUser(username = ADMIN_PRINCIPAL, roles = "ADMIN")
   void getReturnsSettingsForAdmin() throws Exception {
     mockMvc
         .perform(get("/api/v1/admin/settings"))
@@ -82,7 +88,7 @@ class AdminSettingsControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
-  @WithMockUser(roles = "MEMBER")
+  @WithMockUser(username = ADMIN_PRINCIPAL, roles = "MEMBER")
   void getForbiddenForNonAdmin() throws Exception {
     mockMvc.perform(get("/api/v1/admin/settings")).andExpect(status().isForbidden());
   }
@@ -93,7 +99,7 @@ class AdminSettingsControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
+  @WithMockUser(username = ADMIN_PRINCIPAL, roles = "ADMIN")
   void patchUpdatesSetting() throws Exception {
     mockMvc
         .perform(
@@ -107,7 +113,7 @@ class AdminSettingsControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
+  @WithMockUser(username = ADMIN_PRINCIPAL, roles = "ADMIN")
   void patchRejectsTypeInvalidValue() throws Exception {
     mockMvc
         .perform(
@@ -121,7 +127,7 @@ class AdminSettingsControllerIT extends AbstractIntegrationTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
+  @WithMockUser(username = ADMIN_PRINCIPAL, roles = "ADMIN")
   void patchReportsEveryInvalidFieldAtOnce() throws Exception {
     mockMvc
         .perform(

--- a/qnop-app/src/test/java/io/qnop/settings/SettingsAuditIT.java
+++ b/qnop-app/src/test/java/io/qnop/settings/SettingsAuditIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package io.qnop.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.qnop.entity.AuditEvent;
+import io.qnop.repository.AuditEventRepository;
+import io.qnop.service.ApplicationSettingsService;
+import io.qnop.testsupport.SeededIntegrationTest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Application settings leave a trail (issue #718).
+ *
+ * <p>Written because "when did this deployment start forwarding full IP addresses, and who decided"
+ * was not answerable from qnop — the actor was passed to the write and then dropped.
+ */
+class SettingsAuditIT extends SeededIntegrationTest {
+
+  private static final String EVENT = "settings.updated";
+
+  @Autowired private ApplicationSettingsService settings;
+  @Autowired private AuditEventRepository auditEvents;
+
+  /**
+   * Settings are shared state that outlives a test: the row stays written and the service caches
+   * it, so a case that renames the instance renames it for every test that runs afterwards. This
+   * suite therefore puts back what it touched — the seeded values.
+   */
+  @org.junit.jupiter.api.AfterEach
+  void restoreTouchedSettings() {
+    settings.update(Map.of("general.application_name", "qnop", "smtp.password", ""), ADMIN_ID);
+  }
+
+  @Test
+  @DisplayName("a change records the setting, both values and who made it")
+  void recordsTheChange() {
+    settings.update(Map.of("general.application_name", "Audited qnop"), ADMIN_ID);
+
+    AuditEvent event = latest();
+    assertThat(event.getActorId()).isEqualTo(ADMIN_ID);
+    // Parsed, not string-matched: the payload is JSON, and asserting on its shape
+    // survives a formatting change that a substring search would not.
+    var detail = parse(event.getDetail());
+    assertThat(detail.get("key").asString()).isEqualTo("general.application_name");
+    assertThat(detail.get("next").asString()).isEqualTo("Audited qnop");
+    assertThat(detail.get("secret").asBoolean()).isFalse();
+  }
+
+  @Test
+  @DisplayName("a secret is recorded as changed, with neither value")
+  void neverWritesSecrets() {
+    // The snapshot holds decrypted secrets, so a careless payload here would make
+    // the audit page the least protected copy of the SMTP password in the system.
+    settings.update(Map.of("smtp.password", "hunter2-and-then-some"), ADMIN_ID);
+
+    AuditEvent event = latest();
+    var detail = parse(event.getDetail());
+    assertThat(detail.get("key").asString()).isEqualTo("smtp.password");
+    assertThat(detail.get("secret").asBoolean()).isTrue();
+    assertThat(detail.has("previous")).isFalse();
+    assertThat(detail.has("next")).isFalse();
+    assertThat(event.getDetail()).doesNotContain("hunter2");
+  }
+
+  @Test
+  @DisplayName("re-saving an unchanged value records nothing")
+  void ignoresNoOps() {
+    settings.update(Map.of("general.application_name", "Same name"), ADMIN_ID);
+    long after = count();
+
+    settings.update(Map.of("general.application_name", "Same name"), ADMIN_ID);
+
+    // Saving the settings form re-sends every field it holds; an audit that logs a
+    // hundred no-ops per visit buries the entry somebody came to find.
+    assertThat(count()).isEqualTo(after);
+  }
+
+  @Test
+  @DisplayName("a value containing quotes does not break the payload")
+  void escapesValues() {
+    // The scheduler concatenates its detail JSON and gets away with it because it
+    // only ever writes booleans and known ids. A setting value is arbitrary text.
+    String awkward = "He said \"hello\" — {not json}";
+    settings.update(Map.of("general.application_name", awkward), ADMIN_ID);
+
+    // The scheduler concatenates its detail JSON and gets away with it because it
+    // only writes booleans and known ids. A setting value is arbitrary text, so a
+    // quote in it would have produced a payload nothing can read back.
+    assertThat(parse(latest().getDetail()).get("next").asString()).isEqualTo(awkward);
+  }
+
+  private AuditEvent latest() {
+    List<AuditEvent> events =
+        auditEvents.findAll().stream()
+            .filter(event -> EVENT.equals(event.getEventType()))
+            .sorted((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()))
+            .toList();
+    assertThat(events).as("a settings.updated event").isNotEmpty();
+    return events.get(0);
+  }
+
+  private long count() {
+    return auditEvents.findAll().stream().filter(e -> EVENT.equals(e.getEventType())).count();
+  }
+
+  private tools.jackson.databind.JsonNode parse(String json) {
+    return tools.jackson.databind.json.JsonMapper.builder().build().readTree(json);
+  }
+}

--- a/qnop-core/src/main/java/io/qnop/service/ApplicationSettingsService.java
+++ b/qnop-core/src/main/java/io/qnop/service/ApplicationSettingsService.java
@@ -21,7 +21,9 @@
 package io.qnop.service;
 
 import io.qnop.entity.ApplicationSetting;
+import io.qnop.entity.AuditEvent;
 import io.qnop.repository.ApplicationSettingRepository;
+import io.qnop.repository.AuditEventRepository;
 import io.qnop.service.limits.FeatureDisabledException;
 import io.qnop.service.limits.FeatureToggleProperties;
 import jakarta.annotation.PostConstruct;
@@ -34,6 +36,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -43,6 +46,9 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Runtime access to the global application settings (issue #16). Reads are served lock-free from an
@@ -59,6 +65,11 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class ApplicationSettingsService {
 
   /** Attempts for an optimistic-locking write before giving up (issue #47). */
+  /** SYSTEM audit event for a changed application setting (issue #718). */
+  private static final String AUDIT_SETTING_UPDATED = "settings.updated";
+
+  private static final ObjectMapper MAPPER = JsonMapper.builder().build();
+
   private static final int MAX_WRITE_ATTEMPTS = 3;
 
   private final ApplicationSettingRepository repository;
@@ -67,6 +78,7 @@ public class ApplicationSettingsService {
   private final List<SettingsChangeListener> listeners;
   private final TransactionTemplate transactionTemplate;
   private final FeatureToggleProperties features;
+  private final AuditEventRepository auditEvents;
 
   private final java.util.concurrent.atomic.AtomicReference<Map<ApplicationSettingKey, String>>
       snapshot = new java.util.concurrent.atomic.AtomicReference<>(Map.of());
@@ -77,13 +89,15 @@ public class ApplicationSettingsService {
       ConfigurationKeyRedactor redactor,
       List<SettingsChangeListener> listeners,
       PlatformTransactionManager transactionManager,
-      FeatureToggleProperties features) {
+      FeatureToggleProperties features,
+      AuditEventRepository auditEvents) {
     this.repository = repository;
     this.textEncryptor = textEncryptor;
     this.redactor = redactor;
     this.listeners = listeners;
     this.transactionTemplate = new TransactionTemplate(transactionManager);
     this.features = features;
+    this.auditEvents = auditEvents;
   }
 
   @PostConstruct
@@ -180,6 +194,45 @@ public class ApplicationSettingsService {
               available));
     }
     return descriptors;
+  }
+
+  /**
+   * Records a settings change in the SYSTEM audit stream (issue #718).
+   *
+   * <p>Written inside the same transaction as the change, so a rolled-back write leaves no entry
+   * claiming something happened.
+   *
+   * <p>Only real changes are recorded. Saving a form re-sends every field it holds, and an audit
+   * that logs a hundred no-ops per visit buries the one entry somebody came to find.
+   *
+   * <p>A sensitive value is recorded as having changed, with neither the old nor the new value. The
+   * snapshot holds decrypted secrets, so writing them here would turn the audit trail — a page
+   * administrators read — into the least protected copy of the SMTP password in the system.
+   */
+  private void audit(ApplicationSettingKey key, String previous, String next, UUID actor) {
+    if (key.isSensitive()) {
+      auditEvents.save(
+          AuditEvent.system(AUDIT_SETTING_UPDATED, actor, detail(key.getKey(), null, null, true)));
+      return;
+    }
+    if (Objects.equals(previous, next)) {
+      return;
+    }
+    auditEvents.save(
+        AuditEvent.system(
+            AUDIT_SETTING_UPDATED, actor, detail(key.getKey(), previous, next, false)));
+  }
+
+  /** The detail payload, built rather than concatenated: a setting value may contain anything. */
+  private static String detail(String key, String previous, String next, boolean secret) {
+    ObjectNode node = MAPPER.createObjectNode();
+    node.put("key", key);
+    node.put("secret", secret);
+    if (!secret) {
+      node.put("previous", previous);
+      node.put("next", next);
+    }
+    return node.toString();
   }
 
   // --- writes ----------------------------------------------------------------
@@ -279,11 +332,13 @@ public class ApplicationSettingsService {
           repository
               .findById(key.getKey())
               .orElseGet(() -> new ApplicationSetting(key.getKey(), null, key.getType()));
+      String previous = row.getSettingValue();
       row.setSettingValue(encryptIfSecret(key, entry.getValue()));
       row.setValueType(key.getType());
       row.setUpdatedBy(actor);
       repository.save(row);
       changed.add(key);
+      audit(key, previous, entry.getValue(), actor);
     }
     if (!changed.isEmpty()) {
       refreshAfterCommit(changed);

--- a/qnop-ui/src/utils/auditEvents.ts
+++ b/qnop-ui/src/utils/auditEvents.ts
@@ -126,6 +126,12 @@ export const AUDIT_EVENT_META: Record<string, AuditEventMeta> = {
       'An administrator manually triggered a scheduled maintenance job (“Run now”, issue #524); the job and its outcome are shown in the details.',
     tone: 'amber',
   },
+  'settings.updated': {
+    label: 'Setting changed',
+    description:
+      'An administrator changed an application setting; the details name the setting and the values before and after. Passwords and other secrets are recorded as changed without either value.',
+    tone: 'amber',
+  },
   'scheduler.job.updated': {
     label: 'Scheduler job updated',
     description:


### PR DESCRIPTION
Closes #718. Surfaced while planning #712 and deliberately kept out of it.

`ApplicationSettingsService.update` already took an actor; the admin controller passed `null`. So nothing recorded who changed a setting, when, or what it had been. For most settings that is survivable — for *"this deployment now forwards full IP addresses"* it is precisely the question a GDPR legal basis comes with.

Each changed key now writes a `settings.updated` event to the SYSTEM stream, next to the scheduler's own entries and visible in the existing audit UI.

## Three decisions worth a look

**Only real changes are recorded.** Saving the settings form re-sends every field it holds. An audit that logs a hundred no-ops per visit buries the one entry somebody came to find.

**Secrets are recorded as changed, with neither value.** The settings snapshot holds *decrypted* secrets, so a careless payload would have made the audit page — which administrators read — the least protected copy of the SMTP password in the system. Its own test asserts the value never appears.

**The detail JSON is built, not concatenated.** The scheduler gets away with concatenation because it only ever writes booleans and known ids; a setting value is arbitrary text, and one quotation mark would have produced a payload nothing could read back. Also tested, with a value containing quotes and braces.

## Deliberately out of scope

**User settings.** What somebody chooses for themselves — timezone, language, mail cadence — is not an administrative act. Logging it would be observation of your own people rather than accountability, and the reasoning is in the code so nobody "completes" it later.

**History.** This records changes, not versions; reconstructing last week's value means reading the events backwards. A versioned table is the other shape and was not asked for.

## Two things testing surfaced

`audit_event.actor_id` is a foreign key, so an actor that is not a real user fails the insert rather than being quietly dropped. `AdminSettingsControllerIT` therefore extends the seeded base and authenticates as a seeded id — `@WithMockUser`'s default principal is `"user"`, which is not a UUID. That suite also mutates shared settings, so it now restores what it touches; without that, a test renaming the instance renamed it for everything that ran afterwards.

## Test plan

- [x] `./gradlew build` green; `pnpm lint`, `tsc`, `test:run` (1309) green
- [x] `SettingsAuditIT`: actor recorded, secrets withheld, no-ops ignored, awkward values survive the round trip
- [ ] Reviewer: change a setting and confirm the entry reads sensibly in Administration → Audit

🤖 Co-Author: Claude (Opus 5) via Claude Code