### PR TITLE
feat(review): composer-body extension point in the runtime UI extension model

### DIFF
--- a/docs/adr/0039-enterprise-packaging-and-runtime-extensions.md
+++ b/docs/adr/0039-enterprise-packaging-and-runtime-extensions.md
@@ -57,4 +57,6 @@ The Community bundle never contains enterprise JavaScript; enterprise bundles in
 
 ## Status notes
 
+**2026-08-30 — first slot landed (issue #599).** The composer-mode extension point exists in `qnop-ui` (`src/extensions/composerModes.ts`): a registered contribution adds a tab to the shared Markdown composer's mode strip and renders its own editing surface against the controlled contract (raw Markdown in and out, submit chord, disabled/fullscreen state, mention roster, attachment callback, a handle for caret-level insertion). The registry is in-app for now; its types are written as the future `qnop-ui-spi` shape for this slot and move there with the loader. Without a registration the composer's behaviour and DOM are unchanged, and the per-user `composer_mode` setting is neither read nor written.
+
 Finalizes the directions of [ADR-0012](0012-edition-vs-entitlements.md) and [ADR-0014](0014-frontend-enterprise-separation.md); both remain as recorded context. The Liquibase seam (2) lands with issue #254; slots, `qnop-ui-spi` and the extension loader are built with the first enterprise UI feature (first candidate: e-signature, [ADR-0035](0035-esignature-approval-enterprise-feature.md)).

--- a/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
+++ b/qnop-core/src/main/java/io/qnop/service/UserSettingKey.java
@@ -79,7 +79,17 @@ public enum UserSettingKey {
       "usage_tracking_opt_out",
       SettingValueType.BOOLEAN,
       "false",
-      "Exclude me from anonymous usage measurement, on every device I sign in from.");
+      "Exclude me from anonymous usage measurement, on every device I sign in from."),
+  // The composer mode the person last wrote in (issue #599): "write" for the Markdown
+  // textarea, or the id of a mode a runtime UI extension contributed (ADR-0039). Free-form
+  // because the set of modes is not known to the server — an extension registers them in the
+  // browser; the frontend ignores a value no registered mode answers to. Empty until an
+  // extension is present and the person picks a mode, so Community installs never write it.
+  COMPOSER_MODE(
+      "composer_mode",
+      SettingValueType.STRING,
+      "",
+      "The editing mode the comment composer opens in; empty follows the default.");
 
   private static final Map<String, UserSettingKey> BY_KEY =
       Arrays.stream(values())

--- a/qnop-ui/src/components/reviews/markdown/ComposerModeMemory.tsx
+++ b/qnop-ui/src/components/reviews/markdown/ComposerModeMemory.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useRef } from 'react';
+import { useUpdateUserSettings, useUserSettingValue } from '../../../api/hooks/useUserSettings';
+import type { ComposerModeContribution } from '../../../extensions/composerModes';
+
+/** The per-user setting that remembers the composer mode (issue #599). */
+export const COMPOSER_MODE_KEY = 'composer_mode';
+
+interface ComposerModeMemoryProps {
+  modes: readonly ComposerModeContribution[];
+  /** The composer's current mode: `write`, `preview` or a contributed id. */
+  mode: string;
+  /** Applies the remembered mode once the setting has loaded. */
+  onRestore: (mode: string) => void;
+}
+
+/**
+ * Remembers the last-used composer mode through the user settings (issue
+ * #599). Rendered by the composer only while a mode is registered, so that
+ * without extensions the composer neither reads nor writes the setting — and
+ * needs no query client, which keeps its existing tests untouched.
+ *
+ * Restores once, when the setting arrives and names a registered mode (or
+ * `write`); persists every later change that is a writing mode. Preview is
+ * a glance, not a place to come back to, so it is never stored.
+ */
+export function ComposerModeMemory({ modes, mode, onRestore }: ComposerModeMemoryProps) {
+  const stored = useUserSettingValue(COMPOSER_MODE_KEY);
+  const { mutate } = useUpdateUserSettings();
+  const restored = useRef(false);
+  const lastPersisted = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (restored.current || stored === undefined) return;
+    restored.current = true;
+    const known = stored === 'write' || modes.some((candidate) => candidate.id === stored);
+    lastPersisted.current = stored;
+    if (known && stored !== mode) onRestore(stored);
+  }, [stored, modes, mode, onRestore]);
+
+  useEffect(() => {
+    if (!restored.current || mode === 'preview' || mode === lastPersisted.current) return;
+    lastPersisted.current = mode;
+    mutate({ [COMPOSER_MODE_KEY]: mode });
+  }, [mode, mutate]);
+
+  return null;
+}

--- a/qnop-ui/src/components/reviews/markdown/MarkdownComposer.modes.test.tsx
+++ b/qnop-ui/src/components/reviews/markdown/MarkdownComposer.modes.test.tsx
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useEffect, useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+import { buildTheme } from '../../../theme/theme';
+import {
+  registerComposerMode,
+  unregisterComposerMode,
+  type ComposerModeSurfaceProps,
+} from '../../../extensions/composerModes';
+import { userSettingsApi } from '../../../api/config';
+import { useAuthStore } from '../../../stores/authStore';
+import { MarkdownComposer } from './MarkdownComposer';
+import type { UploadedAttachment } from './useCommentAttachmentUpload';
+
+/**
+ * A test-only mode (issue #599): a plain input that speaks the surface
+ * contract — value in, Markdown out, the submit chord, the handle for the
+ * composer's shared affordances — and reports what it was given.
+ */
+const seen: { props?: ComposerModeSurfaceProps } = {};
+
+function FakeSurface(props: ComposerModeSurfaceProps) {
+  const { value, onChange, onSubmit, disabled, inputAriaLabel, handleRef } = props;
+  useEffect(() => {
+    seen.props = props;
+    handleRef.current = {
+      insertText: (text) => onChange(value + text),
+      replaceText: (search, replacement) => onChange(value.replace(search, replacement)),
+    };
+    return () => {
+      handleRef.current = null;
+    };
+  });
+  return (
+    <input
+      data-testid="fake-surface"
+      aria-label={`${inputAriaLabel} (fake)`}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' && event.metaKey) onSubmit?.();
+      }}
+    />
+  );
+}
+
+function Host({
+  onSubmit,
+  onUploadAttachment,
+  disabled = false,
+  initial = '',
+  authenticated = false,
+}: {
+  onSubmit?: () => void;
+  onUploadAttachment?: (file: File) => Promise<UploadedAttachment>;
+  disabled?: boolean;
+  initial?: string;
+  authenticated?: boolean;
+}) {
+  const [value, setValue] = useState(initial);
+  const [client] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  useAuthStore.setState({ isAuthenticated: authenticated });
+  return (
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={buildTheme('light')}>
+        <MarkdownComposer
+          value={value}
+          onChange={setValue}
+          onSubmit={onSubmit}
+          onUploadAttachment={onUploadAttachment}
+          disabled={disabled}
+          inputAriaLabel="Test comment"
+          mentionCandidates={[{ id: 'u1', name: 'Alice', slug: 'alice' }]}
+        />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+const fake = { id: 'fake', label: 'Fancy', Surface: FakeSurface };
+
+afterEach(() => {
+  unregisterComposerMode('fake');
+  unregisterComposerMode('wysiwyg');
+  seen.props = undefined;
+  vi.restoreAllMocks();
+  useAuthStore.setState({ isAuthenticated: false });
+});
+
+describe('MarkdownComposer — contributed modes (#599)', () => {
+  it('shows no extra tab and no surface without a registered mode', () => {
+    render(<Host />);
+    expect(screen.getByRole('button', { name: 'Write' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
+    expect(screen.queryByTestId(/composer-mode-/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Test comment').tagName).toBe('TEXTAREA');
+  });
+
+  it('adds a tab for a registered mode and swaps the textarea for its surface', () => {
+    registerComposerMode(fake);
+    render(<Host initial="**bold**" />);
+    const tab = screen.getByTestId('composer-mode-fake');
+    expect(tab).toHaveTextContent('Fancy');
+    expect(tab).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(tab);
+
+    expect(tab).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByLabelText('Test comment')).not.toBeInTheDocument();
+    expect(screen.getByTestId('fake-surface')).toHaveValue('**bold**');
+    // The formatting toolbar belongs to the textarea, not to a surface.
+    expect(screen.queryByRole('button', { name: 'Bold' })).not.toBeInTheDocument();
+  });
+
+  it('round-trips the Markdown value through the surface and back to Write', () => {
+    registerComposerMode(fake);
+    render(<Host />);
+    fireEvent.click(screen.getByTestId('composer-mode-fake'));
+    fireEvent.change(screen.getByTestId('fake-surface'), { target: { value: '# From fake' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Write' }));
+
+    expect(screen.getByLabelText('Test comment')).toHaveValue('# From fake');
+    expect(screen.queryByTestId('fake-surface')).not.toBeInTheDocument();
+  });
+
+  it('passes the submit chord, disabled state, roster and upload callback through', () => {
+    const onSubmit = vi.fn();
+    const onUploadAttachment = vi.fn();
+    registerComposerMode(fake);
+    render(<Host onSubmit={onSubmit} onUploadAttachment={onUploadAttachment} disabled />);
+    fireEvent.click(screen.getByTestId('composer-mode-fake'));
+
+    expect(seen.props?.disabled).toBe(true);
+    expect(screen.getByTestId('fake-surface')).toBeDisabled();
+    expect(seen.props?.mentionCandidates).toEqual([{ id: 'u1', name: 'Alice', slug: 'alice' }]);
+    expect(seen.props?.onUploadAttachment).toBe(onUploadAttachment);
+    expect(seen.props?.fullscreen).toBe(false);
+
+    fireEvent.keyDown(screen.getByTestId('fake-surface'), { key: 'Enter', metaKey: true });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes the shared attach button into the surface through its handle', async () => {
+    const onUploadAttachment = vi.fn(async (): Promise<UploadedAttachment> => ({
+      id: 'a1',
+      url: '/api/v1/attachments/a1',
+      fileName: 'notes.txt',
+      contentType: 'text/plain',
+    }));
+    registerComposerMode(fake);
+    render(<Host initial="see " onUploadAttachment={onUploadAttachment} />);
+    fireEvent.click(screen.getByTestId('composer-mode-fake'));
+
+    const file = new File(['x'], 'notes.txt', { type: 'text/plain' });
+    fireEvent.change(screen.getByTestId('composer-file-input'), { target: { files: [file] } });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('fake-surface')).toHaveValue(
+        'see [notes.txt](/api/v1/attachments/a1)',
+      ),
+    );
+    expect(onUploadAttachment).toHaveBeenCalledWith(file);
+  });
+
+  it('lets the active mode hide the Preview tab', () => {
+    registerComposerMode({ ...fake, id: 'wysiwyg', label: 'Rich', hidesPreview: true });
+    render(<Host />);
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('composer-mode-wysiwyg'));
+    expect(screen.queryByRole('button', { name: 'Preview' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Write' }));
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
+  });
+
+  it('restores the remembered mode and persists a change through the user settings', async () => {
+    registerComposerMode(fake);
+    const get = vi.spyOn(userSettingsApi, 'getCurrentUserSettings').mockResolvedValue({
+      data: { settings: [{ key: 'composer_mode', value: 'fake', type: 'STRING' }] },
+    } as never);
+    const update = vi.spyOn(userSettingsApi, 'updateCurrentUserSettings').mockResolvedValue({
+      data: { settings: [] },
+    } as never);
+    render(<Host authenticated />);
+
+    await waitFor(() => expect(screen.getByTestId('fake-surface')).toBeInTheDocument());
+    expect(get).toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    expect(update).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Write' }));
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith({
+        userSettingsUpdateRequest: { values: { composer_mode: 'write' } },
+      }),
+    );
+  });
+
+  it('ignores a remembered mode no registration answers to', async () => {
+    registerComposerMode(fake);
+    vi.spyOn(userSettingsApi, 'getCurrentUserSettings').mockResolvedValue({
+      data: { settings: [{ key: 'composer_mode', value: 'gone', type: 'STRING' }] },
+    } as never);
+    render(<Host authenticated />);
+    await waitFor(() => expect(screen.getByLabelText('Test comment')).toBeInTheDocument());
+    expect(screen.queryByTestId('fake-surface')).not.toBeInTheDocument();
+  });
+});

--- a/qnop-ui/src/components/reviews/markdown/MarkdownComposer.modes.test.tsx
+++ b/qnop-ui/src/components/reviews/markdown/MarkdownComposer.modes.test.tsx
@@ -116,7 +116,9 @@ afterEach(() => {
 describe('MarkdownComposer — contributed modes (#599)', () => {
   it('shows no extra tab and no surface without a registered mode', () => {
     render(<Host />);
+    // Alone, the tab keeps its conventional name.
     expect(screen.getByRole('button', { name: 'Write' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Markdown' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
     expect(screen.queryByTestId(/composer-mode-/)).not.toBeInTheDocument();
     expect(screen.getByLabelText('Test comment').tagName).toBe('TEXTAREA');
@@ -128,6 +130,10 @@ describe('MarkdownComposer — contributed modes (#599)', () => {
     const tab = screen.getByTestId('composer-mode-fake');
     expect(tab).toHaveTextContent('Fancy');
     expect(tab).toHaveAttribute('aria-pressed', 'false');
+    // Beside a contributed mode the first tab names what you get (#599):
+    // "Write" would claim the other modes are not for writing.
+    expect(screen.getByRole('button', { name: 'Markdown' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Write' })).not.toBeInTheDocument();
 
     fireEvent.click(tab);
 
@@ -138,13 +144,13 @@ describe('MarkdownComposer — contributed modes (#599)', () => {
     expect(screen.queryByRole('button', { name: 'Bold' })).not.toBeInTheDocument();
   });
 
-  it('round-trips the Markdown value through the surface and back to Write', () => {
+  it('round-trips the Markdown value through the surface and back to the Markdown tab', () => {
     registerComposerMode(fake);
     render(<Host />);
     fireEvent.click(screen.getByTestId('composer-mode-fake'));
     fireEvent.change(screen.getByTestId('fake-surface'), { target: { value: '# From fake' } });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Write' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown' }));
 
     expect(screen.getByLabelText('Test comment')).toHaveValue('# From fake');
     expect(screen.queryByTestId('fake-surface')).not.toBeInTheDocument();
@@ -197,7 +203,7 @@ describe('MarkdownComposer — contributed modes (#599)', () => {
     fireEvent.click(screen.getByTestId('composer-mode-wysiwyg'));
     expect(screen.queryByRole('button', { name: 'Preview' })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Write' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown' }));
     expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
   });
 
@@ -218,7 +224,7 @@ describe('MarkdownComposer — contributed modes (#599)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
     expect(update).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Write' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Markdown' }));
     await waitFor(() =>
       expect(update).toHaveBeenCalledWith({
         userSettingsUpdateRequest: { values: { composer_mode: 'write' } },

--- a/qnop-ui/src/components/reviews/markdown/MarkdownComposer.tsx
+++ b/qnop-ui/src/components/reviews/markdown/MarkdownComposer.tsx
@@ -20,6 +20,7 @@
  */
 
 import {
+  useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -53,6 +54,8 @@ import { MarkdownToolbar } from './MarkdownToolbar';
 import { caretViewportRect } from './caretRect';
 import { activeMentionQuery, mentionToken, type MentionCandidate } from './mentionToken';
 import type { UploadedAttachment } from './useCommentAttachmentUpload';
+import { ComposerModeMemory } from './ComposerModeMemory';
+import { useComposerModes, type ComposerModeHandle } from '../../../extensions/composerModes';
 
 /** How many roster matches the @-picker offers at once. */
 const MENTION_LIMIT = 6;
@@ -192,14 +195,24 @@ export function MarkdownComposer({
     const rect = caretViewportRect(mentionAnchor as HTMLTextAreaElement, mention.start);
     return { getBoundingClientRect: () => rect };
   }, [mention, mentionAnchor]);
-  // Write/Preview (issue #445 follow-up) — GitHub's comment-box anatomy.
-  const [previewing, setPreviewing] = useState(false);
+  // Write/Preview (issue #445 follow-up) — GitHub's comment-box anatomy —
+  // plus whatever modes a runtime extension registered (issue #599): the mode
+  // is `write`, `preview` or a contributed id, and a contributed mode renders
+  // its own surface where the textarea would be. The contribution's handle is
+  // how the shared affordances below reach into that surface.
+  const modes = useComposerModes();
+  const [mode, setMode] = useState('write');
+  const contributed = modes.find((candidate) => candidate.id === mode);
+  const previewing = mode === 'preview';
+  const writing = !previewing && !contributed;
+  const modeHandleRef = useRef<ComposerModeHandle | null>(null);
 
   const showWrite = () => {
-    setPreviewing(false);
+    setMode('write');
     // Back to writing means back to the caret.
     requestAnimationFrame(() => inputRef.current?.focus());
   };
+  const restoreMode = useCallback((remembered: string) => setMode(remembered), []);
 
   useLayoutEffect(() => {
     if (!pendingSelection.current || !inputRef.current) return;
@@ -255,8 +268,13 @@ export function MarkdownComposer({
   };
 
   const insertEmoji = (emoji: string) => {
+    if (disabled) return;
+    if (contributed) {
+      insertIntoSurface(emoji);
+      return;
+    }
     const el = inputRef.current;
-    if (!el || disabled) return;
+    if (!el) return;
     const start = el.selectionStart ?? el.value.length;
     const end = el.selectionEnd ?? start;
     const caret = start + emoji.length;
@@ -292,8 +310,25 @@ export function MarkdownComposer({
     setMention(null);
   };
 
+  /**
+   * The contributed surface's caret, or — for a surface that publishes no
+   * handle — the end of the draft, through the controlled value.
+   */
+  const insertIntoSurface = (text: string) => {
+    if (modeHandleRef.current) modeHandleRef.current.insertText(text);
+    else onChange(value + text);
+  };
+  const replaceInSurface = (search: string, replacement: string) => {
+    if (modeHandleRef.current) modeHandleRef.current.replaceText(search, replacement);
+    else onChange(value.replace(search, replacement));
+  };
+
   /** Replaces the first occurrence of `search` in the CURRENT field value. */
   const replaceOnce = (search: string, replacement: string) => {
+    if (contributed) {
+      replaceInSurface(search, replacement);
+      return;
+    }
     const el = inputRef.current;
     if (!el) return;
     const index = el.value.indexOf(search);
@@ -320,19 +355,23 @@ export function MarkdownComposer({
     // The optimistic form follows the browser-declared type; the final form
     // follows the server-sniffed one.
     const placeholder = `${file.type.startsWith('image/') ? '!' : ''}[Uploading ${label}…]()`;
-    const el = inputRef.current;
-    if (!el) return;
-    const start = el.selectionStart ?? el.value.length;
-    const end = el.selectionEnd ?? start;
-    const caret = start + placeholder.length;
-    splice(
-      start,
-      end,
-      placeholder,
-      caret,
-      caret,
-      el.value.slice(0, start) + placeholder + el.value.slice(end),
-    );
+    if (contributed) {
+      insertIntoSurface(placeholder);
+    } else {
+      const el = inputRef.current;
+      if (!el) return;
+      const start = el.selectionStart ?? el.value.length;
+      const end = el.selectionEnd ?? start;
+      const caret = start + placeholder.length;
+      splice(
+        start,
+        end,
+        placeholder,
+        caret,
+        caret,
+        el.value.slice(0, start) + placeholder + el.value.slice(end),
+      );
+    }
     try {
       const uploaded = await upload(file);
       const bang = uploaded.contentType.startsWith('image/') ? '!' : '';
@@ -481,23 +520,32 @@ export function MarkdownComposer({
             flexShrink: 0,
           }}
         >
-          <ButtonBase
-            onClick={showWrite}
-            aria-pressed={!previewing}
-            sx={modeTabSx(theme, !previewing)}
-          >
+          <ButtonBase onClick={showWrite} aria-pressed={writing} sx={modeTabSx(theme, writing)}>
             Write
           </ButtonBase>
-          <ButtonBase
-            onClick={() => setPreviewing(true)}
-            aria-pressed={previewing}
-            sx={modeTabSx(theme, previewing)}
-          >
-            Preview
-          </ButtonBase>
+          {modes.map((candidate) => (
+            <ButtonBase
+              key={candidate.id}
+              data-testid={`composer-mode-${candidate.id}`}
+              onClick={() => setMode(candidate.id)}
+              aria-pressed={mode === candidate.id}
+              sx={modeTabSx(theme, mode === candidate.id)}
+            >
+              {candidate.label}
+            </ButtonBase>
+          ))}
+          {!contributed?.hidesPreview && (
+            <ButtonBase
+              onClick={() => setMode('preview')}
+              aria-pressed={previewing}
+              sx={modeTabSx(theme, previewing)}
+            >
+              Preview
+            </ButtonBase>
+          )}
         </Stack>
         <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
-          {!previewing && <MarkdownToolbar onAction={handleAction} disabled={disabled} />}
+          {writing && <MarkdownToolbar onAction={handleAction} disabled={disabled} />}
           {onToggleFullscreen && (
             <Tooltip title={fullscreen ? 'Exit full screen' : 'Full screen'}>
               <IconButton
@@ -533,6 +581,27 @@ export function MarkdownComposer({
               Nothing to preview.
             </Typography>
           )}
+        </Box>
+      ) : contributed ? (
+        <Box
+          data-testid={`composer-surface-${contributed.id}`}
+          sx={bare ? { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' } : null}
+        >
+          <contributed.Surface
+            value={value}
+            onChange={onChange}
+            onSubmit={onSubmit}
+            disabled={disabled}
+            placeholder={placeholder}
+            inputAriaLabel={inputAriaLabel}
+            minRows={minRows}
+            maxRows={maxRows}
+            fullscreen={fullscreen}
+            bare={bare}
+            mentionCandidates={mentionCandidates}
+            onUploadAttachment={onUploadAttachment}
+            handleRef={modeHandleRef}
+          />
         </Box>
       ) : (
         <InputBase
@@ -673,6 +742,7 @@ export function MarkdownComposer({
           </Stack>
         )}
       </Stack>
+      {modes.length > 0 && <ComposerModeMemory modes={modes} mode={mode} onRestore={restoreMode} />}
       {dragActive && (
         <Stack
           data-testid="composer-drop-overlay"

--- a/qnop-ui/src/components/reviews/markdown/MarkdownComposer.tsx
+++ b/qnop-ui/src/components/reviews/markdown/MarkdownComposer.tsx
@@ -521,7 +521,11 @@ export function MarkdownComposer({
           }}
         >
           <ButtonBase onClick={showWrite} aria-pressed={writing} sx={modeTabSx(theme, writing)}>
-            Write
+            {/* Alone, the GitHub-conventional pair Write | Preview carries the
+                meaning. Beside a contributed mode "Write" stops being true —
+                one writes in the other mode too — so each tab then names what
+                you get, not what you do: Markdown | <mode> | Preview (#599). */}
+            {modes.length > 0 ? 'Markdown' : 'Write'}
           </ButtonBase>
           {modes.map((candidate) => (
             <ButtonBase

--- a/qnop-ui/src/extensions/composerModes.test.ts
+++ b/qnop-ui/src/extensions/composerModes.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { registerComposerMode, unregisterComposerMode, useComposerModes } from './composerModes';
+
+const surface = () => null;
+
+afterEach(() => {
+  unregisterComposerMode('a');
+  unregisterComposerMode('b');
+});
+
+describe('composer mode registry (#599)', () => {
+  it('publishes registrations to subscribers in order and replaces by id', () => {
+    const { result } = renderHook(() => useComposerModes());
+    expect(result.current).toEqual([]);
+
+    act(() => {
+      registerComposerMode({ id: 'a', label: 'A', Surface: surface });
+      registerComposerMode({ id: 'b', label: 'B', Surface: surface });
+    });
+    expect(result.current.map((mode) => mode.label)).toEqual(['A', 'B']);
+
+    act(() => {
+      registerComposerMode({ id: 'a', label: 'A2', Surface: surface });
+    });
+    expect(result.current.map((mode) => mode.label)).toEqual(['B', 'A2']);
+  });
+
+  it('unregisters through the returned disposer', () => {
+    const { result } = renderHook(() => useComposerModes());
+    let dispose = () => {};
+    act(() => {
+      dispose = registerComposerMode({ id: 'a', label: 'A', Surface: surface });
+    });
+    expect(result.current).toHaveLength(1);
+    act(() => dispose());
+    expect(result.current).toEqual([]);
+  });
+
+  it("rejects the composer's own mode ids", () => {
+    expect(() => registerComposerMode({ id: 'write', label: 'W', Surface: surface })).toThrow(
+      /reserved/,
+    );
+    expect(() => registerComposerMode({ id: 'preview', label: 'P', Surface: surface })).toThrow(
+      /reserved/,
+    );
+  });
+});

--- a/qnop-ui/src/extensions/composerModes.ts
+++ b/qnop-ui/src/extensions/composerModes.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026-present devtank42 GmbH
+ *
+ * This file is part of qnop (Qualified Notes on Papers).
+ *
+ * qnop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * qnop is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with qnop. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useSyncExternalStore, type ComponentType, type RefObject } from 'react';
+import type { MentionCandidate } from '../components/reviews/markdown/mentionToken';
+import type { UploadedAttachment } from '../components/reviews/markdown/useCommentAttachmentUpload';
+
+/**
+ * The composer-mode extension point (issue #599) of the runtime UI extension
+ * model (ADR-0039): a registered contribution adds a tab to the composer's
+ * mode strip and renders its own editing surface in place of the Markdown
+ * textarea while active.
+ *
+ * The contract is the one the textarea already honours. `value` is raw
+ * Markdown and stays the single source of truth — a surface may present it
+ * any way it likes, but what it hands back through `onChange` is what gets
+ * stored, so the storage format cannot change from here. The Community bundle
+ * ships no mode; it only holds the seam. These types are the future
+ * `qnop-ui-spi` shape for this slot and move there with the loader.
+ */
+export interface ComposerModeSurfaceProps {
+  /** The draft, as raw Markdown. */
+  value: string;
+  /** Replaces the draft — with raw Markdown, nothing else. */
+  onChange: (value: string) => void;
+  /**
+   * The platform submit chord ({@link isSubmitShortcut}) belongs to the
+   * surface while it is active; it calls this and the host guards validity.
+   */
+  onSubmit?: () => void;
+  disabled: boolean;
+  placeholder: string;
+  /** The accessible name the host gave the writing surface. */
+  inputAriaLabel: string;
+  minRows: number;
+  maxRows: number;
+  /** True on the full-screen stage. */
+  fullscreen: boolean;
+  /** The stage's frameless, fill-the-host layout (see MarkdownComposer). */
+  bare: boolean;
+  /** The document roster for @-mentions; absent where identities are hidden. */
+  mentionCandidates?: MentionCandidate[];
+  /**
+   * Uploads a file and resolves to its Markdown reference. Absent when the
+   * host offers no attachments. The composer's own attach button, drop zone
+   * and clipboard paste keep working on top of the surface through
+   * {@link ComposerModeHandle}; a surface may also call this itself.
+   */
+  onUploadAttachment?: (file: File) => Promise<UploadedAttachment>;
+  /**
+   * Where the surface publishes its caret-level operations, so the composer's
+   * shared affordances (emoji picker, attachments) land in the surface rather
+   * than at the end of the text. A surface that does not set it still works —
+   * the composer then appends.
+   */
+  handleRef: RefObject<ComposerModeHandle | null>;
+}
+
+/** What the composer needs from a surface to keep its shared affordances working. */
+export interface ComposerModeHandle {
+  /** Inserts Markdown at the caret (an emoji, an upload placeholder). */
+  insertText: (text: string) => void;
+  /** Replaces the first occurrence of `search` (an upload placeholder resolving). */
+  replaceText: (search: string, replacement: string) => void;
+}
+
+export interface ComposerModeContribution {
+  /** Stable, unique; `write` and `preview` are the composer's own. */
+  id: string;
+  /** The tab label. */
+  label: string;
+  /** The editing surface rendered while the mode is active. */
+  Surface: ComponentType<ComposerModeSurfaceProps>;
+  /**
+   * A surface that shows the rendered result as you type has no use for the
+   * Preview tab; the active mode owns its visibility.
+   */
+  hidesPreview?: boolean;
+}
+
+const RESERVED = new Set(['write', 'preview']);
+
+let modes: readonly ComposerModeContribution[] = [];
+const listeners = new Set<() => void>();
+
+function publish(next: readonly ComposerModeContribution[]) {
+  modes = next;
+  for (const listener of listeners) listener();
+}
+
+/** Registers a mode; returns the matching unregister. Re-registering an id replaces it. */
+export function registerComposerMode(contribution: ComposerModeContribution): () => void {
+  if (RESERVED.has(contribution.id)) {
+    throw new Error(`Composer mode id "${contribution.id}" is reserved`);
+  }
+  publish([...modes.filter((mode) => mode.id !== contribution.id), contribution]);
+  return () => unregisterComposerMode(contribution.id);
+}
+
+export function unregisterComposerMode(id: string): void {
+  if (modes.some((mode) => mode.id === id)) publish(modes.filter((mode) => mode.id !== id));
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+const getSnapshot = () => modes;
+
+/** The registered modes, in registration order; re-renders on registry changes. */
+export function useComposerModes(): readonly ComposerModeContribution[] {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## Summary

First UI slot of ADR-0039's runtime extension model (prerequisite for qnophq/qnop-ee#2, follow-up to #445): a registered **composer-mode contribution** adds a tab to the shared Markdown composer's `Write | Preview` strip and renders its own editing surface in place of the textarea — without the community bundle shipping (or knowing about) any editor.

- `qnop-ui/src/extensions/composerModes.ts` — registry (`registerComposerMode` / `useComposerModes`) and the contract (`ComposerModeSurfaceProps`, `ComposerModeHandle`), written as the future `qnop-ui-spi` shape for this slot and kept in-app until the loader exists. `write`/`preview` are reserved ids.
- The contribution receives the controlled contract the textarea already honours: **raw Markdown stays the single source of truth** in `value`/`onChange` (the point exposes no way to submit anything else), submit chord, `disabled`/`fullscreen`/`bare`, mention roster, attachment callback. The composer's shared affordances (emoji picker, attach button, drop, paste) land at the surface's caret through the handle; a surface without a handle still works (append).
- The active mode owns the Preview tab's visibility (`hidesPreview`) — a WYSIWYG-style mode can suppress it.
- Mode preference persists per user through the new `composer_mode` setting (registry-typed, ADR-0025), read/written **only while a mode is registered**: the memory component mounts only then, so without extensions behaviour, DOM and test environment are unchanged.
- ADR-0039 gains a status note recording the first slot.

## Test plan

- [x] Existing composer/panel/review-page suites untouched and green (294 tests)
- [x] Test-only fake mode proves the contract end to end (11 new tests): tab, Markdown round-trip, submit/disabled, roster/upload pass-through, handle routing for the shared attach button, `hidesPreview`, restore/persist via user settings, unknown stored mode ignored
- [x] Registry unit tests (order, replace-by-id, disposer, reserved ids)
- [x] Backend: `UserSettingsControllerIT` green with the new key; `spotlessApply` run
- [ ] CI green

Closes #599

🤖 Co-Author: Claude (Fable 5) via Claude Code