### PR TITLE
fix(ui): keep the keyboard caret and region draft in view while they move (#782)

### DIFF
--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.test.tsx
@@ -230,6 +230,29 @@ describe('RegionSelectLayer keyboard path (issue #771)', () => {
     expect(screen.queryByTestId('region-draft-0')).toBeNull();
   });
 
+  it('keeps the moving keyboard rectangle in view, but not a pointer drag (issue #782)', () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    vi.useFakeTimers();
+    try {
+      const { layer } = renderLayer();
+      drag(layer, [10, 10], [50, 50]);
+      vi.advanceTimersToNextFrame();
+      expect(scrollIntoView).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(layer, { key: 'ArrowDown' });
+      fireEvent.keyDown(layer, { key: 'ArrowDown' });
+      vi.advanceTimersToNextFrame();
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView.mock.instances[0]).toBe(screen.getByTestId('region-draft-0'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('ignores keys when disabled', () => {
     const { layer, onRegionSelected } = renderLayer(false);
 

--- a/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/RegionSelectLayer.tsx
@@ -27,6 +27,7 @@ import type { NormalizedBox } from '../../../api/generated';
 import type { ScreenPosition } from './anchoring';
 import { MARKER_YELLOW_BORDER, SELECTION_MARKER_BG } from './markerColors';
 import { visuallyHidden } from '../../../theme/visuallyHidden';
+import { useKeepInView } from './useKeepInView';
 
 /** How the keyboard path is announced to assistive tech (issue #771). */
 const KEYBOARD_HINT =
@@ -200,6 +201,13 @@ export function RegionSelectLayer({
     height: Math.abs(draft.y2 - draft.y1),
   };
   const preview = pointerPreview ?? keyboardBox;
+  // Only the keyboard rectangle needs following — a pointer drag is by
+  // definition where the user is looking (#782).
+  const draftRef = useKeepInView<HTMLDivElement>(
+    !pointerPreview && keyboardBox
+      ? `${keyboardBox.x},${keyboardBox.y},${keyboardBox.width},${keyboardBox.height}`
+      : null,
+  );
 
   return (
     <Box
@@ -231,6 +239,7 @@ export function RegionSelectLayer({
       )}
       {preview && (
         <div
+          ref={draftRef}
           data-testid={`region-draft-${surfaceIndex}`}
           style={{
             position: 'absolute',

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.test.tsx
@@ -227,6 +227,26 @@ describe('TextSpanLayer', () => {
       expect(screen.queryByTestId('keyboard-caret-0')).not.toBeInTheDocument();
     });
 
+    it('keeps the moving caret in view (issue #782)', () => {
+      const scrollIntoView = vi.fn();
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: scrollIntoView,
+      });
+      vi.useFakeTimers();
+      try {
+        renderLayer();
+        const layer = layerAt();
+        fireEvent.keyDown(layer, { key: 'ArrowRight' });
+        fireEvent.keyDown(layer, { key: 'ArrowDown' });
+        vi.advanceTimersToNextFrame();
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        expect(scrollIntoView.mock.instances[0]).toBe(screen.getByTestId('keyboard-caret-0'));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('ignores keys while disabled', () => {
       const onTextSelected = renderLayer({ enabled: false });
       const layer = layerAt();

--- a/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
+++ b/qnop-ui/src/components/reviews/viewer/TextSpanLayer.tsx
@@ -37,6 +37,7 @@ import {
 import { SELECTION_MARKER_BG } from './markerColors';
 import { visuallyHidden } from '../../../theme/visuallyHidden';
 import { keyboardCaretMove, spanAtOffset } from './keyboardSelection';
+import { useKeepInView } from './useKeepInView';
 
 /** How the keyboard path is announced to assistive tech (issue #460). */
 const KEYBOARD_HINT =
@@ -215,6 +216,9 @@ export function TextSpanLayer({
         )
       : null;
 
+  // Follows the caret as it moves so it never leaves the scrolled viewport (#782).
+  const caretRef = useKeepInView<HTMLDivElement>(caretBox ? `${caretBox.x},${caretBox.y}` : null);
+
   return (
     <Box
       ref={rootRef}
@@ -250,6 +254,7 @@ export function TextSpanLayer({
       )}
       {caretBox && (
         <div
+          ref={caretRef}
           data-testid={`keyboard-caret-${surfaceIndex}`}
           style={{
             position: 'absolute',

--- a/qnop-ui/src/components/reviews/viewer/useKeepInView.test.tsx
+++ b/qnop-ui/src/components/reviews/viewer/useKeepInView.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useKeepInView } from './useKeepInView';
+
+function Draft({ positionKey }: { positionKey: string | null }) {
+  const ref = useKeepInView<HTMLDivElement>(positionKey);
+  return <div ref={ref} data-testid="draft" />;
+}
+
+const scrollIntoView = vi.fn();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  scrollIntoView.mockClear();
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: scrollIntoView,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useKeepInView (issue #782)', () => {
+  it('scrolls the element into view once per frame after a move', () => {
+    const { rerender } = render(<Draft positionKey="0,0" />);
+    rerender(<Draft positionKey="0,0.1" />);
+    rerender(<Draft positionKey="0,0.2" />);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    vi.advanceTimersToNextFrame();
+
+    // Three position changes, one scroll — the held-down key never thrashes.
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', inline: 'nearest' });
+  });
+
+  it('does nothing without a position', () => {
+    render(<Draft positionKey={null} />);
+    vi.advanceTimersToNextFrame();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending scroll on unmount', () => {
+    const { unmount } = render(<Draft positionKey="0,0" />);
+    unmount();
+    vi.advanceTimersToNextFrame();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/qnop-ui/src/components/reviews/viewer/useKeepInView.ts
+++ b/qnop-ui/src/components/reviews/viewer/useKeepInView.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Keeps a moving element inside the scrolled viewport (issue #782). Both
+ * keyboard paths in the viewer — the text caret (#460) and the region
+ * rectangle (#771) — render a draft element that arrow keys move; on a page
+ * taller than the viewport that draft can walk out of view while the page
+ * container stays put, and a sighted keyboard user steers blind.
+ *
+ * Pass a value that changes whenever the draft moves (a position key). Each
+ * change schedules one `scrollIntoView({ block: 'nearest' })` on the next
+ * animation frame; a held-down key produces many changes per frame, and only
+ * the last one runs, so the scroller is never thrashed. `nearest` is a no-op
+ * while the element is already visible. Null means "nothing to follow".
+ */
+export function useKeepInView<T extends HTMLElement>(
+  positionKey: string | null,
+): RefObject<T | null> {
+  const ref = useRef<T | null>(null);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (positionKey === null) return;
+    if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      ref.current?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    });
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
+  }, [positionKey]);
+
+  return ref;
+}


### PR DESCRIPTION
Closes #782 (follow-up from the review of #780).

On a page taller than the viewport, moving the keyboard caret (`TextSpanLayer`, #460) or the keyboard rectangle (`RegionSelectLayer`, #771) could push the draft out of the scrolled viewport — the container did not follow, so a sighted keyboard user steered blind.

## Change

- **`viewer/useKeepInView.ts`** — one shared hook. It takes a position key; every change schedules a single `scrollIntoView({ block: 'nearest', inline: 'nearest' })` on the next animation frame, so a held-down arrow coalesces to one scroll per frame and a draft already in view is a no-op. Pending frames are cancelled on unmount.
- **`TextSpanLayer`** — ref on the caret element, keyed by caret position.
- **`RegionSelectLayer`** — ref on the draft rectangle, keyed by its geometry; only the keyboard rectangle is followed, a pointer drag is left alone (the pointer is where the user is looking).

## Tests

- `useKeepInView.test.tsx`: three moves → one scroll per frame; nothing without a position; unmount cancels a pending scroll.
- One case each in the text-layer and region-layer keyboard suites (region: drag does not scroll, arrows scroll once, on the draft element).

## Test plan

- [x] `pnpm test:run` — 1379 tests green; `tsc`, `eslint`, `prettier` clean
- [ ] CI green
- [ ] Manual: tall PDF page, Tab into the text layer, hold ↓ — the caret stays visible; same with the region rectangle

🤖 Co-Author: Claude (Fable 5) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139RpvTw7gWocFXstb6N3x1