### PR TITLE
fix(ui): the review title keeps its words at laptop widths

### DIFF
--- a/qnop-ui/src/components/admin/layout/PageHeader.tsx
+++ b/qnop-ui/src/components/admin/layout/PageHeader.tsx
@@ -74,7 +74,16 @@ export function PageHeader({
       <Stack direction="row" spacing={1.5} sx={{ minWidth: 0, alignItems: 'center' }}>
         {leading && <Box sx={{ flexShrink: 0 }}>{leading}</Box>}
         <Box sx={{ minWidth: 0 }}>
-          <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+          {/* The title row wraps (issue #775): when the slot gets tight the
+              adornment steps below the title instead of crushing the h1 to a
+              few letters — the ellipsis is reserved for a title that alone
+              exceeds the slot. */}
+          <Stack
+            direction="row"
+            spacing={1.5}
+            useFlexGap
+            sx={{ alignItems: 'center', flexWrap: 'wrap' }}
+          >
             <Typography variant="h1" sx={{ fontSize: 28 }} noWrap={Boolean(titleAdornment)}>
               {title}
             </Typography>

--- a/qnop-ui/src/components/reviews/hub/ReviewPageHeader.tsx
+++ b/qnop-ui/src/components/reviews/hub/ReviewPageHeader.tsx
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import Stack from '@mui/material/Stack';
 import type { AnnotationView, DocumentResponse } from '../../../api/generated';
 import { AnnotationStatus } from '../../../api/generated';
 import { PageHeader } from '../../admin/layout/PageHeader';
@@ -66,7 +67,10 @@ export function ReviewPageHeader({
       title={document.title}
       leading={<DocumentIcon size={34} contentType={document.contentType} />}
       titleAdornment={
-        <>
+        // One Stack, not a Fragment: the header's title row wraps (issue
+        // #775), and two loose flex items could split onto separate lines —
+        // milestones and badge travel as a single unit instead.
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
           <WorkflowMilestones
             state={document.workflowState}
             total={annotations.length}
@@ -74,7 +78,7 @@ export function ReviewPageHeader({
             archivedAt={document.archivedAt ?? null}
           />
           {document.anonymous && <AnonymousBadge />}
-        </>
+        </Stack>
       }
       action={
         <ReviewHubHead


### PR DESCRIPTION
## Summary

**Re-delivery of #775** — the original PR #785 was merged seven seconds after its base #784, so it landed on the already-merged branch `fix/issue-774-review-head-wrap` instead of main (GitHub's auto-retarget did not fire). Its two commits never reached main; this PR carries them, rebased cleanly onto the current main. Content and review history live on #785 (verdict APPROVE; the one MEDIUM finding — the Fragment adornment splitting into loose wrap items — is fixed in the second commit).

- The title row wraps (`flexWrap` + `useFlexGap`): the adornment steps below the title when space runs out, instead of crushing the `h1` to "S…" in a 286 px slot at 1440 px. Ellipsis is reserved for a title that alone exceeds the slot.
- `ReviewPageHeader` passes milestones + anonymous badge as one `Stack`, so the wrapped head resolves to two lines, never three.

## Test plan

- [x] `pnpm test:run` after the rebase (1374 tests green)
- [ ] Screenshot-baseline verification lands with PR #777 (asked there to include an anonymous review at ~1330–1420 px)

Closes #775

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)