### PR TITLE
fix(ci): re-green the three gates that turned red under every Renovate PR

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,15 +30,21 @@ springBoot = "4.1.1"
 # (com.fasterxml.jackson) — the generated models only carry annotations.
 openapiGenerator = "7.24.0"
 jacksonAnnotations = "2.22"
-# Two pins ahead of the Spring Boot 4.1.0 BOM, both for published advisories
-# (issue #668). Remove them when a Boot release carries these versions or newer;
-# Renovate will offer the bump and the constraint below keeps it honest.
-# - pgjdbc 42.7.12 fixes CVE-2026-54291: with channelBinding=require, a
-#   connection could be silently downgraded to SCRAM without channel binding.
-# - Jackson 3.1.5 fixes CVE-2026-59889: @JsonView was not applied to
-#   @JsonUnwrapped properties on deserialisation.
+# Pins ahead of the Spring Boot BOM, each for published advisories. Remove one
+# when a Boot release carries that version or newer; Renovate will offer the
+# bump and the version.ref below keeps it honest.
+# - pgjdbc 42.7.12 fixes CVE-2026-54291 (issue #668): with channelBinding=require,
+#   a connection could be silently downgraded to SCRAM without channel binding.
+# - Jackson 3.1.5 fixes CVE-2026-59889 (issue #668): @JsonView was not applied
+#   to @JsonUnwrapped properties on deserialisation.
+# - Tomcat 11.0.25 fixes CVE-2026-65182, CVE-2026-65905 and CVE-2026-68525
+#   (issue #817): three authentication/authorization bypasses in the embedded
+#   container (security-constraint bypass, DIGEST replay, FORM login bypass).
+#   Boot 4.1.1 manages 11.0.24; qnop-app constrains all three tomcat-embed
+#   artifacts so core, el and websocket move together.
 postgresql = "42.7.13"
 jackson3 = "3.2.2"
+tomcat = "11.0.25"
 swaggerAnnotations = "2.2.54"
 jakartaValidation = "3.1.1"
 jakartaAnnotation = "3.0.0"
@@ -87,6 +93,12 @@ spring-boot-dependencies = { group = "org.springframework.boot", name = "spring-
 # autocomplete and the effective-configuration page's per-property tooltips (issue #522).
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
+# Embedded Tomcat, pinned ahead of the BOM (the `tomcat` version above says why).
+# Never declared as dependencies — spring-boot-starter-web brings them — but
+# qnop-app uses these coordinates as constraints so the pin lifts the BOM's version.
+tomcat-embed-core = { module = "org.apache.tomcat.embed:tomcat-embed-core", version.ref = "tomcat" }
+tomcat-embed-el = { module = "org.apache.tomcat.embed:tomcat-embed-el", version.ref = "tomcat" }
+tomcat-embed-websocket = { module = "org.apache.tomcat.embed:tomcat-embed-websocket", version.ref = "tomcat" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 # Prometheus scrape registry for Actuator metrics (issue #348, ADR-0013). Version via the BOM;
 # auto-configured at runtime, so it is a runtime-only dependency (no compile-time symbols).

--- a/qnop-app/build.gradle.kts
+++ b/qnop-app/build.gradle.kts
@@ -103,6 +103,16 @@ dependencies {
     implementation(project(":qnop-api:qnop-api-endpoint")) // generated Spring interfaces (+ DTOs transitively)
 
     implementation(libs.spring.boot.starter.web)
+    // Embedded Tomcat ahead of the Boot BOM (issue #817; the `tomcat` pin in the
+    // version catalog names the advisories). Constraints, not dependencies: the
+    // starter still decides *that* Tomcat is on the classpath, this only lifts the
+    // version — Gradle resolves the higher of the BOM's and this one — and all
+    // three tomcat-embed artifacts move together. Drop when Boot catches up.
+    constraints {
+        implementation(libs.tomcat.embed.core)
+        implementation(libs.tomcat.embed.el)
+        implementation(libs.tomcat.embed.websocket)
+    }
     implementation(libs.spring.boot.starter.actuator)
     // Prometheus scrape registry for the /actuator/prometheus endpoint (issue #348). Runtime-only:
     // Boot auto-configures it; the metrics/health code uses micrometer-core (via actuator) directly.

--- a/qnop-ui/pnpm-lock.yaml
+++ b/qnop-ui/pnpm-lock.yaml
@@ -1276,8 +1276,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.37:
-    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
+  baseline-browser-mapping@2.11.21:
+    resolution: {integrity: sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1292,8 +1292,8 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.9:
+    resolution: {integrity: sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1313,8 +1313,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001799:
-    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1521,8 +1521,8 @@ packages:
   easy-table@1.1.0:
     resolution: {integrity: sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==}
 
-  electron-to-chromium@1.5.372:
-    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+  electron-to-chromium@1.5.422:
+    resolution: {integrity: sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==}
 
   emoji-mart@5.6.0:
     resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
@@ -2457,8 +2457,8 @@ packages:
       encoding:
         optional: true
 
-  node-releases@2.0.47:
-    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
 
   normalize-wheel@1.0.1:
@@ -3071,8 +3071,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -3370,7 +3370,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -4490,7 +4490,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.37: {}
+  baseline-browser-mapping@2.11.21: {}
 
   basic-ftp@5.3.1: {}
 
@@ -4502,13 +4502,13 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.2:
+  browserslist@4.28.9:
     dependencies:
-      baseline-browser-mapping: 2.10.37
-      caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.372
-      node-releases: 2.0.47
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.21
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.422
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.9)
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4529,7 +4529,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001799: {}
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -4735,7 +4735,7 @@ snapshots:
     optionalDependencies:
       wcwidth: 1.0.1
 
-  electron-to-chromium@1.5.372: {}
+  electron-to-chromium@1.5.422: {}
 
   emoji-mart@5.6.0: {}
 
@@ -5958,7 +5958,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-releases@2.0.47: {}
+  node-releases@2.0.54: {}
 
   normalize-wheel@1.0.1: {}
 
@@ -6697,9 +6697,9 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.9):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/scripts/smoke-oidc.sh
+++ b/scripts/smoke-oidc.sh
@@ -38,8 +38,18 @@ fail() {
   echo "[oidc-smoke] FAIL: $*" >&2
   exit 1
 }
-# Location header value of a saved response (CR-stripped).
-location() { grep -i '^location:' "$1" | tr -d '\r' | sed -E 's/^[Ll]ocation:[[:space:]]*//'; }
+# Location header value of a saved response (CR-stripped). Empty when the
+# response carried none — deliberately not a pipeline failure, so the caller's
+# `case` reports *what* came back instead of `set -e` killing the run silently.
+location() {
+  { grep -i '^location:' "$1" || true; } | tr -d '\r' | sed -E 's/^[Ll]ocation:[[:space:]]*//'
+}
+# Cookie header value assembled from every Set-Cookie of a saved response
+# ("name=value; name=value"), attributes stripped.
+cookies_of() {
+  { grep -i '^set-cookie:' "$1" || true; } | tr -d '\r' |
+    sed -E 's/^[Ss]et-[Cc]ookie:[[:space:]]*//; s/;.*$//' | paste -sd ';' - | sed 's/;/; /g'
+}
 
 wait_for() {
   local name="$1" url="$2" ok=
@@ -98,7 +108,17 @@ esac
 log "authorization request initiated"
 
 # 5) Fetch the Keycloak login page and extract the form POST action.
-curl -s -c "$JAR" -b "$JAR" -o "${TMP}/login.html" "$auth_url"
+#    Keycloak binds the pending login to cookies it sets on this response
+#    (AUTH_SESSION_ID, KC_RESTART) and expects them back on the credential POST.
+#    They travel explicitly, not via the cookie jar: curl 8.22.0 refuses to save
+#    or load jar cookies whose host is a public suffix, and under the PSL
+#    wildcard rule a single-label hostname such as `keycloak` is one — the
+#    round-trip silently dropped them and Keycloak answered the POST with
+#    LOGIN_ERROR cookie_not_found (issue #817). The jar stays in use for the
+#    app hops on localhost, which curl special-cases.
+curl -s -o "${TMP}/login.html" -D "${TMP}/b" "$auth_url"
+kc_cookies="$(cookies_of "${TMP}/b")"
+[ -n "$kc_cookies" ] || fail "Keycloak set no cookies on the login page"
 form_action="$(
   grep -oiE '<form[^>]+id="kc-form-login"[^>]+action="[^"]+"' "${TMP}/login.html" |
     sed -E 's/.*action="([^"]+)".*/\1/' | sed 's/&amp;/\&/g'
@@ -113,7 +133,7 @@ fi
 log "login form parsed"
 
 # 6) Submit credentials -> 302 back to the app's callback with the authorization code.
-curl -s -c "$JAR" -b "$JAR" -o /dev/null -D "${TMP}/c" \
+curl -s -b "$kc_cookies" -o /dev/null -D "${TMP}/c" \
   --data-urlencode "username=${KC_USER}" \
   --data-urlencode "password=${KC_PASS}" \
   --data-urlencode "credentialId=" \

--- a/scripts/smoke-oidc.sh
+++ b/scripts/smoke-oidc.sh
@@ -42,13 +42,15 @@ fail() {
 # response carried none — deliberately not a pipeline failure, so the caller's
 # `case` reports *what* came back instead of `set -e` killing the run silently.
 location() {
-  { grep -i '^location:' "$1" || true; } | tr -d '\r' | sed -E 's/^[Ll]ocation:[[:space:]]*//'
+  { grep -i '^location:' "$1" || true; } | tr -d '\r' | sed -E 's/^[^:]*:[[:space:]]*//'
 }
 # Cookie header value assembled from every Set-Cookie of a saved response
-# ("name=value; name=value"), attributes stripped.
+# ("name=value; name=value"), attributes stripped. Deletion cookies (an empty
+# value, i.e. `name=; Max-Age=0`) are left out rather than sent back as `name=`.
 cookies_of() {
   { grep -i '^set-cookie:' "$1" || true; } | tr -d '\r' |
-    sed -E 's/^[Ss]et-[Cc]ookie:[[:space:]]*//; s/;.*$//' | paste -sd ';' - | sed 's/;/; /g'
+    sed -E 's/^[^:]*:[[:space:]]*//; s/;.*$//' | { grep -vE '^[^=]*=$' || true; } |
+    paste -sd ';' - | sed 's/;/; /g'
 }
 
 wait_for() {
@@ -110,12 +112,12 @@ log "authorization request initiated"
 # 5) Fetch the Keycloak login page and extract the form POST action.
 #    Keycloak binds the pending login to cookies it sets on this response
 #    (AUTH_SESSION_ID, KC_RESTART) and expects them back on the credential POST.
-#    They travel explicitly, not via the cookie jar: curl 8.22.0 refuses to save
-#    or load jar cookies whose host is a public suffix, and under the PSL
-#    wildcard rule a single-label hostname such as `keycloak` is one — the
-#    round-trip silently dropped them and Keycloak answered the POST with
-#    LOGIN_ERROR cookie_not_found (issue #817). The jar stays in use for the
-#    app hops on localhost, which curl special-cases.
+#    They travel explicitly, not via the cookie jar: curl 8.22.0 still writes
+#    them to the jar but refuses to load jar cookies whose host is a public
+#    suffix, and under the PSL wildcard rule a single-label hostname such as
+#    `keycloak` is one — the round-trip silently dropped them and Keycloak
+#    answered the POST with LOGIN_ERROR cookie_not_found (issue #817). The jar
+#    stays in use for the app hops on localhost, which curl special-cases.
 curl -s -o "${TMP}/login.html" -D "${TMP}/b" "$auth_url"
 kc_cookies="$(cookies_of "${TMP}/b")"
 [ -n "$kc_cookies" ] || fail "Keycloak set no cookies on the login page"


### PR DESCRIPTION
## Summary

Every open Renovate PR (#813–#816) is red, and so is `main` (CI run 33558461557). None of it is the dependency being bumped — three gates went red underneath them, two purely by the passage of time. One PR, three independent minimal fixes:

- **Frontend — `pnpm audit --audit-level high`.** `browserslist` 4.28.2 (transitive via `eslint-plugin-react-hooks › @babel/core`) picked up two high advisories (GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g), fixed in 4.28.7. Lockfile-only move to 4.28.9 with its data packages; `package.json` untouched.
- **Security — Trivy SBOM gate.** `tomcat-embed-core` 11.0.24 (Spring Boot 4.1.1 BOM) carries three CRITICAL advisories — CVE-2026-65182, CVE-2026-65905, CVE-2026-68525: security-constraint, DIGEST-replay and FORM authentication bypasses — fixed in 11.0.25, which no Boot release carries yet. Pinned ahead of the BOM the #668 way: a `tomcat` version in the catalog, three `tomcat-embed-*` coordinates on it, and a `constraints {}` block in `qnop-app` so the starter still decides *that* Tomcat is on the classpath while the pin only lifts the version and core/el/websocket move together. Renovate keeps it moving; drop when Boot catches up.
- **CI smoke — OIDC sidecar.** The sidecar installs curl from the Alpine 3.24 repo at run time; curl **8.22.0** landed there on 2026-09-02 with two cookie changes (*cookies set for an exact PSL domain are host-only*; *refuse to load jar cookies set against a PSL domain*). A single-label hostname like `keycloak` is a public suffix under the PSL wildcard rule, so the `AUTH_SESSION_ID` cookie from the login page was silently dropped between two curl invocations and Keycloak answered the credential POST with `LOGIN_ERROR cookie_not_found`. Reproduced in isolation (jar round-trip keeps cookies for `localhost` and `keycloak.internal`, drops them for `keycloak`). The script now carries Keycloak's `Set-Cookie` values across the login hop explicitly and keeps the jar for the `localhost` hops, which curl special-cases. Also: `location()` no longer turns a missing `Location` header into a silent `set -e` exit — the caller's `case` reports what came back.

Nothing in the app, the Keycloak realm, or the compose topology changes.

## Test plan

- [x] `corepack pnpm install --frozen-lockfile` + `pnpm audit --audit-level high` → *No known vulnerabilities found*
- [x] `./gradlew :qnop-app:dependencies --configuration runtimeClasspath` → all three `tomcat-embed-*` resolve `11.0.24 -> 11.0.25`
- [x] `./gradlew clean` + `./gradlew build :qnop-app:cyclonedxBom --stacktrace`, then Trivy (`aquasec/trivy` container) on the SBOM with `--severity CRITICAL --exit-code 1`
- [x] Smoke stack locally (`docker compose -f docker-compose.smoke.yml up -d --build`, app image built from this branch): `scripts/smoke-test.sh` seeds and passes its first API checks, then stops at a macOS-only `date -d` incompatibility of the script (GNU date; CI is Ubuntu) — unrelated, left alone.
- [x] `docker compose -f docker-compose.smoke.yml run --rm smoke-oidc` against that seeded stack — the sidecar installs today's Alpine 3.24 curl **8.22.0**, i.e. exactly the curl that broke CI → *authenticated at Keycloak … ALL OIDC SMOKE CHECKS PASSED*
- [ ] CI green on this PR; then rebase the Renovate PRs (#813–#816) via their checkbox

Closes #817

🤖 Co-Author: Claude (Fable 5.1) via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEcYhdEbA1Bc3BoR76wzH
