### PR TITLE
ci: verify the pinned Gradle distribution checksum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,3 +208,18 @@ jobs:
           done < <(find . -type f \( -name '*.java' -o -name '*.kts' \) \
                    -not -path './**/build/*' -not -path './.gradle/*')
           exit $missing
+
+  wrapper-checksum:
+    name: Gradle wrapper checksum pin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # The distributionSha256Sum pin (issue #194) is what protects a cold
+      # `./gradlew` run from a substituted distribution — setup-gradle validates
+      # the wrapper JAR, not the distribution ZIP. Renovate bumps distributionUrl
+      # on a Gradle release without touching the checksum (issue #763), so the two
+      # drift apart and every Gradle-invoking job dies on an opaque
+      # "Verification of Gradle distribution failed!". Catch the drift here, in
+      # seconds, with the correct value to paste in.
+      - name: Verify the pinned Gradle distribution checksum
+        run: scripts/check-gradle-wrapper-checksum.sh

--- a/scripts/check-gradle-wrapper-checksum.sh
+++ b/scripts/check-gradle-wrapper-checksum.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Verify that gradle/wrapper/gradle-wrapper.properties pins a
+# distributionSha256Sum matching the checksum Gradle publishes for the pinned
+# distributionUrl (issue #763).
+#
+# Why: the pin (issue #194) is what protects a cold `./gradlew` run from a
+# substituted distribution — setup-gradle validates the wrapper JAR, not the
+# distribution ZIP. Renovate's gradle-wrapper manager bumps distributionUrl on a
+# new Gradle release but leaves the checksum untouched, so the pair silently
+# drifts apart and every Gradle-invoking job then dies on an opaque
+# "Verification of Gradle distribution failed!". This fails first, and prints
+# the value to paste in.
+#
+# This checks that the pin *matches its URL*; it is a freshness check, not a
+# second trust anchor — the pin itself is what does the security work, locally,
+# on every wrapper run.
+#
+# Run from the repo root:
+#   scripts/check-gradle-wrapper-checksum.sh [path/to/gradle-wrapper.properties]
+
+set -euo pipefail
+
+PROPS="${1:-gradle/wrapper/gradle-wrapper.properties}"
+
+fail() {
+  echo "::error file=${PROPS}::$1"
+  shift
+  # Remaining args are plain-text detail lines; annotations collapse newlines.
+  for line in "$@"; do echo "  $line"; done
+  exit 1
+}
+
+[[ -f "$PROPS" ]] || fail "$PROPS not found"
+
+# Java .properties: take the last assignment and unescape the URL's `https\://`.
+read_prop() {
+  sed -n "s/^$1=//p" "$PROPS" | tail -n 1 | tr -d '\r' | sed 's/\\:/:/g'
+}
+
+url="$(read_prop distributionUrl)"
+pinned="$(read_prop distributionSha256Sum | tr '[:upper:]' '[:lower:]')"
+
+[[ -n "$url" ]] || fail "distributionUrl is missing"
+
+[[ -n "$pinned" ]] || fail \
+  "distributionSha256Sum is missing" \
+  "The pin from issue #194 is what protects a cold ./gradlew run against a" \
+  "substituted Gradle distribution. Restore it rather than removing this check."
+
+published="$(curl -fsSL --retry 3 --retry-delay 2 "${url}.sha256" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')" \
+  || fail "could not fetch ${url}.sha256"
+
+[[ "$published" =~ ^[0-9a-f]{64}$ ]] || fail \
+  "${url}.sha256 did not return a SHA-256 digest" \
+  "Got: ${published:0:100}"
+
+if [[ "$pinned" != "$published" ]]; then
+  fail \
+    "distributionSha256Sum does not match the checksum published for distributionUrl" \
+    "distributionUrl: $url" \
+    "pinned:          $pinned" \
+    "published:       $published" \
+    "" \
+    "Fix by setting in $PROPS:" \
+    "  distributionSha256Sum=$published"
+fi
+
+echo "distributionSha256Sum matches the checksum published for ${url##*/}"


### PR DESCRIPTION
Closes #763.

## Why

The `distributionSha256Sum` pin added in `ae37de8f` (issue #194) is what protects a cold `./gradlew` run from a substituted distribution — `setup-gradle` validates the wrapper JAR, not the distribution ZIP. That commit assumed *"Renovate's gradle-wrapper manager keeps this in sync on future version bumps."* It does not, and #743 was the first wrapper bump to prove it: Renovate rewrote `distributionUrl` to 9.7.1 and left the checksum at the 9.6.1 value, so all four Gradle-invoking checks died on the same opaque error.

```
Verification of Gradle distribution failed!
Expected checksum: '9c0f7fae…c9e14'   ← gradle-9.6.1-bin.zip
Actual checksum:   'acd53f1e…d20a'    ← gradle-9.7.1-bin.zip (official)
```

Nothing in the repo notices the drift until Gradle itself refuses to start.

## What this adds

A `Gradle wrapper checksum pin` job that runs `scripts/check-gradle-wrapper-checksum.sh`: it reads `distributionUrl` + `distributionSha256Sum` and compares the pin against the checksum Gradle publishes for that exact URL, failing in seconds with the value to paste in.

It also fails on a **missing** pin, so the #194 control cannot be dropped unnoticed.

To be precise about what this is: a freshness check that the pin matches its URL, not a second trust anchor. The pin itself still does the security work, locally, on every wrapper run.

## Why not fix it in Renovate instead

#763 offered that alternative, so I checked the source rather than guess. Renovate *does* support it — `lib/modules/manager/gradle-wrapper/artifacts.ts` fetches `${distributionUrl}.sha256` and rewrites the property — but only inside `updateArtifacts`, which aborts earlier:

```js
if (!isGradleExecutionAllowed(gradlewFile)) {
  logger.trace('Not allowed to execute gradle due to allowedUnsafeExecutions - aborting update');
  return null;
}
```

Our self-hosted instance does not set `allowedUnsafeExecutions`, so only the regex-based `updateDependency` runs — which touches the `distributionUrl` line and nothing else. Exactly the observed behaviour.

Enabling it would let Renovate execute the repo's own `gradlew` while holding the App installation token (ADR-0017). That is a poor trade for a convenience, so this PR takes the guard instead and leaves the Renovate config alone.

## Test plan

Five cases exercised locally against the script:

- [x] **Good case** (current `main`, Gradle 9.7.1) — passes
- [x] **Stale pin** — reproduces the #743 failure and prints the correct `distributionSha256Sum=` line to paste in
- [x] **Missing pin** — fails, pointing at the #194 rationale
- [x] **Nonexistent distribution** (404 on `.sha256`) — fails with the URL it could not fetch
- [x] **Missing properties file** — fails cleanly
- [x] `ci.yml` parses (7 jobs), `bash -n` clean, `./gradlew spotlessCheck` green

CI on this PR is itself the end-to-end check: the new job must go green against the (correct) pin on `main`.

## Trade-off worth flagging

The job makes one network call to `services.gradle.org` per PR (`curl --retry 3`). If that service is down, CI goes red for an unrelated reason. A non-blocking guard would be worthless, so it blocks — flagging it as a deliberate choice rather than an oversight.

🤖 Co-Author: Claude (Opus 5) via Claude Code
