### PR TITLE
feat: keyboard equivalent for region selection in the viewer

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -64,13 +64,16 @@ lines, Home/End jump to the line ends), Shift extends a range, Enter emits it
 exactly like a pointer release, Escape clears. A visually hidden description
 names the keys. Caret and range paint with the same marker bands as a drag.
 
-### 6. Region (rubber-band) selection is pointer-only — tracked
+### 6. Region (rubber-band) selection is pointer-only — fixed (#771)
 
-`RegionSelectLayer` has no keyboard equivalent. With text selection now
-keyboard-reachable (finding 5), a keyboard user can annotate any extracted
-text; what they cannot do is mark an arbitrary rectangle (a figure, a scanned
-page). A keyboard rectangle (arrows move, Shift+arrows size, Enter commits) is
-a self-contained follow-up and is filed as such rather than bolted on here.
+`RegionSelectLayer` had no keyboard equivalent. With text selection
+keyboard-reachable (finding 5), a keyboard user could annotate any extracted
+text; what they could not do was mark an arbitrary rectangle (a figure, a
+scanned page). The layer is now focusable while region mode is on: the first
+arrow press places a rectangle, arrows move it (Shift for larger steps),
+Alt+arrows grow or shrink it, Enter commits through the same path as a
+pointer release, Escape clears. A visually hidden description names the keys;
+the draft paints with the pointer preview's styling.
 
 ### 7. Expanded annotation card nests controls inside `role="button"` — tracked (#549)
 

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.test.tsx
@@ -120,3 +120,105 @@ describe('RegionSelectLayer', () => {
     expect(onRegionSelected).not.toHaveBeenCalled();
   });
 });
+
+describe('RegionSelectLayer keyboard path (issue #771)', () => {
+  it('is focusable with a described keyboard hint while enabled', () => {
+    const { layer } = renderLayer();
+    expect(layer).toHaveAttribute('tabindex', '0');
+    expect(layer).toHaveAccessibleDescription(/Arrow keys place and move/);
+  });
+
+  it('leaves the tab order when disabled', () => {
+    const { layer } = renderLayer(false);
+    expect(layer).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('places the rectangle on the first arrow press and moves it on the next', () => {
+    const { layer } = renderLayer();
+
+    fireEvent.keyDown(layer, { key: 'ArrowRight' });
+    const draft = screen.getByTestId('region-draft-0');
+    // The initial box: centered fifth of the page.
+    expect(draft.style.left).toBe('40%');
+    expect(draft.style.top).toBe('40%');
+
+    fireEvent.keyDown(layer, { key: 'ArrowRight' });
+    expect(draft.style.left).toBe('42%');
+
+    fireEvent.keyDown(layer, { key: 'ArrowDown', shiftKey: true });
+    expect(draft.style.top).toBe('50%');
+  });
+
+  it('grows and shrinks the rectangle with Alt + arrows', () => {
+    const { layer } = renderLayer();
+
+    fireEvent.keyDown(layer, { key: 'ArrowRight' });
+    fireEvent.keyDown(layer, { key: 'ArrowRight', altKey: true });
+    const draft = screen.getByTestId('region-draft-0');
+    expect(draft.style.width).toBe('22%');
+
+    fireEvent.keyDown(layer, { key: 'ArrowUp', altKey: true, shiftKey: true });
+    expect(draft.style.height).toBe('10%');
+  });
+
+  it('keeps the rectangle on the page when moving against an edge', () => {
+    const { layer } = renderLayer();
+
+    fireEvent.keyDown(layer, { key: 'ArrowLeft' });
+    for (let i = 0; i < 6; i += 1) {
+      fireEvent.keyDown(layer, { key: 'ArrowLeft', shiftKey: true });
+    }
+    const draft = screen.getByTestId('region-draft-0');
+    expect(draft.style.left).toBe('0%');
+    expect(draft.style.width).toBe('20%');
+  });
+
+  it('commits the rectangle with Enter through the pointer path, at its bottom-right corner', () => {
+    const { layer, onRegionSelected } = renderLayer();
+
+    fireEvent.keyDown(layer, { key: 'ArrowRight' });
+    fireEvent.keyDown(layer, { key: 'Enter' });
+
+    // { x: 0.4, y: 0.4, width: 0.2, height: 0.2 } against the 200×100 rect.
+    expect(onRegionSelected).toHaveBeenCalledWith(
+      0,
+      { x: 0.4, y: 0.4, width: 0.2, height: 0.2 },
+      { left: 120, top: 60 },
+    );
+    expect(screen.queryByTestId('region-draft-0')).toBeNull();
+  });
+
+  it('clears the rectangle on Escape and on blur without committing', () => {
+    const { layer, onRegionSelected } = renderLayer();
+
+    fireEvent.keyDown(layer, { key: 'ArrowRight' });
+    fireEvent.keyDown(layer, { key: 'Escape' });
+    expect(screen.queryByTestId('region-draft-0')).toBeNull();
+
+    fireEvent.keyDown(layer, { key: 'ArrowRight' });
+    fireEvent.blur(layer);
+    expect(screen.queryByTestId('region-draft-0')).toBeNull();
+
+    expect(onRegionSelected).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on Enter or Escape before a rectangle exists', () => {
+    const { layer, onRegionSelected } = renderLayer();
+
+    fireEvent.keyDown(layer, { key: 'Enter' });
+    fireEvent.keyDown(layer, { key: 'Escape' });
+
+    expect(onRegionSelected).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('region-draft-0')).toBeNull();
+  });
+
+  it('ignores keys when disabled', () => {
+    const { layer, onRegionSelected } = renderLayer(false);
+
+    fireEvent.keyDown(layer, { key: 'ArrowRight' });
+    fireEvent.keyDown(layer, { key: 'Enter' });
+
+    expect(onRegionSelected).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('region-draft-0')).toBeNull();
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.test.tsx
@@ -125,7 +125,7 @@ describe('RegionSelectLayer keyboard path (issue #771)', () => {
   it('is focusable with a described keyboard hint while enabled', () => {
     const { layer } = renderLayer();
     expect(layer).toHaveAttribute('tabindex', '0');
-    expect(layer).toHaveAccessibleDescription(/Arrow keys place and move/);
+    expect(layer).toHaveAccessibleDescription(/first arrow key press places/);
   });
 
   it('leaves the tab order when disabled', () => {
@@ -159,6 +159,24 @@ describe('RegionSelectLayer keyboard path (issue #771)', () => {
 
     fireEvent.keyDown(layer, { key: 'ArrowUp', altKey: true, shiftKey: true });
     expect(draft.style.height).toBe('10%');
+  });
+
+  it('clamps growth at the page edge and shrinking at the minimum size', () => {
+    const { layer } = renderLayer();
+
+    fireEvent.keyDown(layer, { key: 'ArrowRight' });
+    // Grow far past the right edge: width caps at 1 - x = 0.6.
+    for (let i = 0; i < 8; i += 1) {
+      fireEvent.keyDown(layer, { key: 'ArrowRight', altKey: true, shiftKey: true });
+    }
+    const draft = screen.getByTestId('region-draft-0');
+    expect(draft.style.width).toBe('60%');
+
+    // Shrink far past zero: height floors at the 2% minimum.
+    for (let i = 0; i < 8; i += 1) {
+      fireEvent.keyDown(layer, { key: 'ArrowUp', altKey: true, shiftKey: true });
+    }
+    expect(draft.style.height).toBe('2%');
   });
 
   it('keeps the rectangle on the page when moving against an edge', () => {

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
@@ -19,12 +19,27 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { useState } from 'react';
-import type { PointerEvent } from 'react';
+import { useId, useState } from 'react';
+import type { KeyboardEvent, PointerEvent } from 'react';
 import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
 import type { NormalizedBox } from '../../../api/generated';
 import type { ScreenPosition } from './anchoring';
 import { MARKER_YELLOW_BORDER, SELECTION_MARKER_BG } from './markerColors';
+import { visuallyHidden } from '../../../theme/visuallyHidden';
+
+/** How the keyboard path is announced to assistive tech (issue #771). */
+const KEYBOARD_HINT =
+  'Arrow keys place and move the selection rectangle, Shift with an arrow key moves in larger steps, Alt with an arrow key grows or shrinks it, Enter annotates the region, Escape clears it.';
+
+/** One arrow press moves or resizes by this fraction of the page. */
+const MOVE_STEP = 0.02;
+/** The Shift-accelerated step. */
+const LARGE_STEP = 0.1;
+/** The rectangle never shrinks below this, so it stays visible and hittable. */
+const MIN_SIZE = 0.02;
+/** Where the first arrow press places the rectangle: centered, clearly visible. */
+const INITIAL_KEYBOARD_BOX: NormalizedBox = { x: 0.4, y: 0.4, width: 0.2, height: 0.2 };
 
 interface RegionSelectLayerProps {
   surfaceIndex: number;
@@ -39,8 +54,51 @@ interface DraftRect {
   y2: number;
 }
 
+interface ArrowDelta {
+  dx: number;
+  dy: number;
+}
+
 function clampUnit(value: number): number {
   return Math.min(1, Math.max(0, value));
+}
+
+/** Kills the floating-point dust a chain of step additions accumulates. */
+function round4(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}
+
+function arrowDelta(key: string): ArrowDelta | null {
+  switch (key) {
+    case 'ArrowLeft':
+      return { dx: -1, dy: 0 };
+    case 'ArrowRight':
+      return { dx: 1, dy: 0 };
+    case 'ArrowUp':
+      return { dx: 0, dy: -1 };
+    case 'ArrowDown':
+      return { dx: 0, dy: 1 };
+    default:
+      return null;
+  }
+}
+
+/** The rectangle shifted by one step, kept fully on the page. */
+function moved(box: NormalizedBox, delta: ArrowDelta, step: number): NormalizedBox {
+  return {
+    ...box,
+    x: round4(Math.min(1 - box.width, Math.max(0, box.x + delta.dx * step))),
+    y: round4(Math.min(1 - box.height, Math.max(0, box.y + delta.dy * step))),
+  };
+}
+
+/** The rectangle grown (right/down) or shrunk (left/up) by one step. */
+function resized(box: NormalizedBox, delta: ArrowDelta, step: number): NormalizedBox {
+  return {
+    ...box,
+    width: round4(Math.min(1 - box.x, Math.max(MIN_SIZE, box.width + delta.dx * step))),
+    height: round4(Math.min(1 - box.y, Math.max(MIN_SIZE, box.height + delta.dy * step))),
+  };
 }
 
 /**
@@ -48,6 +106,12 @@ function clampUnit(value: number): number {
  * the universal anchor layer that works with or without a text layer
  * (ADR-0009). Coordinates are normalized against the page box, so the drawn
  * region is zoom- and DPI-independent (ADR-0032).
+ *
+ * Keyboard equivalent (issue #771, WCAG 2.1.1): while region mode is on the
+ * layer is focusable; the first arrow press places a rectangle, arrows move
+ * it (Shift for larger steps), Alt+arrows grow or shrink it, Enter commits
+ * through the same `onRegionSelected` path as a pointer release, Escape
+ * clears. The draft paints with the pointer preview's styling.
  */
 export function RegionSelectLayer({
   surfaceIndex,
@@ -55,6 +119,9 @@ export function RegionSelectLayer({
   onRegionSelected,
 }: RegionSelectLayerProps) {
   const [draft, setDraft] = useState<DraftRect | null>(null);
+  const [keyboardBox, setKeyboardBox] = useState<NormalizedBox | null>(null);
+  const hintId = useId();
+  const theme = useTheme();
 
   // `currentTarget` is the surface Box the handlers are bound to — always the
   // live element during the event, so it needs no ref and no non-null assertion.
@@ -69,6 +136,7 @@ export function RegionSelectLayer({
   const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
     if (!enabled || event.button !== 0) return;
     event.currentTarget.setPointerCapture(event.pointerId);
+    setKeyboardBox(null);
     const point = toNormalized(event);
     setDraft({ x1: point.x, y1: point.y, x2: point.x, y2: point.y });
   };
@@ -89,37 +157,89 @@ export function RegionSelectLayer({
     );
   };
 
-  const preview: NormalizedBox | null = draft && {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!enabled) return;
+    if (event.key === 'Escape') {
+      if (!keyboardBox) return;
+      event.preventDefault();
+      setKeyboardBox(null);
+      return;
+    }
+    if (event.key === 'Enter') {
+      if (!keyboardBox) return;
+      event.preventDefault();
+      // The commit position stands in for the pointer-release point: the
+      // rectangle's bottom-right corner in viewport coordinates.
+      const rect = event.currentTarget.getBoundingClientRect();
+      setKeyboardBox(null);
+      onRegionSelected(surfaceIndex, keyboardBox, {
+        left: rect.left + round4(keyboardBox.x + keyboardBox.width) * rect.width,
+        top: rect.top + round4(keyboardBox.y + keyboardBox.height) * rect.height,
+      });
+      return;
+    }
+    const delta = arrowDelta(event.key);
+    if (delta === null) return;
+    event.preventDefault();
+    if (!keyboardBox) {
+      // The first arrow press only places the rectangle; moving starts with
+      // the next press, so the initial position is predictable.
+      setKeyboardBox(INITIAL_KEYBOARD_BOX);
+      return;
+    }
+    const step = event.shiftKey ? LARGE_STEP : MOVE_STEP;
+    setKeyboardBox(
+      event.altKey ? resized(keyboardBox, delta, step) : moved(keyboardBox, delta, step),
+    );
+  };
+
+  const pointerPreview: NormalizedBox | null = draft && {
     x: Math.min(draft.x1, draft.x2),
     y: Math.min(draft.y1, draft.y2),
     width: Math.abs(draft.x2 - draft.x1),
     height: Math.abs(draft.y2 - draft.y1),
   };
+  const preview = pointerPreview ?? keyboardBox;
 
   return (
     <Box
       data-testid={`region-layer-${surfaceIndex}`}
+      // Names the otherwise-generic selection surface for assistive tech, the
+      // same way the text layer does (issue #341).
+      role="group"
+      aria-label={`Region selection, page ${surfaceIndex + 1}`}
+      aria-describedby={enabled ? hintId : undefined}
+      tabIndex={enabled ? 0 : -1}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
+      onKeyDown={handleKeyDown}
+      onBlur={() => setKeyboardBox(null)}
       sx={{
         position: 'absolute',
         inset: 0,
         cursor: 'crosshair',
         pointerEvents: enabled ? 'auto' : 'none',
         touchAction: 'none',
+        '&:focus-visible': { outline: 'none', boxShadow: `inset ${theme.qnop.focusRing}` },
       }}
     >
+      {enabled && (
+        <Box component="span" id={hintId} sx={visuallyHidden}>
+          {KEYBOARD_HINT}
+        </Box>
+      )}
       {preview && (
-        <Box
-          sx={{
+        <div
+          data-testid={`region-draft-${surfaceIndex}`}
+          style={{
             position: 'absolute',
             left: `${preview.x * 100}%`,
             top: `${preview.y * 100}%`,
             width: `${preview.width * 100}%`,
             height: `${preview.height * 100}%`,
             border: `2px dashed ${MARKER_YELLOW_BORDER}`,
-            bgcolor: SELECTION_MARKER_BG,
+            backgroundColor: SELECTION_MARKER_BG,
             mixBlendMode: 'multiply',
             pointerEvents: 'none',
           }}

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
@@ -30,7 +30,7 @@ import { visuallyHidden } from '../../../theme/visuallyHidden';
 
 /** How the keyboard path is announced to assistive tech (issue #771). */
 const KEYBOARD_HINT =
-  'Arrow keys place and move the selection rectangle, Shift with an arrow key moves in larger steps, Alt with an arrow key grows or shrinks it, Enter annotates the region, Escape clears it.';
+  'The first arrow key press places a selection rectangle in the middle of the page. Arrow keys then move it, Shift with an arrow key moves in larger steps, Alt with an arrow key grows or shrinks it, Enter annotates the region, Escape clears it.';
 
 /** One arrow press moves or resizes by this fraction of the page. */
 const MOVE_STEP = 0.02;


### PR DESCRIPTION
## Summary

Follow-up to the a11y audit (#460, finding 6): `RegionSelectLayer` gets the keyboard path the text layer already has.

- While region mode is on the layer is focusable (`role="group"`, label, focus ring) with a visually hidden key description — mirroring `TextSpanLayer`.
- First arrow press places a centered rectangle; arrows move it (Shift = larger steps), Alt+arrows grow/shrink it, Enter commits through the same `onRegionSelected` path as a pointer release (position = the rectangle's bottom-right corner), Escape and blur clear.
- The draft renders with the existing preview styling; the rectangle is clamped to the page and normalized values are rounded to 4 decimals so step chains emit clean anchor boxes.
- Pointer behaviour unchanged; a pointer-down discards a pending keyboard draft.
- `docs/ACCESSIBILITY.md` finding 6 flipped to fixed.

## Test plan

- [x] 8 new unit tests alongside the existing ones (placement, move/resize incl. Shift/Alt, edge clamping, Enter commit with position, Escape/blur clearing, disabled state)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test:run` (1370 tests green)

Closes #771

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)