### PR TITLE
fix(ui): the page header stacks when the action row stops fitting

### DIFF
--- a/qnop-ui/src/components/admin/layout/PageHeader.tsx
+++ b/qnop-ui/src/components/admin/layout/PageHeader.tsx
@@ -61,9 +61,15 @@ export function PageHeader({
       // flexWrap never fired because its parent never imposed a limit.
       // Stacking hands the actions the full content width instead, and the
       // wrap that was always there finally has an edge to wrap at.
+      //
+      // Above md the row itself wraps (issue #774): beside an open sidebar
+      // the content can be narrower than the action row even at 1024 px, so
+      // the actions drop below the title exactly when they stop fitting —
+      // stacking follows the available width, not a fixed breakpoint.
       direction={{ xs: 'column', md: 'row' }}
       spacing={2}
-      sx={{ justifyContent: 'space-between', alignItems: { md: 'center' } }}
+      useFlexGap
+      sx={{ justifyContent: 'space-between', alignItems: { md: 'center' }, flexWrap: 'wrap' }}
     >
       <Stack direction="row" spacing={1.5} sx={{ minWidth: 0, alignItems: 'center' }}>
         {leading && <Box sx={{ flexShrink: 0 }}>{leading}</Box>}
@@ -81,7 +87,9 @@ export function PageHeader({
           )}
         </Box>
       </Stack>
-      {action && <Box sx={{ flexShrink: 0 }}>{action}</Box>}
+      {/* maxWidth caps the slot at the line it wrapped onto, so a wide action
+          bar's own flexWrap finally has an edge to break at (issue #774). */}
+      {action && <Box sx={{ flexShrink: 0, maxWidth: '100%' }}>{action}</Box>}
     </Stack>
   );
 }

--- a/qnop-ui/src/components/admin/layout/PageHeader.tsx
+++ b/qnop-ui/src/components/admin/layout/PageHeader.tsx
@@ -88,8 +88,10 @@ export function PageHeader({
         </Box>
       </Stack>
       {/* maxWidth caps the slot at the line it wrapped onto, so a wide action
-          bar's own flexWrap finally has an edge to break at (issue #774). */}
-      {action && <Box sx={{ flexShrink: 0, maxWidth: '100%' }}>{action}</Box>}
+          bar's own flexWrap finally has an edge to break at; ml: 'auto' keeps
+          the slot right-aligned even when it is alone on a wrapped line, where
+          space-between would park a lone item at line start (issue #774). */}
+      {action && <Box sx={{ flexShrink: 0, maxWidth: '100%', ml: { md: 'auto' } }}>{action}</Box>}
     </Stack>
   );
 }

--- a/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewHubHead.tsx
@@ -185,7 +185,10 @@ export function ReviewHubHead({
   const shown = participants.slice(0, MAX_STACK_AVATARS);
 
   return (
-    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+    // useFlexGap: with margin-based spacing a wrapped second row would sit
+    // flush against the first — the wrap fires for real now that PageHeader
+    // hands this bar a width limit (issue #774).
+    <Stack direction="row" spacing={1.5} useFlexGap sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
       {/* The owner is structurally public (issue #472), so the hover card
           (issue #482) may attach even in anonymous reviews — it replaces the
           old "Review owner" tooltip, which the OWNER label already spells. */}


### PR DESCRIPTION
## Summary

On every review route at 1024 × 768 beside the open sidebar, `main` (764 px) scrolled to 824 px: #723 stacks the header below `md`, but at 1024 px the header is side-by-side again and the `flexShrink: 0` action slot (784 px review action row) cannot be narrowed (#774, found by the responsive net #725).

The fix makes stacking intrinsic instead of breakpoint-bound, in `PageHeader` (one change for every surface using the canonical header):

- The `md`+ header row is a **wrapping** flex row (`flexWrap` + `useFlexGap`): the action slot drops below the title exactly when it stops fitting — "stack until the row fits, not until a fixed breakpoint", the first option the issue proposes.
- The action slot keeps `flexShrink: 0` (titles still cannot crush buttons) but gains `maxWidth: '100%'`, so once wrapped onto its own line a wide action bar's internal `flexWrap` (already present in `ReviewHubHead`) finally has an edge to break at.
- Below `md` nothing changes (#723's stacking stays).

**Note on the `test.fail()` marker:** the responsive spec lives in the still-open PR #777; its marker for #774 flips when that branch rebases onto this fix.

## Test plan

- [x] `pnpm typecheck`, `pnpm test:run` (1361 tests green)
- [ ] Pixel verification through PR #777's 1024 px overflow checks once both meet

Closes #774

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)