### PR TITLE
fix(ui): the page header stacks below md, so wide action bars wrap

### DIFF
--- a/docs/RESPONSIVE.md
+++ b/docs/RESPONSIVE.md
@@ -42,15 +42,28 @@ templates 849 px, users 785 px, teams 563 px — and every one of them sits insi
 an ancestor with `overflow-x: auto`. This is the behaviour the issue asks for,
 already built.
 
-### 3. A primary action sits outside the viewport at 768 px — the real finding
+### 3. A primary action sat outside the viewport at 768 px — fixed (#723)
 
-On the review workspace at 768 px, **“New version” spans x = 692…798** against a
-768 px viewport: 30 px past the edge. It is not lost — its action bar scrolls
-horizontally (`scrollWidth` 798 vs `clientWidth` 768) — but nothing indicates
-that, so on a portrait tablet the control looks cut off rather than scrollable.
+On the review workspace at 768 px, **“New version” spanned x = 692…798** against
+a 768 px viewport: 30 px past the edge, reachable only through an action bar
+that scrolled without saying so.
 
-That is the gap worth closing: not overflow, but an affordance that hides a
-primary action behind an invisible gesture.
+The cause was a chain, not the bar: the bar itself always had `flexWrap`, but
+`PageHeader`'s action slot is `flexShrink: 0` (so long titles cannot crush the
+buttons), which also means the slot never imposes a width the wrap could fire
+at — and the shell's `overflow: auto` below `md` swallowed the resulting
+horizontal scroll instead of surfacing it.
+
+Fixed by stacking the header below `md` (title above, actions in full width
+underneath), so the wrap that was always there finally has an edge to wrap at.
+Re-measured live after the change: the button sits at x = 36…142, and no hidden
+horizontal scroller remains on the route.
+
+**A consequence worth keeping in mind:** the shell's `overflow: auto` masks
+body-level overflow on sub-`md` viewports. The audit's “no body overflow”
+numbers are partly *because* that container swallows; the regression assertion
+(#725) must therefore check the shell content element as well as
+`document.body`, or it will pass while a surface silently scrolls.
 
 ### 4. Header controls are 28×28 px
 

--- a/qnop-ui/src/components/admin/layout/PageHeader.tsx
+++ b/qnop-ui/src/components/admin/layout/PageHeader.tsx
@@ -53,9 +53,17 @@ export function PageHeader({
 }: PageHeaderProps) {
   return (
     <Stack
-      direction={{ xs: 'column', sm: 'row' }}
+      // Stacked below md, side by side above (issue #723). The action slot is
+      // flexShrink: 0 so long titles cannot crush the buttons — which also
+      // means a wide action bar can never be given a smaller width than it
+      // asks for. Between 600 and 900px that produced a 798px row in a 768px
+      // viewport, silently scrolling inside the shell; the review head's own
+      // flexWrap never fired because its parent never imposed a limit.
+      // Stacking hands the actions the full content width instead, and the
+      // wrap that was always there finally has an edge to wrap at.
+      direction={{ xs: 'column', md: 'row' }}
       spacing={2}
-      sx={{ justifyContent: 'space-between', alignItems: { sm: 'center' } }}
+      sx={{ justifyContent: 'space-between', alignItems: { md: 'center' } }}
     >
       <Stack direction="row" spacing={1.5} sx={{ minWidth: 0, alignItems: 'center' }}>
         {leading && <Box sx={{ flexShrink: 0 }}>{leading}</Box>}


### PR DESCRIPTION
Closes #723.

At 768 px the review workspace put **"New version"** at x = 692…798 — 30 px past the viewport, reachable only through an action bar that scrolled without saying so.

## The cause was a chain, not the bar

The bar has had `flexWrap` all along. Above it:

1. `PageHeader`'s action slot is `flexShrink: 0` — so long titles cannot crush the buttons, which also means the slot **never imposes a width the wrap could fire at**
2. The shell's `overflow: auto` below `md` swallowed the resulting horizontal scroll instead of surfacing it as body overflow anyone would notice
3. The header went side-by-side from `sm` (600 px) — exactly the 600–900 window where a 798 px row meets a 768 px viewport

## The fix is one line

The header stacks below `md` instead of below `sm`. Actions get the full content width under the title, and the wrap that was always there finally has an edge to wrap at. `flexShrink: 0` stays — side by side it is still right.

**Applies to every `PageHeader` user deliberately:** on admin pages the action is a single button, stacking at tablet width is the ordinary pattern, and a header that behaves the same everywhere is the point of having one.

## Verified live, not by a unit test — on purpose

jsdom evaluates no media queries and does no layout; a test asserting the `sx` prop would pin the implementation, not the behaviour. Re-measured against the running instance after the change:

| | before | after |
|---|---|---|
| "New version" at 768 px | x = 692…798 (clipped) | **x = 36…142** |
| hidden horizontal scroller on the route | yes (798 > 768) | none |
| body overflow on review + 2 admin pages | 0 | 0 |

The Playwright net (#725) is where this belongs as a screenshot; a comment there also records that the shell's `overflow: auto` **masks body overflow below `md`**, so the regression assertion must check the shell content element too — otherwise it passes while a surface silently scrolls.

## Test plan

- [x] Live measurement at 768 px: review workspace, admin users, admin settings — button in viewport, no hidden scroller, no body overflow
- [x] `pnpm lint`, `format:check`, `test:run` (1313), `build` green
- [ ] Reviewer: eyeball an admin page at ~700 px — the header stacking should read as intended, not as a regression

🤖 Co-Author: Claude (Fable 5) via Claude Code