### PR TITLE
fix(ui): the title keeps its words, the adornment steps aside

### DIFF
--- a/qnop-ui/src/components/admin/layout/PageHeader.tsx
+++ b/qnop-ui/src/components/admin/layout/PageHeader.tsx
@@ -74,7 +74,16 @@ export function PageHeader({
       <Stack direction="row" spacing={1.5} sx={{ minWidth: 0, alignItems: 'center' }}>
         {leading && <Box sx={{ flexShrink: 0 }}>{leading}</Box>}
         <Box sx={{ minWidth: 0 }}>
-          <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+          {/* The title row wraps (issue #775): when the slot gets tight the
+              adornment steps below the title instead of crushing the h1 to a
+              few letters — the ellipsis is reserved for a title that alone
+              exceeds the slot. */}
+          <Stack
+            direction="row"
+            spacing={1.5}
+            useFlexGap
+            sx={{ alignItems: 'center', flexWrap: 'wrap' }}
+          >
             <Typography variant="h1" sx={{ fontSize: 28 }} noWrap={Boolean(titleAdornment)}>
               {title}
             </Typography>

--- a/qnop-ui/src/components/reviews/hub/ReviewPageHeader.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewPageHeader.tsx
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import Stack from '@mui/material/Stack';
 import type { AnnotationView, DocumentResponse } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { PageHeader } from '../../admin/layout/PageHeader';
@@ -66,7 +67,10 @@ export function ReviewPageHeader({
       title={document.title}
       leading={<DocumentIcon size={34} contentType={document.contentType} />}
       titleAdornment={
-        <>
+        // One Stack, not a Fragment: the header's title row wraps (issue
+        // #775), and two loose flex items could split onto separate lines —
+        // milestones and badge travel as a single unit instead.
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
           <WorkflowMilestones
             state={document.workflowState}
             total={annotations.length}
@@ -74,7 +78,7 @@ export function ReviewPageHeader({
             archivedAt={document.archivedAt ?? null}
           />
           {document.anonymous && <AnonymousBadge />}
-        </>
+        </Stack>
       }
       action={
         <ReviewHubHead


### PR DESCRIPTION
## Summary

At 1440 × 900 the review workspace title rendered as "S…" — a 45 px h1 in a 286 px slot — while the middle segment (workflow milestones, badges) and the 784 px action row kept their full width (#775, seen in the responsive net's screenshot baselines #725).

Fix in `PageHeader`, on top of #774 (**this PR is stacked on `fix/issue-774-review-head-wrap` and retargets to `main` automatically once #784 merges**):

- The title row wraps (`flexWrap` + `useFlexGap`): when the slot gets tight, the `titleAdornment` steps onto its own line **below** the title instead of crushing the h1.
- The `noWrap` ellipsis now only ever hits a title that alone exceeds the slot — "reserve the ellipsis for genuinely long titles", as the issue asks. No magic `minWidth` constant needed: flex line-packing gives the title priority naturally.
- Together with #774's width-driven stacking the 1440 px head now resolves as: everything on one line when it fits → action row below when not → adornment below the title as the last step.

## Test plan

- [x] `pnpm typecheck`, `pnpm test:run` (1361 tests green)
- [ ] Screenshot-baseline verification through PR #777 once both meet (this finding is not an overflow, so the net asserts it visually)

Closes #775

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)