### PR TITLE
fix(ui): KPI tiles share the row on phones instead of overflowing

### DIFF
--- a/qnop-ui/src/components/dashboard/StatStrip.tsx
+++ b/qnop-ui/src/components/dashboard/StatStrip.tsx
@@ -109,6 +109,10 @@ export function StatStrip({ tiles }: { tiles: StatTile[] }) {
                     lineHeight: 1.2,
                     fontVariantNumeric: 'tabular-nums',
                     color: tile.value > 0 ? color : 'text.primary',
+                    // Defensive: a many-digit value is one unbreakable token;
+                    // without this it would re-open the overflow the
+                    // minmax(0, 1fr) columns just closed (issue #773).
+                    overflowWrap: 'anywhere',
                   }}
                 >
                   {tile.value}

--- a/qnop-ui/src/components/dashboard/StatStrip.tsx
+++ b/qnop-ui/src/components/dashboard/StatStrip.tsx
@@ -56,7 +56,14 @@ export function StatStrip({ tiles }: { tiles: StatTile[] }) {
     <Box
       sx={{
         display: 'grid',
-        gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(4, 1fr)' },
+        // minmax(0, 1fr): a plain 1fr column refuses to shrink below its
+        // content's min width, so the longest label pushed the whole grid
+        // past a 320 px viewport (issue #773). With the floor at 0 the tiles
+        // share the row and the labels wrap instead.
+        gridTemplateColumns: {
+          xs: 'repeat(2, minmax(0, 1fr))',
+          sm: 'repeat(4, minmax(0, 1fr))',
+        },
         gap: 1.5,
       }}
     >
@@ -106,7 +113,10 @@ export function StatStrip({ tiles }: { tiles: StatTile[] }) {
                 >
                   {tile.value}
                 </Typography>
-                <Typography variant="caption" color="text.secondary" noWrap component="p">
+                {/* Wrapping beats truncation for a KPI label: on a 320 px
+                    phone "Resolved this week" takes a second line instead of
+                    an ellipsis. */}
+                <Typography variant="caption" color="text.secondary" component="p">
                   {tile.label}
                 </Typography>
               </Box>


### PR DESCRIPTION
## Summary

At 320 px the KPI rows overflowed `main` (dashboard → 415 px, storage consistency → 348 px; #773, found by the responsive net #725). Both surfaces render the same `StatStrip`, so the fix is one component:

- Grid columns are `minmax(0, 1fr)` instead of `1fr` — a plain `1fr` column never shrinks below its content's min width, and the `noWrap` label set that floor.
- The label may wrap to a second line now instead of truncating ("Resolved this week" stays fully readable on a phone); tiles in the same grid row keep equal height.
- Covers the dashboard, storage consistency and scheduler KPI rows in one change.

**Note on the `test.fail()` markers:** the responsive spec lives in the still-open PR #777; its markers for #773 flip when that branch rebases onto this fix — the net fails on an unexpected pass, so it cannot be forgotten.

## Test plan

- [x] `pnpm typecheck`, `pnpm test:run` (1361 tests green)
- [ ] Pixel verification through PR #777's 320/375 px overflow checks once both meet

Closes #773

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)