### PR TITLE
feat(ui): give header controls a 44 px touch target

### DIFF
--- a/docs/RESPONSIVE.md
+++ b/docs/RESPONSIVE.md
@@ -76,6 +76,13 @@ at 768 px, 90+ on admin tables at 320 px), but most of those are table-row
 actions where density is the point. The header is not: it is chrome, present on
 every screen, and the first thing a thumb reaches for.
 
+Fixed in #724 by growing the hit area, not the icon: `touchTargetSx`
+(`src/theme/touchTarget.ts`) lays a transparent `::before` overlay of
+`max(100%, 44px)` on each axis over the control, so the header keeps its 28 px
+visual weight while the box a finger or cursor has to hit is 44 px. Applied to
+the three header controls and the banner dismiss; reusable for any other
+chrome-level control that falls under the target.
+
 ## Support tiers — proposed, pending the rest of the audit
 
 Derived from what was measured. The 375 px line in particular is a

--- a/qnop-ui/src/components/banner/InfoBanner.test.tsx
+++ b/qnop-ui/src/components/banner/InfoBanner.test.tsx
@@ -23,6 +23,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { InfoBanner as InfoBannerModel } from '../../api/generated';
+import { hasTouchTarget } from '../../test/cssRules';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import { InfoBanner } from './InfoBanner';
 
@@ -95,5 +96,11 @@ describe('InfoBanner', () => {
     // A future severity must never blank the notice out.
     expect(screen.getByText('Still readable')).toBeInTheDocument();
     expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('gives the dismiss button a 44 px hit area (#724)', () => {
+    renderWithProviders(<InfoBanner banner={banner()} onDismiss={vi.fn()} />);
+
+    expect(hasTouchTarget(screen.getByRole('button', { name: 'Dismiss this notice' }))).toBe(true);
   });
 });

--- a/qnop-ui/src/components/banner/InfoBanner.tsx
+++ b/qnop-ui/src/components/banner/InfoBanner.tsx
@@ -128,12 +128,14 @@ export function InfoBanner({ banner, variant = 'bar', onDismiss }: InfoBannerPro
           size="small"
           onClick={onDismiss}
           aria-label="Dismiss this notice"
-          // 25 px visually, 44 px to hit (#724).
+          // 25 px visually, 44 px to hit (#724). The overlay reaches ~10 px past
+          // the button, so the extra margin keeps it clear of the message link.
           sx={{
             ...touchTargetSx,
             color: 'inherit',
             opacity: 0.7,
             mt: '-2px',
+            ml: 1.25,
             '&:hover': { opacity: 1 },
           }}
         >

--- a/qnop-ui/src/components/banner/InfoBanner.tsx
+++ b/qnop-ui/src/components/banner/InfoBanner.tsx
@@ -27,6 +27,7 @@ import { useTheme } from '@mui/material/styles';
 import { ArrowUpRight, Info, OctagonAlert, TriangleAlert, X } from 'lucide-react';
 import type { InfoBanner as InfoBannerModel } from '../../api/generated';
 import { tokens } from '../../theme/tokens';
+import { touchTargetSx } from '../../theme/touchTarget';
 
 /**
  * Tone per severity: the translucent badge tint (composites over both the light
@@ -127,7 +128,14 @@ export function InfoBanner({ banner, variant = 'bar', onDismiss }: InfoBannerPro
           size="small"
           onClick={onDismiss}
           aria-label="Dismiss this notice"
-          sx={{ color: 'inherit', opacity: 0.7, mt: '-2px', '&:hover': { opacity: 1 } }}
+          // 25 px visually, 44 px to hit (#724).
+          sx={{
+            ...touchTargetSx,
+            color: 'inherit',
+            opacity: 0.7,
+            mt: '-2px',
+            '&:hover': { opacity: 1 },
+          }}
         >
           <X size={15} />
         </IconButton>

--- a/qnop-ui/src/components/shell/TopBar.test.tsx
+++ b/qnop-ui/src/components/shell/TopBar.test.tsx
@@ -26,6 +26,7 @@ import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../theme/theme';
+import { hasTouchTarget } from '../../test/cssRules';
 import { TopBar } from './TopBar';
 
 // The embedded GlobalSearch (#540) queries through TanStack Query; the bar's
@@ -114,4 +115,18 @@ describe('TopBar notifications (#538)', () => {
     expect(screen.getByLabelText('Search reviews, people and teams')).toBeInTheDocument();
     expect(screen.queryByText(/jump to any review/i)).not.toBeInTheDocument();
   });
+});
+
+describe('TopBar touch targets (#724)', () => {
+  it.each(['Toggle menu', 'Switch to dark mode', 'Notifications'])(
+    'gives "%s" a 44 px hit area while keeping the small icon button',
+    (name) => {
+      renderTopBar();
+
+      const button = screen.getByRole('button', { name });
+
+      expect(button.className).toMatch(/MuiIconButton-sizeSmall/);
+      expect(hasTouchTarget(button)).toBe(true);
+    },
+  );
 });

--- a/qnop-ui/src/components/shell/TopBar.tsx
+++ b/qnop-ui/src/components/shell/TopBar.tsx
@@ -29,6 +29,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { Bell, Menu as MenuIcon, Moon, PanelLeft, Sun } from 'lucide-react';
 import { useUnreadCount } from '../../api/hooks/useNotifications';
 import { useUiStore } from '../../stores/uiStore';
+import { touchTargetSx } from '../../theme/touchTarget';
 import { NotificationsPopover } from './NotificationsPopover';
 import { Breadcrumbs } from './Breadcrumbs';
 import { GlobalSearch } from './search/GlobalSearch';
@@ -38,7 +39,13 @@ interface TopBarProps {
   onToggleSidebar: () => void;
 }
 
-/** The application top bar: sidebar toggle, breadcrumbs, search and quick actions. */
+/**
+ * The application top bar: sidebar toggle, breadcrumbs, search and quick actions.
+ *
+ * <p>The icon buttons keep their 28 px visual size but carry a 44 px hit area
+ * (issue #724): they are chrome on every screen and the first thing a thumb
+ * reaches for.
+ */
 export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
   const themeMode = useUiStore((s) => s.themeMode);
   const toggleTheme = useUiStore((s) => s.toggleTheme);
@@ -55,7 +62,13 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
     >
       <Toolbar sx={{ gap: 1.5, minHeight: { xs: 56, sm: 56 } }}>
         <Tooltip title={isMobile ? 'Menu' : 'Toggle menu'}>
-          <IconButton onClick={onToggleSidebar} size="small" edge="start" aria-label="Toggle menu">
+          <IconButton
+            onClick={onToggleSidebar}
+            size="small"
+            edge="start"
+            aria-label="Toggle menu"
+            sx={touchTargetSx}
+          >
             {isMobile ? <MenuIcon size={18} /> : <PanelLeft size={18} />}
           </IconButton>
         </Tooltip>
@@ -73,6 +86,7 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
           <IconButton
             onClick={toggleTheme}
             size="small"
+            sx={touchTargetSx}
             aria-label={themeMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
           >
             {themeMode === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
@@ -88,6 +102,7 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
             aria-haspopup="dialog"
             aria-expanded={notificationsAnchor ? true : undefined}
             onClick={(event) => setNotificationsAnchor(event.currentTarget)}
+            sx={touchTargetSx}
           >
             <Badge
               color="primary"

--- a/qnop-ui/src/test/cssRules.ts
+++ b/qnop-ui/src/test/cssRules.ts
@@ -32,7 +32,8 @@ export function pseudoBeforeRule(element: Element): string | undefined {
     .map((style) => style.textContent ?? '')
     .join('\n');
   for (const className of Array.from(element.classList)) {
-    const match = css.match(new RegExp(`\\.${className}::before\\{([^}]*)\\}`));
+    const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = css.match(new RegExp(`\\.${escaped}::before\\{([^}]*)\\}`));
     if (match) return match[1];
   }
   return undefined;

--- a/qnop-ui/src/test/cssRules.ts
+++ b/qnop-ui/src/test/cssRules.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Returns the declaration block of the `::before` rule Emotion emitted for one
+ * of the element's own classes, or `undefined` when there is none.
+ *
+ * <p>jsdom lays out no pseudo-elements, so a test that cares about a `::before`
+ * overlay (the 44 px touch target of #724, say) asserts on the CSS that was
+ * emitted — which is exactly what a browser would apply.
+ */
+export function pseudoBeforeRule(element: Element): string | undefined {
+  const css = Array.from(document.querySelectorAll('style'))
+    .map((style) => style.textContent ?? '')
+    .join('\n');
+  for (const className of Array.from(element.classList)) {
+    const match = css.match(new RegExp(`\\.${className}::before\\{([^}]*)\\}`));
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+/** True when the element's `::before` overlay is the #724 44 px touch target. */
+export function hasTouchTarget(element: Element): boolean {
+  const rule = pseudoBeforeRule(element);
+  return (
+    rule !== undefined &&
+    rule.includes('position:absolute') &&
+    rule.includes('width:max(100%, 44px)') &&
+    rule.includes('height:max(100%, 44px)')
+  );
+}

--- a/qnop-ui/src/theme/touchTarget.test.tsx
+++ b/qnop-ui/src/theme/touchTarget.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import IconButton from '@mui/material/IconButton';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from './theme';
+import { pseudoBeforeRule } from '../test/cssRules';
+import { TOUCH_TARGET_PX, touchTargetSx } from './touchTarget';
+
+describe('touchTargetSx (#724)', () => {
+  it('asks for a 44 px minimum', () => {
+    expect(TOUCH_TARGET_PX).toBe(44);
+  });
+
+  it('emits a centred ::before overlay of at least 44×44 px on a small icon button', () => {
+    const { getByRole } = render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <IconButton size="small" aria-label="Probe" sx={touchTargetSx} />
+      </ThemeProvider>,
+    );
+
+    const rule = pseudoBeforeRule(getByRole('button', { name: 'Probe' }));
+
+    expect(rule).toBeDefined();
+    expect(rule).toContain('position:absolute');
+    expect(rule).toContain('width:max(100%, 44px)');
+    expect(rule).toContain('height:max(100%, 44px)');
+    expect(rule).toContain('translate(-50%, -50%)');
+  });
+});

--- a/qnop-ui/src/theme/touchTarget.ts
+++ b/qnop-ui/src/theme/touchTarget.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { SxProps, Theme } from '@mui/material/styles';
+
+/** The minimum pointer/touch target the responsive audit asks for (#461). */
+export const TOUCH_TARGET_PX = 44;
+
+/**
+ * Grows a control's hit area to at least 44×44 px without touching its visual
+ * size (issue #724).
+ *
+ * <p>A transparent `::before` overlay is centred on the element and sized to
+ * `max(100%, 44px)` on each axis, so a 28 px icon button keeps its 28 px ring
+ * and ripple while the box the finger (or the trackpad cursor) has to hit is
+ * 44 px. Neighbouring overlays may overlap; the topmost wins, which is fine
+ * for controls that sit 12 px apart. Requires a positioned host — MUI's
+ * `ButtonBase` already is.
+ */
+export const touchTargetSx: SxProps<Theme> = {
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: `max(100%, ${TOUCH_TARGET_PX}px)`,
+    height: `max(100%, ${TOUCH_TARGET_PX}px)`,
+  },
+};


### PR DESCRIPTION
## Summary

The sidebar toggle, theme switch and notifications bell measured 28×28 px on every route, the banner dismiss 25×25 px — under the 44 px minimum the #461 audit asks for, on the controls a thumb reaches for first.

- `touchTargetSx` lays a transparent `::before` overlay of `max(100%, 44px)` per axis over the control: the header keeps its visual weight, the box to hit is 44 px.
- Applied to the three header controls and the InfoBanner dismiss; the dismiss gets a small left margin so its overlay stays clear of the message link.
- Tests assert on the emitted CSS (jsdom lays out no pseudo-elements) through a shared `cssRules` test helper.
- `docs/RESPONSIVE.md` finding 4 records the fix.

Closes #724 · part of #461

## Test plan

- [x] `pnpm test:run` — banner, shell and helper suites green
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- [x] CI green
- [ ] Follow-up: #725 measures these controls live at every breakpoint

🤖 Co-Author: Claude (Fable 5) via Claude Code
