### PR TITLE
fix(deps): unblock the pnpm-audit gate — postcss 8.5.26 pulls a patched nanoid

### DIFF
--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -2440,8 +2440,8 @@ packages:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2580,8 +2580,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.25:
-    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -5974,7 +5974,7 @@ snapshots:
 
   mute-stream@1.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -6116,9 +6116,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.25:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6745,7 +6745,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.25
+      postcss: 8.5.26
       rolldown: 1.2.1
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
Unblocks the Frontend check across the whole repository. Found while investigating why #694's build was broken — it turned out not to be #694's doing.

## What is actually failing

```
high  nanoid: custom generators can loop indefinitely when size is zero
      Vulnerable <3.3.17 · GHSA-2v37-7h3g-55p8
      Paths: vite > postcss > nanoid   (8 of them)
```

`pnpm audit --audit-level high` is step 2 of 7 in the Frontend job, so an affected run dies after ~20 s — before `generate:api`, before tests, before the build. The job name says "lint + format + test + build", which makes it easy to misread as a code failure.

## It is repo-wide, not per-PR

| PR | Subject | Frontend |
|---|---|---|
| #738 | AWS SDK | **fail** |
| #737 | npm dependencies | **fail** |
| #736 | vite v8.2.1 | **fail** |
| #729 | MUI | **fail** |
| #694 | Docker base images | **fail** |
| #721 | timezone formatter cache | pass¹ |

¹ only because it last ran on 2026-08-05, before the advisory was published; it fails on a re-run too. `main`'s last green run was 2026-08-07.

#694 is the clearest illustration: it updates Docker base images and does not touch the npm tree at all.

## Why a lockfile refresh, not an override

`pnpm-workspace.yaml` already carries four overrides (`brace-expansion`, `shell-quote`, `ip-address`, `undici`) — all cases where the fix was not reachable through normal resolution. This is not one of those: **postcss 8.5.26 already declares `nanoid: ^3.3.17`**, so a plain `pnpm update postcss` resolves it correctly.

An override would work too, but it would pin a version that has to be unpinned again later and would hide the upgrade from Renovate. The diff here is 8 lines:

```
postcss  8.5.25 → 8.5.26
nanoid   3.3.16 → 3.3.18
```

## Verification — the Frontend job's own seven steps, locally

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm audit --audit-level high` → *No known vulnerabilities found*
- [x] `pnpm generate:api`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm test:run` → 1313/1313
- [x] `tsc -b` + `vite build`

## After this merges

The five blocked PRs only need a re-run or a rebase; none of them needs its own fix. #736 (vite v8.2.1) would likely have pulled a fixed postcss along eventually, but this lands immediately and does not wait on a major-version review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Co-Author: Claude (Opus 5) via Claude Code
