### PR TITLE
fix(ui): make the annotation card's toggle an explicit control

### DIFF
--- a/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationHead.tsx
@@ -211,8 +211,8 @@ export function AnnotationHead({
             borderColor: 'divider',
             bgcolor: theme.qnop.surface2,
             borderRadius: '0 6px 6px 0',
-            // The passage is copy material (issue #478) — selectable even
-            // inside the clickable card (ButtonBase disables selection).
+            // The passage is copy material (issue #478): explicitly selectable
+            // so no ancestor styling can ever take that away again.
             userSelect: 'text',
             px: 1.25,
             py: 0.75,

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -319,9 +319,15 @@ function AnnotationListItemBase({
               size="small"
               aria-label="Collapse annotation"
               aria-expanded
+              aria-controls={`annotation-item-${annotation.id}`}
               onClick={toggle}
               data-testid={`annotation-toggle-${annotation.id}`}
-              sx={{ color: 'text.secondary', flexShrink: 0, mt: '-2px' }}
+              sx={{
+                color: 'text.secondary',
+                flexShrink: 0,
+                mt: '-2px',
+                '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+              }}
             >
               <ChevronUp size={16} aria-hidden />
             </IconButton>
@@ -332,6 +338,7 @@ function AnnotationListItemBase({
           ref={rowRef}
           onClick={toggle}
           aria-expanded={false}
+          aria-controls={`annotation-item-${annotation.id}`}
           data-testid={`annotation-toggle-${annotation.id}`}
           sx={{
             display: 'block',

--- a/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationListItem.tsx
@@ -19,14 +19,15 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { memo, type MouseEvent } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
+import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { alpha, useTheme, type Theme } from '@mui/material/styles';
-import { MessageSquare, MoveRight, Unlink } from 'lucide-react';
+import { ChevronUp, MessageSquare, MoveRight, Unlink } from 'lucide-react';
 import type { AnnotationView } from '../../../api/generated';
 import { PlacementStatus } from '../../../api/generated';
 import { useComments } from '../../../api/hooks/useComments';
@@ -99,6 +100,12 @@ function ParticipantAvatars({
             userId={realAuthorId(review, userId, participant.id)}
             slug={participant.slug}
             profileName={participant.name ?? undefined}
+            // The stack lives inside the collapsed row's toggle button, so the
+            // triggers stay previews rather than links (issue #549) — a link
+            // inside a button is invalid, and these 20px avatars were never the
+            // way to a profile. The card still previews on hover; the expanded
+            // card's author row carries the real link.
+            link={false}
           >
             <Box
               sx={{
@@ -160,6 +167,11 @@ interface AnnotationListItemProps {
  * status speaks through icon, badge and the mark on the page; interaction —
  * hover, the linked mark, the active card — speaks the brand blue in two
  * quiet steps instead of a status rail with a pointer arrow.
+ *
+ * The card itself is never a button (issue #549): collapsed, the whole row is
+ * one — a single dense target that expands on click or Enter; expanded, it is a
+ * plain container whose controls are real controls, closed again by the chevron
+ * beside the head. Focus follows that toggle in both directions.
  *
  * Memoized (issue #333): the panel re-renders on every hover/selection, but with stable props only
  * the two items whose {@code active}/{@code linked} actually changed re-render — not the whole list.
@@ -231,39 +243,44 @@ function AnnotationListItemBase({
   // annotation keeps its anchor, so it never lands here.
   const fallbackLabel = region ? 'Region annotation' : 'Whole document';
 
+  // Expanding swaps the row's button for the card's collapse control (and back
+  // again), so the element that had focus disappears mid-interaction. Focus
+  // therefore follows the toggle — but only when the reviewer pressed it HERE:
+  // a mark click on the page selects the row too (issue #491) and must not
+  // yank focus out of the document (issue #549).
+  const toggledHere = useRef(false);
+  const rowRef = useRef<HTMLButtonElement>(null);
+  const collapseRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (!toggledHere.current) return;
+    toggledHere.current = false;
+    (active ? collapseRef : rowRef).current?.focus();
+  }, [active]);
+  const toggle = () => {
+    toggledHere.current = true;
+    onSelect(active ? null : annotation.id);
+  };
+
   return (
-    <ButtonBase
-      // Expanded, the card hosts real buttons (the head's copy-link) — a
-      // <button> may not nest, so the active card is a div with button role.
-      component={active ? 'div' : 'button'}
-      onClick={(event: MouseEvent<HTMLElement>) => {
-        // The expanded card hosts real interactive controls (placement
-        // actions, copy, reactions, profile links). Each stops propagation,
-        // but the row must not depend on every future control remembering to
-        // — a click originating on any interactive descendant never toggles
-        // the card (issue #480).
-        const interactive = (event.target as HTMLElement).closest(
-          'button, a, [role="button"], input, textarea, [contenteditable="true"]',
-        );
-        if (interactive && interactive !== event.currentTarget) return;
-        // Selecting quote text inside the card ends with a click on it —
-        // don't treat a live selection as a toggle (issue #478).
-        const selection = window.getSelection();
-        if (selection && !selection.isCollapsed) return;
-        onSelect(active ? null : annotation.id);
-      }}
+    <Box
+      // The card is a plain container (issue #549). Expanded it hosts real
+      // controls — placement actions, copy, reactions, profile links — and
+      // interactive content inside a role="button" is invalid ARIA: a screen
+      // reader announces the whole card as one button and every nested control
+      // depends on stopping propagation. So the toggle is an explicit control
+      // instead: collapsed, the entire row IS the button; expanded, the card
+      // carries a collapse chevron. That also retires #480's
+      // interactive-descendant guard and #478's selection guard — nothing on
+      // the expanded card listens for a click any more, so selecting the
+      // quoted passage simply selects it.
       onMouseEnter={() => onHover?.(annotation.id)}
       onMouseLeave={() => onHover?.(null)}
       onFocus={() => onHover?.(annotation.id)}
       onBlur={() => onHover?.(null)}
-      aria-expanded={active}
       // Stable DOM id — the scroll target when a mark click selects this row (#491).
       id={`annotation-item-${annotation.id}`}
       data-testid={`annotation-item-${annotation.id}`}
       sx={{
-        display: 'block',
-        width: '100%',
-        textAlign: 'left',
         position: 'relative',
         borderRadius: 0.75,
         border: '1px solid',
@@ -273,183 +290,218 @@ function AnnotationListItemBase({
         borderColor: active || linked ? theme.qnop.brand.blue : theme.palette.divider,
         bgcolor: active || linked ? alpha(theme.qnop.brand.blue, 0.06) : 'background.paper',
         boxShadow: linked && theme.palette.mode === 'light' ? tokens.shadow.sm : 'none',
-        px: 1.25,
-        py: active ? 1.25 : 0.75,
+        // Collapsed, the padding belongs to the button so the whole padded row
+        // is the click target; expanded, the container owns it.
+        ...(active ? { px: 1.25, py: 1.25 } : null),
         transition: 'border-color 120ms ease, background-color 120ms ease, box-shadow 120ms ease',
         '@media (prefers-reduced-motion: reduce)': { transition: 'none' },
         '&:hover': {
           borderColor: active || linked ? theme.qnop.brand.blue : alpha(theme.qnop.brand.blue, 0.4),
           bgcolor: active || linked ? alpha(theme.qnop.brand.blue, 0.06) : theme.qnop.surface2,
         },
-        '&:focus-visible': { boxShadow: theme.qnop.focusRing },
       }}
     >
       {active ? (
-        <AnnotationHead
-          annotation={annotation}
-          unseen={unseen}
-          permalinkUrl={permalinkUrl}
-          notify={notify}
-          onConfirmPlacement={onConfirmPlacement}
-          onReattachPlacement={onReattachPlacement}
-        />
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: 'flex-start', minWidth: 0 }}>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <AnnotationHead
+              annotation={annotation}
+              unseen={unseen}
+              permalinkUrl={permalinkUrl}
+              notify={notify}
+              onConfirmPlacement={onConfirmPlacement}
+              onReattachPlacement={onReattachPlacement}
+            />
+          </Box>
+          <Tooltip title="Collapse">
+            <IconButton
+              ref={collapseRef}
+              size="small"
+              aria-label="Collapse annotation"
+              aria-expanded
+              onClick={toggle}
+              data-testid={`annotation-toggle-${annotation.id}`}
+              sx={{ color: 'text.secondary', flexShrink: 0, mt: '-2px' }}
+            >
+              <ChevronUp size={16} aria-hidden />
+            </IconButton>
+          </Tooltip>
+        </Stack>
       ) : (
-        <Stack spacing={0.5} sx={{ minWidth: 0 }}>
-          {/* Title line: status tile, the content itself, participants. */}
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
-            <Tooltip title={statusCue.label}>
-              <Box
+        <ButtonBase
+          ref={rowRef}
+          onClick={toggle}
+          aria-expanded={false}
+          data-testid={`annotation-toggle-${annotation.id}`}
+          sx={{
+            display: 'block',
+            width: '100%',
+            textAlign: 'left',
+            borderRadius: 'inherit',
+            px: 1.25,
+            py: 0.75,
+            '&:focus-visible': { boxShadow: theme.qnop.focusRing },
+          }}
+        >
+          <Stack spacing={0.5} sx={{ minWidth: 0 }}>
+            {/* Title line: status tile, the content itself, participants. */}
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center', minWidth: 0 }}>
+              <Tooltip title={statusCue.label}>
+                <Box
+                  sx={{
+                    position: 'relative',
+                    width: 26,
+                    height: 26,
+                    borderRadius: '8px',
+                    display: 'grid',
+                    placeItems: 'center',
+                    bgcolor: alpha(statusCue.color(theme), 0.12),
+                    color: statusCue.color(theme),
+                    flexShrink: 0,
+                  }}
+                >
+                  <StatusIcon size={14} aria-label={statusCue.label} />
+                  {unseen && (
+                    <Tooltip title="New since your last visit">
+                      <Box
+                        data-testid="unseen-dot"
+                        sx={{
+                          position: 'absolute',
+                          top: -3,
+                          right: -3,
+                          width: 9,
+                          height: 9,
+                          borderRadius: '50%',
+                          bgcolor: theme.qnop.brand.blue,
+                          border: '2px solid',
+                          borderColor: 'background.paper',
+                        }}
+                      />
+                    </Tooltip>
+                  )}
+                </Box>
+              </Tooltip>
+              <Typography
+                variant="body2"
+                noWrap
                 sx={{
-                  position: 'relative',
-                  width: 26,
-                  height: 26,
-                  borderRadius: '8px',
-                  display: 'grid',
-                  placeItems: 'center',
-                  bgcolor: alpha(statusCue.color(theme), 0.12),
-                  color: statusCue.color(theme),
+                  flex: 1,
+                  minWidth: 0,
+                  color: annotation.status === 'RESOLVED' ? 'text.secondary' : 'text.primary',
+                  fontStyle: quote ? 'italic' : 'normal',
+                }}
+              >
+                {quote
+                  ? `“${quote}”`
+                  : plainExcerpt(resolveMentions(annotation.firstComment ?? '')) || fallbackLabel}
+              </Typography>
+              <ParticipantAvatars participants={participants} review={review} />
+            </Stack>
+            {/* Meta line: who, when, what kind — then the counters. */}
+            <Stack
+              direction="row"
+              spacing={0.75}
+              sx={{ alignItems: 'center', minWidth: 0, pl: TILE_INDENT, color: 'text.secondary' }}
+            >
+              <UserHoverCard
+                userId={hoverUserId}
+                slug={annotation.authorSlug}
+                profileName={authorName}
+                // Preview, not link — see the participant stack above (#549).
+                link={false}
+                sx={{ alignItems: 'center', gap: 0.75, flexShrink: 1 }}
+              >
+                <UserAvatar
+                  name={authorName}
+                  size={16}
+                  imageUrl={
+                    annotation.authorId === viewerId
+                      ? viewerAvatarUrl
+                      : avatarSrc(annotation.authorId)
+                  }
+                />
+                <Typography variant="caption" noWrap sx={{ fontWeight: 500, flexShrink: 1 }}>
+                  {authorName}
+                </Typography>
+              </UserHoverCard>
+              <Typography
+                variant="caption"
+                title={formatDateTime(annotation.createdAt)}
+                sx={{ flexShrink: 0, color: 'text.disabled' }}
+              >
+                {shortRelativeTime(annotation.createdAt)}
+              </Typography>
+              {placementCue && (
+                <Stack
+                  direction="row"
+                  spacing={0.4}
+                  sx={{ alignItems: 'center', color: placementCue.color(theme), flexShrink: 0 }}
+                >
+                  <placementCue.icon size={11} aria-hidden />
+                  <Typography component="span" sx={{ fontSize: 11, fontWeight: 700 }}>
+                    {placementCue.label}
+                  </Typography>
+                </Stack>
+              )}
+              {typeCue && (
+                <Stack
+                  direction="row"
+                  spacing={0.4}
+                  sx={{ alignItems: 'center', color: typeCue.color(theme), flexShrink: 0 }}
+                >
+                  <typeCue.icon size={11} aria-hidden />
+                  <Typography variant="caption">{typeCue.label}</Typography>
+                </Stack>
+              )}
+              {priorityCue && (
+                <Tooltip title={`${priorityCue.label} priority`}>
+                  <Box
+                    sx={{
+                      width: 7,
+                      height: 7,
+                      borderRadius: '50%',
+                      bgcolor: priorityCue.color(theme),
+                      flexShrink: 0,
+                    }}
+                  />
+                </Tooltip>
+              )}
+              <Box sx={{ flex: 1 }} />
+              <Stack
+                direction="row"
+                spacing={0.5}
+                data-testid="comment-count"
+                sx={{
+                  alignItems: 'center',
+                  color: freshComments ? theme.qnop.brand.blue : 'text.secondary',
+                  fontWeight: freshComments ? 600 : undefined,
                   flexShrink: 0,
                 }}
               >
-                <StatusIcon size={14} aria-label={statusCue.label} />
-                {unseen && (
-                  <Tooltip title="New since your last visit">
-                    <Box
-                      data-testid="unseen-dot"
-                      sx={{
-                        position: 'absolute',
-                        top: -3,
-                        right: -3,
-                        width: 9,
-                        height: 9,
-                        borderRadius: '50%',
-                        bgcolor: theme.qnop.brand.blue,
-                        border: '2px solid',
-                        borderColor: 'background.paper',
-                      }}
-                    />
-                  </Tooltip>
-                )}
-              </Box>
-            </Tooltip>
-            <Typography
-              variant="body2"
-              noWrap
-              sx={{
-                flex: 1,
-                minWidth: 0,
-                color: annotation.status === 'RESOLVED' ? 'text.secondary' : 'text.primary',
-                fontStyle: quote ? 'italic' : 'normal',
-              }}
-            >
-              {quote
-                ? `“${quote}”`
-                : plainExcerpt(resolveMentions(annotation.firstComment ?? '')) || fallbackLabel}
-            </Typography>
-            <ParticipantAvatars participants={participants} review={review} />
-          </Stack>
-          {/* Meta line: who, when, what kind — then the counters. */}
-          <Stack
-            direction="row"
-            spacing={0.75}
-            sx={{ alignItems: 'center', minWidth: 0, pl: TILE_INDENT, color: 'text.secondary' }}
-          >
-            <UserHoverCard
-              userId={hoverUserId}
-              slug={annotation.authorSlug}
-              profileName={authorName}
-              sx={{ alignItems: 'center', gap: 0.75, flexShrink: 1 }}
-            >
-              <UserAvatar
-                name={authorName}
-                size={16}
-                imageUrl={
-                  annotation.authorId === viewerId
-                    ? viewerAvatarUrl
-                    : avatarSrc(annotation.authorId)
-                }
-              />
-              <Typography variant="caption" noWrap sx={{ fontWeight: 500, flexShrink: 1 }}>
-                {authorName}
-              </Typography>
-            </UserHoverCard>
-            <Typography
-              variant="caption"
-              title={formatDateTime(annotation.createdAt)}
-              sx={{ flexShrink: 0, color: 'text.disabled' }}
-            >
-              {shortRelativeTime(annotation.createdAt)}
-            </Typography>
-            {placementCue && (
-              <Stack
-                direction="row"
-                spacing={0.4}
-                sx={{ alignItems: 'center', color: placementCue.color(theme), flexShrink: 0 }}
-              >
-                <placementCue.icon size={11} aria-hidden />
-                <Typography component="span" sx={{ fontSize: 11, fontWeight: 700 }}>
-                  {placementCue.label}
+                <MessageSquare size={12} aria-hidden />
+                <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
+                  {annotation.commentCount}
                 </Typography>
               </Stack>
-            )}
-            {typeCue && (
-              <Stack
-                direction="row"
-                spacing={0.4}
-                sx={{ alignItems: 'center', color: typeCue.color(theme), flexShrink: 0 }}
-              >
-                <typeCue.icon size={11} aria-hidden />
-                <Typography variant="caption">{typeCue.label}</Typography>
-              </Stack>
-            )}
-            {priorityCue && (
-              <Tooltip title={`${priorityCue.label} priority`}>
-                <Box
-                  sx={{
-                    width: 7,
-                    height: 7,
-                    borderRadius: '50%',
-                    bgcolor: priorityCue.color(theme),
-                    flexShrink: 0,
-                  }}
-                />
-              </Tooltip>
-            )}
-            <Box sx={{ flex: 1 }} />
-            <Stack
-              direction="row"
-              spacing={0.5}
-              data-testid="comment-count"
-              sx={{
-                alignItems: 'center',
-                color: freshComments ? theme.qnop.brand.blue : 'text.secondary',
-                fontWeight: freshComments ? 600 : undefined,
-                flexShrink: 0,
-              }}
-            >
-              <MessageSquare size={12} aria-hidden />
-              <Typography variant="caption" aria-label={`${annotation.commentCount} comments`}>
-                {annotation.commentCount}
-              </Typography>
+              {region ? (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}
+                >
+                  p. {region.surfaceIndex + 1}
+                </Typography>
+              ) : (
+                // In the flat list (issue #481) the scope must read per card —
+                // collapsed document-scoped rows mark themselves like the
+                // anchored ones mark their page.
+                isDocumentScoped(annotation) && <WholeDocumentChip compact />
+              )}
             </Stack>
-            {region ? (
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}
-              >
-                p. {region.surfaceIndex + 1}
-              </Typography>
-            ) : (
-              // In the flat list (issue #481) the scope must read per card —
-              // collapsed document-scoped rows mark themselves like the
-              // anchored ones mark their page.
-              isDocumentScoped(annotation) && <WholeDocumentChip compact />
-            )}
           </Stack>
-        </Stack>
+        </ButtonBase>
       )}
-    </ButtonBase>
+    </Box>
   );
 }
 

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -251,8 +251,9 @@ describe('AnnotationPanel', () => {
     expect(props.onSelect).toHaveBeenCalledWith('a1');
   });
 
-  // Issue #480: placement actions live inside the row's ButtonBase — acting on
-  // a placement must never toggle the card the reviewer is reading.
+  // Issue #480: acting on a placement must never toggle the card the reviewer
+  // is reading. Since #549 the expanded card is no longer a button at all, so
+  // this holds structurally rather than through a click guard.
   it('keeps the row expanded when "Looks right" confirms a MOVED placement (#480)', () => {
     useAuthStore.setState({ userId: 'u1' });
     const props = renderPanel({

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -21,11 +21,14 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { axe } from 'vitest-axe';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router';
 import type { AnnotationView } from '../../../api/generated';
 import { AnnotationStatus, ParticipantKind, PlacementStatus } from '../../../api/generated';
 import { useParticipants } from '../../../api/hooks/useReviews';
+import { useDocument } from '../../../api/hooks/useDocuments';
 import { buildTheme } from '../../../theme/theme';
 import { useAuthStore } from '../../../stores/authStore';
 import { AnnotationPanel } from './AnnotationPanel';
@@ -52,6 +55,14 @@ vi.mock('./CommentThread', () => ({
   ),
 }));
 
+// Partial: only the review lookup is steered. It gates the profile hover cards
+// (issue #482) — without a review they render neither card nor link, and the
+// nested-interactive assertions below would be vacuous.
+vi.mock('../../../api/hooks/useDocuments', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../api/hooks/useDocuments')>()),
+  useDocument: vi.fn(),
+}));
+
 vi.mock('../../../api/hooks/useComments', () => ({
   useComments: vi.fn().mockReturnValue({ isPending: false, isError: false, data: undefined }),
 }));
@@ -74,6 +85,7 @@ vi.mock('../../../api/hooks/useAnnotations', () => ({
 beforeEach(() => {
   resolveMutate.mockClear();
   confirmMutate.mockClear();
+  vi.mocked(useDocument).mockReturnValue({ data: undefined } as never);
   vi.mocked(useParticipants).mockReturnValue({
     data: { participants: [{ principalId: 'other', displayName: 'Anna Weber' }] },
   } as never);
@@ -113,13 +125,17 @@ function renderPanel(props: Partial<Parameters<typeof AnnotationPanel>[0]> = {})
   const wrap = (current: Parameters<typeof AnnotationPanel>[0]) => (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={buildTheme('light')}>
-        <AnnotationPanel {...current} />
+        {/* The profile links in the hover cards (issue #482) are router links. */}
+        <MemoryRouter>
+          <AnnotationPanel {...current} />
+        </MemoryRouter>
       </ThemeProvider>
     </QueryClientProvider>
   );
-  const { rerender } = render(wrap(merged));
+  const { rerender, container } = render(wrap(merged));
   return {
     ...merged,
+    container,
     /** Re-renders the same panel with patched props — the panel keeps its own state. */
     update: (patch: Partial<Parameters<typeof AnnotationPanel>[0]>) =>
       rerender(wrap({ ...merged, ...patch })),
@@ -222,8 +238,17 @@ describe('AnnotationPanel', () => {
     const props = renderPanel({ annotations: [annotation('a1')], activeAnnotationId: 'a1' });
 
     expect(screen.getByTestId('thread-a1')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('annotation-item-a1'));
+    // Expanded, the card is a plain container and collapsing is an explicit
+    // control rather than a click anywhere on it (issue #549).
+    fireEvent.click(screen.getByTestId('annotation-toggle-a1'));
     expect(props.onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('expands a collapsed row from its toggle', () => {
+    const props = renderPanel({ annotations: [annotation('a1')], activeAnnotationId: null });
+
+    fireEvent.click(screen.getByTestId('annotation-toggle-a1'));
+    expect(props.onSelect).toHaveBeenCalledWith('a1');
   });
 
   // Issue #480: placement actions live inside the row's ButtonBase — acting on
@@ -236,8 +261,6 @@ describe('AnnotationPanel', () => {
       versionNumber: 3,
     });
 
-    // Exact name: the expanded row is itself role="button" and its accessible
-    // name contains the action's text, so a substring match would be ambiguous.
     fireEvent.click(screen.getByRole('button', { name: 'Looks right' }));
 
     expect(confirmMutate).toHaveBeenCalledWith({
@@ -745,5 +768,110 @@ describe('AnnotationPanel', () => {
     fireEvent.keyUp(ta, { key: 'l' });
 
     expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+});
+
+// Issue #549: the expanded card hosts real controls — placement actions, copy,
+// reactions, profile links — so it may not be a role="button" itself. The
+// toggle is explicit instead: the collapsed row IS the button, the expanded
+// card carries a collapse chevron.
+describe('AnnotationPanel accessibility (#549)', () => {
+  beforeEach(() => {
+    // A non-anonymous review: every author id is real, so the hover cards and
+    // their profile links render (issue #482).
+    vi.mocked(useDocument).mockReturnValue({
+      data: { id: 'd1', anonymous: false, ownerId: 'u1' },
+    } as never);
+  });
+
+  /** Every focusable element that sits inside something announced as a button. */
+  const nestedInteractives = (container: HTMLElement) =>
+    [...container.querySelectorAll('button, [role="button"]')].flatMap((widget) => [
+      ...widget.querySelectorAll('a[href], button, input, select, textarea, [tabindex]'),
+    ]);
+
+  const AXE_OPTIONS = { rules: { region: { enabled: false } } };
+
+  /** An annotation with every expanded-state control in play. */
+  const loaded = () =>
+    annotation('a1', {
+      placementStatus: PlacementStatus.Moved,
+      reactions: [{ emoji: '👍', count: 1, reactedByMe: false, reactors: ['Anna Weber'] }],
+    });
+
+  it('nests no interactive control inside a button, collapsed or expanded', () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const collapsed = renderPanel({ annotations: [loaded()], activeAnnotationId: null });
+    expect(nestedInteractives(collapsed.container)).toEqual([]);
+    cleanup();
+
+    const expanded = renderPanel({
+      annotations: [loaded()],
+      activeAnnotationId: 'a1',
+      versionNumber: 3,
+      buildPermalink: () => 'https://qnop.test/reviews/d1?annotation=a1',
+      onArmReattach: vi.fn(),
+    });
+    // The card really does carry the controls this test is about.
+    expect(screen.getByRole('button', { name: 'Looks right' })).toBeInTheDocument();
+    expect(nestedInteractives(expanded.container)).toEqual([]);
+  });
+
+  it('has no axe violations with a collapsed list', async () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const { container } = renderPanel({
+      annotations: [loaded(), annotation('a2')],
+      activeAnnotationId: null,
+    });
+
+    expect(await axe(container, AXE_OPTIONS)).toHaveNoViolations();
+  });
+
+  it('has no axe violations with the card expanded', async () => {
+    useAuthStore.setState({ userId: 'u1' });
+    const { container } = renderPanel({
+      annotations: [loaded()],
+      activeAnnotationId: 'a1',
+      versionNumber: 3,
+      buildPermalink: () => 'https://qnop.test/reviews/d1?annotation=a1',
+      onArmReattach: vi.fn(),
+    });
+
+    expect(await axe(container, AXE_OPTIONS)).toHaveNoViolations();
+  });
+
+  it('announces the toggle state on the control that carries it', () => {
+    const panel = renderPanel({ annotations: [annotation('a1')], activeAnnotationId: null });
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAttribute('aria-expanded', 'false');
+
+    panel.update({ activeAnnotationId: 'a1' });
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAccessibleName('Collapse annotation');
+  });
+
+  // Expanding replaces the focused row button with the collapse chevron, so
+  // without this the keyboard user is dropped back to the document body.
+  it('carries focus across the toggle in both directions', () => {
+    const panel = renderPanel({ annotations: [annotation('a1')], activeAnnotationId: null });
+
+    const row = screen.getByTestId('annotation-toggle-a1');
+    row.focus();
+    fireEvent.click(row);
+    panel.update({ activeAnnotationId: 'a1' });
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveFocus();
+
+    fireEvent.click(screen.getByTestId('annotation-toggle-a1'));
+    panel.update({ activeAnnotationId: null });
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveFocus();
+  });
+
+  // A mark click on the page selects the row too (#491) — focus belongs to the
+  // document there, not to the panel.
+  it('leaves focus alone when the selection arrives from outside', () => {
+    const panel = renderPanel({ annotations: [annotation('a1')], activeAnnotationId: null });
+
+    panel.update({ activeAnnotationId: 'a1' });
+
+    expect(screen.getByTestId('annotation-toggle-a1')).not.toHaveFocus();
   });
 });

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -266,7 +266,7 @@ describe('DocumentReviewPage', () => {
     expect(screen.getByText('Annotations (1)')).toBeInTheDocument();
     expect(screen.getByText('“Hello”')).toBeInTheDocument();
     // Placement cues are expanded-state details.
-    fireEvent.click(screen.getByTestId('annotation-item-a1'));
+    fireEvent.click(screen.getByTestId('annotation-toggle-a1'));
     expect(screen.getByText('Moved')).toBeInTheDocument();
   });
 
@@ -397,7 +397,7 @@ describe('DocumentReviewPage deep link', () => {
   it('activates the annotation named by ?annotation=', () => {
     seedHappyPath();
     renderPage('/reviews/doc-1?annotation=a1');
-    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAttribute('aria-expanded', 'true');
   });
 
   // Issue #412: a comment permalink opens the annotation AND scrolls its thread
@@ -431,7 +431,7 @@ describe('DocumentReviewPage deep link', () => {
 
     renderPage('/reviews/doc-1?annotation=a1&comment=c9');
 
-    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAttribute('aria-expanded', 'true');
     expect(scrollIntoView).toHaveBeenCalled();
   });
 
@@ -465,14 +465,12 @@ describe('DocumentReviewPage placement actions (#480)', () => {
     useAuthStore.setState({ userId: 'u1' });
     seedOrphaned();
     renderPage('/reviews/doc-1?annotation=a1');
-    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAttribute('aria-expanded', 'true');
 
-    // Exact name: the expanded row is itself role="button" and its accessible
-    // name contains the action's text, so a substring match would be ambiguous.
     fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
 
     expect(screen.getByTestId('reattach-hint')).toBeInTheDocument();
-    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('still clears the selection and closes the drawer when arming re-attach in focus mode', () => {
@@ -481,14 +479,14 @@ describe('DocumentReviewPage placement actions (#480)', () => {
     renderPage('/reviews/doc-1?annotation=a1&view=focus');
 
     fireEvent.click(screen.getByRole('button', { name: /Show annotations/ }));
-    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAttribute('aria-expanded', 'true');
 
     fireEvent.click(screen.getByRole('button', { name: 'Re-attach' }));
     expect(screen.getByTestId('reattach-hint')).toBeInTheDocument();
 
     // The selection is cleared so the focus overlay cannot spring back onto
     // the thread (issue #403); the drawer closes, its content stays mounted.
-    expect(screen.getByTestId('annotation-item-a1')).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByTestId('annotation-toggle-a1')).toHaveAttribute('aria-expanded', 'false');
   });
 });
 
@@ -520,7 +518,7 @@ describe('DocumentReviewPage on an older version', () => {
       useAuthStore.setState({ userId: 'u1' });
       renderPage('/reviews/doc-1?version=1');
 
-      fireEvent.click(screen.getByTestId('annotation-item-a1'));
+      fireEvent.click(screen.getByTestId('annotation-toggle-a1'));
       expect(screen.queryByTestId('resolve-bar')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('Add a comment')).not.toBeInTheDocument();
     });
@@ -530,7 +528,7 @@ describe('DocumentReviewPage on an older version', () => {
       useAuthStore.setState({ userId: 'u1' });
       renderPage('/reviews/doc-1?version=2');
 
-      fireEvent.click(screen.getByTestId('annotation-item-a1'));
+      fireEvent.click(screen.getByTestId('annotation-toggle-a1'));
       expect(screen.getByTestId('resolve-bar')).toBeInTheDocument();
       expect(screen.getByLabelText('Add a comment')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary

The expanded annotation card hosted real controls inside a `role="button"` container — invalid ARIA: a screen reader announced the whole card as one button and every nested control depended on stopping propagation.

- Collapsed, the whole row is the single toggle button; expanded, the card is a plain container closed by a chevron beside the head.
- Focus follows the toggle in both directions, but only when it was pressed in the panel — a mark click on the page (#491) still selects without stealing focus from the document.
- The 20 px participant avatars inside the row button stay hover previews rather than nested links (a link inside a button is invalid); the expanded card's author row carries the real link.
- Retires #480's interactive-descendant guard and #478's selection guard: nothing on the expanded card listens for a click any more.
- Tests target the new `annotation-toggle-*` control; `AnnotationPanel` gains nested-interactive and axe checks (collapsed + expanded), `aria-expanded` and focus-handoff cases.
- Polish after review: the chevron carries the branded focus ring, both toggle states point at the card via `aria-controls`, stale comments updated.

Closes #549 · part of #460

## Test plan

- [x] `pnpm test:run` — full suite green (178 files / 1320 tests)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- [ ] CI green
- [ ] Manual: keyboard through the panel — Enter expands, the chevron collapses, focus lands on the toggle each way

🤖 Co-Author: Claude (Fable 5) via Claude Code
