### PR TITLE
docs: record the AlternativeTo submission

### DIFF
--- a/docs/marketing/listings/README.md
+++ b/docs/marketing/listings/README.md
@@ -9,7 +9,7 @@ when the positioning changes.
 | Directory | Status | Kit |
 |---|---|---|
 | [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted-data) | ⏳ **Blocked until 2026-11-19** — their rule: *"first released more than 4 months ago"* (qnop v1.0.0: 2026-07-19) | [awesome-selfhosted-qnop.yml](awesome-selfhosted-qnop.yml) |
-| [AlternativeTo](https://alternativeto.net/manage-item/) | ⏳ **Blocked until 2026-08-09, 10:32 (Europe/Stockholm)** — new-app submissions require an account age of 7+ days; the account exists, so this is a pure waiting period | [alternativeto.md](alternativeto.md) |
+| [AlternativeTo](https://alternativeto.net/manage-item/) | ✅ **Submitted 2026-08-16** — app page [alternativeto.net/software/qnop](https://alternativeto.net/software/qnop/) pending review; Filestage, Ziflow, PageProof and PandaDoc suggested as alternatives (GoVisually is not on AlternativeTo; Acrobat Reader skipped — no shared app type) | [alternativeto.md](alternativeto.md) |
 | [selfh.st](https://selfh.st/apps/) | ✅ **Submitted** via their Project Launch form — awaiting listing | [selfhst.md](selfhst.md) |
 | [SaaSHub](https://www.saashub.com/submit) | ✅ **Submitted**, ownership verified — awaiting listing | [saashub.md](saashub.md) |
 

--- a/docs/marketing/listings/alternativeto.md
+++ b/docs/marketing/listings/alternativeto.md
@@ -4,9 +4,13 @@
 
 Submit at <https://alternativeto.net/manage-item/> (account required).
 
-> **Not yet submitted** — new-app submissions need an account age of 7+ days,
-> so the earliest possible attempt is **2026-08-09, 10:32 (Europe/Stockholm)**.
-> See the status table in [README.md](README.md).
+> **Submitted 2026-08-16** — app page:
+> <https://alternativeto.net/software/qnop/> (visible to the submitter only
+> until approved; the free queue takes months, priority review 1–2 business
+> days). Suggested as alternative to Filestage, Ziflow, PageProof and
+> PandaDoc — all pending the same approval. GoVisually does not exist on
+> AlternativeTo, and Acrobat Reader was skipped deliberately: no shared app
+> type, and weak links hurt maker-submission credibility.
 
 **Name:** qnop
 


### PR DESCRIPTION
## Summary

Updates the listings status: qnop was submitted to AlternativeTo on 2026-08-16 (app page pending review), with Filestage, Ziflow, PageProof and PandaDoc suggested as alternatives. Notes why GoVisually (not on AlternativeTo) and Acrobat Reader (no shared app type) are not among them.

Closes #747

## Test plan

- [x] Docs-only change

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)