### PR TITLE
feat(ui): WCAG 2.2 audit — axe regression net, keyboard text selection, landmark fixes (#460)

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,0 +1,113 @@
+<!--
+Copyright (c) 2026-present devtank42 GmbH
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# Accessibility (WCAG 2.2 AA): findings and the regression net
+
+Issue #460. This is the structural pass: what an automated checker can see in
+the DOM, plus the pointer-only interactions walked by hand in the source. It is
+honest about its limits — see the last section for what still needs a browser.
+
+## What was checked, and how
+
+**Automated, in CI.** `vitest-axe` (axe-core 4.12) runs over a rendered,
+populated state of every page-level surface named in #460 and the review
+components underneath them: login, dashboard, reviews list, new review,
+document review page, version compare, tasks board and page, annotation panel,
+comment thread, sidebar, profile, search, messages, my teams, audit, and the
+admin pages (users, teams, settings, OIDC, scheduler). The shared configuration
+lives in `qnop-ui/src/test/axe.ts`; one rule (`region`) is off globally because
+a component rendered in isolation has no landmark around it, and one surface
+(document review page) exempts `nested-interactive` for the finding tracked by
+#549. Every new violation fails `pnpm test:run`, which CI runs on every PR.
+
+The `jsx-a11y` recommended preset is active in ESLint with no rule disabled.
+
+**By hand, in the source.** Every pointer handler in the review workspace
+(`onPointerDown`/`onMouseDown`, drag, resize) was traced for a keyboard path.
+
+## Findings
+
+Each maps to *fixed*, *tracked* (another issue owns it) or *wontfix* with the
+reason.
+
+### 1. Unnamed column header in the reviews table — fixed
+
+The trailing actions column had an empty `<th>`. axe: `empty-table-header`.
+It now carries a visually hidden "Actions" (`theme/visuallyHidden.ts`).
+
+### 2. Profile hover link without an accessible name — fixed
+
+`UserHoverCard` renders a link around a decorative avatar (`alt=""`) and only
+set `aria-label` when the profile name was known. With an unnamed participant
+that left a focusable link with no name. axe: `link-name`. The link now always
+has a name ("View profile" as the fallback).
+
+### 3. Sidebar navigation: no landmark, invalid list — fixed
+
+The rail's navigation was a plain `<div>`, and each entry was an `<a>` as a
+direct child of `<ul>`. axe: `list`. It is now `<nav aria-label="Main
+navigation">` with an `<li>` per entry.
+
+### 4. Rescan spinner not behind `prefers-reduced-motion` — fixed
+
+The one animation in the app without the guard (storage-consistency page). All
+other `keyframes`/`animation` uses already carried it; verified by grep.
+
+### 5. Text selection was pointer-only — fixed
+
+`TextSpanLayer` had no keyboard path at all, so a keyboard-only user could not
+start the core review loop (WCAG 2.1.1). The layer is now focusable: arrow
+keys move a caret through the canonical text (Up/Down keep the column across
+lines, Home/End jump to the line ends), Shift extends a range, Enter emits it
+exactly like a pointer release, Escape clears. A visually hidden description
+names the keys. Caret and range paint with the same marker bands as a drag.
+
+### 6. Region (rubber-band) selection is pointer-only — tracked
+
+`RegionSelectLayer` has no keyboard equivalent. With text selection now
+keyboard-reachable (finding 5), a keyboard user can annotate any extracted
+text; what they cannot do is mark an arbitrary rectangle (a figure, a scanned
+page). A keyboard rectangle (arrows move, Shift+arrows size, Enter commits) is
+a self-contained follow-up and is filed as such rather than bolted on here.
+
+### 7. Expanded annotation card nests controls inside `role="button"` — tracked (#549)
+
+axe: `nested-interactive`. #549 restructures the card; the page-level axe test
+exempts exactly this rule until it lands.
+
+### 8. Panel splitter and drawer resize handles — already compliant
+
+`PanelResizer` and `ResizeHandle` are `role="separator"` with
+`aria-valuemin/max/now`, `tabIndex=0`, arrow keys (plus Home/End on the
+splitter) and a `focus-visible` ring. No change.
+
+### 9. Dialogs, drawers, popovers — already compliant
+
+All are MUI `Dialog`/`Drawer`/`Popover`, which trap focus and restore it to the
+opener on close. Toasts are MUI `Alert` inside `Snackbar` (`role="alert"`), so
+they are announced. Form fields are MUI `TextField` with `error`/`helperText`,
+which wires `aria-invalid` and `aria-describedby`. No change.
+
+### 10. PDF canvas content — wontfix here
+
+Screen-reader access to the rendered page image is out of scope per #460; the
+extracted text layer is what assistive tech gets today.
+
+## What this cannot see — still a browser step
+
+jsdom builds a DOM but never lays out or paints, and axe reports what it
+cannot judge as *incomplete*, not as a violation. So none of the following is
+covered by the net above, and none is claimed here:
+
+- **Colour contrast (1.4.3)** in either theme. The dark palette was calibrated
+  in #423; the light palette has not had that treatment.
+- **Target size (2.5.8)** beyond the header controls fixed in #724.
+- **Focus visibility (2.4.7/2.4.11)** — the rings exist in the source; that
+  they render unobscured is a visual check.
+- **A real screen-reader walkthrough** of the review loop.
+
+These belong to the Playwright net #725 introduces (`@axe-core/playwright`
+runs in a browser and does evaluate contrast); until then they are a manual
+pass before a release, not something CI guarantees.

--- a/docs/RESPONSIVE.md
+++ b/docs/RESPONSIVE.md
@@ -76,6 +76,13 @@ at 768 px, 90+ on admin tables at 320 px), but most of those are table-row
 actions where density is the point. The header is not: it is chrome, present on
 every screen, and the first thing a thumb reaches for.
 
+Fixed in #724 by growing the hit area, not the icon: `touchTargetSx`
+(`src/theme/touchTarget.ts`) lays a transparent `::before` overlay of
+`max(100%, 44px)` on each axis over the control, so the header keeps its 28 px
+visual weight while the box a finger or cursor has to hit is 44 px. Applied to
+the three header controls and the banner dismiss; reusable for any other
+chrome-level control that falls under the target.
+
 ## Support tiers — proposed, pending the rest of the audit
 
 Derived from what was measured. The 375 px line in particular is a

--- a/qnop-ui/src/components/banner/InfoBanner.test.tsx
+++ b/qnop-ui/src/components/banner/InfoBanner.test.tsx
@@ -23,6 +23,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { InfoBanner as InfoBannerModel } from '../../api/generated';
+import { hasTouchTarget } from '../../test/cssRules';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import { InfoBanner } from './InfoBanner';
 
@@ -95,5 +96,11 @@ describe('InfoBanner', () => {
     // A future severity must never blank the notice out.
     expect(screen.getByText('Still readable')).toBeInTheDocument();
     expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('gives the dismiss button a 44 px hit area (#724)', () => {
+    renderWithProviders(<InfoBanner banner={banner()} onDismiss={vi.fn()} />);
+
+    expect(hasTouchTarget(screen.getByRole('button', { name: 'Dismiss this notice' }))).toBe(true);
   });
 });

--- a/qnop-ui/src/components/banner/InfoBanner.tsx
+++ b/qnop-ui/src/components/banner/InfoBanner.tsx
@@ -27,6 +27,7 @@ import { useTheme } from '@mui/material/styles';
 import { ArrowUpRight, Info, OctagonAlert, TriangleAlert, X } from 'lucide-react';
 import type { InfoBanner as InfoBannerModel } from '../../api/generated';
 import { tokens } from '../../theme/tokens';
+import { touchTargetSx } from '../../theme/touchTarget';
 
 /**
  * Tone per severity: the translucent badge tint (composites over both the light
@@ -127,7 +128,14 @@ export function InfoBanner({ banner, variant = 'bar', onDismiss }: InfoBannerPro
           size="small"
           onClick={onDismiss}
           aria-label="Dismiss this notice"
-          sx={{ color: 'inherit', opacity: 0.7, mt: '-2px', '&:hover': { opacity: 1 } }}
+          // 25 px visually, 44 px to hit (#724).
+          sx={{
+            ...touchTargetSx,
+            color: 'inherit',
+            opacity: 0.7,
+            mt: '-2px',
+            '&:hover': { opacity: 1 },
+          }}
         >
           <X size={15} />
         </IconButton>

--- a/qnop-ui/src/components/people/UserHoverCard.tsx
+++ b/qnop-ui/src/components/people/UserHoverCard.tsx
@@ -137,7 +137,10 @@ function TriggerFrame({ children, to, profileName, sx, ...events }: TriggerFrame
             // Rows and cards underneath often have their own click targets
             // (open review, expand annotation) — the profile click wins.
             onClick: (event: MouseEvent) => event.stopPropagation(),
-            'aria-label': profileName ? `View ${profileName}'s profile` : undefined,
+            // Always named: the trigger is often a bare avatar with an empty
+            // `alt`, which leaves a focusable link with no accessible name
+            // when the profile name is unknown (issue #460).
+            'aria-label': profileName ? `View ${profileName}'s profile` : 'View profile',
           }
         : {})}
       sx={{

--- a/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
+++ b/qnop-ui/src/components/reviews/list/ReviewsTable.tsx
@@ -42,6 +42,25 @@ import { ToneBadge } from '../../admin/ToneBadge';
 import { readyToFinalize } from '../../dashboard/dashboardModel';
 import { DocumentIcon, OwnerChip, ProgressBar, ReviewerStack, RoleBadge } from './ReviewListParts';
 import { progressOf, roleOf } from './reviewListModel';
+import { visuallyHidden } from '../../../theme/visuallyHidden';
+
+/**
+ * The column headers. The trailing actions column shows nothing on screen, but
+ * a `<th>` with no text is an unnamed column header — axe flags it, and a
+ * screen reader announces the column as blank. Naming it and hiding the name
+ * visually keeps the layout and fixes the announcement (issue #460).
+ */
+const HEADERS: { label: string; hidden?: boolean }[] = [
+  { label: 'Document' },
+  { label: 'Role' },
+  { label: 'Owner' },
+  { label: 'Status' },
+  { label: 'Progress' },
+  { label: 'Reviewers' },
+  { label: 'Due' },
+  { label: 'Updated' },
+  { label: 'Actions', hidden: true },
+];
 
 interface ReviewsTableProps {
   reviews: DocumentSummary[];
@@ -94,19 +113,9 @@ export function ReviewsTable({
                   />
                 </TableCell>
               )}
-              {[
-                'Document',
-                'Role',
-                'Owner',
-                'Status',
-                'Progress',
-                'Reviewers',
-                'Due',
-                'Updated',
-                '',
-              ].map((header) => (
+              {HEADERS.map(({ label, hidden }) => (
                 <TableCell
-                  key={header}
+                  key={label}
                   sx={{
                     fontSize: 10.5,
                     fontWeight: 500,
@@ -116,7 +125,13 @@ export function ReviewsTable({
                     whiteSpace: 'nowrap',
                   }}
                 >
-                  {header}
+                  {hidden ? (
+                    <Box component="span" sx={visuallyHidden}>
+                      {label}
+                    </Box>
+                  ) : (
+                    label
+                  )}
                 </TableCell>
               ))}
             </TableRow>

--- a/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/AnnotationPanel.test.tsx
@@ -29,6 +29,7 @@ import { useParticipants } from '../../../api/hooks/useReviews';
 import { buildTheme } from '../../../theme/theme';
 import { useAuthStore } from '../../../stores/authStore';
 import { AnnotationPanel } from './AnnotationPanel';
+import { checkA11y } from '../../../test/axe';
 
 // The reaction toggles (issue #410) reach for the query client; the data
 // hooks above stay mocked, so a bare client per file is all the tests need.
@@ -117,9 +118,10 @@ function renderPanel(props: Partial<Parameters<typeof AnnotationPanel>[0]> = {})
       </ThemeProvider>
     </QueryClientProvider>
   );
-  const { rerender } = render(wrap(merged));
+  const { rerender, container } = render(wrap(merged));
   return {
     ...merged,
+    container,
     /** Re-renders the same panel with patched props — the panel keeps its own state. */
     update: (patch: Partial<Parameters<typeof AnnotationPanel>[0]>) =>
       rerender(wrap({ ...merged, ...patch })),
@@ -745,5 +747,10 @@ describe('AnnotationPanel', () => {
     fireEvent.keyUp(ta, { key: 'l' });
 
     expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderPanel({ annotations: [annotation('a1'), annotation('a2')] });
+    expect(await checkA11y(container)).toHaveNoViolations();
   });
 });

--- a/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
+++ b/qnop-ui/src/components/reviews/panel/CommentThread.test.tsx
@@ -27,6 +27,7 @@ import { buildTheme } from '../../../theme/theme';
 import { useAuthStore } from '../../../stores/authStore';
 import { CommentThread } from './CommentThread';
 import { useAddComment, useComments } from '../../../api/hooks/useComments';
+import { checkA11y } from '../../../test/axe';
 
 // The reaction toggles (issue #410) reach for the query client; the data
 // hooks above stay mocked, so a bare client per file is all the tests need.
@@ -473,5 +474,10 @@ describe('full-screen writing stage (issue #403)', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('fullscreen-composer')).not.toBeInTheDocument(),
     );
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderThread();
+    expect(await checkA11y(container)).toHaveNoViolations();
   });
 });

--- a/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
+++ b/qnop-ui/src/components/reviews/tasks/TaskBoard.test.tsx
@@ -33,6 +33,7 @@ import {
 import { buildTheme } from '../../../theme/theme';
 import { TaskBoard } from './TaskBoard';
 import { TASK_DRAG_TYPE } from './TaskCard';
+import { checkA11y } from '../../../test/axe';
 
 // TaskCard resolves mention tokens through the review roster (issue #462);
 // these tests run without a query client, so the resolver stays identity.
@@ -75,7 +76,7 @@ function renderBoard({
   onResolve?: Mock<(annotationId: string) => void>;
   onOpen?: Mock<(annotationId: string) => void>;
 } = {}) {
-  render(
+  const { container } = render(
     <ThemeProvider theme={buildTheme('light')}>
       <TaskBoard
         annotations={ANNOTATIONS}
@@ -87,7 +88,7 @@ function renderBoard({
       />
     </ThemeProvider>,
   );
-  return { onResolve, onOpen };
+  return { container, onResolve, onOpen };
 }
 
 const dataTransfer = (id: string) => ({
@@ -149,5 +150,10 @@ describe('TaskBoard', () => {
     expect(screen.getByTestId('task-card-a-open')).toHaveAttribute('draggable', 'true');
     expect(screen.getByTestId('task-card-a-talk')).toHaveAttribute('draggable', 'false');
     expect(screen.getByTestId('task-card-a-done')).toHaveAttribute('draggable', 'false');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderBoard();
+    expect(await checkA11y(container)).toHaveNoViolations();
   });
 });

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -177,4 +177,63 @@ describe('TextSpanLayer', () => {
 
     expect(onTextSelected).not.toHaveBeenCalled();
   });
+
+  describe('keyboard selection (issue #460)', () => {
+    it('is focusable and describes its keys while enabled', () => {
+      renderLayer();
+      const layer = layerAt();
+      expect(layer).toHaveAttribute('tabindex', '0');
+      expect(layer).toHaveAccessibleDescription(/Arrow keys move the caret/);
+    });
+
+    it('is out of the tab order while disabled', () => {
+      renderLayer({ enabled: false });
+      expect(layerAt()).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('extends a range with Shift+Arrow and emits it on Enter', () => {
+      const onTextSelected = renderLayer();
+      const layer = layerAt();
+      layer.focus();
+      fireEvent.keyDown(layer, { key: 'ArrowRight' });
+      fireEvent.keyDown(layer, { key: 'ArrowRight', shiftKey: true });
+      fireEvent.keyDown(layer, { key: 'ArrowRight', shiftKey: true });
+      expect(screen.getByTestId('live-selection-0')).toBeInTheDocument();
+      fireEvent.keyDown(layer, { key: 'Enter' });
+
+      expect(onTextSelected).toHaveBeenCalledWith(
+        { surfaceIndex: 0, start: 1, end: 3 },
+        expect.objectContaining({ left: expect.any(Number), top: expect.any(Number) }),
+      );
+      expect(screen.queryByTestId('live-selection-0')).not.toBeInTheDocument();
+    });
+
+    it('walks lines with ArrowDown and shows a caret', () => {
+      renderLayer();
+      const layer = layerAt();
+      fireEvent.keyDown(layer, { key: 'ArrowRight' });
+      fireEvent.keyDown(layer, { key: 'ArrowDown' });
+      // Column 1 of the second line, whose box starts at y = 0.15.
+      expect(screen.getByTestId('keyboard-caret-0').style.top).not.toBe('10%');
+    });
+
+    it('does not emit a collapsed caret on Enter and clears on Escape', () => {
+      const onTextSelected = renderLayer();
+      const layer = layerAt();
+      fireEvent.keyDown(layer, { key: 'ArrowRight' });
+      fireEvent.keyDown(layer, { key: 'Enter' });
+      expect(onTextSelected).not.toHaveBeenCalled();
+      fireEvent.keyDown(layer, { key: 'Escape' });
+      expect(screen.queryByTestId('keyboard-caret-0')).not.toBeInTheDocument();
+    });
+
+    it('ignores keys while disabled', () => {
+      const onTextSelected = renderLayer({ enabled: false });
+      const layer = layerAt();
+      fireEvent.keyDown(layer, { key: 'ArrowRight', shiftKey: true });
+      fireEvent.keyDown(layer, { key: 'Enter' });
+      expect(onTextSelected).not.toHaveBeenCalled();
+      expect(screen.queryByTestId('keyboard-caret-0')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -19,19 +19,28 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useRef, useState } from 'react';
-import type { MouseEvent, PointerEvent } from 'react';
+import { useId, useRef, useState } from 'react';
+import type { KeyboardEvent, MouseEvent, PointerEvent } from 'react';
 import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
 import type { RenderedTextSpan } from '../../../api/generated';
 import type { ScreenPosition, TextSelectionOffsets } from './anchoring';
 import {
   boxesForRange,
   caretOffsetAtPoint,
+  charLeftEdge,
   markerLineBox,
   surfaceLinePitch,
+  surfaceText,
   wordRangeAt,
 } from './anchoring';
 import { SELECTION_MARKER_BG } from './markerColors';
+import { visuallyHidden } from '../../../theme/visuallyHidden';
+import { keyboardCaretMove, spanAtOffset } from './keyboardSelection';
+
+/** How the keyboard path is announced to assistive tech (issue #460). */
+const KEYBOARD_HINT =
+  'Arrow keys move the caret through the text, Shift with an arrow key extends the selection, Enter annotates the selection, Escape clears it.';
 
 interface TextSpanLayerProps {
   spans: RenderedTextSpan[];
@@ -51,6 +60,11 @@ interface TextSpanLayerProps {
  * to the pending preview and persisted highlights; double-click selects the
  * word under the pointer. The emitted offsets are the canonical-text offsets
  * the anchor model needs (ADR-0009).
+ *
+ * Keyboard equivalent (issue #460, WCAG 2.1.1): the layer is focusable; arrow
+ * keys walk a caret through the same canonical text, Shift extends a range
+ * from the anchor, Enter emits it exactly like a pointer release, Escape
+ * clears. The caret and range paint with the same marker bands.
  */
 export function TextSpanLayer({
   spans,
@@ -61,8 +75,14 @@ export function TextSpanLayer({
   const rootRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ anchor: number } | null>(null);
   const [liveRange, setLiveRange] = useState<{ start: number; end: number } | null>(null);
+  // The keyboard caret: `anchor` is where Shift-extension started, `focus`
+  // the moving end. Null until the layer is focused and a key is pressed.
+  const [caret, setCaret] = useState<{ anchor: number; focus: number } | null>(null);
+  const hintId = useId();
+  const theme = useTheme();
 
   const pitch = surfaceLinePitch(spans);
+  const textLength = surfaceText(spans).length;
 
   const caretAt = (event: PointerEvent | MouseEvent): number | null => {
     const root = rootRef.current;
@@ -127,11 +147,73 @@ export function TextSpanLayer({
     }
   };
 
+  /** Viewport position of a range's trailing edge — the keyboard stand-in for the pointer. */
+  const screenPositionAtEnd = (end: number): ScreenPosition => {
+    const rect = rootRef.current?.getBoundingClientRect();
+    const span = spanAtOffset(spans, Math.max(end - 1, 0));
+    if (!rect || !span) return { left: 0, top: 0 };
+    const x = charLeftEdge(span, Math.min(end - span.startOffset, span.text.length));
+    return {
+      left: rect.left + x * rect.width,
+      top: rect.top + (span.box.y + span.box.height) * rect.height,
+    };
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!enabled || textLength === 0) return;
+    if (event.key === 'Escape') {
+      if (!caret) return;
+      event.preventDefault();
+      setCaret(null);
+      return;
+    }
+    if (event.key === 'Enter') {
+      if (!caret || caret.anchor === caret.focus) return;
+      event.preventDefault();
+      const start = Math.min(caret.anchor, caret.focus);
+      const end = Math.max(caret.anchor, caret.focus);
+      setCaret(null);
+      onTextSelected({ surfaceIndex, start, end }, screenPositionAtEnd(end));
+      return;
+    }
+    const focus = keyboardCaretMove(spans, caret?.focus ?? 0, event.key, textLength);
+    if (focus === null) return;
+    event.preventDefault();
+    setCaret({ anchor: event.shiftKey && caret ? caret.anchor : focus, focus });
+  };
+
+  const keyboardRange =
+    caret && caret.anchor !== caret.focus
+      ? { start: Math.min(caret.anchor, caret.focus), end: Math.max(caret.anchor, caret.focus) }
+      : null;
+
   // Guarded by `enabled` so a stale range never paints on a disabled layer.
+  const paintedRange = liveRange ?? keyboardRange;
   const liveBoxes =
-    enabled && liveRange
-      ? boxesForRange(spans, liveRange.start, liveRange.end).map((box) => markerLineBox(box, pitch))
+    enabled && paintedRange
+      ? boxesForRange(spans, paintedRange.start, paintedRange.end).map((box) =>
+          markerLineBox(box, pitch),
+        )
       : [];
+
+  // A thin bar at the keyboard caret, so a sighted keyboard user sees where
+  // the selection will start.
+  const caretSpan = enabled && caret ? spanAtOffset(spans, caret.focus) : null;
+  const caretBox =
+    caretSpan && caret
+      ? markerLineBox(
+          {
+            x: charLeftEdge(
+              caretSpan,
+              Math.min(caret.focus - caretSpan.startOffset, caretSpan.text.length),
+            ),
+            y: caretSpan.box.y,
+            width: 0,
+            height: caretSpan.box.height,
+          },
+          pitch,
+        )
+      : null;
 
   return (
     <Box
@@ -141,11 +223,15 @@ export function TextSpanLayer({
       // the printed glyphs live in the canvas below, so this layer needs its own label.
       role="group"
       aria-label={`Selectable document text, page ${surfaceIndex + 1}`}
+      aria-describedby={enabled ? hintId : undefined}
+      tabIndex={enabled ? 0 : -1}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerCancel={endDrag}
       onDoubleClick={handleDoubleClick}
+      onKeyDown={handleKeyDown}
+      onBlur={() => setCaret(null)}
       sx={{
         position: 'absolute',
         inset: 0,
@@ -154,8 +240,29 @@ export function TextSpanLayer({
         pointerEvents: enabled ? 'auto' : 'none',
         userSelect: 'none',
         touchAction: 'none',
+        '&:focus-visible': { outline: 'none', boxShadow: `inset ${theme.qnop.focusRing}` },
       }}
     >
+      {enabled && (
+        <Box component="span" id={hintId} sx={visuallyHidden}>
+          {KEYBOARD_HINT}
+        </Box>
+      )}
+      {caretBox && (
+        <div
+          data-testid={`keyboard-caret-${surfaceIndex}`}
+          style={{
+            position: 'absolute',
+            left: `${caretBox.x * 100}%`,
+            top: `${caretBox.y * 100}%`,
+            width: '2px',
+            marginLeft: '-1px',
+            height: `${caretBox.height * 100}%`,
+            backgroundColor: theme.qnop.brand.blue,
+            pointerEvents: 'none',
+          }}
+        />
+      )}
       {liveBoxes.map((box, index) => (
         <div
           key={index}

--- a/qnop-ui/src/components/reviews/viewer/keyboardSelection.test.ts
+++ b/qnop-ui/src/components/reviews/viewer/keyboardSelection.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { RenderedTextSpan } from '../../../api/generated';
+import { keyboardCaretMove, spanAtOffset } from './keyboardSelection';
+
+const SPANS: RenderedTextSpan[] = [
+  { text: 'Hello', startOffset: 0, endOffset: 5, box: { x: 0, y: 0, width: 0.5, height: 0.02 } },
+  { text: 'Hi', startOffset: 6, endOffset: 8, box: { x: 0, y: 0.05, width: 0.2, height: 0.02 } },
+];
+const LENGTH = 8;
+
+describe('keyboardCaretMove (issue #460)', () => {
+  it('steps one character and clamps at the text ends', () => {
+    expect(keyboardCaretMove(SPANS, 0, 'ArrowRight', LENGTH)).toBe(1);
+    expect(keyboardCaretMove(SPANS, 0, 'ArrowLeft', LENGTH)).toBe(0);
+    expect(keyboardCaretMove(SPANS, 8, 'ArrowRight', LENGTH)).toBe(8);
+  });
+
+  it('keeps the column across lines, clamped to the shorter line', () => {
+    expect(keyboardCaretMove(SPANS, 4, 'ArrowDown', LENGTH)).toBe(8);
+    expect(keyboardCaretMove(SPANS, 7, 'ArrowUp', LENGTH)).toBe(1);
+    expect(keyboardCaretMove(SPANS, 7, 'ArrowDown', LENGTH)).toBeNull();
+  });
+
+  it('jumps to the line ends with Home and End', () => {
+    expect(keyboardCaretMove(SPANS, 7, 'Home', LENGTH)).toBe(6);
+    expect(keyboardCaretMove(SPANS, 1, 'End', LENGTH)).toBe(5);
+  });
+
+  it('leaves unrelated keys alone', () => {
+    expect(keyboardCaretMove(SPANS, 1, 'a', LENGTH)).toBeNull();
+    expect(keyboardCaretMove(SPANS, 1, 'Tab', LENGTH)).toBeNull();
+  });
+
+  it('resolves the span at an offset, including the trailing boundary', () => {
+    expect(spanAtOffset(SPANS, 5)?.text).toBe('Hello');
+    expect(spanAtOffset(SPANS, 6)?.text).toBe('Hi');
+    expect(spanAtOffset([], 0)).toBeNull();
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/keyboardSelection.ts
+++ b/qnop-ui/src/components/reviews/viewer/keyboardSelection.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { RenderedTextSpan } from '../../../api/generated';
+
+/** The span whose offsets contain `offset` (a span's trailing boundary counts as its own). */
+export function spanAtOffset(spans: RenderedTextSpan[], offset: number): RenderedTextSpan | null {
+  return (
+    spans.find((span) => offset >= span.startOffset && offset <= span.endOffset) ??
+    (spans.length > 0 && offset >= spans[spans.length - 1].endOffset
+      ? spans[spans.length - 1]
+      : null)
+  );
+}
+
+function clampOffset(offset: number, textLength: number): number {
+  return Math.min(Math.max(offset, 0), textLength);
+}
+
+/**
+ * Where the keyboard caret goes for a navigation key, in canonical-text
+ * offsets (issue #460). Left/Right step one character; Up/Down keep the
+ * column while moving one span (line) — clamped to the shorter line; Home/End
+ * jump to the current line's ends. Null for any other key, so the caller lets
+ * it bubble.
+ */
+export function keyboardCaretMove(
+  spans: RenderedTextSpan[],
+  focus: number,
+  key: string,
+  textLength: number,
+): number | null {
+  switch (key) {
+    case 'ArrowRight':
+      return clampOffset(focus + 1, textLength);
+    case 'ArrowLeft':
+      return clampOffset(focus - 1, textLength);
+    case 'ArrowDown':
+    case 'ArrowUp': {
+      const index = spans.findIndex((span) => focus >= span.startOffset && focus <= span.endOffset);
+      const target = spans[index + (key === 'ArrowDown' ? 1 : -1)];
+      if (index < 0 || !target) return null;
+      const column = focus - spans[index].startOffset;
+      return clampOffset(target.startOffset + Math.min(column, target.text.length), textLength);
+    }
+    case 'Home':
+    case 'End': {
+      const span = spanAtOffset(spans, focus);
+      if (!span) return null;
+      return clampOffset(
+        key === 'Home' ? span.startOffset : span.startOffset + span.text.length,
+        textLength,
+      );
+    }
+    default:
+      return null;
+  }
+}

--- a/qnop-ui/src/components/shell/SidebarContent.test.tsx
+++ b/qnop-ui/src/components/shell/SidebarContent.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../theme/theme';
+import { useAuthStore } from '../../stores/authStore';
+import { checkA11y } from '../../test/axe';
+import { SidebarContent } from './SidebarContent';
+
+vi.mock('../../api/hooks/useConfig', () => ({
+  useConfig: () => ({ data: undefined }),
+}));
+
+function renderSidebar(collapsed = false) {
+  return render(
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
+      <ThemeProvider theme={buildTheme('light')}>
+        <MemoryRouter>
+          <SidebarContent collapsed={collapsed} />
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('SidebarContent landmarks (issue #460)', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ role: 'ADMIN', userId: 'u1', displayName: 'Ada' });
+  });
+
+  it('exposes the rail as a named navigation landmark', () => {
+    renderSidebar();
+    expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations expanded', async () => {
+    const { container } = renderSidebar();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations collapsed', async () => {
+    const { container } = renderSidebar(true);
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+});

--- a/qnop-ui/src/components/shell/SidebarContent.tsx
+++ b/qnop-ui/src/components/shell/SidebarContent.tsx
@@ -22,6 +22,7 @@
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -134,8 +135,13 @@ export function SidebarContent({ collapsed, onNavigate }: SidebarContentProps) {
         )}
       </Box>
 
-      {/* Navigation */}
-      <Box sx={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', py: 1 }}>
+      {/* Navigation — a named landmark, so a screen reader can jump straight to
+          it instead of walking the rail (issue #460). */}
+      <Box
+        component="nav"
+        aria-label="Main navigation"
+        sx={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', py: 1 }}
+      >
         {groups.map((group, gi) => (
           <Box key={group.label || `g${gi}`} sx={{ px: 1, pt: gi === 0 ? 0.5 : 1.5 }}>
             {group.label && !collapsed && (
@@ -158,7 +164,6 @@ export function SidebarContent({ collapsed, onNavigate }: SidebarContentProps) {
               {group.items.map((item) => {
                 const button = (
                   <ListItemButton
-                    key={item.id}
                     component={NavLink}
                     to={item.path}
                     end={item.path === '/'}
@@ -197,12 +202,19 @@ export function SidebarContent({ collapsed, onNavigate }: SidebarContentProps) {
                     )}
                   </ListItemButton>
                 );
-                return collapsed ? (
-                  <Tooltip key={item.id} title={item.label} placement="right">
-                    {button}
-                  </Tooltip>
-                ) : (
-                  button
+                // Each entry sits in its own `<li>`: a `<ul>` whose direct
+                // children are anchors is invalid list markup and axe flags
+                // it (issue #460).
+                return (
+                  <ListItem key={item.id} disablePadding disableGutters>
+                    {collapsed ? (
+                      <Tooltip title={item.label} placement="right">
+                        {button}
+                      </Tooltip>
+                    ) : (
+                      button
+                    )}
+                  </ListItem>
                 );
               })}
             </List>

--- a/qnop-ui/src/components/shell/TopBar.test.tsx
+++ b/qnop-ui/src/components/shell/TopBar.test.tsx
@@ -26,6 +26,7 @@ import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from '../../theme/theme';
+import { hasTouchTarget } from '../../test/cssRules';
 import { TopBar } from './TopBar';
 
 // The embedded GlobalSearch (#540) queries through TanStack Query; the bar's
@@ -114,4 +115,18 @@ describe('TopBar notifications (#538)', () => {
     expect(screen.getByLabelText('Search reviews, people and teams')).toBeInTheDocument();
     expect(screen.queryByText(/jump to any review/i)).not.toBeInTheDocument();
   });
+});
+
+describe('TopBar touch targets (#724)', () => {
+  it.each(['Toggle menu', 'Switch to dark mode', 'Notifications'])(
+    'gives "%s" a 44 px hit area while keeping the small icon button',
+    (name) => {
+      renderTopBar();
+
+      const button = screen.getByRole('button', { name });
+
+      expect(button.className).toMatch(/MuiIconButton-sizeSmall/);
+      expect(hasTouchTarget(button)).toBe(true);
+    },
+  );
 });

--- a/qnop-ui/src/components/shell/TopBar.tsx
+++ b/qnop-ui/src/components/shell/TopBar.tsx
@@ -29,6 +29,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { Bell, Menu as MenuIcon, Moon, PanelLeft, Sun } from 'lucide-react';
 import { useUnreadCount } from '../../api/hooks/useNotifications';
 import { useUiStore } from '../../stores/uiStore';
+import { touchTargetSx } from '../../theme/touchTarget';
 import { NotificationsPopover } from './NotificationsPopover';
 import { Breadcrumbs } from './Breadcrumbs';
 import { GlobalSearch } from './search/GlobalSearch';
@@ -38,7 +39,13 @@ interface TopBarProps {
   onToggleSidebar: () => void;
 }
 
-/** The application top bar: sidebar toggle, breadcrumbs, search and quick actions. */
+/**
+ * The application top bar: sidebar toggle, breadcrumbs, search and quick actions.
+ *
+ * <p>The icon buttons keep their 28 px visual size but carry a 44 px hit area
+ * (issue #724): they are chrome on every screen and the first thing a thumb
+ * reaches for.
+ */
 export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
   const themeMode = useUiStore((s) => s.themeMode);
   const toggleTheme = useUiStore((s) => s.toggleTheme);
@@ -55,7 +62,13 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
     >
       <Toolbar sx={{ gap: 1.5, minHeight: { xs: 56, sm: 56 } }}>
         <Tooltip title={isMobile ? 'Menu' : 'Toggle menu'}>
-          <IconButton onClick={onToggleSidebar} size="small" edge="start" aria-label="Toggle menu">
+          <IconButton
+            onClick={onToggleSidebar}
+            size="small"
+            edge="start"
+            aria-label="Toggle menu"
+            sx={touchTargetSx}
+          >
             {isMobile ? <MenuIcon size={18} /> : <PanelLeft size={18} />}
           </IconButton>
         </Tooltip>
@@ -73,6 +86,7 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
           <IconButton
             onClick={toggleTheme}
             size="small"
+            sx={touchTargetSx}
             aria-label={themeMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
           >
             {themeMode === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
@@ -88,6 +102,7 @@ export function TopBar({ isMobile, onToggleSidebar }: TopBarProps) {
             aria-haspopup="dialog"
             aria-expanded={notificationsAnchor ? true : undefined}
             onClick={(event) => setNotificationsAnchor(event.currentTarget)}
+            sx={touchTargetSx}
           >
             <Badge
               color="primary"

--- a/qnop-ui/src/pages/HomePage.test.tsx
+++ b/qnop-ui/src/pages/HomePage.test.tsx
@@ -30,6 +30,7 @@ import { useUserProfile } from '../api/hooks/useUsers';
 import { buildTheme } from '../theme/theme';
 import { useAuthStore } from '../stores/authStore';
 import { HomePage } from './HomePage';
+import { checkA11y } from '../test/axe';
 
 vi.mock('../api/hooks/useReviews', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../api/hooks/useReviews')>()),
@@ -257,5 +258,14 @@ describe('HomePage dashboard (issue #454)', () => {
 
     // All four entry points have to agree; this is the dashboard one.
     expect(screen.getByRole('button', { name: /New review/i })).toBeDisabled();
+  });
+
+  it('has no accessibility violations', async () => {
+    mockData([
+      review({ id: 'w1', title: 'Their contract' }),
+      review({ id: 'o1', title: 'My own paper', ownerId: ME }),
+    ]);
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
   });
 });

--- a/qnop-ui/src/pages/UserProfilePage.test.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.test.tsx
@@ -113,7 +113,9 @@ describe('UserProfilePage slug URLs (issue #486)', () => {
     const { container } = renderPage('anna-krause');
     await screen.findByText('Anna Krause');
     expect(await checkA11y(container)).toHaveNoViolations();
-  });
+    // The profile is the largest single tree axe walks here (~1.5 s alone);
+    // under a loaded full-suite run it brushed the 5 s default.
+  }, 15_000);
 
   it('resolves a slug segment via the by-slug endpoint and keeps the pretty URL', async () => {
     vi.mocked(usersApi.getUserProfileBySlug).mockReturnValue(respond(profile()) as never);

--- a/qnop-ui/src/pages/UserProfilePage.test.tsx
+++ b/qnop-ui/src/pages/UserProfilePage.test.tsx
@@ -30,6 +30,7 @@ import { usersApi } from '../api/config';
 import { buildTheme } from '../theme/theme';
 import { useAuthStore } from '../stores/authStore';
 import { UserProfilePage } from './UserProfilePage';
+import { checkA11y } from '../test/axe';
 
 vi.mock('../api/config', () => ({
   usersApi: {
@@ -105,6 +106,15 @@ beforeEach(() => {
 });
 
 describe('UserProfilePage slug URLs (issue #486)', () => {
+  it('has no accessibility violations', async () => {
+    vi.mocked(usersApi.getUserProfileBySlug).mockReturnValue(
+      respond(profile({ teams: [{ id: 't1', name: 'Platform', role: 'LEAD' }] })) as never,
+    );
+    const { container } = renderPage('anna-krause');
+    await screen.findByText('Anna Krause');
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('resolves a slug segment via the by-slug endpoint and keeps the pretty URL', async () => {
     vi.mocked(usersApi.getUserProfileBySlug).mockReturnValue(respond(profile()) as never);
 

--- a/qnop-ui/src/pages/admin/OidcProvidersPage.test.tsx
+++ b/qnop-ui/src/pages/admin/OidcProvidersPage.test.tsx
@@ -27,6 +27,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { OidcProviderDto } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { OidcProvidersPage } from './OidcProvidersPage';
+import { checkA11y } from '../../test/axe';
 
 const { updateMutate, deleteMutate, useOidcProvidersMock } = vi.hoisted(() => ({
   updateMutate: vi.fn(),
@@ -118,6 +119,11 @@ function wrapper({ children }: { children: ReactNode }) {
 const renderPage = () => render(<OidcProvidersPage />, { wrapper });
 
 describe('OidcProvidersPage', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('lists the configured providers', () => {
     renderPage();
 

--- a/qnop-ui/src/pages/admin/SchedulerPage.test.tsx
+++ b/qnop-ui/src/pages/admin/SchedulerPage.test.tsx
@@ -27,6 +27,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { SchedulerJob } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { SchedulerPage } from './SchedulerPage';
+import { checkA11y } from '../../test/axe';
 
 const { updateMutate, runMutate, useSchedulerJobsMock } = vi.hoisted(() => ({
   updateMutate: vi.fn(),
@@ -112,6 +113,11 @@ function wrapper({ children }: { children: ReactNode }) {
 const renderPage = () => render(<SchedulerPage />, { wrapper });
 
 describe('SchedulerPage', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('lists the catalogued jobs', () => {
     renderPage();
     expect(screen.getByText('Refresh token sweep')).toBeTruthy();

--- a/qnop-ui/src/pages/admin/SettingsPage.test.tsx
+++ b/qnop-ui/src/pages/admin/SettingsPage.test.tsx
@@ -26,6 +26,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { buildTheme } from '../../theme/theme';
 import { SettingsPage } from './SettingsPage';
+import { checkA11y } from '../../test/axe';
 
 // SettingsPage is a thin composition wrapper: it delegates to
 // ApplicationSettingsForm, whose own hooks are out of scope here. Stub the
@@ -46,6 +47,11 @@ function wrapper({ children }: { children: ReactNode }) {
 const renderPage = () => render(<SettingsPage />, { wrapper });
 
 describe('SettingsPage', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('renders the page header title and description', () => {
     renderPage();
 

--- a/qnop-ui/src/pages/admin/StorageConsistencyPage.tsx
+++ b/qnop-ui/src/pages/admin/StorageConsistencyPage.tsx
@@ -152,10 +152,19 @@ export function StorageConsistencyPage() {
           <Button
             variant="outlined"
             startIcon={
-              <RefreshCw
-                size={16}
-                style={isFetching ? { animation: 'qnop-spin 1s linear infinite' } : undefined}
-              />
+              <Box
+                component="span"
+                sx={{
+                  display: 'inline-flex',
+                  // The one animation on this page; stilled for reduced-motion
+                  // users like every other spinner in the app (issue #460).
+                  animation: isFetching ? 'qnop-spin 1s linear infinite' : 'none',
+                  '@keyframes qnop-spin': { to: { transform: 'rotate(360deg)' } },
+                  '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+                }}
+              >
+                <RefreshCw size={16} />
+              </Box>
             }
             onClick={handleRescan}
             disabled={isFetching}
@@ -164,7 +173,6 @@ export function StorageConsistencyPage() {
           </Button>
         }
       />
-      <style>{'@keyframes qnop-spin { to { transform: rotate(360deg); } }'}</style>
 
       {isScanLimit(error) ? (
         <Alert severity="warning">

--- a/qnop-ui/src/pages/admin/TeamsPage.test.tsx
+++ b/qnop-ui/src/pages/admin/TeamsPage.test.tsx
@@ -28,6 +28,7 @@ import { MemoryRouter } from 'react-router';
 import type { AdminTeamListResponse, AdminTeamSummary } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { TeamsPage } from './TeamsPage';
+import { checkA11y } from '../../test/axe';
 
 type TeamsHookResult = {
   data: AdminTeamListResponse | undefined;
@@ -158,6 +159,11 @@ const openRowMenu = async (teamName: string) => {
 };
 
 describe('TeamsPage', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('renders a row per team with description, member count and status', () => {
     renderPage();
 

--- a/qnop-ui/src/pages/admin/UsersPage.test.tsx
+++ b/qnop-ui/src/pages/admin/UsersPage.test.tsx
@@ -28,6 +28,7 @@ import type { AdminUserListResponse, AdminUserSummary } from '../../api/generate
 import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';
 import { UsersPage } from './UsersPage';
+import { checkA11y } from '../../test/axe';
 
 // The four page-owned mutations plus a mutable query-state object so each test
 // can steer loading / error / empty / populated list responses.
@@ -219,6 +220,11 @@ function wrapper({ children }: { children: ReactNode }) {
 const renderPage = () => render(<UsersPage />, { wrapper });
 
 describe('UsersPage', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('renders the header and the current page of users', () => {
     renderPage();
 

--- a/qnop-ui/src/pages/audit/AuditPage.test.tsx
+++ b/qnop-ui/src/pages/audit/AuditPage.test.tsx
@@ -24,6 +24,7 @@ import { fireEvent, screen, within } from '@testing-library/react';
 import type { AuditEvent, AuditEventListResponse } from '../../api/generated';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import { AuditPage } from './AuditPage';
+import { checkA11y } from '../../test/axe';
 
 const { queryState, hookCalls } = vi.hoisted(() => ({
   queryState: {
@@ -88,6 +89,12 @@ beforeEach(() => {
 });
 
 describe('AuditPage', () => {
+  it('has no accessibility violations', async () => {
+    queryState.data = page({ items: [event, { ...event, id: 'e2' }], total: 2 });
+    const { container } = renderWithProviders(<AuditPage />);
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('renders the page header', () => {
     renderWithProviders(<AuditPage />);
     expect(screen.getByRole('heading', { name: 'Audit trail' })).toBeInTheDocument();

--- a/qnop-ui/src/pages/auth/LoginPage.test.tsx
+++ b/qnop-ui/src/pages/auth/LoginPage.test.tsx
@@ -27,6 +27,7 @@ import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';
 import { useConfig } from '../../api/hooks/useConfig';
 import { LoginPage } from './LoginPage';
+import { checkA11y } from '../../test/axe';
 
 vi.mock('../../api/hooks/useConfig', () => ({
   useConfig: vi.fn(),
@@ -94,6 +95,18 @@ beforeEach(() => {
 });
 
 describe('LoginPage', () => {
+  it('has no accessibility violations', async () => {
+    mockConfig({
+      selfRegistrationEnabled: true,
+      oidcProviders: [
+        { id: 'p1', name: 'Acme SSO', loginUrl: '/oauth2/authorization/acme', iconKind: 'OIDC' },
+      ],
+      banner: { severity: 'info', message: 'Demo installation' },
+    });
+    const { container } = renderLogin();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('renders the credential form with required fields', () => {
     renderLogin();
 

--- a/qnop-ui/src/pages/messages/MessagesPage.test.tsx
+++ b/qnop-ui/src/pages/messages/MessagesPage.test.tsx
@@ -28,6 +28,7 @@ import type { NotificationSummary } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { useMarkAllNotificationsRead, useNotifications } from '../../api/hooks/useNotifications';
 import { MessagesPage } from './MessagesPage';
+import { checkA11y } from '../../test/axe';
 
 vi.mock('../../api/hooks/useNotifications', () => ({
   useNotifications: vi.fn(),
@@ -100,6 +101,11 @@ beforeEach(() => {
 });
 
 describe('MessagesPage', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('lists notifications with their review and quoted excerpt', () => {
     renderPage();
 

--- a/qnop-ui/src/pages/my-teams/MyTeamsPage.test.tsx
+++ b/qnop-ui/src/pages/my-teams/MyTeamsPage.test.tsx
@@ -26,6 +26,7 @@ import { MemoryRouter } from 'react-router';
 import type { MyTeamListResponse } from '../../api/generated';
 import { buildTheme } from '../../theme/theme';
 import { MyTeamsPage } from './MyTeamsPage';
+import { checkA11y } from '../../test/axe';
 
 const { myTeamsState } = vi.hoisted(() => ({
   myTeamsState: { data: undefined, isLoading: false, isError: false } as {
@@ -67,6 +68,11 @@ function renderPage() {
 }
 
 describe('MyTeamsPage', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('renders led teams as management cards that link to their detail page', () => {
     renderPage();
 

--- a/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/DocumentReviewPage.test.tsx
@@ -39,6 +39,7 @@ import { useAnnotations, useCreateAnnotation } from '../../api/hooks/useAnnotati
 import { useComments } from '../../api/hooks/useComments';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
 import { useAuthStore } from '../../stores/authStore';
+import { checkA11y } from '../../test/axe';
 
 // The reaction toggles (issue #410) reach for the query client; the data
 // hooks above stay mocked, so a bare client per file is all the tests need.
@@ -188,7 +189,7 @@ function seedHappyPath(extractionStatus: ExtractionStatus = ExtractionStatus.Rea
 }
 
 function renderPage(initialEntry = '/reviews/doc-1') {
-  render(
+  return render(
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={buildTheme('light')}>
         <MemoryRouter initialEntries={[initialEntry]}>
@@ -534,5 +535,17 @@ describe('DocumentReviewPage on an older version', () => {
       expect(screen.getByTestId('resolve-bar')).toBeInTheDocument();
       expect(screen.getByLabelText('Add a comment')).toBeInTheDocument();
     });
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(
+      await checkA11y(container, {
+        // The expanded annotation card is a `ButtonBase` hosting real
+        // controls; issue #549 replaces that structure. Until it lands, the
+        // rule would only ever report that one known finding.
+        rules: { 'nested-interactive': { enabled: false } },
+      }),
+    ).toHaveNoViolations();
   });
 });

--- a/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/NewReviewPage.test.tsx
@@ -31,6 +31,7 @@ import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';
 import { axiosInstance, documentsApi, principalsApi, reviewWorkflowApi } from '../../api/config';
 import { NewReviewPage } from './NewReviewPage';
+import { checkA11y } from '../../test/axe';
 
 vi.mock('../../api/config', () => ({
   axiosInstance: { post: vi.fn(), get: vi.fn() },
@@ -112,6 +113,20 @@ beforeEach(() => {
   vi.mocked(reviewWorkflowApi.transitionDocumentWorkflow).mockResolvedValue({
     data: started,
   } as Awaited<ReturnType<typeof reviewWorkflowApi.transitionDocumentWorkflow>>);
+});
+
+describe('NewReviewPage accessibility (issue #460)', () => {
+  it('has no accessibility violations on step 1 with a picked file', async () => {
+    const { container } = renderPage();
+    pickPdf();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations on step 3', async () => {
+    const { container } = renderPage();
+    await goToStep3WithMax();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
 });
 
 describe('NewReviewPage — step 1', () => {

--- a/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewTasksPage.test.tsx
@@ -37,6 +37,7 @@ import { useParticipants } from '../../api/hooks/useReviews';
 import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';
 import { ReviewTasksPage } from './ReviewTasksPage';
+import { checkA11y } from '../../test/axe';
 
 // The reaction toggles (issue #410) reach for the query client; the data
 // hooks above stay mocked, so a bare client per file is all the tests need.
@@ -123,7 +124,7 @@ function mockData() {
 }
 
 function renderPage(initialEntry = '/reviews/d1/tasks') {
-  render(
+  return render(
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={buildTheme('light')}>
         <MemoryRouter initialEntries={[initialEntry]}>
@@ -148,6 +149,12 @@ afterEach(() => {
 });
 
 describe('ReviewTasksPage', () => {
+  it('has no accessibility violations', async () => {
+    mockData();
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+
   it('renders the board with derived columns and filter counts', () => {
     mockData();
     renderPage();

--- a/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
+++ b/qnop-ui/src/pages/reviews/ReviewsPage.test.tsx
@@ -30,6 +30,7 @@ import { buildTheme } from '../../theme/theme';
 import { useAuthStore } from '../../stores/authStore';
 import { useReviews } from '../../api/hooks/useReviews';
 import { ReviewsPage } from './ReviewsPage';
+import { checkA11y } from '../../test/axe';
 
 vi.mock('../../api/hooks/useReviews', () => ({
   useReviews: vi.fn(),
@@ -787,5 +788,10 @@ describe('ReviewsPage — the admin moderation listing (#563)', () => {
     expect(await screen.findByRole('button', { name: /New review/i })).toBeDisabled();
     // Was a tooltip, which only a pointer could reach (issue #690).
     expect(screen.getByRole('alert')).toHaveTextContent(/Finalizing or archiving a review/);
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
   });
 });

--- a/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
+++ b/qnop-ui/src/pages/reviews/VersionComparePage.test.tsx
@@ -36,6 +36,7 @@ import {
 import { useParticipants } from '../../api/hooks/useReviews';
 import { useVersionDiff } from '../../api/hooks/useVersionDiff';
 import { usePdfDocument } from '../../components/reviews/viewer/usePdfDocument';
+import { checkA11y } from '../../test/axe';
 
 vi.mock('../../components/reviews/hub/ReviewHubHead', () => ({
   ReviewHubHead: ({ isOwner }: { isOwner: boolean }) => (
@@ -238,5 +239,10 @@ describe('VersionComparePage', () => {
       expect(screen.getByTestId('rail-collapsed')).toBeInTheDocument();
       expect(screen.queryByTestId('change-summary')).not.toBeInTheDocument();
     });
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
   });
 });

--- a/qnop-ui/src/pages/search/SearchPage.test.tsx
+++ b/qnop-ui/src/pages/search/SearchPage.test.tsx
@@ -25,6 +25,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { buildTheme } from '../../theme/theme';
 import { SearchPage } from './SearchPage';
+import { checkA11y } from '../../test/axe';
 
 const quick = {
   data: {
@@ -129,6 +130,11 @@ function renderPage(initialEntry = '/search?q=alpha') {
 describe('SearchPage', () => {
   beforeEach(() => {
     quick.isPending = false;
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = renderPage();
+    expect(await checkA11y(container)).toHaveNoViolations();
   });
 
   it('reads the query from the URL and shows counted type chips', () => {

--- a/qnop-ui/src/test/axe.ts
+++ b/qnop-ui/src/test/axe.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { axe } from 'vitest-axe';
+
+type AxeOptions = NonNullable<Parameters<typeof axe>[1]>;
+
+/**
+ * Shared axe configuration for the component-level accessibility net (issue
+ * #460). Previously each auth test carried its own copy of these options
+ * (issue #352); one definition keeps the surfaces comparable and gives a
+ * single place to record *why* a rule is off.
+ *
+ * <h2>What this can and cannot catch</h2>
+ *
+ * These checks run in jsdom, which parses and builds a DOM but never lays out
+ * or paints. Everything that needs geometry or computed colour is therefore
+ * out of reach here, and axe says so itself: it returns `color-contrast` as
+ * **incomplete**, not as a violation. Verified — text at #eee on #fff passes
+ * this harness untouched. The same goes for target size (2.5.8) and anything
+ * depending on visible focus rings.
+ *
+ * So this net catches the structural half of WCAG: names, roles, labels, ARIA
+ * validity, heading order, duplicated ids, form-control association. Contrast
+ * and the pointer/vision criteria need a real browser, which the repository
+ * does not have today (no Playwright); until it does, they stay a manual step.
+ */
+export const AXE_OPTIONS = {
+  rules: {
+    // `region` requires every node to sit inside a landmark. A component
+    // rendered in isolation has no page around it, so this fires on the
+    // harness rather than on the component. Landmark structure is a page-level
+    // property and is asserted where a page is rendered whole.
+    region: { enabled: false },
+  },
+} as const;
+
+/**
+ * Runs axe over a rendered container with the shared configuration. Per-call
+ * `options` merge on top of it, so a surface can switch off a rule for a
+ * known, tracked finding without touching the shared baseline — always say
+ * which issue tracks it.
+ *
+ * Usage mirrors the existing auth tests:
+ * `expect(await checkA11y(container)).toHaveNoViolations();`
+ */
+export function checkA11y(container: Element, options: AxeOptions = {}) {
+  return axe(container, {
+    ...AXE_OPTIONS,
+    ...options,
+    rules: { ...AXE_OPTIONS.rules, ...options.rules },
+  });
+}

--- a/qnop-ui/src/test/cssRules.ts
+++ b/qnop-ui/src/test/cssRules.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * Returns the declaration block of the `::before` rule Emotion emitted for one
+ * of the element's own classes, or `undefined` when there is none.
+ *
+ * <p>jsdom lays out no pseudo-elements, so a test that cares about a `::before`
+ * overlay (the 44 px touch target of #724, say) asserts on the CSS that was
+ * emitted — which is exactly what a browser would apply.
+ */
+export function pseudoBeforeRule(element: Element): string | undefined {
+  const css = Array.from(document.querySelectorAll('style'))
+    .map((style) => style.textContent ?? '')
+    .join('\n');
+  for (const className of Array.from(element.classList)) {
+    const match = css.match(new RegExp(`\\.${className}::before\\{([^}]*)\\}`));
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+/** True when the element's `::before` overlay is the #724 44 px touch target. */
+export function hasTouchTarget(element: Element): boolean {
+  const rule = pseudoBeforeRule(element);
+  return (
+    rule !== undefined &&
+    rule.includes('position:absolute') &&
+    rule.includes('width:max(100%, 44px)') &&
+    rule.includes('height:max(100%, 44px)')
+  );
+}

--- a/qnop-ui/src/theme/touchTarget.test.tsx
+++ b/qnop-ui/src/theme/touchTarget.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import IconButton from '@mui/material/IconButton';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from './theme';
+import { pseudoBeforeRule } from '../test/cssRules';
+import { TOUCH_TARGET_PX, touchTargetSx } from './touchTarget';
+
+describe('touchTargetSx (#724)', () => {
+  it('asks for a 44 px minimum', () => {
+    expect(TOUCH_TARGET_PX).toBe(44);
+  });
+
+  it('emits a centred ::before overlay of at least 44×44 px on a small icon button', () => {
+    const { getByRole } = render(
+      <ThemeProvider theme={buildTheme('light')}>
+        <IconButton size="small" aria-label="Probe" sx={touchTargetSx} />
+      </ThemeProvider>,
+    );
+
+    const rule = pseudoBeforeRule(getByRole('button', { name: 'Probe' }));
+
+    expect(rule).toBeDefined();
+    expect(rule).toContain('position:absolute');
+    expect(rule).toContain('width:max(100%, 44px)');
+    expect(rule).toContain('height:max(100%, 44px)');
+    expect(rule).toContain('translate(-50%, -50%)');
+  });
+});

--- a/qnop-ui/src/theme/touchTarget.ts
+++ b/qnop-ui/src/theme/touchTarget.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { SxProps, Theme } from '@mui/material/styles';
+
+/** The minimum pointer/touch target the responsive audit asks for (#461). */
+export const TOUCH_TARGET_PX = 44;
+
+/**
+ * Grows a control's hit area to at least 44×44 px without touching its visual
+ * size (issue #724).
+ *
+ * <p>A transparent `::before` overlay is centred on the element and sized to
+ * `max(100%, 44px)` on each axis, so a 28 px icon button keeps its 28 px ring
+ * and ripple while the box the finger (or the trackpad cursor) has to hit is
+ * 44 px. Neighbouring overlays may overlap; the topmost wins, which is fine
+ * for controls that sit 12 px apart. Requires a positioned host — MUI's
+ * `ButtonBase` already is.
+ */
+export const touchTargetSx: SxProps<Theme> = {
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: `max(100%, ${TOUCH_TARGET_PX}px)`,
+    height: `max(100%, ${TOUCH_TARGET_PX}px)`,
+  },
+};

--- a/qnop-ui/src/theme/visuallyHidden.ts
+++ b/qnop-ui/src/theme/visuallyHidden.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { SxProps, Theme } from '@mui/material/styles';
+
+/**
+ * Hides content visually while keeping it in the accessibility tree (issue
+ * #460) — for text a screen reader needs but the layout does not show, such as
+ * the header of an actions column that is deliberately blank on screen.
+ *
+ * The clip-rect recipe rather than the obvious alternatives, because those
+ * remove the element from the accessibility tree too and would defeat the
+ * point: `display: none`, `visibility: hidden`, and `width/height: 0` without
+ * clipping are all announced as absent. `white-space: nowrap` stops a
+ * 1px-wide box from wrapping its text into a tall column that can still be
+ * scrolled to.
+ *
+ * MUI ships an equivalent in newer `@mui/utils`, which this version does not
+ * carry; if a future bump brings it, prefer theirs and delete this.
+ */
+export const visuallyHidden: SxProps<Theme> = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  clipPath: 'inset(50%)',
+  height: '1px',
+  width: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+};


### PR DESCRIPTION
First pass on #460. Keeps the issue open — the browser-only criteria (contrast, target size, focus visibility, screen-reader walkthrough) belong to the Playwright net in #725 and are named as such in the new doc.

## What's in here

- **Automated a11y net in CI** — shared `src/test/axe.ts` (`checkA11y`, vitest-axe) with a documented baseline; axe assertions over ~21 populated page/component states: login, dashboard, reviews list, new review, document review page, version compare, tasks board/page, annotation panel, comment thread, sidebar, profile, search, messages, my teams, audit, admin (users/teams/settings/OIDC/scheduler). Runs in `pnpm test:run`, so CI fails on new violations.
- **Keyboard text selection in the viewer** (WCAG 2.1.1) — `TextSpanLayer` is focusable; arrows move a caret through the canonical text (Up/Down keep the column, Home/End jump to line ends), Shift extends a range, Enter emits it exactly like a pointer release, Escape clears. Caret/range paint with the existing marker bands; a visually hidden description names the keys. New `viewer/keyboardSelection.ts` with unit tests.
- **Fixes surfaced by axe** — reviews table's blank actions header now named (visually hidden); profile hover link always has an accessible name; sidebar is a `<nav aria-label>` landmark with valid `<ul>/<li>` markup; storage-consistency rescan spinner joins the rest behind `prefers-reduced-motion`.
- **`docs/ACCESSIBILITY.md`** — every finding mapped to fixed / tracked / wontfix with reasoning, plus what jsdom cannot see.

## Tracked elsewhere

- `nested-interactive` on the expanded annotation card → #549 (one rule exempted in one test until it lands)
- keyboard rubber-band region selection → #771 (filed from this audit)
- contrast / target size / focus-visible / screen-reader pass → #725

## Test plan

- [x] `pnpm test:run` — 1354 tests green
- [x] `pnpm exec tsc -b --noEmit`, `pnpm lint`, `pnpm format:check`
- [ ] CI green
- [ ] Manual: open a PDF review, Tab to the text layer, Shift+→ a few characters, Enter → composer opens at the selection

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139RpvTw7gWocFXstb6N3x1