### PR TITLE
ci: auto-correct the Gradle wrapper checksum on Renovate branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,9 @@
   "prHourlyLimit": 10,
   "description": "Hold updates until packages clear pnpm 11's supply-chain minimum release age (~24h), plus margin, so deps PRs never fail `pnpm install --frozen-lockfile` for being too fresh. See ADR-0017 / issue #264.",
   "minimumReleaseAge": "3 days",
+  "gitIgnoredAuthors": [
+    "qnop-wrapper-checksum-fix[bot]@users.noreply.github.com"
+  ],
   "packageRules": [
     {
       "description": "OpenAPI Generator — the Gradle plugin (Java DTOs + Spring interfaces) and the npm CLI (TypeScript client) run against the same openapi.yaml, so they must move in lockstep to avoid template/serialization drift",

--- a/.github/workflows/gradle-wrapper-checksum-fix.yml
+++ b/.github/workflows/gradle-wrapper-checksum-fix.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Auto-correct the Gradle wrapper checksum on Renovate branches (issue #769).
+#
+# Renovate's gradle-wrapper manager bumps distributionUrl on a Gradle release
+# but leaves distributionSha256Sum untouched (issue #763), so every wrapper PR
+# arrives with a stale pin. The CI guard (issue #768) catches that in seconds
+# and prints the value to paste in; this workflow pastes it. It runs the same
+# script in `--fix` mode, so guard and fixer can never disagree, and commits
+# the single corrected line.
+#
+# Two things make this work at all, both from ADR-0017:
+#  - The push uses the Renovate App's installation token, not GITHUB_TOKEN. A
+#    GITHUB_TOKEN push starts no workflow runs (GitHub's anti-recursion rule),
+#    so the PR would keep its stale red checks and nothing would be gained.
+#  - The commit carries its own author, listed in gitIgnoredAuthors of
+#    .github/renovate.json, so Renovate keeps updating the branch instead of
+#    treating it as modified by a human — and the fix stays recognisable in
+#    `git log`.
+#
+# Scope guard: only branches under renovate/**, only when that one file
+# changed, and the job refuses to push anything but a one-line change to it.
+# Everything wider is a privileged workflow with push access looking for a
+# way to go wrong. A push by this workflow re-triggers it once; the second run
+# finds the pin correct and ends without a commit.
+
+name: Gradle wrapper checksum fix
+
+on:
+  push:
+    branches: ['renovate/**']
+    paths: ['gradle/wrapper/gradle-wrapper.properties']
+
+permissions:
+  contents: read
+
+jobs:
+  fix:
+    name: Correct a stale distributionSha256Sum
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint Renovate App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Correct the pin if it is stale
+        run: scripts/check-gradle-wrapper-checksum.sh --fix
+      - name: Commit and push the corrected line
+        run: |
+          if git diff --quiet; then
+            echo "pin already matches — nothing to push"
+            exit 0
+          fi
+          # The scope guard: exactly one file, exactly one line replaced.
+          changed="$(git diff --name-only)"
+          [ "$changed" = "gradle/wrapper/gradle-wrapper.properties" ] || {
+            echo "::error::refusing to push: unexpected changes in $changed"; exit 1; }
+          read -r added removed _ < <(git diff --numstat -- gradle/wrapper/gradle-wrapper.properties)
+          [ "$added" = 1 ] && [ "$removed" = 1 ] || {
+            echo "::error::refusing to push: expected a one-line change, got +$added -$removed"; exit 1; }
+          git config user.name 'qnop-wrapper-checksum-fix[bot]'
+          git config user.email 'qnop-wrapper-checksum-fix[bot]@users.noreply.github.com'
+          git commit -am 'chore(deps): correct the Gradle wrapper distribution checksum' \
+            -m 'The wrapper bump left distributionSha256Sum on the previous release (issue #763); set it to the checksum Gradle publishes for the new distributionUrl. Automated by gradle-wrapper-checksum-fix.yml (issue #769).'
+          git push

--- a/docs/adr/0017-renovate-dependency-automation.md
+++ b/docs/adr/0017-renovate-dependency-automation.md
@@ -59,3 +59,15 @@ An App installation token is a distinct identity: it is not bound by the Actions
 ## Amendment (2026-07-16): frontend lockfile
 
 The frontend lockfile noted as missing under *Consequences* (`qnop-ui/pnpm-lock.yaml`) has since been committed; Renovate updates it as part of its npm PRs.
+
+## Amendment (2026-08-29): Gradle wrapper checksum auto-fix
+
+Renovate's `gradle-wrapper` manager bumps `distributionUrl` on a Gradle release but leaves `distributionSha256Sum` (the pin from issue #194) untouched, so every wrapper PR arrived with a stale pin and four opaque "Verification of Gradle distribution failed!" jobs (issue #763). The CI guard from issue #768 turned that into a fast failure that prints the value to paste in; issue #769 closes the remaining manual step.
+
+**Decision:** a second privileged workflow, `.github/workflows/gradle-wrapper-checksum-fix.yml`, runs on `push` to `renovate/**` when `gradle/wrapper/gradle-wrapper.properties` changed, runs the guard script in `--fix` mode (one script for guard and fixer, so they cannot disagree), and commits the corrected line.
+
+- It pushes with the **Renovate App installation token** — the same identity and secrets as the Renovate run — because a `GITHUB_TOKEN` push starts no workflow runs and the PR would keep its stale red checks.
+- It commits as its **own author**, `qnop-wrapper-checksum-fix[bot]`, listed in `gitIgnoredAuthors` of `.github/renovate.json`, so Renovate keeps updating the branch (it otherwise stops on a branch whose last commit is not its own) and the fix stays distinguishable in `git log`. The alternative — committing under Renovate's identity — needs no config but hides the automation.
+- **Scope guard:** the job refuses to push anything but a one-line change to that one file, and only on `renovate/**`. Its own push re-triggers it once; that run finds the pin correct and ends without a commit.
+
+**Consequence:** one more workflow holds the App private key and can push to Renovate branches — the trade-off issue #769 weighs. Accepted because the blast radius is bounded by the scope guard, and because the alternative was a monthly hand-edit that the guard only made faster, not unnecessary.

--- a/scripts/check-gradle-wrapper-checksum.sh
+++ b/scripts/check-gradle-wrapper-checksum.sh
@@ -18,10 +18,22 @@
 # on every wrapper run.
 #
 # Run from the repo root:
-#   scripts/check-gradle-wrapper-checksum.sh [path/to/gradle-wrapper.properties]
+#   scripts/check-gradle-wrapper-checksum.sh [--fix] [path/to/gradle-wrapper.properties]
+#
+# --fix (issue #769) rewrites the distributionSha256Sum line to the published
+# value instead of failing, and touches nothing else in the file. The guard and
+# the fixer share this one script so their notion of "the pinned URL" and "the
+# published checksum" can never drift apart. Exit status is 0 whether the pin
+# already matched or was just corrected; the caller reads `git diff` to learn
+# which.
 
 set -euo pipefail
 
+FIX=0
+if [[ "${1:-}" == "--fix" ]]; then
+  FIX=1
+  shift
+fi
 PROPS="${1:-gradle/wrapper/gradle-wrapper.properties}"
 
 fail() {
@@ -55,6 +67,16 @@ published="$(curl -fsSL --retry 3 --retry-delay 2 "${url}.sha256" | tr -d '[:spa
 [[ "$published" =~ ^[0-9a-f]{64}$ ]] || fail \
   "${url}.sha256 did not return a SHA-256 digest" \
   "Got: ${published:0:100}"
+
+if [[ "$pinned" != "$published" && "$FIX" == 1 ]]; then
+  # Replace the value on the existing line only; every other line stays byte
+  # for byte, so the resulting diff is exactly one line.
+  sed -i "s/^distributionSha256Sum=.*$/distributionSha256Sum=${published}/" "$PROPS"
+  echo "distributionSha256Sum corrected to the checksum published for ${url##*/}"
+  echo "  was: $pinned"
+  echo "  now: $published"
+  exit 0
+fi
 
 if [[ "$pinned" != "$published" ]]; then
   fail \


### PR DESCRIPTION
## Summary

Follow-up to #763 / #768. Renovate's `gradle-wrapper` manager bumps `distributionUrl` and leaves the `distributionSha256Sum` pin behind; the guard from #768 fails fast and prints the value to paste in. This pastes it.

- `scripts/check-gradle-wrapper-checksum.sh --fix` rewrites only the `distributionSha256Sum` line — guard and fixer are one script and cannot drift apart.
- `.github/workflows/gradle-wrapper-checksum-fix.yml` runs on `push` to `renovate/**` when that file changed, and commits the corrected line if there is one.
  - Pushes with the **Renovate App installation token** (same secrets as `renovate.yml`) so CI re-runs on the PR — a `GITHUB_TOKEN` push starts no workflow runs.
  - Commits as its own author `qnop-wrapper-checksum-fix[bot]`, listed in `gitIgnoredAuthors` of `.github/renovate.json`, so Renovate keeps rebasing the branch and the fix stays visible in `git log` (option 2 from the issue).
  - **Scope guard:** refuses to push anything but a one-line change to that one file. Its own push re-triggers it once; that run ends without a commit.
- ADR-0017 amendment records the decision and the trade-off (one more workflow holding the App key with push access, bounded by the guard).

Closes #769

## Test plan

- [x] Script: guard fails on a wrong pin; `--fix` yields a byte-identical correct file; `--fix` on a correct file is a no-op
- [x] `actionlint` (with shellcheck) clean on the new workflow
- [ ] CI green
- [ ] **Live verification only possible on the next Renovate wrapper PR**: fix commit appears, CI re-runs on the PR, Renovate still rebases the branch afterwards

🤖 Co-Author: Claude (Fable 5) via Claude Code