### PR TITLE
fix(ui): let the viewer toolbar's trailing controls wrap on phones

### DIFF
--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import type { ReviewViewMode } from '../focus/useViewMode';
+import { ViewerToolbar } from './ViewerToolbar';
+
+function renderToolbar(viewMode: ReviewViewMode = 'panel') {
+  render(
+    <ThemeProvider theme={buildTheme('light')}>
+      <ViewerToolbar
+        versions={[{ versionNumber: 1 } as never]}
+        currentVersion={1}
+        onVersionChange={vi.fn()}
+        currentPage={0}
+        pageCount={3}
+        onNavigateToPage={vi.fn()}
+        tool="text"
+        onToolChange={vi.fn()}
+        textToolAvailable
+        canAnnotate
+        zoom={1}
+        onZoomChange={vi.fn()}
+        viewMode={viewMode}
+        onViewModeChange={vi.fn()}
+        annotationCount={4}
+        onOpenAnnotationList={vi.fn()}
+      />
+    </ThemeProvider>,
+  );
+}
+
+/**
+ * Locks the trailing cluster's structure (issue #772): both sub-groups exist
+ * with their controls, and both dividers are present — the second one hides
+ * below `sm` via CSS only, so wrapping never leaves a dangling divider.
+ */
+describe('ViewerToolbar', () => {
+  it('keeps both trailing sub-groups and their separators', () => {
+    renderToolbar();
+
+    expect(screen.getByRole('group', { name: 'Annotation tool' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Document layout' })).toBeInTheDocument();
+    expect(screen.getAllByRole('separator')).toHaveLength(2);
+  });
+
+  it('shows the annotation-list entry point only in focus mode', () => {
+    renderToolbar('focus');
+    expect(screen.getByRole('button', { name: 'Show annotations (4)' })).toBeInTheDocument();
+  });
+
+  it('hides the annotation-list entry point in panel mode', () => {
+    renderToolbar('panel');
+    expect(screen.queryByRole('button', { name: /Show annotations/ })).toBeNull();
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -167,80 +167,92 @@ export function ViewerToolbar({
         <ToneBadge tone="red" label="Extraction failed" />
       )}
 
-      <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', ml: 'auto' }}>
-        <ToggleButtonGroup
-          exclusive
-          size="small"
-          value={tool}
-          onChange={(_event, next: ViewerTool | null) => next && onToolChange(next)}
-          disabled={!canAnnotate}
-          aria-label="Annotation tool"
-        >
-          <ToggleButton value="text" disabled={!textToolAvailable} aria-label="Select text">
-            <Tooltip title="Select text to annotate a quote">
-              <TextCursor size={16} />
+      {/* The trailing controls: two sub-groups inside a wrapping, right-aligned
+          cluster, so a 320 px viewport breaks between the groups instead of
+          overflowing `main` (issue #772). `ml: 'auto'` keeps the whole cluster
+          right-aligned on wide screens; `justifyContent: 'flex-end'` keeps a
+          wrapped second row right-aligned too. */}
+      <Stack
+        direction="row"
+        spacing={1.5}
+        useFlexGap
+        sx={{ alignItems: 'center', ml: 'auto', flexWrap: 'wrap', justifyContent: 'flex-end' }}
+      >
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+          <ToggleButtonGroup
+            exclusive
+            size="small"
+            value={tool}
+            onChange={(_event, next: ViewerTool | null) => next && onToolChange(next)}
+            disabled={!canAnnotate}
+            aria-label="Annotation tool"
+          >
+            <ToggleButton value="text" disabled={!textToolAvailable} aria-label="Select text">
+              <Tooltip title="Select text to annotate a quote">
+                <TextCursor size={16} />
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton value="region" aria-label="Draw region">
+              <Tooltip title="Draw a rectangle to annotate a region">
+                <BoxSelect size={16} />
+              </Tooltip>
+            </ToggleButton>
+          </ToggleButtonGroup>
+
+          <Divider orientation="vertical" flexItem />
+
+          <ZoomControls zoom={zoom} onZoomChange={onZoomChange} />
+        </Stack>
+
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+          {/* Panel vs. focus is a presentation of THIS tab (issue #403), so the
+              switch lives here rather than in the page-level tab strip. */}
+          <ToggleButtonGroup
+            exclusive
+            size="small"
+            value={viewMode}
+            onChange={(_event, next: ReviewViewMode | null) => next && onViewModeChange(next)}
+            aria-label="Document layout"
+          >
+            <ToggleButton value="panel" aria-label="Panel view" sx={{ gap: 0.5, px: 1 }}>
+              <Tooltip title="Document beside the annotation panel">
+                <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                  <PanelRight size={15} />
+                  <Typography variant="caption" sx={{ fontWeight: 600, lineHeight: 1 }}>
+                    Panel
+                  </Typography>
+                </Stack>
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton value="focus" aria-label="Focus view" sx={{ gap: 0.5, px: 1 }}>
+              <Tooltip title="Full-width document with the spotlight overlay">
+                <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                  <Focus size={15} />
+                  <Typography variant="caption" sx={{ fontWeight: 600, lineHeight: 1 }}>
+                    Focus
+                  </Typography>
+                </Stack>
+              </Tooltip>
+            </ToggleButton>
+          </ToggleButtonGroup>
+
+          {focusMode && (
+            <Tooltip title="Show the annotation list">
+              <IconButton
+                size="small"
+                aria-label={`Show annotations (${annotationCount})`}
+                onClick={onOpenAnnotationList}
+              >
+                <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                  <NotebookPen size={16} />
+                  <Typography variant="caption" sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                    {annotationCount}
+                  </Typography>
+                </Stack>
+              </IconButton>
             </Tooltip>
-          </ToggleButton>
-          <ToggleButton value="region" aria-label="Draw region">
-            <Tooltip title="Draw a rectangle to annotate a region">
-              <BoxSelect size={16} />
-            </Tooltip>
-          </ToggleButton>
-        </ToggleButtonGroup>
-
-        <Divider orientation="vertical" flexItem />
-
-        <ZoomControls zoom={zoom} onZoomChange={onZoomChange} />
-
-        <Divider orientation="vertical" flexItem />
-
-        {/* Panel vs. focus is a presentation of THIS tab (issue #403), so the
-            switch lives here rather than in the page-level tab strip. */}
-        <ToggleButtonGroup
-          exclusive
-          size="small"
-          value={viewMode}
-          onChange={(_event, next: ReviewViewMode | null) => next && onViewModeChange(next)}
-          aria-label="Document layout"
-        >
-          <ToggleButton value="panel" aria-label="Panel view" sx={{ gap: 0.5, px: 1 }}>
-            <Tooltip title="Document beside the annotation panel">
-              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-                <PanelRight size={15} />
-                <Typography variant="caption" sx={{ fontWeight: 600, lineHeight: 1 }}>
-                  Panel
-                </Typography>
-              </Stack>
-            </Tooltip>
-          </ToggleButton>
-          <ToggleButton value="focus" aria-label="Focus view" sx={{ gap: 0.5, px: 1 }}>
-            <Tooltip title="Full-width document with the spotlight overlay">
-              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-                <Focus size={15} />
-                <Typography variant="caption" sx={{ fontWeight: 600, lineHeight: 1 }}>
-                  Focus
-                </Typography>
-              </Stack>
-            </Tooltip>
-          </ToggleButton>
-        </ToggleButtonGroup>
-
-        {focusMode && (
-          <Tooltip title="Show the annotation list">
-            <IconButton
-              size="small"
-              aria-label={`Show annotations (${annotationCount})`}
-              onClick={onOpenAnnotationList}
-            >
-              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
-                <NotebookPen size={16} />
-                <Typography variant="caption" sx={{ fontVariantNumeric: 'tabular-nums' }}>
-                  {annotationCount}
-                </Typography>
-              </Stack>
-            </IconButton>
-          </Tooltip>
-        )}
+          )}
+        </Stack>
       </Stack>
     </Paper>
   );

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -205,6 +205,14 @@ export function ViewerToolbar({
         </Stack>
 
         <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+          {/* Separates the sub-groups on one row; hidden below sm, where the
+              cluster may wrap and a dangling divider would end the first row. */}
+          <Divider
+            orientation="vertical"
+            flexItem
+            sx={{ display: { xs: 'none', sm: 'block' } }}
+          />
+
           {/* Panel vs. focus is a presentation of THIS tab (issue #403), so the
               switch lives here rather than in the page-level tab strip. */}
           <ToggleButtonGroup

--- a/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
+++ b/qnop-ui/src/components/reviews/viewer/ViewerToolbar.tsx
@@ -207,11 +207,7 @@ export function ViewerToolbar({
         <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
           {/* Separates the sub-groups on one row; hidden below sm, where the
               cluster may wrap and a dangling divider would end the first row. */}
-          <Divider
-            orientation="vertical"
-            flexItem
-            sx={{ display: { xs: 'none', sm: 'block' } }}
-          />
+          <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', sm: 'block' } }} />
 
           {/* Panel vs. focus is a presentation of THIS tab (issue #403), so the
               switch lives here rather than in the page-level tab strip. */}


### PR DESCRIPTION
## Summary

At 320/375 px the viewer toolbar's trailing control group (tool toggle, zoom, Panel/Focus switch, focus-mode list button) overflowed `main` to 441 px — it was a single non-wrapping 412 px `Stack` with `ml: 'auto'` (#772, found by the responsive net #725).

The cluster is now **two sub-groups inside one wrapping, right-aligned Stack**: tools + zoom, and view switch (+ focus-mode list button). A phone viewport breaks between the groups; `ml: 'auto'` keeps the cluster right-aligned on wide screens, `justifyContent: 'flex-end'` keeps a wrapped second row right-aligned as well. No control changed behaviour.

**Note on the `test.fail()` marker:** the responsive spec lives in the still-open PR #777, so the marker for #772 cannot be flipped from this branch. It flips when #777 rebases onto this fix — by design the net fails on an unexpected pass, so it cannot be forgotten.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test:run` (1361 tests green)
- [ ] Visual confirmation happens through PR #777's 320/375 px overflow checks once both meet

Closes #772

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)